### PR TITLE
Adds _ and ~ as allowed slug characters

### DIFF
--- a/app/utils/routeHelpers.js
+++ b/app/utils/routeHelpers.js
@@ -66,7 +66,7 @@ export function notFoundUrl(): string {
 }
 
 export const matchDocumentSlug =
-  ':documentSlug([0-9a-zA-Z-]*-[a-zA-z0-9]{10,15})';
+  ':documentSlug([0-9a-zA-Z-_~]*-[a-zA-z0-9]{10,15})';
 
 export const matchDocumentEdit = `/doc/${matchDocumentSlug}/edit`;
 export const matchDocumentMove = `/doc/${matchDocumentSlug}/move`;


### PR DESCRIPTION
Several characters that the slug library allows through but we weren't deeming as acceptable for a document route: https://github.com/dodo/node-slug/blob/master/slug.js#L60

closes #636