### PR TITLE
fix: Account for migrations ran on old versions of Sequelize

### DIFF
--- a/server/migrations/20191118023010-cascade-delete.js
+++ b/server/migrations/20191118023010-cascade-delete.js
@@ -1,22 +1,43 @@
 const tableName = 'revisions';
-const constraintName = 'revisions_documentId_fkey';
+
+// because of this issue in Sequelize the foreign key constraint may be named differently depending
+// on when the previous migrations were ran https://github.com/sequelize/sequelize/pull/9890
+const constraintNames = ['revisions_documentId_fkey', 'documentId_foreign_idx'];
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.sequelize.query(`alter table "${tableName}" drop constraint "${constraintName}"`)
-    await queryInterface.sequelize.query(
-      `alter table "${tableName}"
-        add constraint "${constraintName}" foreign key("documentId") references "documents" ("id")
-        on delete cascade`
-    );
+    let error;
+    for (const constraintName of constraintNames) {
+      try {
+        await queryInterface.sequelize.query(`alter table "${tableName}" drop constraint "${constraintName}"`)
+        await queryInterface.sequelize.query(
+          `alter table "${tableName}"
+            add constraint "${constraintName}" foreign key("documentId") references "documents" ("id")
+            on delete cascade`
+        );
+        return;
+      } catch (err) {
+        error = err;
+      }
+    }
+    throw error;
   },
 
   down: async (queryInterface, Sequelize) => {
-    await queryInterface.sequelize.query(`alter table "${tableName}" drop constraint "${constraintName}"`)
-    await queryInterface.sequelize.query(
-      `alter table "${tableName}"\
-        add constraint "${constraintName}" foreign key("documentId") references "documents" ("id")
-        on delete no action`
-    );
+    let error;
+    for (const constraintName of constraintNames) {
+      try {
+        await queryInterface.sequelize.query(`alter table "${tableName}" drop constraint "${constraintName}"`)
+        await queryInterface.sequelize.query(
+          `alter table "${tableName}"\
+            add constraint "${constraintName}" foreign key("documentId") references "documents" ("id")
+            on delete no action`
+        );
+        return;
+      } catch (err) {
+        error = err;
+      }
+    }
+    throw error;
   },
 };

--- a/server/migrations/20191119023010-cascade-backlinks.js
+++ b/server/migrations/20191119023010-cascade-backlinks.js
@@ -1,22 +1,43 @@
 const tableName = 'backlinks';
-const constraintName = 'backlinks_reverseDocumentId_fkey';
+
+// because of this issue in Sequelize the foreign key constraint may be named differently depending
+// on when the previous migrations were ran https://github.com/sequelize/sequelize/pull/9890
+const constraintNames = ['backlinks_reverseDocumentId_fkey', 'reverseDocumentId_foreign_idx'];
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.sequelize.query(`alter table "${tableName}" drop constraint "${constraintName}"`)
-    await queryInterface.sequelize.query(
-      `alter table "${tableName}"
-        add constraint "${constraintName}" foreign key("reverseDocumentId") references "documents" ("id")
-        on delete cascade`
-    );
+    let error;
+    for (const constraintName of constraintNames) {
+      try {
+        await queryInterface.sequelize.query(`alter table "${tableName}" drop constraint "${constraintName}"`)
+        await queryInterface.sequelize.query(
+          `alter table "${tableName}"
+            add constraint "${constraintName}" foreign key("reverseDocumentId") references "documents" ("id")
+            on delete cascade`
+        );
+        return;
+      } catch (err) {
+        error = err;
+      }
+    }
+    throw error;
   },
 
   down: async (queryInterface, Sequelize) => {
-    await queryInterface.sequelize.query(`alter table "${tableName}" drop constraint "${constraintName}"`)
-    await queryInterface.sequelize.query(
-      `alter table "${tableName}"\
-        add constraint "${constraintName}" foreign key("reverseDocumentId") references "documents" ("id")
-        on delete no action`
-    );
+    let error;
+    for (const constraintName of constraintNames) {
+      try {
+        await queryInterface.sequelize.query(`alter table "${tableName}" drop constraint "${constraintName}"`)
+        await queryInterface.sequelize.query(
+          `alter table "${tableName}"\
+            add constraint "${constraintName}" foreign key("reverseDocumentId") references "documents" ("id")
+            on delete no action`
+        );
+        return;
+      } catch (err) {
+        error = err;
+      }
+    }
+    throw error;
   },
 };

--- a/server/migrations/20191119023011-cascade-parent-documents.js
+++ b/server/migrations/20191119023011-cascade-parent-documents.js
@@ -1,22 +1,43 @@
 const tableName = 'documents';
-const constraintName = 'documents_parentDocumentId_fkey';
+
+// because of this issue in Sequelize the foreign key constraint may be named differently depending
+// on when the previous migrations were ran https://github.com/sequelize/sequelize/pull/9890
+const constraintNames = ['documents_parentDocumentId_fkey', 'parentDocumentId_foreign_idx'];
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.sequelize.query(`alter table "${tableName}" drop constraint "${constraintName}"`)
-    await queryInterface.sequelize.query(
-      `alter table "${tableName}"
-        add constraint "${constraintName}" foreign key("parentDocumentId") references "documents" ("id")
-        on delete cascade`
-    );
+    let error;
+    for (const constraintName of constraintNames) {
+      try {
+        await queryInterface.sequelize.query(`alter table "${tableName}" drop constraint "${constraintName}"`)
+        await queryInterface.sequelize.query(
+          `alter table "${tableName}"
+            add constraint "${constraintName}" foreign key("parentDocumentId") references "documents" ("id")
+            on delete cascade`
+        );
+        return;
+      } catch (err) {
+        error = err;
+      }
+    }
+    throw error;
   },
 
   down: async (queryInterface, Sequelize) => {
-    await queryInterface.sequelize.query(`alter table "${tableName}" drop constraint "${constraintName}"`)
-    await queryInterface.sequelize.query(
-      `alter table "${tableName}"\
-        add constraint "${constraintName}" foreign key("parentDocumentId") references "documents" ("id")
-        on delete no action`
-    );
+    let error;
+    for (const constraintName of constraintNames) {
+      try {
+        await queryInterface.sequelize.query(`alter table "${tableName}" drop constraint "${constraintName}"`)
+        await queryInterface.sequelize.query(
+          `alter table "${tableName}"\
+            add constraint "${constraintName}" foreign key("parentDocumentId") references "documents" ("id")
+            on delete no action`
+        );
+        return;
+      } catch (err) {
+        error = err;
+      }
+    }
+    throw error;
   },
 };

--- a/server/migrations/20191119023012-cascade-shares.js
+++ b/server/migrations/20191119023012-cascade-shares.js
@@ -1,22 +1,43 @@
 const tableName = 'shares';
-const constraintName = 'shares_documentId_fkey';
+
+// because of this issue in Sequelize the foreign key constraint may be named differently depending
+// on when the previous migrations were ran https://github.com/sequelize/sequelize/pull/9890
+const constraintNames = ['shares_documentId_fkey', 'documentId_foreign_idx'];
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.sequelize.query(`alter table "${tableName}" drop constraint "${constraintName}"`)
-    await queryInterface.sequelize.query(
-      `alter table "${tableName}"
-        add constraint "${constraintName}" foreign key("documentId") references "documents" ("id")
-        on delete cascade`
-    );
+    let error;
+    for (const constraintName of constraintNames) {
+      try {
+        await queryInterface.sequelize.query(`alter table "${tableName}" drop constraint "${constraintName}"`)
+        await queryInterface.sequelize.query(
+          `alter table "${tableName}"
+            add constraint "${constraintName}" foreign key("documentId") references "documents" ("id")
+            on delete cascade`
+        );
+        return;
+      } catch (err) {
+        error = err;
+      }
+    }
+    throw error;
   },
 
   down: async (queryInterface, Sequelize) => {
-    await queryInterface.sequelize.query(`alter table "${tableName}" drop constraint "${constraintName}"`)
-    await queryInterface.sequelize.query(
-      `alter table "${tableName}"\
-        add constraint "${constraintName}" foreign key("documentId") references "documents" ("id")
-        on delete no action`
-    );
+    let error;
+    for (const constraintName of constraintNames) {
+      try {
+        await queryInterface.sequelize.query(`alter table "${tableName}" drop constraint "${constraintName}"`)
+        await queryInterface.sequelize.query(
+          `alter table "${tableName}"\
+            add constraint "${constraintName}" foreign key("documentId") references "documents" ("id")
+            on delete no action`
+        );
+        return;
+      } catch (err) {
+        error = err;
+      }
+    }
+    throw error;
   },
 };

--- a/server/migrations/20191119023013-cascade-backlinks2.js
+++ b/server/migrations/20191119023013-cascade-backlinks2.js
@@ -1,22 +1,43 @@
 const tableName = 'backlinks';
-const constraintName = 'backlinks_documentId_fkey';
+
+// because of this issue in Sequelize the foreign key constraint may be named differently depending
+// on when the previous migrations were ran https://github.com/sequelize/sequelize/pull/9890
+const constraintNames = ['backlinks_documentId_fkey', 'documentId_foreign_idx'];
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.sequelize.query(`alter table "${tableName}" drop constraint "${constraintName}"`)
-    await queryInterface.sequelize.query(
-      `alter table "${tableName}"
-        add constraint "${constraintName}" foreign key("documentId") references "documents" ("id")
-        on delete cascade`
-    );
+    let error;
+    for (const constraintName of constraintNames) {
+      try {
+        await queryInterface.sequelize.query(`alter table "${tableName}" drop constraint "${constraintName}"`)
+        await queryInterface.sequelize.query(
+          `alter table "${tableName}"
+            add constraint "${constraintName}" foreign key("documentId") references "documents" ("id")
+            on delete cascade`
+        );
+        return;
+      } catch (err) {
+        error = err;
+      }
+    }
+    throw error;
   },
 
   down: async (queryInterface, Sequelize) => {
-    await queryInterface.sequelize.query(`alter table "${tableName}" drop constraint "${constraintName}"`)
-    await queryInterface.sequelize.query(
-      `alter table "${tableName}"\
-        add constraint "${constraintName}" foreign key("documentId") references "documents" ("id")
-        on delete no action`
-    );
+    let error;
+    for (const constraintName of constraintNames) {
+      try {
+        await queryInterface.sequelize.query(`alter table "${tableName}" drop constraint "${constraintName}"`)
+        await queryInterface.sequelize.query(
+          `alter table "${tableName}"\
+            add constraint "${constraintName}" foreign key("documentId") references "documents" ("id")
+            on delete no action`
+        );
+        return;
+      } catch (err) {
+        error = err;
+      }
+    }
+    throw error;
   },
 };


### PR DESCRIPTION
Seems like the issue was caused by changes made in https://github.com/sequelize/sequelize/pull/9890 – the foreign key name will change depending on which version of the app the migrations were originally made on.

closes https://github.com/outline/outline/issues/1117