### PR TITLE
Fixed database urls in .env.sample file

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,8 +4,8 @@
 #
 # Please use `openssl rand -hex 32` to create SECRET_KEY
 
-DATABASE_URL=postgres://user:pass@localhost:5432/outline
-DATABASE_URL_TEST=postgres://user:pass@localhost:5432/outline-test
+DATABASE_URL=postgres://user:pass@postgres:5432/outline
+DATABASE_URL_TEST=postgres://user:pass@postgres:5432/outline-test
 SECRET_KEY=F0E5AD933D7F6FD8F4DBB3E038C501C052DC0593C686D21ACB30AE205D2F634B
 PORT=3000
 REDIS_URL=redis://redis:6379


### PR DESCRIPTION
I do not have applying migrations, the problem is why it's written [here](https://stackoverflow.com/questions/33357567/econnrefused-for-postgres-on-nodejs-with-dockers/33363660).

