### PR TITLE
Fix: negative numbers in pagination (limit/offset)

### DIFF
--- a/server/api/middlewares/pagination.js
+++ b/server/api/middlewares/pagination.js
@@ -17,9 +17,9 @@ export default function pagination(options?: Object) {
     let query = ctx.request.query;
     let body = ctx.request.body;
     // $FlowFixMe
-    let limit = parseInt(query.limit || body.limit, 10);
+    let limit = Math.abs(parseInt(query.limit || body.limit, 10));
     // $FlowFixMe
-    let offset = parseInt(query.offset || body.offset, 10);
+    let offset = Math.abs(parseInt(query.offset || body.offset, 10));
     limit = isNaN(limit) ? opts.defaultLimit : limit;
     offset = isNaN(offset) ? 0 : offset;
 


### PR DESCRIPTION
Hello 🖖

This method returns an error 😞 (500 HTTP Code): 

POST /api/documents.list?limit=**-20**&offset=**-10**

**Example:**

<img width="1110" alt="outline_screenshot" src="https://user-images.githubusercontent.com/41549580/58097013-144c9f00-7bdf-11e9-98e6-5aa9a4e803c9.png">

