### PR TITLE
Heroku deploy support

### DIFF
--- a/app.json
+++ b/app.json
@@ -36,6 +36,7 @@
         "required": true
       },
       "DEPLOYMENT": {
+		"description": "Should be 'self' for self hosted installations, turns off things like pricing pages"
         "value": "self",
         "required": true
       },
@@ -46,7 +47,7 @@
       "SUBDOMAINS_ENABLED": {
         "value": "false",
         "required": true,
-        "description": "Running different subdomains. Not needed in single org mode"
+        "description": "Allows each team to have a different subdomain. Not recommend when self hosting"
       },
       "URL": {
         "description": "https://{your app name}.herokuapp.com",
@@ -97,7 +98,7 @@
         "required": false
       },
       "AWS_S3_UPLOAD_MAX_SIZE": {
-        "description": "",
+        "description": "Maximum file upload size in bytes",
         "value": "26214400",
         "required": false
       },
@@ -130,11 +131,11 @@
         "required": false
       },
       "BUGSNAG_KEY": {
-        "description": "(optional)",
+        "description": "An API key for bugsnag if you wish to collect error reporting (optional)",
         "required": false
       },
       "GITHUB_ACCESS_TOKEN": {
-        "description": "(optional)",
+        "description": "An API token for GitHub, optional for self hosted (optional)",
         "required": false
       }
 

--- a/app.json
+++ b/app.json
@@ -73,7 +73,8 @@
         "required": false
       },
       "SLACK_VERIFICATION_TOKEN": {
-        "description": "Your Slack verification token - PLxk6OlXXXXXVj3YYYY"
+        "description": "Your Slack verification token - PLxk6OlXXXXXVj3YYYY",
+        "required": false
       },
       "SLACK_APP_ID": {
         "description": "A0XXXXXXXXX",

--- a/app.json
+++ b/app.json
@@ -39,101 +39,80 @@
         "required": true
       },
       "ENABLE_UPDATES": {
-        "value": true,
+        "value": "true",
         "required": true
       },
       "SUBDOMAINS_ENABLED": {
-        "value": false,
+        "value": "false",
         "required": true,
         "description": "Running different subdomains. Likely not needed in single org mode"
       },
       "URL": {
         "description": "https://{your app name}.herokuapp.com",
-        "required": false
+        "required": true
       },
       "GOOGLE_CLIENT_ID": {
-        "description": "See https://developers.google.com/identity/protocols/OAuth2 to create a new Google OAuth client. You must configure at least one of Slack or Google to control login.",
-        "required": false
+        "description": "See https://developers.google.com/identity/protocols/OAuth2 to create a new Google OAuth client. You must configure at least one of Slack or Google to control login."
       },
       "GOOGLE_CLIENT_SECRET": {
-        "description": "",
-        "required": false
+        "description": ""
       },
       "GOOGLE_ALLOWED_DOMAINS": {
-        "description": "Comma separated list of domains to be allowed (optional). If not set, all Google apps domains are allowed by default",
-        "required": false
+        "description": "Comma separated list of domains to be allowed (optional). If not set, all Google apps domains are allowed by default"
       },
       "SLACK_KEY": {
-        "description": "See https://api.slack.com/apps to create a new Slack app. You must configure at least one of Slack or Google to control login.",
-        "required": false
+        "description": "See https://api.slack.com/apps to create a new Slack app. You must configure at least one of Slack or Google to control login."
       },
       "SLACK_SECRET": {
-        "description": "Your Slack client secret - d2dc414f9953226bad0a356cXXXXYYYY",
-        "required": false
+        "description": "Your Slack client secret - d2dc414f9953226bad0a356cXXXXYYYY"
       },
       "SLACK_VERIFICATION_TOKEN": {
-        "description": "Your Slack verification token - PLxk6OlXXXXXVj3YYYY",
-        "required": false
+        "description": "Your Slack verification token - PLxk6OlXXXXXVj3YYYY"
       },
       "SLACK_APP_ID": {
-        "description": "A0XXXXXXXXX",
-        "required": false
+        "description": "A0XXXXXXXXX"
       },
       "AWS_ACCESS_KEY_ID": {
-        "description": "",
-        "required": false
+        "description": "Needed to save file uploads. Optional for dev / testing."
       },
       "AWS_SECRET_ACCESS_KEY": {
-        "description": "",
-        "required": false
+        "description": ""
       },
       "AWS_S3_UPLOAD_BUCKET_NAME": {
-        "description": "yourbucket.example.com",
-        "required": false
+        "description": "yourbucket.example.com"
       },
       "AWS_S3_UPLOAD_BUCKET_URL": {
-        "description": "Live web link to your bucket. For CNAMEs, https://yourbucket.example.com",
-        "required": false
+        "description": "Live web link to your bucket. For CNAMEs, https://yourbucket.example.com"
       },
       "AWS_S3_UPLOAD_MAX_SIZE": {
         "description": "",
-        "required": false,
         "value": "26214400"
       },
       "SMTP_HOST": {
-        "description": "smtp.example.com (optional)",
-        "required": false
+        "description": "smtp.example.com (optional)"
       },
       "SMTP_PORT": {
-        "description": "1234 (optional)",
-        "required": false
+        "description": "1234 (optional)"
       },
       "SMTP_USERNAME": {
-        "description": "me@example.com (optional)",
-        "required": false
+        "description": "me@example.com (optional)"
       },
       "SMTP_PASSWORD": {
-        "description": "(optional)",
-        "required": false
+        "description": "(optional)"
       },
       "SMTP_FROM_EMAIL": {
-        "description": "wiki@example.com (optional)",
-        "required": false
+        "description": "wiki@example.com (optional)"
       },
       "SMTP_REPLY_EMAIL": {
-        "description": "wikireply@example.com (optional)",
-        "required": false
+        "description": "wikireply@example.com (optional)"
       },
       "GOOGLE_ANALYTICS_ID": {
-        "required": false,
         "description": "UA-xxxx (optional)"
       },
       "BUGSNAG_KEY": {
-        "required": false,
         "description": "(optional)"
       },
       "GITHUB_ACCESS_TOKEN": {
-        "required": false,
         "description": "(optional)"
       }
 

--- a/app.json
+++ b/app.json
@@ -32,7 +32,8 @@
     "env": {
       "SECRET_KEY": {
         "description": "A secret key",
-        "generator": "secret"
+        "generator": "secret",
+        "required": true
       },
       "DEPLOYMENT": {
         "value": "self",
@@ -45,75 +46,95 @@
       "SUBDOMAINS_ENABLED": {
         "value": "false",
         "required": true,
-        "description": "Running different subdomains. Likely not needed in single org mode"
+        "description": "Running different subdomains. Not needed in single org mode"
       },
       "URL": {
         "description": "https://{your app name}.herokuapp.com",
         "required": true
       },
       "GOOGLE_CLIENT_ID": {
-        "description": "See https://developers.google.com/identity/protocols/OAuth2 to create a new Google OAuth client. You must configure at least one of Slack or Google to control login."
+        "description": "See https://developers.google.com/identity/protocols/OAuth2 to create a new Google OAuth client. You must configure at least one of Slack or Google to control login.",
+        "required": false
       },
       "GOOGLE_CLIENT_SECRET": {
-        "description": ""
+        "description": "",
+        "required": false
       },
       "GOOGLE_ALLOWED_DOMAINS": {
-        "description": "Comma separated list of domains to be allowed (optional). If not set, all Google apps domains are allowed by default"
+        "description": "Comma separated list of domains to be allowed (optional). If not set, all Google apps domains are allowed by default",
+        "required": false
       },
       "SLACK_KEY": {
-        "description": "See https://api.slack.com/apps to create a new Slack app. You must configure at least one of Slack or Google to control login."
+        "description": "See https://api.slack.com/apps to create a new Slack app. You must configure at least one of Slack or Google to control login.",
+        "required": false
       },
       "SLACK_SECRET": {
-        "description": "Your Slack client secret - d2dc414f9953226bad0a356cXXXXYYYY"
+        "description": "Your Slack client secret - d2dc414f9953226bad0a356cXXXXYYYY",
+        "required": false
       },
       "SLACK_VERIFICATION_TOKEN": {
         "description": "Your Slack verification token - PLxk6OlXXXXXVj3YYYY"
       },
       "SLACK_APP_ID": {
-        "description": "A0XXXXXXXXX"
+        "description": "A0XXXXXXXXX",
+        "required": false
       },
       "AWS_ACCESS_KEY_ID": {
-        "description": "Needed to save file uploads. Optional for dev / testing."
+        "description": "Needed to save file uploads. Optional for dev / testing.",
+        "required": false
       },
       "AWS_SECRET_ACCESS_KEY": {
-        "description": ""
+        "description": "",
+        "required": false
       },
       "AWS_S3_UPLOAD_BUCKET_NAME": {
-        "description": "yourbucket.example.com"
+        "description": "yourbucket.example.com",
+        "required": false
       },
       "AWS_S3_UPLOAD_BUCKET_URL": {
-        "description": "Live web link to your bucket. For CNAMEs, https://yourbucket.example.com"
+        "description": "Live web link to your bucket. For CNAMEs, https://yourbucket.example.com",
+        "required": false
       },
       "AWS_S3_UPLOAD_MAX_SIZE": {
         "description": "",
-        "value": "26214400"
+        "value": "26214400",
+        "required": false
       },
       "SMTP_HOST": {
-        "description": "smtp.example.com (optional)"
+        "description": "smtp.example.com (optional)",
+        "required": false
       },
       "SMTP_PORT": {
-        "description": "1234 (optional)"
+        "description": "1234 (optional)",
+        "required": false
       },
       "SMTP_USERNAME": {
-        "description": "me@example.com (optional)"
+        "description": "me@example.com (optional)",
+        "required": false
       },
       "SMTP_PASSWORD": {
-        "description": "(optional)"
+        "description": "(optional)",
+        "required": false
       },
       "SMTP_FROM_EMAIL": {
-        "description": "wiki@example.com (optional)"
+        "description": "wiki@example.com (optional)",
+        "required": false
       },
       "SMTP_REPLY_EMAIL": {
-        "description": "wikireply@example.com (optional)"
+        "description": "wikireply@example.com (optional)",
+        "required": false
       },
       "GOOGLE_ANALYTICS_ID": {
-        "description": "UA-xxxx (optional)"
+        "description": "UA-xxxx (optional)",
+        "required": false
       },
       "BUGSNAG_KEY": {
-        "description": "(optional)"
+        "description": "(optional)",
+        "required": false
       },
       "GITHUB_ACCESS_TOKEN": {
-        "description": "(optional)"
+        "description": "(optional)",
+        "required": false
       }
 
     }

--- a/app.json
+++ b/app.json
@@ -1,0 +1,141 @@
+{
+    "name": "Outline",
+    "description": "Open source wiki and knowledge base for growing teams",
+    "website": "https://www.getoutline.com/",
+    "repository": "https://github.com/outline/outline",
+    "keywords": [
+      "wiki",
+      "team",
+      "node",
+      "markdown",
+      "slack"
+    ],
+    "success_url": "/",
+    "formation": {
+      "web": {
+        "quantity": 1,
+        "size": "Hobby"
+      }
+    },
+    "image": "heroku/node",
+    "addons": [
+      {
+        "plan": "heroku-redis"
+      },
+      {
+        "plan": "heroku-postgresql"
+      }
+    ],
+    "scripts": {
+      "postdeploy": "yarn sequelize db:migrate"
+    },
+    "env": {
+      "SECRET_KEY": {
+        "description": "A secret key",
+        "generator": "secret"
+      },
+      "DEPLOYMENT": {
+        "value": "self",
+        "required": true
+      },
+      "ENABLE_UPDATES": {
+        "value": true,
+        "required": true
+      },
+      "SUBDOMAINS_ENABLED": {
+        "value": false,
+        "required": true,
+        "description": "Running different subdomains. Likely not needed in single org mode"
+      },
+      "URL": {
+        "description": "https://{your app name}.herokuapp.com",
+        "required": false
+      },
+      "GOOGLE_CLIENT_ID": {
+        "description": "See https://developers.google.com/identity/protocols/OAuth2 to create a new Google OAuth client. You must configure at least one of Slack or Google to control login.",
+        "required": false
+      },
+      "GOOGLE_CLIENT_SECRET": {
+        "description": "",
+        "required": false
+      },
+      "GOOGLE_ALLOWED_DOMAINS": {
+        "description": "Comma separated list of domains to be allowed (optional). If not set, all Google apps domains are allowed by default",
+        "required": false
+      },
+      "SLACK_KEY": {
+        "description": "See https://api.slack.com/apps to create a new Slack app. You must configure at least one of Slack or Google to control login.",
+        "required": false
+      },
+      "SLACK_SECRET": {
+        "description": "Your Slack client secret - d2dc414f9953226bad0a356cXXXXYYYY",
+        "required": false
+      },
+      "SLACK_VERIFICATION_TOKEN": {
+        "description": "Your Slack verification token - PLxk6OlXXXXXVj3YYYY",
+        "required": false
+      },
+      "SLACK_APP_ID": {
+        "description": "A0XXXXXXXXX",
+        "required": false
+      },
+      "AWS_ACCESS_KEY_ID": {
+        "description": "",
+        "required": false
+      },
+      "AWS_SECRET_ACCESS_KEY": {
+        "description": "",
+        "required": false
+      },
+      "AWS_S3_UPLOAD_BUCKET_NAME": {
+        "description": "yourbucket.example.com",
+        "required": false
+      },
+      "AWS_S3_UPLOAD_BUCKET_URL": {
+        "description": "Live web link to your bucket. For CNAMEs, https://yourbucket.example.com",
+        "required": false
+      },
+      "AWS_S3_UPLOAD_MAX_SIZE": {
+        "description": "",
+        "required": false,
+        "value": "26214400"
+      },
+      "SMTP_HOST": {
+        "description": "smtp.example.com (optional)",
+        "required": false
+      },
+      "SMTP_PORT": {
+        "description": "1234 (optional)",
+        "required": false
+      },
+      "SMTP_USERNAME": {
+        "description": "me@example.com (optional)",
+        "required": false
+      },
+      "SMTP_PASSWORD": {
+        "description": "(optional)",
+        "required": false
+      },
+      "SMTP_FROM_EMAIL": {
+        "description": "wiki@example.com (optional)",
+        "required": false
+      },
+      "SMTP_REPLY_EMAIL": {
+        "description": "wikireply@example.com (optional)",
+        "required": false
+      },
+      "GOOGLE_ANALYTICS_ID": {
+        "required": false,
+        "description": "UA-xxxx (optional)"
+      },
+      "BUGSNAG_KEY": {
+        "required": false,
+        "description": "(optional)"
+      },
+      "GITHUB_ACCESS_TOKEN": {
+        "required": false,
+        "description": "(optional)"
+      }
+
+    }
+  }


### PR DESCRIPTION
Hey there! 

I saw a previous attempt to get this working, and you already have a Procfile in the root that Heroku needs.

I have tested this and done a couple of installs. Getting Google or Slack auth login support working is the hardest part, with Slack being easier. I still had a bit of difficulty -- probably walking people through what they need to do would be helpful.

Also, SLACK VERIFICATION is, I think deprecated, and might not be needed anymore -- both in your `env.sample` and in `app.json`.

You can do a test yourself by following this link, which will deploy from the branch that I am PR'ing here: https://heroku.com/deploy?template=https://github.com/bmann/outline/tree/heroku-deploy-support