### PR TITLE
Prevents accidental overwriting of another users work

### DIFF
--- a/app/models/Document.js
+++ b/app/models/Document.js
@@ -39,6 +39,7 @@ class Document extends BaseModel {
   updatedBy: User;
   url: string;
   views: number;
+  revision: number;
 
   data: Object;
 
@@ -168,6 +169,7 @@ class Document extends BaseModel {
           id: this.id,
           title: this.title,
           text: this.text,
+          lastRevision: this.revision,
         });
       } else {
         if (!this.title) {

--- a/app/scenes/Document/Document.js
+++ b/app/scenes/Document/Document.js
@@ -232,7 +232,7 @@ class DocumentScene extends Component {
                 message={DISCARD_CHANGES}
               />
               <Editor
-                key={document.id}
+                key={`${document.id}-${document.revision}`}
                 text={document.text}
                 emoji={document.emoji}
                 onImageUploadStart={this.onImageUploadStart}

--- a/server/api/__snapshots__/documents.test.js.snap
+++ b/server/api/__snapshots__/documents.test.js.snap
@@ -45,6 +45,15 @@ Object {
 }
 `;
 
+exports[`#documents.update should fail if document lastRevision does not match 1`] = `
+Object {
+  "error": "document_has_changed_since_last_revision",
+  "message": "Document has changed since last revision",
+  "ok": false,
+  "status": 400,
+}
+`;
+
 exports[`#documents.viewed should require authentication 1`] = `
 Object {
   "error": "authentication_required",

--- a/server/api/documents.js
+++ b/server/api/documents.js
@@ -242,13 +242,17 @@ router.post('documents.create', auth(), async ctx => {
 });
 
 router.post('documents.update', auth(), async ctx => {
-  const { id, title, text } = ctx.body;
+  const { id, title, text, lastRevision } = ctx.body;
   ctx.assertPresent(id, 'id is required');
   ctx.assertPresent(title || text, 'title or text is required');
 
   const user = ctx.state.user;
   const document = await Document.findById(id);
   const collection = document.collection;
+
+  if (lastRevision && lastRevision !== document.revisionCount) {
+    throw httpErrors.BadRequest('Document has changed since last revision');
+  }
 
   authDocumentForUser(ctx, document);
 

--- a/server/api/documents.test.js
+++ b/server/api/documents.test.js
@@ -277,6 +277,7 @@ describe('#documents.update', async () => {
         id: document.id,
         title: 'Updated title',
         text: 'Updated text',
+        lastRevision: document.revision,
       },
     });
     const body = await res.json();
@@ -285,6 +286,23 @@ describe('#documents.update', async () => {
     expect(body.data.title).toBe('Updated title');
     expect(body.data.text).toBe('Updated text');
     expect(body.data.collection.documents[1].title).toBe('Updated title');
+  });
+
+  it('should fail if document lastRevision does not match', async () => {
+    const { user, document } = await seed();
+
+    const res = await server.post('/api/documents.update', {
+      body: {
+        token: user.getJwtToken(),
+        id: document.id,
+        text: 'Updated text',
+        lastRevision: 123,
+      },
+    });
+    const body = await res.json();
+
+    expect(res.status).toEqual(400);
+    expect(body).toMatchSnapshot();
   });
 
   it('should update document details for children', async () => {

--- a/server/presenters/document.js
+++ b/server/presenters/document.js
@@ -36,6 +36,7 @@ async function present(ctx: Object, document: Document, options: ?Options) {
     team: document.teamId,
     collaborators: [],
     starred: !!(document.starred && document.starred.length),
+    revision: document.revisionCount,
     collectionId: document.atlasId,
     collaboratorCount: undefined,
     collection: undefined,


### PR DESCRIPTION
Whilst we're waiting on collaborative editing this simple safety measure ensures that you can't accidentally overwrite another users edits.

It also ensures that the latest content is always displayed when entering edit mode which wasn't happening previously – the content would be fetched but the Editor would not update.

Note: Base is `collection-home` for review purposes. Needs changing to `master` to merge.