### PR TITLE
chore: add missing EXPOSE rule

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,3 +12,5 @@ RUN yarn install --pure-lockfile
 RUN cp -r /opt/outline/node_modules /opt/node_modules
 
 CMD yarn build && yarn start
+
+EXPOSE 3000


### PR DESCRIPTION
Otherwise, the running container does not show up in Traefik 😅 