### PR TITLE
Fix to inline tags in text

### DIFF
--- a/frontend/components/Editor/plugins/MarkdownShortcuts.js
+++ b/frontend/components/Editor/plugins/MarkdownShortcuts.js
@@ -78,13 +78,16 @@ export default function MarkdownShortcuts() {
           const { text } = startBlock;
           const start = i;
           const end = i + shortcut.length;
+          const beginningOfBlock = start === 0;
+          const endOfBlock = end === text.length;
+          const surroundedByWhitespaces = [
+            text.slice(start - 1, start),
+            text.slice(end, end + 1),
+          ].includes(' ');
+
           if (
             text.slice(start, end) === shortcut &&
-            (start === 0 ||
-              end === text.length ||
-              [text.slice(start - 1, start), text.slice(end, end + 1)].includes(
-                ' '
-              ))
+            (beginningOfBlock || endOfBlock || surroundedByWhitespaces)
           )
             inlineTags.push(i);
         }


### PR DESCRIPTION
`word_word_word` lead to `word<i>word</i>word` before. This adds a check:

- inline tag is either at the beginning or at the end of the block
- or it has ` ` on either side of it

@tommoor happy to clean this up if you have feedback

Fixes #342