### PR TITLE
Add new document sort options to collections

### DIFF
--- a/app/components/DocumentList.js
+++ b/app/components/DocumentList.js
@@ -7,12 +7,14 @@ import ArrowKeyNavigation from 'boundless-arrow-key-navigation';
 type Props = {
   documents: Document[],
   showCollection?: boolean,
+  showPublished?: boolean,
   limit?: number,
 };
 
 export default function DocumentList({
   limit,
   showCollection,
+  showPublished,
   documents,
 }: Props) {
   const items = limit ? documents.splice(0, limit) : documents;
@@ -27,6 +29,7 @@ export default function DocumentList({
           key={document.id}
           document={document}
           showCollection={showCollection}
+          showPublished={showPublished}
         />
       ))}
     </ArrowKeyNavigation>

--- a/app/components/DocumentPreview/DocumentPreview.js
+++ b/app/components/DocumentPreview/DocumentPreview.js
@@ -15,6 +15,7 @@ type Props = {
   highlight?: ?string,
   context?: ?string,
   showCollection?: boolean,
+  showPublished?: boolean,
   ref?: *,
 };
 
@@ -133,6 +134,7 @@ class DocumentPreview extends React.Component<Props> {
     const {
       document,
       showCollection,
+      showPublished,
       highlight,
       context,
       ...rest
@@ -173,6 +175,7 @@ class DocumentPreview extends React.Component<Props> {
         <PublishingInfo
           document={document}
           collection={showCollection ? document.collection : undefined}
+          showPublished={showPublished}
         />
       </DocumentLink>
     );

--- a/app/components/DocumentPreview/components/PublishingInfo.js
+++ b/app/components/DocumentPreview/components/PublishingInfo.js
@@ -19,11 +19,12 @@ const Modified = styled.span`
 
 type Props = {
   collection?: Collection,
+  showPublished?: boolean,
   document: Document,
   views?: number,
 };
 
-function PublishingInfo({ collection, document }: Props) {
+function PublishingInfo({ collection, showPublished, document }: Props) {
   const {
     modifiedSinceViewed,
     updatedAt,
@@ -35,7 +36,7 @@ function PublishingInfo({ collection, document }: Props) {
 
   return (
     <Container align="center">
-      {publishedAt && neverUpdated ? (
+      {publishedAt && (neverUpdated || showPublished) ? (
         <span>
           {updatedBy.name} published <Time dateTime={publishedAt} /> ago
         </span>
@@ -48,7 +49,7 @@ function PublishingInfo({ collection, document }: Props) {
             </span>
           ) : (
             <Modified highlight={modifiedSinceViewed}>
-              &nbsp;modified <Time dateTime={updatedAt} /> ago
+              &nbsp;updated <Time dateTime={updatedAt} /> ago
             </Modified>
           )}
         </React.Fragment>

--- a/app/components/PaginatedDocumentList.js
+++ b/app/components/PaginatedDocumentList.js
@@ -11,6 +11,7 @@ import { ListPlaceholder } from 'components/LoadingPlaceholder';
 
 type Props = {
   showCollection?: boolean,
+  showPublished?: boolean,
   documents: Document[],
   fetch: (options: ?Object) => Promise<*>,
   options?: Object,
@@ -64,11 +65,15 @@ class PaginatedDocumentList extends React.Component<Props> {
   };
 
   render() {
-    const { showCollection, documents } = this.props;
+    const { showCollection, showPublished, documents } = this.props;
 
     return this.isLoaded || documents.length ? (
       <React.Fragment>
-        <DocumentList documents={documents} showCollection={showCollection} />
+        <DocumentList
+          documents={documents}
+          showCollection={showCollection}
+          showPublished={showPublished}
+        />
         {this.allowLoadMore && (
           <Waypoint key={this.offset} onEnter={this.loadMoreResults} />
         )}

--- a/app/components/Sidebar/components/CollectionLink.js
+++ b/app/components/Sidebar/components/CollectionLink.js
@@ -59,6 +59,7 @@ class CollectionLink extends React.Component<Props> {
           hideDisclosure
           menuOpen={this.menuOpen}
           label={collection.name}
+          exact={false}
           menu={
             <CollectionMenu
               history={history}

--- a/app/components/Tab.js
+++ b/app/components/Tab.js
@@ -10,14 +10,19 @@ const NavItem = styled(NavLink)`
   text-transform: uppercase;
   color: ${props => props.theme.slate};
   letter-spacing: 0.04em;
-  margin-right: 20px;
+  margin-right: 24px;
   padding-bottom: 8px;
+
+  &:hover {
+    color: ${props => props.theme.slateDark};
+  }
 `;
 
 function Tab(props: *) {
   const activeStyle = {
     paddingBottom: '5px',
     borderBottom: `3px solid ${props.theme.slateLight}`,
+    color: props.theme.slate,
   };
 
   return <NavItem {...props} activeStyle={activeStyle} />;

--- a/app/routes.js
+++ b/app/routes.js
@@ -68,6 +68,7 @@ export default function Routes() {
               component={Zapier}
             />
             <Route exact path="/settings/export" component={Export} />
+            <Route exact path="/collections/:id/:tab" component={Collection} />
             <Route exact path="/collections/:id" component={Collection} />
             <Route exact path={`/d/${slug}`} component={RedirectDocument} />
             <Route

--- a/app/scenes/Collection.js
+++ b/app/scenes/Collection.js
@@ -211,8 +211,34 @@ class CollectionScene extends React.Component<Props> {
                   <Tab to={collectionUrl(collection.id, 'recent')} exact>
                     Recently published
                   </Tab>
+                  <Tab to={collectionUrl(collection.id, 'old')} exact>
+                    Least recently updated
+                  </Tab>
+                  <Tab to={collectionUrl(collection.id, 'alphabetical')} exact>
+                    A–Z
+                  </Tab>
                 </Tabs>
                 <Switch>
+                  <Route path={collectionUrl(collection.id, 'alphabetical')}>
+                    <PaginatedDocumentList
+                      key="alphabetical"
+                      documents={documents.alphabeticalInCollection(
+                        collection.id
+                      )}
+                      fetch={documents.fetchAlphabetical}
+                      options={{ collection: collection.id }}
+                    />
+                  </Route>
+                  <Route path={collectionUrl(collection.id, 'old')}>
+                    <PaginatedDocumentList
+                      key="old"
+                      documents={documents.leastRecentlyUpdatedInCollection(
+                        collection.id
+                      )}
+                      fetch={documents.fetchLeastRecentlyUpdated}
+                      options={{ collection: collection.id }}
+                    />
+                  </Route>
                   <Route path={collectionUrl(collection.id, 'recent')}>
                     <PaginatedDocumentList
                       key="recent"

--- a/app/scenes/Dashboard.js
+++ b/app/scenes/Dashboard.js
@@ -12,8 +12,8 @@ import CenteredContent from 'components/CenteredContent';
 import PageTitle from 'components/PageTitle';
 import Tabs from 'components/Tabs';
 import Tab from 'components/Tab';
-import TipInvite from 'components/TipInvite';
 import PaginatedDocumentList from '../components/PaginatedDocumentList';
+import TipInvite from 'components/TipInvite';
 
 type Props = {
   documents: DocumentsStore,

--- a/app/stores/DocumentsStore.js
+++ b/app/stores/DocumentsStore.js
@@ -67,6 +67,18 @@ export default class DocumentsStore extends BaseStore<Document> {
     );
   }
 
+  recentlyPublishedInCollection(collectionId: string): Document[] {
+    return orderBy(
+      filter(
+        Array.from(this.data.values()),
+        document =>
+          document.collectionId === collectionId && !!document.publishedAt
+      ),
+      'publishedAt',
+      'desc'
+    );
+  }
+
   @computed
   get starred(): Document[] {
     return filter(this.orderedData, d => d.starred);
@@ -124,6 +136,15 @@ export default class DocumentsStore extends BaseStore<Document> {
       );
     });
     return data;
+  };
+
+  @action
+  fetchRecentlyPublished = async (options: ?PaginationParams): Promise<*> => {
+    return this.fetchNamedPage('list', {
+      sort: 'publishedAt',
+      direction: 'DESC',
+      ...options,
+    });
   };
 
   @action

--- a/app/stores/DocumentsStore.js
+++ b/app/stores/DocumentsStore.js
@@ -55,13 +55,25 @@ export default class DocumentsStore extends BaseStore<Document> {
     );
   }
 
+  publishedInCollection(collectionId: string): Document[] {
+    return filter(
+      Array.from(this.data.values()),
+      document =>
+        document.collectionId === collectionId && !!document.publishedAt
+    );
+  }
+
+  leastRecentlyUpdatedInCollection(collectionId: string): Document[] {
+    return orderBy(
+      this.publishedInCollection(collectionId),
+      'updatedAt',
+      'asc'
+    );
+  }
+
   recentlyUpdatedInCollection(collectionId: string): Document[] {
     return orderBy(
-      filter(
-        Array.from(this.data.values()),
-        document =>
-          document.collectionId === collectionId && !!document.publishedAt
-      ),
+      this.publishedInCollection(collectionId),
       'updatedAt',
       'desc'
     );
@@ -69,14 +81,14 @@ export default class DocumentsStore extends BaseStore<Document> {
 
   recentlyPublishedInCollection(collectionId: string): Document[] {
     return orderBy(
-      filter(
-        Array.from(this.data.values()),
-        document =>
-          document.collectionId === collectionId && !!document.publishedAt
-      ),
+      this.publishedInCollection(collectionId),
       'publishedAt',
       'desc'
     );
+  }
+
+  alphabeticalInCollection(collectionId: string): Document[] {
+    return naturalSort(this.publishedInCollection(collectionId), 'title');
   }
 
   @computed
@@ -136,6 +148,26 @@ export default class DocumentsStore extends BaseStore<Document> {
       );
     });
     return data;
+  };
+
+  @action
+  fetchAlphabetical = async (options: ?PaginationParams): Promise<*> => {
+    return this.fetchNamedPage('list', {
+      sort: 'title',
+      direction: 'ASC',
+      ...options,
+    });
+  };
+
+  @action
+  fetchLeastRecentlyUpdated = async (
+    options: ?PaginationParams
+  ): Promise<*> => {
+    return this.fetchNamedPage('list', {
+      sort: 'updatedAt',
+      direction: 'ASC',
+      ...options,
+    });
   };
 
   @action

--- a/app/utils/routeHelpers.js
+++ b/app/utils/routeHelpers.js
@@ -14,8 +14,10 @@ export function newCollectionUrl(): string {
   return '/collections/new';
 }
 
-export function collectionUrl(collectionId: string): string {
-  return `/collections/${collectionId}`;
+export function collectionUrl(collectionId: string, section: ?string): string {
+  const path = `/collections/${collectionId}`;
+  if (section) return `${path}/${section}`;
+  return path;
 }
 
 export function documentUrl(doc: Document): string {


### PR DESCRIPTION
Adds 3 additional tabs as sort options when viewing a collection and infinite pagination.

![image](https://user-images.githubusercontent.com/380914/50816674-21bf5780-12d6-11e9-86a5-e87d2a4d2f09.png)

ref https://github.com/outline/outline/issues/834