### PR TITLE
Fixed document.update API

### DIFF
--- a/server/api/__snapshots__/auth.test.js.snap
+++ b/server/api/__snapshots__/auth.test.js.snap
@@ -3,7 +3,7 @@
 exports[`#auth.login should login with email 1`] = `
 Object {
   "avatarUrl": "http://example.com/avatar.png",
-  "id": "86fde1d4-0050-428f-9f0b-0bf77f8bdf61",
+  "id": "46fde1d4-0050-428f-9f0b-0bf77f4bdf61",
   "name": "User 1",
   "username": "user1",
 }
@@ -12,7 +12,7 @@ Object {
 exports[`#auth.login should login with username 1`] = `
 Object {
   "avatarUrl": "http://example.com/avatar.png",
-  "id": "86fde1d4-0050-428f-9f0b-0bf77f8bdf61",
+  "id": "46fde1d4-0050-428f-9f0b-0bf77f4bdf61",
   "name": "User 1",
   "username": "user1",
 }

--- a/server/api/__snapshots__/user.test.js.snap
+++ b/server/api/__snapshots__/user.test.js.snap
@@ -13,7 +13,7 @@ exports[`#user.info should return known user 1`] = `
 Object {
   "data": Object {
     "avatarUrl": "http://example.com/avatar.png",
-    "id": "86fde1d4-0050-428f-9f0b-0bf77f8bdf61",
+    "id": "46fde1d4-0050-428f-9f0b-0bf77f4bdf61",
     "name": "User 1",
     "username": "user1",
   },

--- a/server/api/documents.test.js
+++ b/server/api/documents.test.js
@@ -174,9 +174,7 @@ describe('#documents.update', async () => {
     expect(res.status).toEqual(200);
     expect(body.data.title).toBe('Updated title');
     expect(body.data.text).toBe('Updated text');
-    expect(body.data.collection.documentStructure[1].title).toBe(
-      'Updated title'
-    );
+    expect(body.data.collection.documents[1].title).toBe('Updated title');
   });
 
   it('should update document details for children', async () => {
@@ -210,7 +208,7 @@ describe('#documents.update', async () => {
 
     expect(res.status).toEqual(200);
     expect(body.data.title).toBe('Updated title');
-    expect(body.data.collection.documentStructure[0].children[1].title).toBe(
+    expect(body.data.collection.documents[0].children[1].title).toBe(
       'Updated title'
     );
   });

--- a/server/presenters/document.js
+++ b/server/presenters/document.js
@@ -39,13 +39,16 @@ async function present(ctx, document, options) {
   }
 
   if (options.includeCollection) {
-    data.collection =
-      options.collection ||
-      (await Collection.findOne({
-        where: {
-          id: document.atlasId,
-        },
-      }));
+    data.collection = await ctx.cache.get(document.atlasId, async () => {
+      const collection =
+        options.collection ||
+        (await Collection.findOne({
+          where: {
+            id: document.atlasId,
+          },
+        }));
+      return presentCollection(ctx, collection);
+    });
   }
 
   if (options.includeCollaborators) {

--- a/server/test/support.js
+++ b/server/test/support.js
@@ -23,7 +23,7 @@ const seed = async () => {
   });
 
   const user = await User.create({
-    id: '86fde1d4-0050-428f-9f0b-0bf77f8bdf61',
+    id: '46fde1d4-0050-428f-9f0b-0bf77f4bdf61',
     email: 'user1@example.com',
     username: 'user1',
     name: 'User 1',
@@ -37,7 +37,7 @@ const seed = async () => {
   });
 
   let collection = await Collection.create({
-    id: '86fde1d4-0050-428f-9f0b-0bf77f8bdf61',
+    id: '26fde1d4-0050-428f-9f0b-0bf77f8bdf62',
     name: 'Collection',
     urlId: 'collection',
     teamId: team.id,


### PR DESCRIPTION
- Fixed `document.update` API for updating child documents
- Added tests
- Changed test seed IDs as same IDs lead to cache issues (user returned when expected a collection etc)