### PR TITLE
Improves rendering of headings 

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "slate-collapse-on-escape": "^0.6.0",
     "slate-edit-code": "^0.14.0",
     "slate-edit-list": "^0.11.2",
-    "slate-md-serializer": "3.0.0",
+    "slate-md-serializer": "3.0.3",
     "slate-paste-linkify": "^0.5.0",
     "slate-plain-serializer": "0.5.4",
     "slate-prism": "^0.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8846,9 +8846,9 @@ slate-edit-list@^0.11.2:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/slate-edit-list/-/slate-edit-list-0.11.2.tgz#c67b961d98435f9f7747d20b870cbc51d25af7a8"
 
-slate-md-serializer@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/slate-md-serializer/-/slate-md-serializer-3.0.0.tgz#ed46213f037550b555f785a7411555a1688ceff9"
+slate-md-serializer@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/slate-md-serializer/-/slate-md-serializer-3.0.3.tgz#194aaf74b8c5158cdd45f8d2394a1a1574acaf83"
 
 slate-paste-linkify@^0.5.0:
   version "0.5.0"


### PR DESCRIPTION
…to have better spacing in the Markdown output. Backwards compatible, docs will improve themselves as they are re-saved so no migration needed.