### PR TITLE
Fixed broken License link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,4 +119,4 @@ If you’re looking for ways to get started, here's a list of ways to help us im
 
 ## License
 
-Outline is [BSD licensed](/blob/master/LICENSE).
+Outline is [BSD licensed](https://github.com/outline/outline/blob/master/LICENSE).


### PR DESCRIPTION
The previous link was giving 404. Changed the relative URL to absolute URL.