### PR TITLE
Fix JS error where selection has no startBlock

### DIFF
--- a/app/components/Editor/components/Toolbar/components/LinkToolbar.js
+++ b/app/components/Editor/components/Toolbar/components/LinkToolbar.js
@@ -138,7 +138,8 @@ class LinkToolbar extends Component {
       if (href) {
         change.setInline({ type: 'link', data: { href } });
       } else if (link) {
-        const selContainsLink = !!change.value.startBlock.getChild(link.key);
+        const startBlock = change.value.startBlock;
+        const selContainsLink = !!(startBlock && startBlock.getChild(link.key));
         if (selContainsLink) change.unwrapInlineByKey(link.key);
       }
       change.deselect();


### PR DESCRIPTION
Seems simple and obvious because it is, we should check that startBlock exists before using it

closes #538