### PR TITLE
Fixed sidebar styles when on collection home

### DIFF
--- a/app/components/Sidebar/components/Collections.js
+++ b/app/components/Sidebar/components/Collections.js
@@ -5,7 +5,7 @@ import { observer, inject } from 'mobx-react';
 import type { Location } from 'react-router-dom';
 import Flex from 'shared/components/Flex';
 import styled from 'styled-components';
-import { color } from 'shared/styles/constants';
+import { color, fontWeight } from 'shared/styles/constants';
 
 import Header from './Header';
 import SidebarLink from './SidebarLink';
@@ -264,6 +264,8 @@ const StyledDropToImport = styled(DropToImport)`
 
 const Children = styled(Flex)`
   margin-left: 12px;
+  font-weight: ${fontWeight.regular};
+  color: ${color.slateDark};
 `;
 
 export default inject('collections', 'ui', 'documents')(Collections);


### PR DESCRIPTION
<img width="281" alt="screen shot 2017-12-02 at 6 04 01 pm" src="https://user-images.githubusercontent.com/31465/33521594-4eebac72-d78b-11e7-9cfe-e8e2e359338d.png">

The active link were also applies to collection links