### PR TITLE
Added ability to append to documents. Added test cases for the same

### DIFF
--- a/server/api/__snapshots__/documents.test.js.snap
+++ b/server/api/__snapshots__/documents.test.js.snap
@@ -107,6 +107,15 @@ Object {
 }
 `;
 
+exports[`#documents.update should require text while appending 1`] = `
+Object {
+  "error": "param_required",
+  "message": "Text is required while appending",
+  "ok": false,
+  "status": 400,
+}
+`;
+
 exports[`#documents.viewed should require authentication 1`] = `
 Object {
   "error": "authentication_required",

--- a/server/api/documents.js
+++ b/server/api/documents.js
@@ -612,7 +612,7 @@ router.post('documents.update', auth(), async ctx => {
   } = ctx.body;
   ctx.assertPresent(id, 'id is required');
   ctx.assertPresent(title || text, 'title or text is required');
-  if (append) ctx.assertPresent(text, 'text is required while appending');
+  if (append) ctx.assertPresent(text, 'Text is required while appending');
 
   const user = ctx.state.user;
   const document = await Document.findById(id);

--- a/server/api/documents.js
+++ b/server/api/documents.js
@@ -626,8 +626,11 @@ router.post('documents.update', auth(), async ctx => {
   // Update document
   if (title) document.title = title;
   //append to document
-  if (append) document.text += '\n' + text;
-  else if (text) document.text = text;
+  if (append) {
+    document.text += text;
+  } else if (text) {
+    document.text = text;
+  }
   document.lastModifiedById = user.id;
 
   if (publish) {

--- a/server/api/documents.js
+++ b/server/api/documents.js
@@ -600,10 +600,19 @@ router.post('documents.create', auth(), async ctx => {
 });
 
 router.post('documents.update', auth(), async ctx => {
-  const { id, title, text, publish, autosave, done, lastRevision, append } = ctx.body;
+  const {
+    id,
+    title,
+    text,
+    publish,
+    autosave,
+    done,
+    lastRevision,
+    append,
+  } = ctx.body;
   ctx.assertPresent(id, 'id is required');
   ctx.assertPresent(title || text, 'title or text is required');
-  if(append) ctx.assertPresent(text, 'text is required while appending');
+  if (append) ctx.assertPresent(text, 'text is required while appending');
 
   const user = ctx.state.user;
   const document = await Document.findById(id);
@@ -613,11 +622,11 @@ router.post('documents.update', auth(), async ctx => {
   if (lastRevision && lastRevision !== document.revisionCount) {
     throw new InvalidRequestError('Document has changed since last revision');
   }
-  
+
   // Update document
   if (title) document.title = title;
   //append to document
-  if(append) document.text += "\n"+text;
+  if (append) document.text += '\n' + text;
   else if (text) document.text = text;
   document.lastModifiedById = user.id;
 

--- a/server/api/documents.js
+++ b/server/api/documents.js
@@ -600,9 +600,10 @@ router.post('documents.create', auth(), async ctx => {
 });
 
 router.post('documents.update', auth(), async ctx => {
-  const { id, title, text, publish, autosave, done, lastRevision } = ctx.body;
+  const { id, title, text, publish, autosave, done, lastRevision, append } = ctx.body;
   ctx.assertPresent(id, 'id is required');
   ctx.assertPresent(title || text, 'title or text is required');
+  if(append) ctx.assertPresent(text, 'text is required while appending');
 
   const user = ctx.state.user;
   const document = await Document.findById(id);
@@ -612,10 +613,12 @@ router.post('documents.update', auth(), async ctx => {
   if (lastRevision && lastRevision !== document.revisionCount) {
     throw new InvalidRequestError('Document has changed since last revision');
   }
-
+  
   // Update document
   if (title) document.title = title;
-  if (text) document.text = text;
+  //append to document
+  if(append) document.text += "\n"+text;
+  else if (text) document.text = text;
   document.lastModifiedById = user.id;
 
   if (publish) {

--- a/server/api/documents.test.js
+++ b/server/api/documents.test.js
@@ -1239,6 +1239,7 @@ describe('#documents.update', async () => {
         token: user.getJwtToken(),
         id: document.id,
         lastRevision: document.revision,
+        title: 'Updated Title',
         append: true,
       },
     });

--- a/server/api/documents.test.js
+++ b/server/api/documents.test.js
@@ -1222,29 +1222,30 @@ describe('#documents.update', async () => {
         id: document.id,
         text: 'Additional text',
         lastRevision: document.revision,
-        append: true
+        append: true,
       },
     });
     const body = await res.json();
 
     expect(res.status).toEqual(200);
-    expect(body.data.text).toBe(document.text+'\nAdditional text');
+    expect(body.data.text).toBe(document.text + '\nAdditional text');
   });
 
   it('should require text while appending', async () => {
     const { user, document } = await seed();
-  
+
     const res = await server.post('/api/documents.update', {
       body: {
         token: user.getJwtToken(),
         id: document.id,
         lastRevision: document.revision,
-        append: true
+        append: true,
       },
     });
     const body = await res.json();
-  
+
     expect(res.status).toEqual(400);
+    expect(body).toMatchSnapshot();
   });
 });
 

--- a/server/api/documents.test.js
+++ b/server/api/documents.test.js
@@ -1228,7 +1228,7 @@ describe('#documents.update', async () => {
     const body = await res.json();
 
     expect(res.status).toEqual(200);
-    expect(body.data.text).toBe(document.text + '\nAdditional text');
+    expect(body.data.text).toBe(document.text + 'Additional text');
   });
 
   it('should require text while appending', async () => {

--- a/server/api/documents.test.js
+++ b/server/api/documents.test.js
@@ -1212,6 +1212,40 @@ describe('#documents.update', async () => {
     });
     expect(res.status).toEqual(403);
   });
+
+  it('should append document with text', async () => {
+    const { user, document } = await seed();
+
+    const res = await server.post('/api/documents.update', {
+      body: {
+        token: user.getJwtToken(),
+        id: document.id,
+        text: 'Additional text',
+        lastRevision: document.revision,
+        append: true
+      },
+    });
+    const body = await res.json();
+
+    expect(res.status).toEqual(200);
+    expect(body.data.text).toBe(document.text+'\nAdditional text');
+  });
+
+  it('should require text while appending', async () => {
+    const { user, document } = await seed();
+  
+    const res = await server.post('/api/documents.update', {
+      body: {
+        token: user.getJwtToken(),
+        id: document.id,
+        lastRevision: document.revision,
+        append: true
+      },
+    });
+    const body = await res.json();
+  
+    expect(res.status).toEqual(400);
+  });
 });
 
 describe('#documents.archive', async () => {


### PR DESCRIPTION
the documents.update API has been updated to accept a parameter `append`. When present, the text sent in the request will be appended to the existing document's text instead of replacing it.

Test cases to verify this have been added.
Resolves #950 