### PR TITLE
server: fix content-length-range s3 uplaod policy

### DIFF
--- a/server/utils/s3.js
+++ b/server/utils/s3.js
@@ -17,7 +17,7 @@ export const makePolicy = () => {
       { bucket: process.env.AWS_S3_UPLOAD_BUCKET_NAME },
       ['starts-with', '$key', ''],
       { acl: 'public-read' },
-      ['content-length-range', 0, process.env.AWS_S3_UPLOAD_MAX_SIZE],
+      ['content-length-range', 0, +process.env.AWS_S3_UPLOAD_MAX_SIZE],
       ['starts-with', '$Content-Type', 'image'],
       ['starts-with', '$Cache-Control', ''],
     ],


### PR DESCRIPTION
The max size should be an integer rather than a string (environment variables
are strings). More strict s3 implementations reject the upload because they do
not consider the policy valid if a string is used rather than an integer.