### PR TITLE
feat: Show drafts to author in collections

### DIFF
--- a/app/stores/DocumentsStore.js
+++ b/app/stores/DocumentsStore.js
@@ -77,19 +77,11 @@ export default class DocumentsStore extends BaseStore<Document> {
   }
 
   leastRecentlyUpdatedInCollection(collectionId: string): Document[] {
-    return orderBy(
-      this.publishedInCollection(collectionId),
-      'updatedAt',
-      'asc'
-    );
+    return orderBy(this.inCollection(collectionId), 'updatedAt', 'asc');
   }
 
   recentlyUpdatedInCollection(collectionId: string): Document[] {
-    return orderBy(
-      this.publishedInCollection(collectionId),
-      'updatedAt',
-      'desc'
-    );
+    return orderBy(this.inCollection(collectionId), 'updatedAt', 'desc');
   }
 
   recentlyPublishedInCollection(collectionId: string): Document[] {
@@ -101,7 +93,7 @@ export default class DocumentsStore extends BaseStore<Document> {
   }
 
   alphabeticalInCollection(collectionId: string): Document[] {
-    return naturalSort(this.publishedInCollection(collectionId), 'title');
+    return naturalSort(this.inCollection(collectionId), 'title');
   }
 
   searchResults(query: string): SearchResult[] {


### PR DESCRIPTION
This is the simple solution, drafts are shown mixed in with all other documents with the "Draft" label. They're only visible if you're the author.

closes #1133 