### PR TITLE
chore: Upgrade Node to v12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/outline
     docker:
-      - image: circleci/node:8.11
+      - image: circleci/node:12
       - image: circleci/redis:latest
       - image: circleci/postgres:9.6.5-alpine-ram
     environment:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.11-alpine
+FROM node:12-alpine
 
 ENV PATH /opt/outline/node_modules/.bin:/opt/node_modules/.bin:$PATH
 ENV NODE_PATH /opt/outline/node_modules:/opt/node_modules

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you'd like to run your own copy of Outline or contribute to development then 
 
 Outline requires the following dependencies:
 
-- Node.js >= 8.11
+- Node.js >= 12
 - Postgres >=9.5
 - Redis
 - AWS S3 storage bucket for media and other attachments

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     ]
   },
   "engines": {
-    "node": ">= 8.11"
+    "node": ">= 12"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I recently upgraded Sequelize which was the biggest blocker to going to Node 12. Now it's just a version number update, everything seems to work well in tests and local testing.

closes https://github.com/outline/outline/issues/961