### PR TITLE
CMD+S in a new document should not exit edit mode

### DIFF
--- a/app/scenes/Document/Document.js
+++ b/app/scenes/Document/Document.js
@@ -168,7 +168,7 @@ class DocumentScene extends Component {
     document = await document.save();
     this.isSaving = false;
 
-    if (redirect || this.props.newDocument) {
+    if (redirect) {
       this.props.history.push(document.url);
       this.props.ui.setActiveDocument(document);
     }

--- a/app/scenes/Document/Document.js
+++ b/app/scenes/Document/Document.js
@@ -171,6 +171,9 @@ class DocumentScene extends Component {
     if (redirect) {
       this.props.history.push(document.url);
       this.props.ui.setActiveDocument(document);
+    } else if (this.props.newDocument) {
+      this.props.history.push(documentEditUrl(document));
+      this.props.ui.setActiveDocument(document);
     }
   };
 


### PR DESCRIPTION
Hey guys! Jori especially ;). This project looks awesome! I wanted to get involved if possible so I set it up today. This is a tiny PR to address issue #493. It's a little weird to have the text be Publish when in fact you are just saving, so I'm not sure if this fix is sufficient. Generally there is a publish/save distinction if you can have content that is visible to you in draft form but is not ready for the group to see yet. Also it doesn't look like there are component level tests so I didn't write one, hopefully that's okay!