### PR TITLE
Restrict engines to < node 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     ]
   },
   "engines": {
-    "node": ">= 8.0"
+    "node": ">=8.0 <10.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Deploys are failing. Looks like bcrypt isn't available pre-built for node 10 yet.