### PR TITLE
Fixes for empty document

### DIFF
--- a/frontend/components/Editor/Editor.js
+++ b/frontend/components/Editor/Editor.js
@@ -51,7 +51,7 @@ type KeyData = {
       onImageUploadStop: props.onImageUploadStop,
     });
 
-    if (props.text) {
+    if (props.text.trim().length) {
       this.state = { state: Markdown.deserialize(props.text) };
     } else {
       this.state = { state: Plain.deserialize('') };

--- a/server/presenters/document.js
+++ b/server/presenters/document.js
@@ -14,6 +14,11 @@ async function present(ctx: Object, document: Document, options: ?Options) {
     ...options,
   };
   ctx.cache.set(document.id, document);
+
+  // For empty document content, return the title
+  if (document.text.trim().length === 0)
+    document.text = `# ${document.title || 'Untitled document'}`;
+
   const data = {
     id: document.id,
     url: document.getUrl(),


### PR DESCRIPTION
Document with ` ` as content crashed `<Editor/>`. I added the title as return value if the content is empty as otherwise we'll just render the placeholder.

This fixes a bunch of document for internal deployment