### PR TITLE
Search and routing fixes

### DIFF
--- a/app/scenes/Search/Search.js
+++ b/app/scenes/Search/Search.js
@@ -67,8 +67,8 @@ class Search extends Component {
   @observable query: string = '';
   @observable offset: number = 0;
   @observable allowLoadMore: boolean = true;
-  @observable isFetching = false;
-  @observable pinToTop = false;
+  @observable isFetching: boolean = false;
+  @observable pinToTop: boolean = false;
 
   componentDidMount() {
     this.handleQueryChange();

--- a/app/scenes/Search/Search.js
+++ b/app/scenes/Search/Search.js
@@ -68,6 +68,7 @@ class Search extends Component {
   @observable offset: number = 0;
   @observable allowLoadMore: boolean = true;
   @observable isFetching = false;
+  @observable pinToTop = false;
 
   componentDidMount() {
     this.handleQueryChange();
@@ -103,7 +104,9 @@ class Search extends Component {
 
   handleQueryChange = () => {
     const query = this.props.match.params.query;
-    this.query = query ? decodeURIComponent(query) : '';
+    this.query = query ? query : '';
+    this.resultIds = [];
+    this.offset = 0;
     this.allowLoadMore = true;
 
     // To prevent "no results" showing before debounce kicks in
@@ -137,6 +140,7 @@ class Search extends Component {
           limit: DEFAULT_PAGINATION_LIMIT,
         });
         this.resultIds = this.resultIds.concat(newResults);
+        if (this.resultIds.length > 0) this.pinToTop = true;
         if (
           newResults.length === 0 ||
           newResults.length < DEFAULT_PAGINATION_LIMIT
@@ -150,6 +154,7 @@ class Search extends Component {
       }
     } else {
       this.resultIds = [];
+      this.pinToTop = false;
     }
 
     this.isFetching = false;
@@ -172,8 +177,8 @@ class Search extends Component {
 
   render() {
     const { documents, notFound } = this.props;
-    const hasResults = this.resultIds.length > 0;
-    const showEmpty = !this.isFetching && this.query && !hasResults;
+    const showEmpty =
+      !this.isFetching && this.query && this.resultIds.length === 0;
 
     return (
       <Container auto>
@@ -185,14 +190,14 @@ class Search extends Component {
             <p>We’re unable to find the page you’re accessing.</p>
           </div>
         )}
-        <ResultsWrapper pinToTop={hasResults} column auto>
+        <ResultsWrapper pinToTop={this.pinToTop} column auto>
           <SearchField
             onKeyDown={this.handleKeyDown}
             onChange={this.updateLocation}
             value={this.query}
           />
           {showEmpty && <Empty>No matching documents.</Empty>}
-          <ResultList column visible={hasResults}>
+          <ResultList column visible={this.pinToTop}>
             <StyledArrowKeyNavigation
               mode={ArrowKeyNavigation.mode.VERTICAL}
               defaultActiveChildIndex={0}

--- a/server/routes.js
+++ b/server/routes.js
@@ -94,8 +94,5 @@ router.get('*', async ctx => {
 // middleware
 koa.use(subdomainRedirect());
 koa.use(router.routes());
-koa.use(async () => {
-  throw httpErrors.NotFound();
-});
 
 export default koa;


### PR DESCRIPTION
I noticed that search behaves wonky now: typing from `10` to `100` just appends results and doesn't clear the previous results. Also it seems that react router decodes GET params automatically and re-decoding can lead to exceptions which we seen.

Also removed server side catch which doesn't do anything as we have a wildcard catch before it afaik 