### PR TITLE
Ensure activeDocument is visible in sidebar

### DIFF
--- a/frontend/components/Layout/Layout.js
+++ b/frontend/components/Layout/Layout.js
@@ -35,16 +35,12 @@ type Props = {
   title?: ?React.Element<any>,
   auth: AuthStore,
   ui: UiStore,
-  search: ?boolean,
   notifications?: React.Element<any>,
 };
 
 @observer class Layout extends React.Component {
   props: Props;
-
-  static defaultProps = {
-    search: true,
-  };
+  scrollable: ?HTMLDivElement;
 
   @keydown(['/', 't'])
   goToSearch(ev) {
@@ -81,6 +77,20 @@ type Props = {
     this.props.ui.setActiveModal('collection-edit');
   };
 
+  setScrollableRef = ref => {
+    this.scrollable = ref;
+  };
+
+  scrollToActiveDocument = ref => {
+    const scrollable = this.scrollable;
+    if (!ref || !scrollable) return;
+
+    const container = scrollable.getBoundingClientRect();
+    const bounds = ref.getBoundingClientRect();
+    const scrollTop = bounds.top + container.top;
+    scrollable.scrollTop = scrollTop;
+  };
+
   render() {
     const { auth, documents, ui } = this.props;
     const { user, team } = auth;
@@ -115,7 +125,7 @@ type Props = {
               />
 
               <Flex auto column>
-                <Scrollable>
+                <Scrollable innerRef={this.setScrollableRef}>
                   <LinkSection>
                     <SidebarLink to="/dashboard">
                       <Icon type="Home" /> Home
@@ -132,6 +142,7 @@ type Props = {
                       history={this.props.history}
                       activeDocument={documents.active}
                       onCreateCollection={this.handleCreateCollection}
+                      activeDocumentRef={this.scrollToActiveDocument}
                     />
                   </LinkSection>
                 </Scrollable>

--- a/frontend/components/Layout/components/SidebarLink.js
+++ b/frontend/components/Layout/components/SidebarLink.js
@@ -20,7 +20,7 @@ const styleComponent = component => styled(component)`
   width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
-  margin: 5px 0;
+  padding: 5px 0;
   margin-left: ${({ hasChildren }) => (hasChildren ? '-20px;' : '0')};
   color: ${color.slateDark};
   font-size: 15px;

--- a/frontend/components/Scrollable/Scrollable.js
+++ b/frontend/components/Scrollable/Scrollable.js
@@ -1,18 +1,11 @@
 // @flow
-import React, { Component } from 'react';
 import styled from 'styled-components';
 
-const Scroll = styled.div`
+const Scrollable = styled.div`
   height: 100%;
   overflow-y: auto;
   overflow-x: hidden;
   -webkit-overflow-scrolling: touch;
 `;
-
-class Scrollable extends Component {
-  render() {
-    return <Scroll {...this.props} />;
-  }
-}
 
 export default Scrollable;


### PR DESCRIPTION
Scrolls to show the activeDocument if necessary, also fixed up that margin between document links in the sidebar that would allow you to accidentally click through to the root document.

Closes #146