### PR TITLE
Added natural sorting for documents and collections

### DIFF
--- a/app/stores/CollectionsStore.js
+++ b/app/stores/CollectionsStore.js
@@ -8,6 +8,7 @@ import stores from 'stores';
 import Collection from 'models/Collection';
 import ErrorsStore from 'stores/ErrorsStore';
 import UiStore from 'stores/UiStore';
+import naturalSort from 'shared/utils/naturalSort';
 import type { PaginationParams } from 'types';
 
 type Options = {
@@ -42,7 +43,7 @@ class CollectionsStore {
 
   @computed
   get orderedData(): Collection[] {
-    return _.sortBy(this.data.values(), 'name');
+    return naturalSort(Array.from(this.data.values()), 'name');
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
   "dependencies": {
     "@tommoor/slate-drop-or-paste-images": "^0.8.1",
     "@tommoor/slate-edit-code": "^0.13.3",
-    "aws-sdk": "^2.135.0",
     "autotrack": "^2.4.1",
+    "aws-sdk": "^2.135.0",
     "babel-core": "^6.24.1",
     "babel-eslint": "^8.1.2",
     "babel-loader": "^7.1.2",
@@ -136,6 +136,7 @@
     "mobx-react": "^4.1.8",
     "mobx-react-devtools": "^4.2.11",
     "moment": "2.13.0",
+    "natural-sort": "^1.0.0",
     "node-dev": "3.1.0",
     "nodemailer": "^4.4.0",
     "normalize.css": "^7.0.0",

--- a/server/presenters/collection.js
+++ b/server/presenters/collection.js
@@ -1,7 +1,7 @@
 // @flow
-import _ from 'lodash';
 import { Collection } from '../models';
 import presentDocument from './document';
+import naturalSort from '../../shared/utils/naturalSort';
 
 type Document = {
   children: Document[],
@@ -11,7 +11,7 @@ type Document = {
 };
 
 const sortDocuments = (documents: Document[]) => {
-  const orderedDocs = _.sortBy(documents, ['title']);
+  const orderedDocs = naturalSort(documents, 'title');
   return orderedDocs.map(document => ({
     ...document,
     children: sortDocuments(document.children),

--- a/shared/utils/naturalSort.js
+++ b/shared/utils/naturalSort.js
@@ -1,0 +1,10 @@
+// @flow
+
+import _ from 'lodash';
+import naturalSort from 'natural-sort';
+
+export default (sortableArray: Object[], key: string) => {
+  let keys = sortableArray.map(object => object[key]);
+  keys.sort(naturalSort());
+  return _.sortBy(sortableArray, object => keys.indexOf(object[key]));
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6628,6 +6628,10 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
+natural-sort@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/natural-sort/-/natural-sort-1.0.0.tgz#eac301fd86c268a771222c62dc7719402aa34380"
+
 ncname@1.0.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ncname/-/ncname-1.0.0.tgz#5b57ad18b1ca092864ef62b0b1ed8194f383b71c"


### PR DESCRIPTION
<img width="269" alt="screen shot 2018-02-28 at 10 55 12 pm" src="https://user-images.githubusercontent.com/31465/36831128-4234c528-1cdb-11e8-823b-b20a557bea2c.png">

Sort both collections and documents using natural sorting so that sorting with numbers works better