### PR TITLE
Upgrade Slate, point plugin to branch instead of hash

### DIFF
--- a/frontend/components/Editor/plugins.js
+++ b/frontend/components/Editor/plugins.js
@@ -1,5 +1,5 @@
 // @flow
-import DropOrPasteImages from 'slate-drop-or-paste-images';
+import DropOrPasteImages from '@tommoor/slate-drop-or-paste-images';
 import PasteLinkify from 'slate-paste-linkify';
 import EditList from 'slate-edit-list';
 import CollapseOnEscape from 'slate-collapse-on-escape';

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "url": "git+ssh://git@github.com/jorilallo/atlas.git"
   },
   "dependencies": {
+    "@tommoor/slate-drop-or-paste-images": "0.5.1",
     "babel-core": "^6.24.1",
     "babel-eslint": "^7.2.3",
     "babel-loader": "6.2.5",
@@ -159,7 +160,6 @@
     "sequelize-encrypted": "0.1.0",
     "slate": "^0.21.4",
     "slate-collapse-on-escape": "^0.2.1",
-    "slate-drop-or-paste-images": "tommoor/slate-drop-or-paste-images#dev",
     "slate-edit-code": "^0.10.2",
     "slate-edit-list": "^0.7.0",
     "slate-markdown-serializer": "tommoor/slate-markdown-serializer",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,18 @@
 # yarn lockfile v1
 
 
+"@tommoor/slate-drop-or-paste-images@0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@tommoor/slate-drop-or-paste-images/-/slate-drop-or-paste-images-0.5.1.tgz#67a8853bb59d3a449f2fe7c7071dc19fe3aff93d"
+  dependencies:
+    data-uri-to-blob "0.0.4"
+    es6-promise "^4.0.5"
+    image-to-data-uri "^1.0.0"
+    is-data-uri "^0.1.0"
+    is-image "^1.0.1"
+    is-url "^1.2.2"
+    mime-types "^2.1.11"
+
 "@types/geojson@^1.0.0":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-1.0.3.tgz#fbcf7fa5eb6dd108d51385cc6987ec1f24214523"
@@ -2385,16 +2397,9 @@ domutils@1.1:
   dependencies:
     domelementtype "1"
 
-domutils@1.5.1:
+domutils@1.5.1, domutils@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
-  dependencies:
-    dom-serializer "0"
-    domelementtype "1"
-
-domutils@^1.5.1:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.6.2.tgz#1958cc0b4c9426e9ed367fb1c8e854891b0fa3ff"
   dependencies:
     dom-serializer "0"
     domelementtype "1"
@@ -4933,10 +4938,6 @@ json-loader@0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.4.tgz#8baa1365a632f58a3c46d20175fc6002c96e37de"
 
-json-loader@^0.5.7:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.7.tgz#dca14a70235ff82f0ac9a3abeb60d337a365185d"
-
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
@@ -6001,11 +6002,11 @@ moment-timezone@^0.5.4:
   dependencies:
     moment ">= 2.9.0"
 
-moment@2.13.0:
+moment@2.13.0, moment@^2.13.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.13.0.tgz#24162d99521e6d40f99ae6939e806d2139eaac52"
 
-moment@2.x.x, "moment@>= 2.9.0", moment@^2.13.0, moment@^2.16.0, moment@^2.17.1:
+moment@2.x.x, "moment@>= 2.9.0", moment@^2.16.0, moment@^2.17.1:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 
@@ -8137,19 +8138,6 @@ slate-collapse-on-escape@^0.2.1:
   resolved "https://registry.yarnpkg.com/slate-collapse-on-escape/-/slate-collapse-on-escape-0.2.1.tgz#988f474439f0a21f94cc0016da52ea3c1a061100"
   dependencies:
     to-pascal-case "^1.0.0"
-
-slate-drop-or-paste-images@tommoor/slate-drop-or-paste-images#dev:
-  version "0.5.0"
-  resolved "https://codeload.github.com/tommoor/slate-drop-or-paste-images/tar.gz/f599369ab83bed60f4a804d553d7889716bf9ec1"
-  dependencies:
-    data-uri-to-blob "0.0.4"
-    es6-promise "^4.0.5"
-    image-to-data-uri "^1.0.0"
-    is-data-uri "^0.1.0"
-    is-image "^1.0.1"
-    is-url "^1.2.2"
-    json-loader "^0.5.7"
-    mime-types "^2.1.11"
 
 slate-edit-code@^0.10.2:
   version "0.10.3"


### PR DESCRIPTION
- Upgrade Slate
- Upgrade React
- Point slate-drag-or-drop-images at npm published version