### PR TITLE
Upgrade Slate

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "sequelize": "4.28.6",
     "sequelize-cli": "^2.7.0",
     "sequelize-encrypted": "0.1.0",
-    "slate": "^0.31.5",
+    "slate": "^0.31.8",
     "slate-collapse-on-escape": "^0.6.0",
     "slate-edit-list": "^0.10.2",
     "slate-md-serializer": "^1.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8794,9 +8794,9 @@ slate-trailing-block@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/slate-trailing-block/-/slate-trailing-block-0.4.0.tgz#92573d7729e4c2a05c45521616ae2db28197476c"
 
-slate@^0.31.5:
-  version "0.31.5"
-  resolved "https://registry.npmjs.org/slate/-/slate-0.31.5.tgz#3fe2e7b63e478aaf5cadfa65f7752bb451f6a3bf"
+slate@^0.31.8:
+  version "0.31.8"
+  resolved "https://registry.yarnpkg.com/slate/-/slate-0.31.8.tgz#d93fd397bcceb2b5eb2e1cbafa20643044230d63"
   dependencies:
     debug "^2.3.2"
     direction "^0.1.5"


### PR DESCRIPTION
Fixes a number of the editor JS issues we've seen, including a JS error when pasting text over other text that I could reproduce and can't after the upgrade 😄 