### PR TITLE
LinkToolbar changes

### DIFF
--- a/app/components/Editor/components/Toolbar/Toolbar.js
+++ b/app/components/Editor/components/Toolbar/Toolbar.js
@@ -14,8 +14,10 @@ function getLinkInSelection(value): any {
     const selectedLinks = value.document
       .getInlinesAtRange(value.selection)
       .filter(node => node.type === 'link');
+
     if (selectedLinks.size) {
-      return selectedLinks.first();
+      const link = selectedLinks.first();
+      if (value.selection.hasEdgeIn(link)) return link;
     }
   } catch (err) {
     // It's okay.
@@ -169,7 +171,7 @@ const Menu = styled.div`
   transition-delay: 250ms;
   line-height: 0;
   height: 40px;
-  min-width: 260px;
+  min-width: 300px;
 
   ${({ active }) =>
     active &&

--- a/app/components/Editor/components/Toolbar/components/LinkToolbar.js
+++ b/app/components/Editor/components/Toolbar/components/LinkToolbar.js
@@ -163,6 +163,7 @@ class LinkToolbar extends Component {
             placeholder="Search or paste a link…"
             onKeyDown={this.onKeyDown}
             onChange={this.onChange}
+            autoFocus={href === ''}
           />
           {this.isEditing && (
             <ToolbarButton onMouseDown={this.openLink}>

--- a/app/components/Editor/components/Toolbar/components/LinkToolbar.js
+++ b/app/components/Editor/components/Toolbar/components/LinkToolbar.js
@@ -163,7 +163,6 @@ class LinkToolbar extends Component {
             placeholder="Search or paste a link…"
             onKeyDown={this.onKeyDown}
             onChange={this.onChange}
-            autoFocus
           />
           {this.isEditing && (
             <ToolbarButton onMouseDown={this.openLink}>


### PR DESCRIPTION
Bug: When selecting large section of text with a link it it, LinkToolbar would be opened and focus drawn to it automatically.

With these changes, toolbar is only shown when user has the focus within the link bounds. I also took out the autofocus as I found it feeling wrong as it captures user's focus. Also adjusted the toolbar size to give more space for links