### PR TITLE
Fixed search and added tests

### DIFF
--- a/server/api/__snapshots__/documents.test.js.snap
+++ b/server/api/__snapshots__/documents.test.js.snap
@@ -9,6 +9,15 @@ Object {
 }
 `;
 
+exports[`#documents.search should require authentication 1`] = `
+Object {
+  "error": "authentication_required",
+  "message": "Authentication required",
+  "ok": false,
+  "status": 401,
+}
+`;
+
 exports[`#documents.star should require authentication 1`] = `
 Object {
   "error": "authentication_required",

--- a/server/api/documents.test.js
+++ b/server/api/documents.test.js
@@ -41,6 +41,28 @@ describe('#documents.list', async () => {
   });
 });
 
+describe('#documents.search', async () => {
+  it('should return results', async () => {
+    const { user } = await seed();
+    const res = await server.post('/api/documents.search', {
+      body: { token: user.getJwtToken(), query: 'much' },
+    });
+    const body = await res.json();
+
+    expect(res.status).toEqual(200);
+    expect(body.data.length).toEqual(1);
+    expect(body.data[0].text).toEqual('# Much guidance');
+  });
+
+  it('should require authentication', async () => {
+    const res = await server.post('/api/documents.search');
+    const body = await res.json();
+
+    expect(res.status).toEqual(401);
+    expect(body).toMatchSnapshot();
+  });
+});
+
 describe('#documents.viewed', async () => {
   it('should return empty result if no views', async () => {
     const { user } = await seed();

--- a/server/models/Document.js
+++ b/server/models/Document.js
@@ -156,7 +156,7 @@ const Document = sequelize.define(
           });
         }
       },
-      searchForUser: (user, query, options = {}) => {
+      searchForUser: async (user, query, options = {}) => {
         const limit = options.limit || 15;
         const offset = options.offset || 0;
 
@@ -169,13 +169,18 @@ const Document = sequelize.define(
         LIMIT :limit OFFSET :offset;
         `;
 
-        return sequelize.query(sql, {
-          replacements: {
-            query,
-            limit,
-            offset,
-          },
-          model: Document,
+        const ids = await sequelize
+          .query(sql, {
+            replacements: {
+              query,
+              limit,
+              offset,
+            },
+            model: Document,
+          })
+          .map(document => document.id);
+        return Document.findAll({
+          where: { id: ids },
         });
       },
     },


### PR DESCRIPTION
As we're using a custom SQL query for search, which isn't supported by Sequelize, it stopped working after recent `defaultScope` due to lack of `include`s. I couldn't figure out how to merge includes with a custom query (pure SQL isn't enough) so I just ducktaped this with a second query. It's not most optimal but at least it works until we have time to invest into this