### PR TITLE
Fix to keyboard shortcut modal. Fixes #190

### DIFF
--- a/frontend/components/Layout/Layout.js
+++ b/frontend/components/Layout/Layout.js
@@ -79,9 +79,13 @@ type Props = {
   };
 
   @keydown('shift+/')
-  handleOpenKeyboardShortcuts() {
+  goToOpenKeyboardShortcuts() {
     this.modal = 'keyboard-shortcuts';
   }
+
+  handleOpenKeyboardShortcuts = () => {
+    this.goToOpenKeyboardShortcuts();
+  };
 
   handleOpenSettings = () => {
     this.modal = 'settings';


### PR DESCRIPTION
It was an issue with `this` binding. This was the way I could make both the `onClick` callback and the `@keypress` decorator to work