### PR TITLE
fix: document duplicate command

### DIFF
--- a/app/stores/DocumentsStore.js
+++ b/app/stores/DocumentsStore.js
@@ -354,7 +354,7 @@ export default class DocumentsStore extends BaseStore<Document> {
     const res = await client.post('/documents.create', {
       publish: true,
       parentDocumentId: document.parentDocumentId,
-      collection: document.collectionId,
+      collectionId: document.collectionId,
       title: `${document.title} (duplicate)`,
       text: document.text,
     });


### PR DESCRIPTION
This is because the front-end sends `collectionId` as `collection`, instead of `collectionId`.

Request:

![image](https://user-images.githubusercontent.com/10081640/61988040-921f9300-aff2-11e9-84fe-e98137089bf7.png)

Response:

![image](https://user-images.githubusercontent.com/10081640/61988029-71573d80-aff2-11e9-815e-0c322ad58d6f.png)
