### PR TITLE
`showCollection` option in Dashboard documents list

### DIFF
--- a/app/scenes/Dashboard.js
+++ b/app/scenes/Dashboard.js
@@ -45,6 +45,7 @@ class Dashboard extends React.Component<Props> {
               key="recent"
               documents={documents.recentlyViewed}
               fetch={documents.fetchRecentlyViewed}
+              showCollection
             />
           </Route>
           <Route path="/dashboard/created">
@@ -53,12 +54,14 @@ class Dashboard extends React.Component<Props> {
               documents={documents.createdByUser(user)}
               fetch={documents.fetchOwned}
               options={{ user }}
+              showCollection
             />
           </Route>
           <Route path="/dashboard">
             <PaginatedDocumentList
               documents={documents.recentlyEdited}
               fetch={documents.fetchRecentlyEdited}
+              showCollection
             />
           </Route>
         </Switch>


### PR DESCRIPTION
It was added in #718, but seems to have gone after the new tabs are added in the dashboard.