### PR TITLE
Make isHistory regex slightly more specific

### DIFF
--- a/app/scenes/Document/Document.js
+++ b/app/scenes/Document/Document.js
@@ -310,7 +310,7 @@ class DocumentScene extends React.Component<Props> {
     const document = this.document;
     const revision = this.revision;
     const isShare = match.params.shareId;
-    const isHistory = match.url.match(/history/);
+    const isHistory = match.url.match(/\/history\//); // Can't match on history alone as that can be in the user-generated slug
 
     if (this.notFound) {
       return navigator.onLine ? (


### PR DESCRIPTION
I believe this fixes a bug that means a user cannot edit a document if there is the word "history" in the user-generated part of the slug (ie. the title).

To reproduce the bug - make a document called "Transaction History", then try to edit it. The sidebar will keep opening and the url state will keep getting changed to history rather than edit.

