### PR TITLE
Map keyboard shortcuts on windows

### DIFF
--- a/app/components/Editor/Editor.js
+++ b/app/components/Editor/Editor.js
@@ -19,6 +19,7 @@ import { insertImageFile } from './changes';
 import renderMark from './marks';
 import createRenderNode from './nodes';
 import schema from './schema';
+import { isCmdKey } from './utils';
 import styled from 'styled-components';
 
 type Props = {
@@ -136,7 +137,7 @@ class MarkdownEditor extends Component {
 
   // Handling of keyboard shortcuts within editor focus
   onKeyDown = (ev: SyntheticKeyboardEvent, change: Change) => {
-    if (!ev.metaKey) return;
+    if (!isCmdKey(ev)) return;
 
     switch (ev.key) {
       case 's':

--- a/app/components/Editor/Editor.js
+++ b/app/components/Editor/Editor.js
@@ -19,7 +19,7 @@ import { insertImageFile } from './changes';
 import renderMark from './marks';
 import createRenderNode from './nodes';
 import schema from './schema';
-import { isCmdKey } from './utils';
+import { isModKey } from './utils';
 import styled from 'styled-components';
 
 type Props = {
@@ -137,7 +137,7 @@ class MarkdownEditor extends Component {
 
   // Handling of keyboard shortcuts within editor focus
   onKeyDown = (ev: SyntheticKeyboardEvent, change: Change) => {
-    if (!isCmdKey(ev)) return;
+    if (!isModKey(ev)) return;
 
     switch (ev.key) {
       case 's':

--- a/app/components/Editor/plugins/KeyboardShortcuts.js
+++ b/app/components/Editor/plugins/KeyboardShortcuts.js
@@ -4,7 +4,11 @@ import { Change } from 'slate';
 export default function KeyboardShortcuts() {
   return {
     onKeyDown(ev: SyntheticKeyboardEvent, change: Change) {
-      if (!ev.metaKey) return null;
+      const isMac = /Mac OS/.test(navigator.userAgent);
+      // Mac OS x
+      if (isMac && !ev.metaKey) return null;
+      // Windows etc
+      if (!isMac && !ev.ctrlKey) return null;
 
       switch (ev.key) {
         case 'b':

--- a/app/components/Editor/plugins/KeyboardShortcuts.js
+++ b/app/components/Editor/plugins/KeyboardShortcuts.js
@@ -1,14 +1,11 @@
 // @flow
 import { Change } from 'slate';
+import { isCmdKey } from '../utils';
 
 export default function KeyboardShortcuts() {
   return {
     onKeyDown(ev: SyntheticKeyboardEvent, change: Change) {
-      const isMac = /Mac OS/.test(navigator.userAgent);
-      // Mac OS x
-      if (isMac && !ev.metaKey) return null;
-      // Windows etc
-      if (!isMac && !ev.ctrlKey) return null;
+      if (!isCmdKey(ev)) return null;
 
       switch (ev.key) {
         case 'b':

--- a/app/components/Editor/plugins/KeyboardShortcuts.js
+++ b/app/components/Editor/plugins/KeyboardShortcuts.js
@@ -1,11 +1,11 @@
 // @flow
 import { Change } from 'slate';
-import { isCmdKey } from '../utils';
+import { isModKey } from '../utils';
 
 export default function KeyboardShortcuts() {
   return {
     onKeyDown(ev: SyntheticKeyboardEvent, change: Change) {
-      if (!isCmdKey(ev)) return null;
+      if (!isModKey(ev)) return null;
 
       switch (ev.key) {
         case 'b':

--- a/app/components/Editor/utils.js
+++ b/app/components/Editor/utils.js
@@ -3,7 +3,7 @@
 /**
  * Detect Cmd or Ctrl by platform for keyboard shortcuts
  */
-export function isCmdKey(event: SyntheticKeyboardEvent) {
+export function isModKey(event: SyntheticKeyboardEvent) {
   const isMac =
     typeof window !== 'undefined' &&
     /Mac|iPod|iPhone|iPad/.test(window.navigator.platform);

--- a/app/components/Editor/utils.js
+++ b/app/components/Editor/utils.js
@@ -1,0 +1,11 @@
+// @flow
+
+/**
+ * Detect Cmd or Ctrl by platform for keyboard shortcuts
+ */
+export function isCmdKey(event: SyntheticKeyboardEvent) {
+  const isMac =
+    typeof window !== 'undefined' &&
+    /Mac|iPod|iPhone|iPad/.test(window.navigator.platform);
+  return isMac ? event.metaKey : event.ctrlKey;
+}

--- a/app/components/Layout/Layout.js
+++ b/app/components/Layout/Layout.js
@@ -60,7 +60,7 @@ class Layout extends React.Component {
     this.props.history.push(documentEditUrl(activeDocument));
   }
 
-  @keydown('shift+/')
+  @keydown('meta+/')
   openKeyboardShortcuts() {
     this.props.ui.setActiveModal('keyboard-shortcuts');
   }

--- a/app/components/Layout/Layout.js
+++ b/app/components/Layout/Layout.js
@@ -60,7 +60,7 @@ class Layout extends React.Component {
     this.props.history.push(documentEditUrl(activeDocument));
   }
 
-  @keydown('meta+/')
+  @keydown('shift+/')
   openKeyboardShortcuts() {
     this.props.ui.setActiveModal('keyboard-shortcuts');
   }

--- a/app/scenes/KeyboardShortcuts/KeyboardShortcuts.js
+++ b/app/scenes/KeyboardShortcuts/KeyboardShortcuts.js
@@ -38,7 +38,7 @@ function KeyboardShortcuts() {
         <Label>Jump to dashboard</Label>
 
         <Keys>
-          <Key>⌘</Key> + <Key>/</Key>
+          <Key>?</Key>
         </Keys>
         <Label>Open this guide</Label>
       </List>


### PR DESCRIPTION
`event.metaKey` maps to Windows key and not the Ctrl so keyboard shortcuts weren't working on Windows.

Fixes #525