### PR TITLE
Validation error for missing API key label

### DIFF
--- a/frontend/scenes/Settings/Settings.js
+++ b/frontend/scenes/Settings/Settings.js
@@ -109,10 +109,15 @@ class InlineForm extends React.Component {
     onSubmit: Function,
     disabled?: boolean,
   };
+  validationTimeout: number;
 
   state = {
     validationError: false,
   };
+
+  componentWillUnmount() {
+    clearTimeout(this.validationTimeout);
+  }
 
   handleSubmit = event => {
     event.preventDefault();
@@ -122,7 +127,7 @@ class InlineForm extends React.Component {
       this.setState({
         validationError: true,
       });
-      setTimeout(
+      this.validationTimeout = setTimeout(
         () =>
           this.setState({
             validationError: false,


### PR DESCRIPTION
<img width="872" alt="screen shot 2017-05-01 at 10 31 29 pm" src="https://cloud.githubusercontent.com/assets/31465/25605177/f2f6088e-2ebd-11e7-90e1-360e02e83d01.png">

Pretty lazy solution but I think I can live with this until we put some design into this page. Red validation error is flashed with a modified placeholder for 2.5s

fixes https://github.com/jorilallo/atlas/issues/18