### PR TITLE
Ensure Document remount on nav

### DIFF
--- a/app/scenes/Document/Document.js
+++ b/app/scenes/Document/Document.js
@@ -226,7 +226,7 @@ class DocumentScene extends Component {
     }
 
     return (
-      <Container column auto>
+      <Container key={this.props.location.pathname} column auto>
         {isMoving && document && <DocumentMove document={document} />}
         {titleText && <PageTitle title={titleText} />}
         {(this.isLoading || this.isSaving) && <LoadingIndicator />}


### PR DESCRIPTION
I removed this in https://github.com/outline/outline/pull/529 - that was dumb. The remount is very much needed and navigating between docs is broken without.