### PR TITLE
feat: Moves the child documents display to the top of the page when doc is empty

### DIFF
--- a/app/models/Document.js
+++ b/app/models/Document.js
@@ -53,6 +53,19 @@ export default class Document extends BaseModel {
   }
 
   @computed
+  get isOnlyTitle(): boolean {
+    const { title } = parseTitle(this.text);
+
+    // find and extract title
+    const trimmedBody = this.text
+      .trim()
+      .replace(/^#/, '')
+      .trim();
+
+    return unescape(trimmedBody) === title;
+  }
+
+  @computed
   get modifiedSinceViewed(): boolean {
     return !!this.lastViewedAt && this.lastViewedAt < this.updatedAt;
   }
@@ -80,7 +93,7 @@ export default class Document extends BaseModel {
   @computed
   get permanentlyDeletedAt(): ?string {
     if (!this.deletedAt) {
-      return;
+      return undefined;
     }
 
     return addDays(new Date(this.deletedAt), 30).toString();

--- a/app/scenes/Document/Document.js
+++ b/app/scenes/Document/Document.js
@@ -24,6 +24,8 @@ import DocumentMove from './components/DocumentMove';
 import Branding from './components/Branding';
 import KeyboardShortcuts from './components/KeyboardShortcuts';
 import References from './components/References';
+import Fade from 'components/Fade';
+import Heading from 'components/Heading';
 import ErrorBoundary from 'components/ErrorBoundary';
 import LoadingPlaceholder from 'components/LoadingPlaceholder';
 import LoadingIndicator from 'components/LoadingIndicator';
@@ -399,7 +401,12 @@ class DocumentScene extends React.Component<Props> {
                 onSave={this.onSave}
               />
             )}
-            <MaxWidth archived={document.isArchived} column auto>
+            <MaxWidth
+              archived={document.isArchived}
+              indexPage={document.isOnlyTitle}
+              auto
+              column
+            >
               {document.archivedAt &&
                 !document.deletedAt && (
                   <Notice muted>
@@ -421,26 +428,39 @@ class DocumentScene extends React.Component<Props> {
                   )}
                 </Notice>
               )}
-              <Editor
-                id={document.id}
-                key={embedsDisabled ? 'embeds-disabled' : 'embeds-enabled'}
-                defaultValue={revision ? revision.text : document.text}
-                pretitle={document.emoji}
-                disableEmbeds={embedsDisabled}
-                onImageUploadStart={this.onImageUploadStart}
-                onImageUploadStop={this.onImageUploadStop}
-                onSearchLink={this.onSearchLink}
-                onChange={this.onChange}
-                onSave={this.onSave}
-                onPublish={this.onPublish}
-                onCancel={this.onDiscard}
-                readOnly={!this.isEditing || document.isArchived}
-                toc={!revision}
-                ui={this.props.ui}
-                schema={schema}
-              />
-              {!this.isEditing &&
-                !isShare && <References document={document} />}
+              {document.isOnlyTitle && !this.isEditing ? (
+                <React.Fragment>
+                  <Heading>{document.title}</Heading>
+                  {!isShare && <References document={document} />}
+                </React.Fragment>
+              ) : (
+                <React.Fragment>
+                  <Editor
+                    id={document.id}
+                    key={embedsDisabled ? 'embeds-disabled' : 'embeds-enabled'}
+                    defaultValue={revision ? revision.text : document.text}
+                    pretitle={document.emoji}
+                    disableEmbeds={embedsDisabled}
+                    onImageUploadStart={this.onImageUploadStart}
+                    onImageUploadStop={this.onImageUploadStop}
+                    onSearchLink={this.onSearchLink}
+                    onChange={this.onChange}
+                    onSave={this.onSave}
+                    onPublish={this.onPublish}
+                    onCancel={this.onDiscard}
+                    readOnly={!this.isEditing || document.isArchived}
+                    toc={!revision}
+                    ui={this.props.ui}
+                    schema={schema}
+                  />
+                  {!this.isEditing &&
+                    !isShare && (
+                      <Fade>
+                        <References document={document} />
+                      </Fade>
+                    )}
+                </React.Fragment>
+              )}
             </MaxWidth>
           </Container>
         </Container>
@@ -451,6 +471,7 @@ class DocumentScene extends React.Component<Props> {
 }
 
 const MaxWidth = styled(Flex)`
+  display: ${props => (props.indexPage ? 'block' : 'flex')};
   ${props =>
     props.archived && `* { color: ${props.theme.textSecondary} !important; } `};
   padding: 0 16px;

--- a/app/scenes/Document/components/References.js
+++ b/app/scenes/Document/components/References.js
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import { observer, inject } from 'mobx-react';
 import { withRouter, type Location } from 'react-router-dom';
-import Fade from 'components/Fade';
 import Tabs from 'components/Tabs';
 import Tab from 'components/Tab';
 import DocumentsStore from 'stores/DocumentsStore';
@@ -38,7 +37,7 @@ class References extends React.Component<Props> {
 
     return (
       (showBacklinks || showChildren) && (
-        <Fade>
+        <React.Fragment>
           <Tabs>
             {showChildren && (
               <Tab to="#children" isActive={() => !isBacklinksTab}>
@@ -74,7 +73,7 @@ class References extends React.Component<Props> {
                   />
                 );
               })}
-        </Fade>
+        </React.Fragment>
       )
     );
   }


### PR DESCRIPTION
This works well, but some part of me worries that it's too complex and we might be better just always displaying child documents directly below the content?

closes https://github.com/outline/outline/issues/1097