### PR TITLE
Upgrade slate-edit-code

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -8,8 +8,8 @@
 .*/node_modules/polished/.*
 .*/node_modules/react-side-effect/.*
 .*/node_modules/fbjs/.*
-.*/node_modules/@tommoor/slate-edit-code/example/.*
-.*/node_modules/@tommoor/slate-edit-code/lib/.*
+.*/node_modules/slate-edit-code/example/.*
+.*/node_modules/slate-edit-code/lib/.*
 .*/node_modules/slate-edit-list/.*
 .*/node_modules/slate-prism/.*
 .*/node_modules/config-chain/.*

--- a/app/components/Editor/plugins.js
+++ b/app/components/Editor/plugins.js
@@ -3,7 +3,7 @@ import InsertImages from '@tommoor/slate-drop-or-paste-images';
 import PasteLinkify from 'slate-paste-linkify';
 import CollapseOnEscape from 'slate-collapse-on-escape';
 import TrailingBlock from 'slate-trailing-block';
-import EditCode from '@tommoor/slate-edit-code';
+import EditCode from 'slate-edit-code';
 import Prism from 'slate-prism';
 import EditList from './plugins/EditList';
 import KeyboardShortcuts from './plugins/KeyboardShortcuts';

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
   },
   "dependencies": {
     "@tommoor/slate-drop-or-paste-images": "^0.8.1",
-    "@tommoor/slate-edit-code": "^0.13.3",
     "autotrack": "^2.4.1",
     "aws-sdk": "^2.135.0",
     "babel-core": "^6.24.1",
@@ -170,6 +169,7 @@
     "sequelize-encrypted": "0.1.0",
     "slate": "^0.32.4",
     "slate-collapse-on-escape": "^0.6.0",
+    "slate-edit-code": "^0.14.0",
     "slate-edit-list": "^0.11.2",
     "slate-md-serializer": "^2.0.0",
     "slate-paste-linkify": "^0.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -75,15 +75,6 @@
     mime-types "^2.1.11"
     slate-dev-logger "^0.1.0"
 
-"@tommoor/slate-edit-code@^0.13.3":
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/@tommoor/slate-edit-code/-/slate-edit-code-0.13.3.tgz#05c00bd23e79d1229fccdd9988c23bd8bb94b448"
-  dependencies:
-    detect-indent "^4.0.0"
-    detect-newline "^2.1.0"
-    ends-with "^0.2.0"
-    is-hotkey "^0.1.1"
-
 "@types/geojson@^1.0.0":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-1.0.3.tgz#fbcf7fa5eb6dd108d51385cc6987ec1f24214523"
@@ -8841,6 +8832,15 @@ slate-dev-logger@^0.1.0:
 slate-dev-logger@^0.1.39:
   version "0.1.39"
   resolved "https://registry.yarnpkg.com/slate-dev-logger/-/slate-dev-logger-0.1.39.tgz#744a69b85034244713e6de51483af5713c345af4"
+
+slate-edit-code@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/slate-edit-code/-/slate-edit-code-0.14.0.tgz#8fec510957eaef9a861746d0c7f10c3ede3998d0"
+  dependencies:
+    detect-indent "^4.0.0"
+    detect-newline "^2.1.0"
+    ends-with "^0.2.0"
+    is-hotkey "^0.1.1"
 
 slate-edit-list@^0.11.2:
   version "0.11.2"


### PR DESCRIPTION
They published my fixes for multiline support and Slate 32 compatibility in version `0.14.0` so we no longer have to use my fork 😄 