### PR TITLE
Move document improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Backend is driven by [Koa](http://koajs.com/) (API, web server), [Sequelize](htt
 - `server/models` - Database models (Sequelize)
 - `server/pages` - Server-side rendered public pages (React)
 - `server/presenters` - API responses for database models
+- `server/commands` - Domain logic, currently being refactored from /models
 - `shared` - Code shared between frontend and backend applications
 
 ## Tests

--- a/app/components/PathToDocument.js
+++ b/app/components/PathToDocument.js
@@ -11,8 +11,8 @@ import type { DocumentPath } from 'stores/CollectionsStore';
 
 type Props = {
   result: DocumentPath,
-  document?: Document,
-  collection?: Collection,
+  document?: ?Document,
+  collection: ?Collection,
   onSuccess?: () => void,
   ref?: *,
 };

--- a/app/components/PathToDocument.js
+++ b/app/components/PathToDocument.js
@@ -64,7 +64,9 @@ const Title = styled.span`
   text-overflow: ellipsis;
 `;
 
-const StyledGoToIcon = styled(GoToIcon)``;
+const StyledGoToIcon = styled(GoToIcon)`
+  opacity: 0.25;
+`;
 
 const ResultWrapper = styled.div`
   display: flex;

--- a/app/components/PathToDocument.js
+++ b/app/components/PathToDocument.js
@@ -2,16 +2,18 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
 import styled from 'styled-components';
-import { GoToIcon } from 'outline-icons';
+import { GoToIcon, CollectionIcon, PrivateCollectionIcon } from 'outline-icons';
 import Flex from 'shared/components/Flex';
 
 import Document from 'models/Document';
+import Collection from 'models/Collection';
 import type { DocumentPath } from 'stores/CollectionsStore';
 
 type Props = {
   result: DocumentPath,
   document?: Document,
-  onSuccess?: *,
+  collection?: Collection,
+  onSuccess?: () => void,
   ref?: *,
 };
 
@@ -23,27 +25,28 @@ class PathToDocument extends React.Component<Props> {
     if (!document) return;
 
     if (result.type === 'document') {
-      await document.move(result.id);
-    } else if (
-      result.type === 'collection' &&
-      result.id === document.collection.id
-    ) {
-      await document.move(null);
+      await document.move(result.collectionId, result.id);
     } else {
-      throw new Error('Not implemented yet');
+      await document.move(result.collectionId, null);
     }
 
     if (onSuccess) onSuccess();
   };
 
   render() {
-    const { result, document, ref } = this.props;
+    const { result, collection, document, ref } = this.props;
     const Component = document ? ResultWrapperLink : ResultWrapper;
 
     if (!result) return <div />;
 
     return (
       <Component ref={ref} onClick={this.handleClick} href="" selectable>
+        {collection &&
+          (collection.private ? (
+            <PrivateCollectionIcon color={collection.color} />
+          ) : (
+            <CollectionIcon color={collection.color} />
+          ))}
         {result.path
           .map(doc => <Title key={doc.id}>{doc.title}</Title>)
           .reduce((prev, curr) => [prev, <StyledGoToIcon />, curr])}

--- a/app/models/Collection.js
+++ b/app/models/Collection.js
@@ -25,6 +25,11 @@ export default class Collection extends BaseModel {
   url: string;
 
   @computed
+  get isPrivate(): boolean {
+    return this.private;
+  }
+
+  @computed
   get isEmpty(): boolean {
     return this.documents.length === 0;
   }

--- a/app/models/Document.js
+++ b/app/models/Document.js
@@ -234,8 +234,8 @@ export default class Document extends BaseModel {
     }
   };
 
-  move = (parentDocumentId: ?string) => {
-    return this.store.move(this, parentDocumentId);
+  move = (collectionId: string, parentDocumentId: ?string) => {
+    return this.store.move(this, collectionId, parentDocumentId);
   };
 
   duplicate = () => {

--- a/app/scenes/Document/components/DocumentMove.js
+++ b/app/scenes/Document/components/DocumentMove.js
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom';
 import { observable, computed } from 'mobx';
 import { observer, inject } from 'mobx-react';
 import { Search } from 'js-search';
-import { first, last } from 'lodash';
+import { last } from 'lodash';
 import ArrowKeyNavigation from 'boundless-arrow-key-navigation';
 import styled from 'styled-components';
 

--- a/app/scenes/Document/components/DocumentMove.js
+++ b/app/scenes/Document/components/DocumentMove.js
@@ -86,7 +86,6 @@ class DocumentMove extends React.Component<Props> {
         last(result.path.map(doc => doc.id)) !== document.parentDocumentId
     );
 
-    console.log(results);
     return results;
   }
 

--- a/app/scenes/Document/components/DocumentMove.js
+++ b/app/scenes/Document/components/DocumentMove.js
@@ -86,6 +86,7 @@ class DocumentMove extends React.Component<Props> {
         last(result.path.map(doc => doc.id)) !== document.parentDocumentId
     );
 
+    console.log(results);
     return results;
   }
 
@@ -113,7 +114,12 @@ class DocumentMove extends React.Component<Props> {
     const result = collections.getPathForDocument(document.id);
 
     if (result) {
-      return <PathToDocument result={result} />;
+      return (
+        <PathToDocument
+          result={result}
+          collection={collections.get(result.collectionId)}
+        />
+      );
     }
   }
 
@@ -152,6 +158,7 @@ class DocumentMove extends React.Component<Props> {
                         key={result.id}
                         result={result}
                         document={document}
+                        collection={collections.get(result.collectionId)}
                         ref={ref =>
                           index === 0 && this.setFirstDocumentRef(ref)
                         }

--- a/app/scenes/Document/components/DocumentMove.js
+++ b/app/scenes/Document/components/DocumentMove.js
@@ -33,19 +33,14 @@ class DocumentMove extends React.Component<Props> {
 
   @computed
   get searchIndex() {
-    const { document, collections } = this.props;
+    const { collections } = this.props;
     const paths = collections.pathsToDocuments;
     const index = new Search('id');
     index.addIndex('title');
 
     // Build index
     const indexeableDocuments = [];
-    paths.forEach(path => {
-      // TMP: For now, exclude paths to other collections
-      if (first(path.path).id !== document.collection.id) return;
-
-      indexeableDocuments.push(path);
-    });
+    paths.forEach(path => indexeableDocuments.push(path));
     index.addDocuments(indexeableDocuments);
 
     return index;
@@ -63,20 +58,19 @@ class DocumentMove extends React.Component<Props> {
       } else {
         // Default results, root of the current collection
         results = [];
-        document.collection.documents.forEach(doc => {
-          const path = collections.getPathForDocument(doc.id);
-          if (doc && path) {
-            results.push(path);
+        collections.orderedData.forEach(collection => {
+          collection.documents.forEach(doc => {
+            const path = collections.getPathForDocument(doc.id);
+            if (doc && path) {
+              results.push(path);
+            }
+          });
+
+          const rootPath = collections.getPathForDocument(collection.id);
+          if (rootPath) {
+            results = [rootPath, ...results];
           }
         });
-      }
-    }
-
-    if (document && document.parentDocumentId) {
-      // Add root if document does have a parent document
-      const rootPath = collections.getPathForDocument(document.collection.id);
-      if (rootPath) {
-        results = [rootPath, ...results];
       }
     }
 
@@ -141,7 +135,7 @@ class DocumentMove extends React.Component<Props> {
                 <Labeled label="Choose a new location">
                   <Input
                     type="text"
-                    placeholder="Filter by document name…"
+                    placeholder="Filter…"
                     onKeyDown={this.handleKeyDown}
                     onChange={this.handleFilter}
                     required

--- a/app/stores/BaseStore.js
+++ b/app/stores/BaseStore.js
@@ -65,6 +65,10 @@ export default class BaseStore<T: BaseModel> {
     return this.create(params);
   }
 
+  get(id: string): ?T {
+    return this.data.get(id);
+  }
+
   @action
   async create(params: Object) {
     if (!this.actions.includes('create')) {

--- a/app/stores/CollectionsStore.js
+++ b/app/stores/CollectionsStore.js
@@ -8,13 +8,13 @@ import RootStore from './RootStore';
 import Collection from '../models/Collection';
 import naturalSort from 'shared/utils/naturalSort';
 
-export type DocumentPathItem = {|
+export type DocumentPathItem = {
   id: string,
   collectionId: string,
   title: string,
   url: string,
   type: 'collection' | 'document',
-|};
+};
 
 export type DocumentPath = DocumentPathItem & {
   path: DocumentPathItem[],

--- a/app/stores/CollectionsStore.js
+++ b/app/stores/CollectionsStore.js
@@ -8,12 +8,13 @@ import RootStore from './RootStore';
 import Collection from '../models/Collection';
 import naturalSort from 'shared/utils/naturalSort';
 
-export type DocumentPathItem = {
+export type DocumentPathItem = {|
   id: string,
+  collectionId: string,
   title: string,
   url: string,
-  type: 'document' | 'collection',
-};
+  type: 'collection' | 'document',
+|};
 
 export type DocumentPath = DocumentPathItem & {
   path: DocumentPathItem[],
@@ -52,20 +53,26 @@ export default class CollectionsStore extends BaseStore<Collection> {
   @computed
   get pathsToDocuments(): DocumentPath[] {
     let results = [];
-    const travelDocuments = (documentList, path) =>
+    const travelDocuments = (documentList, collectionId, path) =>
       documentList.forEach(document => {
         const { id, title, url } = document;
-        const node = { id, title, url, type: 'document' };
+        const node = { id, collectionId, title, url, type: 'document' };
         results.push(concat(path, node));
-        travelDocuments(document.children, concat(path, [node]));
+        travelDocuments(document.children, collectionId, concat(path, [node]));
       });
 
     if (this.isLoaded) {
       this.data.forEach(collection => {
         const { id, name, url } = collection;
-        const node = { id, title: name, url, type: 'collection' };
+        const node = {
+          id,
+          collectionId: id,
+          title: name,
+          url,
+          type: 'collection',
+        };
         results.push([node]);
-        travelDocuments(collection.documents, [node]);
+        travelDocuments(collection.documents, id, [node]);
       });
     }
 

--- a/app/stores/DocumentsStore.js
+++ b/app/stores/DocumentsStore.js
@@ -294,17 +294,20 @@ export default class DocumentsStore extends BaseStore<Document> {
   };
 
   @action
-  move = async (document: Document, parentDocumentId: ?string) => {
+  move = async (
+    document: Document,
+    collectionId: string,
+    parentDocumentId: ?string
+  ) => {
     const res = await client.post('/documents.move', {
       id: document.id,
-      parentDocument: parentDocumentId,
+      collectionId,
+      parentDocumentId,
     });
     invariant(res && res.data, 'Data not available');
 
-    const collection = this.getCollectionForDocument(document);
-    if (collection) collection.refresh();
-
-    return this.add(res.data);
+    res.data.documents.forEach(this.add);
+    res.data.collections.forEach(this.rootStore.collections.add);
   };
 
   @action

--- a/server/commands/documentMover.js
+++ b/server/commands/documentMover.js
@@ -40,12 +40,13 @@ export default async function documentMover({
       const childDocuments = await Document.findAll({
         where: { parentDocumentId: documentId },
       });
-      childDocuments.forEach(async child => {
+
+      for (const child of childDocuments) {
         await loopChildren(child.id);
         await child.update({ collectionId });
         child.collection = newCollection;
         response.documents.push(child);
-      });
+      }
     };
 
     await loopChildren(document.id);

--- a/server/commands/documentMover.js
+++ b/server/commands/documentMover.js
@@ -1,6 +1,5 @@
 // @flow
-import Document from '../models/Document';
-import { Collection } from '../models';
+import { Document, Collection } from '../models';
 
 export default async function documentMover({
   document,

--- a/server/commands/documentMover.js
+++ b/server/commands/documentMover.js
@@ -21,6 +21,9 @@ export default async function documentMover({
   const documentJson = await collection.removeDocumentInStructure(document);
 
   // add to new collection (may be the same)
+  document.collectionId = collectionId;
+  document.parentDocumentId = parentDocumentId;
+
   const newCollection: Collection = collectionChanged
     ? await Collection.findById(collectionId)
     : collection;
@@ -46,13 +49,11 @@ export default async function documentMover({
     };
 
     await loopChildren(document.id);
-    await document.update({
-      collectionId,
-      parentDocumentId,
-    });
-    document.collection = newCollection;
-    response.documents.push(document);
   }
+
+  await document.save();
+  document.collection = newCollection;
+  response.documents.push(document);
 
   // we need to send all updated models back to the client
   return response;

--- a/server/commands/documentMover.js
+++ b/server/commands/documentMover.js
@@ -1,0 +1,57 @@
+// @flow
+import Document from '../models/Document';
+import { Collection } from '../models';
+
+export default async function documentMover({
+  document,
+  collectionId,
+  parentDocumentId,
+  index,
+}: {
+  document: Document,
+  collectionId: string,
+  parentDocumentId: string,
+  index?: number,
+}) {
+  const response = { collections: [], documents: [] };
+  const collectionChanged = collectionId !== document.collectionId;
+
+  // remove from original collection
+  const collection: Collection = await document.getCollection();
+  const documentJson = await collection.removeDocumentInStructure(document);
+
+  // add to new collection
+  const newCollection: Collection = collectionChanged
+    ? await Collection.findById(collectionId)
+    : collection;
+  await newCollection.addDocumentToStructure(document, index, { documentJson });
+  response.collections.push(collection);
+
+  // if collection does not remain the same loop through children and change their
+  // collectionId too. This includes archived children, otherwise their collection
+  // would be wrong once restored.
+  if (collectionChanged) {
+    response.collections.push(newCollection);
+
+    const loopChildren = async documentId => {
+      const childDocuments = await Document.findAll({
+        where: { parentDocumentId: documentId },
+      });
+      childDocuments.forEach(async child => {
+        await loopChildren(child.id);
+        await child.update({ collectionId });
+        response.documents.push(child);
+      });
+    };
+
+    await loopChildren(document.id);
+    await document.update({
+      collectionId,
+      parentDocumentId,
+    });
+    response.documents.push(document);
+  }
+
+  // we need to send all updated models back to the client
+  return response;
+}

--- a/server/commands/documentMover.js
+++ b/server/commands/documentMover.js
@@ -20,7 +20,7 @@ export default async function documentMover({
   const collection: Collection = await document.getCollection();
   const documentJson = await collection.removeDocumentInStructure(document);
 
-  // add to new collection
+  // add to new collection (may be the same)
   const newCollection: Collection = collectionChanged
     ? await Collection.findById(collectionId)
     : collection;
@@ -40,6 +40,7 @@ export default async function documentMover({
       childDocuments.forEach(async child => {
         await loopChildren(child.id);
         await child.update({ collectionId });
+        child.collection = newCollection;
         response.documents.push(child);
       });
     };
@@ -49,6 +50,7 @@ export default async function documentMover({
       collectionId,
       parentDocumentId,
     });
+    document.collection = newCollection;
     response.documents.push(document);
   }
 

--- a/server/commands/documentMover.test.js
+++ b/server/commands/documentMover.test.js
@@ -1,0 +1,85 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+import documentMover from '../commands/documentMover';
+import { flushdb, seed } from '../test/support';
+import { buildDocument, buildCollection } from '../test/factories';
+
+beforeEach(flushdb);
+
+describe('documentMover', async () => {
+  it('should move within a collection', async () => {
+    const { document, collection } = await seed();
+
+    const response = await documentMover({
+      document,
+      collectionId: collection.id,
+    });
+
+    expect(response.collections.length).toEqual(1);
+    expect(response.documents.length).toEqual(1);
+  });
+
+  it('should move with children', async () => {
+    const { document, collection } = await seed();
+    const newDocument = await buildDocument({
+      parentDocumentId: document.id,
+      collectionId: collection.id,
+      teamId: collection.teamId,
+      userId: collection.creatorId,
+      title: 'Child document',
+      text: 'content',
+    });
+    await collection.addDocumentToStructure(newDocument);
+
+    const response = await documentMover({
+      document,
+      collectionId: collection.id,
+      parentDocumentId: undefined,
+      index: 0,
+    });
+
+    expect(response.collections[0].documentStructure[0].children[0].id).toBe(
+      newDocument.id
+    );
+    expect(response.collections.length).toEqual(1);
+    expect(response.documents.length).toEqual(1);
+  });
+
+  it('should move with children to another collection', async () => {
+    const { document, collection } = await seed();
+    const newCollection = await buildCollection({
+      teamId: collection.teamId,
+    });
+    const newDocument = await buildDocument({
+      parentDocumentId: document.id,
+      collectionId: collection.id,
+      teamId: collection.teamId,
+      userId: collection.creatorId,
+      title: 'Child document',
+      text: 'content',
+    });
+    await collection.addDocumentToStructure(newDocument);
+
+    const response = await documentMover({
+      document,
+      collectionId: newCollection.id,
+      parentDocumentId: undefined,
+      index: 0,
+    });
+
+    // check document ids where updated
+    await newDocument.reload();
+    expect(newDocument.collectionId).toBe(newCollection.id);
+
+    await document.reload();
+    expect(document.collectionId).toBe(newCollection.id);
+
+    // check collection structure updated
+    expect(response.collections[0].id).toBe(collection.id);
+    expect(response.collections[1].id).toBe(newCollection.id);
+    expect(response.collections[1].documentStructure[0].children[0].id).toBe(
+      newDocument.id
+    );
+    expect(response.collections.length).toEqual(2);
+    expect(response.documents.length).toEqual(2);
+  });
+});

--- a/server/models/Collection.js
+++ b/server/models/Collection.js
@@ -156,8 +156,12 @@ Collection.prototype.addDocumentToStructure = async function(
 ) {
   if (!this.documentStructure) return;
 
+  let unlock;
+
   // documentStructure can only be updated by one request at a time
-  const unlock = await asyncLock(`collection-${this.id}`);
+  if (options.save !== false) {
+    unlock = await asyncLock(`collection-${this.id}`);
+  }
 
   // If moving existing document with children, use existing structure
   const documentJson = {
@@ -195,8 +199,11 @@ Collection.prototype.addDocumentToStructure = async function(
 
   // Sequelize doesn't seem to set the value with splice on JSONB field
   this.documentStructure = this.documentStructure;
-  await this.save(options);
-  unlock();
+
+  if (options.save !== false) {
+    await this.save(options);
+    if (unlock) unlock();
+  }
 
   return this;
 };

--- a/server/models/Collection.test.js
+++ b/server/models/Collection.test.js
@@ -145,34 +145,6 @@ describe('#updateDocument', () => {
   });
 });
 
-describe('#moveDocument', () => {
-  test('should move a document without children', async () => {
-    const { collection, document } = await seed();
-
-    expect(collection.documentStructure[1].id).toBe(document.id);
-    await collection.moveDocument(document, 0);
-    expect(collection.documentStructure[0].id).toBe(document.id);
-  });
-
-  test('should move a document with children', async () => {
-    const { collection, document } = await seed();
-    const newDocument = await Document.create({
-      parentDocumentId: document.id,
-      collectionId: collection.id,
-      teamId: collection.teamId,
-      userId: collection.creatorId,
-      lastModifiedById: collection.creatorId,
-      createdById: collection.creatorId,
-      title: 'Child document',
-      text: 'content',
-    });
-    await collection.addDocumentToStructure(newDocument);
-
-    await collection.moveDocument(document, 0);
-    expect(collection.documentStructure[0].children[0].id).toBe(newDocument.id);
-  });
-});
-
 describe('#removeDocument', () => {
   const destroyMock = jest.fn();
 
@@ -259,19 +231,5 @@ describe('#removeDocument', () => {
       },
     });
     expect(collectionDocuments.count).toBe(2);
-  });
-
-  describe('options: deleteDocument = false', () => {
-    test('should remove documents from the structure but not destroy them from the DB', async () => {
-      const { collection, document } = await seed();
-      jest.spyOn(collection, 'save');
-
-      const removedNode = await collection.removeDocumentInStructure(document);
-      expect(collection.documentStructure.length).toBe(1);
-      expect(destroyMock).not.toBeCalled();
-      expect(collection.save).not.toBeCalled();
-      expect(removedNode.id).toBe(document.id);
-      expect(removedNode.children).toEqual([]);
-    });
   });
 });

--- a/server/models/Collection.test.js
+++ b/server/models/Collection.test.js
@@ -146,8 +146,6 @@ describe('#updateDocument', () => {
 });
 
 describe('#removeDocument', () => {
-  const destroyMock = jest.fn();
-
   test('should save if removing', async () => {
     const { collection, document } = await seed();
     jest.spyOn(collection, 'save');

--- a/server/models/Document.js
+++ b/server/models/Document.js
@@ -363,7 +363,7 @@ Document.prototype.publish = async function() {
 Document.prototype.archive = async function(userId) {
   // archive any children and remove from the document structure
   const collection = await this.getCollection();
-  await collection.removeDocumentInStructure(this, { save: true });
+  await collection.removeDocumentInStructure(this);
   this.collection = collection;
 
   this.archivedAt = new Date();

--- a/server/pages/developers/Api.js
+++ b/server/pages/developers/Api.js
@@ -352,8 +352,7 @@ export default function Pricing() {
 
           <Method method="documents.move" label="Move document in a collection">
             <Description>
-              Move a document into a new location inside the collection. This is
-              easily done by defining the parent document ID. If no parent
+              Move a document to a new location or collection. If no parent
               document is provided, the document will be moved to the collection
               root.
             </Description>
@@ -364,8 +363,13 @@ export default function Pricing() {
                 required
               />
               <Argument
-                id="parentDocument"
-                description="ID of the new parent document (if any)"
+                id="collectionId"
+                description="ID of the collection"
+                required
+              />
+              <Argument
+                id="parentDocumentId"
+                description="ID of the new parent document"
               />
             </Arguments>
           </Method>

--- a/server/policies/document.js
+++ b/server/policies/document.js
@@ -14,7 +14,7 @@ allow(User, ['read', 'delete'], Document, (user, document) => {
   return user.teamId === document.teamId;
 });
 
-allow(User, ['update', 'share'], Document, (user, document) => {
+allow(User, ['update', 'move', 'share'], Document, (user, document) => {
   if (document.collection) {
     if (cannot(user, 'read', document.collection)) return false;
   }


### PR DESCRIPTION
- Allow moving a document between collections
- Introduces a new `commands` pattern to reduce domain logic within models
- Introduces `get` method on base store to retrieve model by `id`
- Adds new server policy for `"move"`
- Improved `documents.move` error messages

### Breaking API Changes

- `parentDocument` parameter is now `parentDocumentId` in `documents.move`
- `collectionId` is now required by `documents.move`

closes https://github.com/outline/outline/issues/233