### PR TITLE
Allowed domains env variable for Google Auth

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -20,7 +20,7 @@ SLACK_SECRET=d2dc414f9953226bad0a356cXXXXYYYY
 
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
-# Comma seperated list of domains to be allowed (optional)
+# Comma separated list of domains to be allowed (optional)
 # If not set, all Google apps domains are allowed by default
 GOOGLE_ALLOWED_DOMAINS=
 

--- a/.env.sample
+++ b/.env.sample
@@ -20,6 +20,9 @@ SLACK_SECRET=d2dc414f9953226bad0a356cXXXXYYYY
 
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
+# Comma seperated list of domains to be allowed (optional)
+# If not set, all Google apps domains are allowed by default
+GOOGLE_ALLOWED_DOMAINS=
 
 # Third party credentials (optional)
 SLACK_VERIFICATION_TOKEN=PLxk6OlXXXXXVj3YYYY

--- a/server/auth/google.js
+++ b/server/auth/google.js
@@ -46,7 +46,7 @@ router.get('google.callback', async ctx => {
 
   // allow all domains by default if the env is not set
   const allowedDomains = allowedDomainsEnv && allowedDomainsEnv.split(',');
-  if (allowedDomains && allowedDomains.indexOf(profile.data.hd) < 0) {
+  if (allowedDomains && !allowedDomains.includes(profile.data.hd)) {
     ctx.redirect('/?notice=hd-not-allowed');
     return;
   }

--- a/server/auth/google.js
+++ b/server/auth/google.js
@@ -12,6 +12,7 @@ const client = new OAuth2Client(
   process.env.GOOGLE_CLIENT_SECRET,
   `${process.env.URL}/auth/google.callback`
 );
+const allowedDomainsEnv = process.env.GOOGLE_ALLOWED_DOMAINS;
 
 // start the oauth process and redirect user to Google
 router.get('google', async ctx => {
@@ -40,6 +41,13 @@ router.get('google.callback', async ctx => {
 
   if (!profile.data.hd) {
     ctx.redirect('/?notice=google-hd');
+    return;
+  }
+
+  // allow all domains by default if the env is not set
+  const allowedDomains =  allowedDomainsEnv && allowedDomainsEnv.split(',');
+  if(allowedDomains && allowedDomains.indexOf(profile.data.hd) < 0){
+    ctx.redirect('/?notice=hd-not-allowed');
     return;
   }
 

--- a/server/auth/google.js
+++ b/server/auth/google.js
@@ -45,8 +45,8 @@ router.get('google.callback', async ctx => {
   }
 
   // allow all domains by default if the env is not set
-  const allowedDomains =  allowedDomainsEnv && allowedDomainsEnv.split(',');
-  if(allowedDomains && allowedDomains.indexOf(profile.data.hd) < 0){
+  const allowedDomains = allowedDomainsEnv && allowedDomainsEnv.split(',');
+  if (allowedDomains && allowedDomains.indexOf(profile.data.hd) < 0) {
     ctx.redirect('/?notice=hd-not-allowed');
     return;
   }

--- a/server/pages/Home.js
+++ b/server/pages/Home.js
@@ -10,7 +10,7 @@ import SigninButtons from './components/SigninButtons';
 import { developers, githubUrl } from '../../shared/utils/routeHelpers';
 
 type Props = {
-  notice?: 'google-hd' | 'auth-error',
+  notice?: 'google-hd' | 'auth-error' | 'hd-not-allowed',
   lastSignedIn: string,
   googleSigninEnabled: boolean,
   slackSigninEnabled: boolean,
@@ -36,6 +36,12 @@ function Home(props: Props) {
             <Notice>
               Sorry, Google sign in cannot be used with a personal email. Please
               try signing in with your company Google account.
+            </Notice>
+          )}
+          {props.notice === 'hd-not-allowed' && (
+            <Notice>
+              Sorry, your Google apps domain is not allowed. Please try again
+              with an allowed company domain.
             </Notice>
           )}
           {props.notice === 'auth-error' && (


### PR DESCRIPTION
Implements #681.

* Added an optional `GOOGLE_ALLOWED_DOMAINS` parameter in the environment which takes a comma separated list of domains to allow in Google auth.
* If it is not set, all Google apps domains are allowed by default.

@tommoor Please let me know if any changes have to be made. Open for feedback.