### PR TITLE
Fixes: Possible to create blocks inside document title

### DIFF
--- a/app/components/Editor/plugins/MarkdownShortcuts.js
+++ b/app/components/Editor/plugins/MarkdownShortcuts.js
@@ -40,6 +40,10 @@ export default function MarkdownShortcuts() {
       const { value } = change;
       if (value.isExpanded) return;
       const { startBlock, startOffset } = value;
+
+      // no markdown shortcuts work in headings
+      if (startBlock.type.match(/heading/)) return;
+
       const chars = startBlock.text.slice(0, startOffset).trim();
       const type = this.getType(chars);
 

--- a/app/components/Editor/schema.js
+++ b/app/components/Editor/schema.js
@@ -3,12 +3,12 @@ import { Block, Change, Node, Mark } from 'slate';
 
 const schema = {
   blocks: {
-    heading1: { marks: [''] },
-    heading2: { marks: [''] },
-    heading3: { marks: [''] },
-    heading4: { marks: [''] },
-    heading5: { marks: [''] },
-    heading6: { marks: [''] },
+    heading1: { nodes: [{ kinds: ['text'] }], marks: [''] },
+    heading2: { nodes: [{ kinds: ['text'] }], marks: [''] },
+    heading3: { nodes: [{ kinds: ['text'] }], marks: [''] },
+    heading4: { nodes: [{ kinds: ['text'] }], marks: [''] },
+    heading5: { nodes: [{ kinds: ['text'] }], marks: [''] },
+    heading6: { nodes: [{ kinds: ['text'] }], marks: [''] },
     'block-quote': { marks: [''] },
     table: {
       nodes: [{ types: ['table-row', 'table-head', 'table-cell'] }],


### PR DESCRIPTION
Two fixes - ensure that Slate gets rid of anything other than text nodes in headings, and make sure that the markdown shortcuts functionality doesn't attempt to even put anything there.

Works beautifully.