### PR TITLE
Add CORS support

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "url": "git+ssh://git@github.com/outline/outline.git"
   },
   "dependencies": {
+    "@koa/cors": "2",
     "@tommoor/remove-markdown": "0.3.1",
     "@tommoor/slate-drop-or-paste-images": "^0.8.1",
     "autotrack": "^2.4.1",

--- a/server/index.js
+++ b/server/index.js
@@ -4,6 +4,7 @@ import { contentSecurityPolicy } from 'koa-helmet';
 import logger from 'koa-logger';
 import mount from 'koa-mount';
 import Koa from 'koa';
+import cors from '@koa/cors';
 import bugsnag from 'bugsnag';
 import onerror from 'koa-onerror';
 import updates from './utils/updates';
@@ -15,6 +16,7 @@ import routes from './routes';
 
 const app = new Koa();
 
+app.use(cors());
 app.use(compress());
 
 if (process.env.NODE_ENV === 'development') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,6 +63,10 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
+"@koa/cors@2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@koa/cors/-/cors-2.2.2.tgz#9084ab7f58107734e6b19d602d99538eda73f2d0"
+
 "@tommoor/remove-markdown@0.3.1":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@tommoor/remove-markdown/-/remove-markdown-0.3.1.tgz#25e7b845d52fcfadf149a3a6a468a931fee7619b"


### PR DESCRIPTION
Hey outline people!

Congratulations for the awesome work on Outline!

I have one issue with Cross-Origin when using the S3 integration.

> Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at https://XXXX.s3.amazonaws.com/XXXX. (Reason: CORS header ‘Access-Control-Allow-Origin’ missing).

I managed how to fix it by adding the [koa-cors](https://github.com/koajs/cors) package to the project.  I didn't add any specific option because I am not sure what it is. What do you think?