### PR TITLE
Improve scrolling behavior

### DIFF
--- a/app/components/Scrollable/Scrollable.js
+++ b/app/components/Scrollable/Scrollable.js
@@ -5,6 +5,7 @@ const Scrollable = styled.div`
   height: 100%;
   overflow-y: auto;
   overflow-x: hidden;
+  overscroll-behavior: none;
   -webkit-overflow-scrolling: touch;
 `;
 


### PR DESCRIPTION
Prevent scrolling in the sidebar/ content area scrolling the other section when the boundary of a scrolling area is reached.

https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior