### PR TITLE
Fixes: Issue with missing collection id

### DIFF
--- a/app/models/Collection.js
+++ b/app/models/Collection.js
@@ -44,6 +44,19 @@ class Collection extends BaseModel {
     return this.documents.length === 0;
   }
 
+  @computed
+  get documentIds(): string[] {
+    const results = [];
+    const travelDocuments = (documentList, path) =>
+      documentList.forEach(document => {
+        results.push(document.id);
+        travelDocuments(document.children);
+      });
+
+    travelDocuments(this.documents);
+    return results;
+  }
+
   /* Actions */
 
   @action

--- a/app/scenes/Collection/Collection.js
+++ b/app/scenes/Collection/Collection.js
@@ -123,8 +123,8 @@ class CollectionScene extends Component {
             </Heading>
             <Subheading>Recently edited</Subheading>
             <DocumentList
-              documents={this.props.documents.recentlyEditedInCollection(
-                this.collection.id
+              documents={this.props.documents.recentlyEditedIn(
+                this.collection.documentIds
               )}
             />
             <Actions align="center" justify="flex-end">

--- a/app/stores/DocumentsStore.js
+++ b/app/stores/DocumentsStore.js
@@ -48,15 +48,14 @@ class DocumentsStore extends BaseStore {
   }
 
   @computed
-  get recentlyEdited(): Array<Document> {
+  get recentlyEdited(): Document[] {
     return _.take(_.orderBy(this.data.values(), 'updatedAt', 'desc'), 5);
   }
 
-  recentlyEditedInCollection(collectionId: string): Array<Document> {
+  recentlyEditedIn(documentIds: string[]): Document[] {
     return _.orderBy(
-      _.filter(
-        this.data.values(),
-        document => document.collection.id === collectionId
+      _.filter(this.data.values(), document =>
+        documentIds.includes(document.id)
       ),
       'updatedAt',
       'desc'


### PR DESCRIPTION
Instead of documents store needing reference to collections we collection the documentIds from the collection model itself as the source of truth. Removes expectation that `document.collection.id` exists.