### PR TITLE
Fixes broken links

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8036,8 +8036,8 @@ slate-edit-list@^0.7.0:
   resolved "https://registry.yarnpkg.com/slate-edit-list/-/slate-edit-list-0.7.1.tgz#84ee960d2d5b5a20ce267ad9df894395a91b93d5"
 
 slate-markdown-serializer@tommoor/slate-markdown-serializer:
-  version "0.5.1"
-  resolved "https://codeload.github.com/tommoor/slate-markdown-serializer/tar.gz/0026e78a125f70874672f8df01996079a1272c69"
+  version "0.5.2"
+  resolved "https://codeload.github.com/tommoor/slate-markdown-serializer/tar.gz/75708cf421c0a0ac0d7d541b295315cbff0839c0"
 
 slate-paste-linkify@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
Note: This fix encodes and decodes links as they come in and out of the slate state. Which means any links already in the document will need to be re-inserted, not much way around that.

closes #323