### PR TITLE
Improve concurrency and reduce one DB call from document saving

### DIFF
--- a/server/api/documents.js
+++ b/server/api/documents.js
@@ -208,9 +208,7 @@ router.post('documents.update', auth(), async ctx => {
   ctx.assertPresent(title || text, 'title or text is required');
 
   const user = ctx.state.user;
-  const document = await Document.findById(id, {
-    include: ['collection'],
-  });
+  const document = await Document.findById(id);
   const collection = document.collection;
 
   if (!document || document.teamId !== user.teamId) throw httpErrors.NotFound();


### PR DESCRIPTION
Addresses #119.

- Remove one DB call by using `include`
- Run document saving and collection update with `Promise.all`

Document still has revision creation in after save hook but I don't think it's worth optimizing now as it might make code harder to understand