### PR TITLE
Address failing startup without .env #459

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,18 +12,19 @@ if (process.env.NODE_ENV === 'production') {
   );
 }
 
-const app = require('./server').default;
-const http = require('http');
-
 if (
+  !process.env.SECRET_KEY ||
   process.env.SECRET_KEY ===
-  'F0E5AD933D7F6FD8F4DBB3E038C501C052DC0593C686D21ACB30AE205D2F634B'
+    'F0E5AD933D7F6FD8F4DBB3E038C501C052DC0593C686D21ACB30AE205D2F634B'
 ) {
   console.error(
     'Please set SECRET_KEY env variable with output of `openssl rand -hex 32`'
   );
   process.exit(1);
 }
+
+const app = require('./server').default;
+const http = require('http');
 
 const server = http.createServer(app.callback());
 server.listen(process.env.PORT || '3000');


### PR DESCRIPTION
Basically check for an undefined SECRET_KEY in index before starting the server. An undefined entry is the result of a missing or misconfigured .env file or environment variables.

The error message could be more specific but as it is you are at least pointed at the right direction to get your install config going.