### PR TITLE
Fixed width issues with search

### DIFF
--- a/frontend/scenes/Search/Search.js
+++ b/frontend/scenes/Search/Search.js
@@ -23,7 +23,9 @@ type Props = {
 };
 
 const Container = styled(CenteredContent)`
-  position: relative;
+  > div {
+    position: relative;
+  }
 `;
 
 const ResultsWrapper = styled(Flex)`


### PR DESCRIPTION
Before:

<img width="993" alt="screen shot 2017-07-12 at 12 45 39 am" src="https://user-images.githubusercontent.com/31465/28107842-468b7b38-669e-11e7-98da-e6e9c8c004f4.png">

After: 

<img width="1007" alt="screen shot 2017-07-12 at 1 11 08 am" src="https://user-images.githubusercontent.com/31465/28108045-05398fde-669f-11e7-9841-fc612ef97b09.png">
