### PR TITLE
Restore static pageview tracking

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -132,8 +132,6 @@ window.addEventListener('load', async () => {
   // https://github.com/googleanalytics/autotrack/issues/137#issuecomment-305890099
   await import('autotrack/autotrack.js');
 
-  window.ga('create', process.env.GOOGLE_ANALYTICS_ID, 'auto');
   window.ga('require', 'outboundLinkTracker');
   window.ga('require', 'urlChangeTracker');
-  window.ga('send', 'pageview');
 });

--- a/shared/components/Analytics.js
+++ b/shared/components/Analytics.js
@@ -10,6 +10,8 @@ function Analytics() {
         dangerouslySetInnerHTML={{
           __html: `
           window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+          ga('create', ${process.env.GOOGLE_ANALYTICS_ID}, 'auto');
+          ga('send', 'pageview');
         `,
         }}
       />


### PR DESCRIPTION
Accidentally removed tracking from static pages by moving the pageview call into the SPA 🙈 