### PR TITLE
Implement a local authentication provider (for development only)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -14,9 +14,12 @@ DEPLOYMENT=self
 ENABLE_UPDATES=true
 DEBUG=sql,cache,presenters,events
 
+# Enable single-user development authentication (leave empty in production)
+LOCAL_AUTH_ENABLED=yes
+
 # Third party signin credentials (at least one is required)
-SLACK_KEY=71315967491.XXXXXXXXXX
-SLACK_SECRET=d2dc414f9953226bad0a356cXXXXYYYY
+SLACK_KEY=
+SLACK_SECRET=
 
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=

--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ In development you can quickly get an environment running using Docker by follow
 
 ## Development
 
+Provided you have Docker installed, this is the bare minimum to get the application up and running for development:
+
+    sed -e "s/SECRET_KEY.*/SECRET_KEY=$(openssl rand -hex 32)/" .env.sample > .env
+    docker-compose up
+
+    # in another terminal
+    docker-compose exec outline yarn sequelize db:migrate
+
+Once you see this message
+
+    outline_1   | > Listening on http://localhost:3000
+
+you should be able to access the service at http://localhost:3000.
+
 ### Server
 
 To enable debugging statements, set the following env vars:

--- a/server/auth/index.js
+++ b/server/auth/index.js
@@ -6,12 +6,14 @@ import validation from '../middlewares/validation';
 
 import slack from './slack';
 import google from './google';
+import local from './local';
 
 const auth = new Koa();
 const router = new Router();
 
 router.use('/', slack.routes());
 router.use('/', google.routes());
+router.use('/', local.routes());
 
 auth.use(bodyParser());
 auth.use(validation());

--- a/server/auth/local.js
+++ b/server/auth/local.js
@@ -1,9 +1,7 @@
 // @flow
 import Router from 'koa-router';
-import auth from '../middlewares/authentication';
 import addMonths from 'date-fns/add_months';
-import { Authentication, Integration, User, Team } from '../models';
-import * as Slack from '../slack';
+import { User, Team } from '../models';
 
 const router = new Router();
 

--- a/server/auth/local.js
+++ b/server/auth/local.js
@@ -1,0 +1,49 @@
+// @flow
+import Router from 'koa-router';
+import auth from '../middlewares/authentication';
+import addMonths from 'date-fns/add_months';
+import { Authentication, Integration, User, Team } from '../models';
+import * as Slack from '../slack';
+
+const router = new Router();
+
+router.get('local', async ctx => {
+  const [team, isFirstUser] = await Team.findOrCreate({
+    where: {
+      name: 'Local',
+    },
+  });
+
+  const [user] = await User.findOrCreate({
+    where: {
+      service: 'local',
+      serviceId: 'admin',
+      teamId: team.id,
+    },
+    defaults: {
+      name: 'admin',
+      email: 'admin@example.com',
+      isAdmin: isFirstUser,
+    },
+  });
+
+  if (isFirstUser) {
+    await team.createFirstCollection(user.id);
+  }
+
+  // not awaiting the promise here so that the request is not blocked
+  user.updateSignedIn(ctx.request.ip);
+
+  ctx.cookies.set('lastSignedIn', 'local', {
+    httpOnly: false,
+    expires: new Date('2100'),
+  });
+  ctx.cookies.set('accessToken', user.getJwtToken(), {
+    httpOnly: false,
+    expires: addMonths(new Date(), 1),
+  });
+
+  ctx.redirect('/');
+});
+
+export default router;

--- a/server/pages/Home.js
+++ b/server/pages/Home.js
@@ -18,6 +18,7 @@ type Props = {
   lastSignedIn: string,
   googleSigninEnabled: boolean,
   slackSigninEnabled: boolean,
+  localSigninEnabled: boolean,
 };
 
 function Home(props: Props) {

--- a/server/pages/components/SigninButtons.js
+++ b/server/pages/components/SigninButtons.js
@@ -11,12 +11,14 @@ type Props = {
   lastSignedIn: string,
   googleSigninEnabled: boolean,
   slackSigninEnabled: boolean,
+  localSigninEnabled: boolean,
 };
 
 const SigninButtons = ({
   lastSignedIn,
   slackSigninEnabled,
   googleSigninEnabled,
+  localSigninEnabled,
 }: Props) => {
   return (
     <Wrapper>
@@ -40,6 +42,17 @@ const SigninButtons = ({
           <LastLogin>
             {lastSignedIn === 'google' &&
               'You signed in with Google previously'}
+          </LastLogin>
+        </Column>
+      )}
+      {localSigninEnabled && (
+        <Column column>
+          <Button href={signin('local')}>
+            <Spacer>Sign In with local authentication</Spacer>
+          </Button>
+          <LastLogin>
+            {lastSignedIn === 'local' &&
+              'You signed in with local authentication previously'}
           </LastLogin>
         </Column>
       )}

--- a/server/routes.js
+++ b/server/routes.js
@@ -75,6 +75,7 @@ router.get('/', async ctx => {
         lastSignedIn={lastSignedIn}
         googleSigninEnabled={!!process.env.GOOGLE_CLIENT_ID}
         slackSigninEnabled={!!process.env.SLACK_KEY}
+        localSigninEnabled={!!process.env.LOCAL_AUTH_ENABLED}
       />
     );
   }


### PR DESCRIPTION
This implements a local single-user authentication provider that makes it easier to try out and develop Outline without GitHub or Slack integration.

Further improvements:

- [ ] Add profile pictures for team and user