### PR TITLE
feat: Store image uploads as attachments in database

### DIFF
--- a/app/components/Editor/Editor.js
+++ b/app/components/Editor/Editor.js
@@ -15,6 +15,7 @@ import Embed from './Embed';
 import embeds from '../../embeds';
 
 type Props = {
+  documentId?: string,
   defaultValue?: string,
   readOnly?: boolean,
   grow?: boolean,
@@ -28,7 +29,8 @@ class Editor extends React.Component<Props> {
   @observable redirectTo: ?string;
 
   onUploadImage = async (file: File) => {
-    const result = await uploadFile(file);
+    const { documentId } = this.props;
+    const result = await uploadFile(file, { documentId });
     return result.url;
   };
 

--- a/app/components/Editor/Editor.js
+++ b/app/components/Editor/Editor.js
@@ -15,7 +15,7 @@ import Embed from './Embed';
 import embeds from '../../embeds';
 
 type Props = {
-  documentId?: string,
+  id: string,
   defaultValue?: string,
   readOnly?: boolean,
   grow?: boolean,
@@ -29,8 +29,7 @@ class Editor extends React.Component<Props> {
   @observable redirectTo: ?string;
 
   onUploadImage = async (file: File) => {
-    const { documentId } = this.props;
-    const result = await uploadFile(file, { documentId });
+    const result = await uploadFile(file, { documentId: this.props.id });
     return result.url;
   };
 

--- a/app/scenes/Document/components/Document.js
+++ b/app/scenes/Document/components/Document.js
@@ -297,6 +297,7 @@ class DocumentScene extends React.Component<Props> {
               )}
               <Editor
                 id={document.id}
+                documentId={document.id}
                 key={embedsDisabled ? 'embeds-disabled' : 'embeds-enabled'}
                 defaultValue={revision ? revision.text : document.text}
                 pretitle={document.emoji}

--- a/app/scenes/Document/components/Document.js
+++ b/app/scenes/Document/components/Document.js
@@ -297,7 +297,6 @@ class DocumentScene extends React.Component<Props> {
               )}
               <Editor
                 id={document.id}
-                documentId={document.id}
                 key={embedsDisabled ? 'embeds-disabled' : 'embeds-enabled'}
                 defaultValue={revision ? revision.text : document.text}
                 pretitle={document.emoji}

--- a/app/scenes/Settings/components/ImageUpload.js
+++ b/app/scenes/Settings/components/ImageUpload.js
@@ -49,7 +49,9 @@ class DropToImport extends React.Component<Props> {
     const canvas = this.avatarEditorRef.getImage();
     const imageBlob = dataUrlToBlob(canvas.toDataURL());
     try {
-      const asset = await uploadFile(imageBlob, { name: this.file.name });
+      const asset = await uploadFile(imageBlob, {
+        name: this.file.name,
+      });
       this.props.onSuccess(asset.url);
     } catch (err) {
       this.props.onError(err.message);

--- a/app/utils/uploadFile.js
+++ b/app/utils/uploadFile.js
@@ -10,11 +10,11 @@ export const uploadFile = async (
   file: File | Blob,
   option?: Options = { name: '' }
 ) => {
-  const filename = file instanceof File ? file.name : option.name;
+  const name = file instanceof File ? file.name : option.name;
   const response = await client.post('/users.s3Upload', {
-    kind: file.type,
+    contentType: file.type,
     size: file.size,
-    filename,
+    name,
   });
 
   invariant(response, 'Response should be available');

--- a/app/utils/uploadFile.js
+++ b/app/utils/uploadFile.js
@@ -4,14 +4,16 @@ import invariant from 'invariant';
 
 type Options = {
   name?: string,
+  documentId?: string,
 };
 
 export const uploadFile = async (
   file: File | Blob,
-  option?: Options = { name: '' }
+  options?: Options = { name: '' }
 ) => {
-  const name = file instanceof File ? file.name : option.name;
+  const name = file instanceof File ? file.name : options.name;
   const response = await client.post('/users.s3Upload', {
+    documentId: options.documentId,
     contentType: file.type,
     size: file.size,
     name,
@@ -35,11 +37,10 @@ export const uploadFile = async (
     formData.append('file', file);
   }
 
-  const options: Object = {
+  await fetch(data.uploadUrl, {
     method: 'post',
     body: formData,
-  };
-  await fetch(data.uploadUrl, options);
+  });
 
   return asset;
 };

--- a/server/api/users.js
+++ b/server/api/users.js
@@ -76,7 +76,7 @@ router.post('users.update', auth(), async ctx => {
 });
 
 router.post('users.s3Upload', auth(), async ctx => {
-  let { name, filename, contentType, kind, size } = ctx.body;
+  let { name, filename, documentId, contentType, kind, size } = ctx.body;
 
   // backwards compatability
   name = name || filename;
@@ -100,6 +100,7 @@ router.post('users.s3Upload', auth(), async ctx => {
     size,
     url,
     contentType,
+    documentId,
     teamId: user.teamId,
     userId: user.id,
   });

--- a/server/api/users.js
+++ b/server/api/users.js
@@ -96,7 +96,7 @@ router.post('users.s3Upload', auth(), async ctx => {
   const url = `${endpoint}/${key}`;
 
   await Attachment.create({
-    name,
+    key,
     size,
     url,
     contentType,

--- a/server/api/users.js
+++ b/server/api/users.js
@@ -10,7 +10,7 @@ import {
   makeCredential,
 } from '../utils/s3';
 import { ValidationError } from '../errors';
-import { Event, User, Team } from '../models';
+import { Attachment, Event, User, Team } from '../models';
 import auth from '../middlewares/authentication';
 import pagination from './middlewares/pagination';
 import userInviter from '../commands/userInviter';
@@ -76,29 +76,39 @@ router.post('users.update', auth(), async ctx => {
 });
 
 router.post('users.s3Upload', auth(), async ctx => {
-  const { filename, kind, size } = ctx.body;
-  ctx.assertPresent(filename, 'filename is required');
-  ctx.assertPresent(kind, 'kind is required');
+  let { name, filename, contentType, kind, size } = ctx.body;
+
+  // backwards compatability
+  name = name || filename;
+  contentType = contentType || kind;
+
+  ctx.assertPresent(name, 'name is required');
+  ctx.assertPresent(contentType, 'contentType is required');
   ctx.assertPresent(size, 'size is required');
 
+  const { user } = ctx.state;
   const s3Key = uuid.v4();
-  const key = `uploads/${ctx.state.user.id}/${s3Key}/${filename}`;
+  const key = `uploads/${user.id}/${s3Key}/${name}`;
   const credential = makeCredential();
   const longDate = format(new Date(), 'YYYYMMDDTHHmmss\\Z');
   const policy = makePolicy(credential, longDate);
   const endpoint = publicS3Endpoint();
   const url = `${endpoint}/${key}`;
 
+  await Attachment.create({
+    name,
+    size,
+    url,
+    contentType,
+    teamId: user.teamId,
+    userId: user.id,
+  });
+
   await Event.create({
     name: 'user.s3Upload',
-    data: {
-      filename,
-      kind,
-      size,
-      url,
-    },
-    teamId: ctx.state.user.teamId,
-    userId: ctx.state.user.id,
+    data: { name },
+    teamId: user.teamId,
+    userId: user.id,
     ip: ctx.request.ip,
   });
 
@@ -108,7 +118,7 @@ router.post('users.s3Upload', auth(), async ctx => {
       uploadUrl: endpoint,
       form: {
         'Cache-Control': 'max-age=31557600',
-        'Content-Type': kind,
+        'Content-Type': contentType,
         acl: 'public-read',
         key,
         policy,
@@ -118,8 +128,8 @@ router.post('users.s3Upload', auth(), async ctx => {
         'x-amz-signature': getSignature(policy),
       },
       asset: {
-        contentType: kind,
-        name: filename,
+        contentType,
+        name,
         url,
         size,
       },

--- a/server/migrations/20200104233831-attachments.js
+++ b/server/migrations/20200104233831-attachments.js
@@ -27,7 +27,7 @@ module.exports = {
           model: 'documents',
         },
       },
-      name: {
+      key: {
         type: Sequelize.STRING,
         allowNull: false,
       },

--- a/server/migrations/20200104233831-attachments.js
+++ b/server/migrations/20200104233831-attachments.js
@@ -6,6 +6,13 @@ module.exports = {
         allowNull: false,
         primaryKey: true,
       },
+      teamId: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'teams',
+        },
+      },
       userId: {
         type: Sequelize.UUID,
         allowNull: false,
@@ -13,11 +20,11 @@ module.exports = {
           model: 'users',
         },
       },
-      teamId: {
+      documentId: {
         type: Sequelize.UUID,
-        allowNull: false,
+        allowNull: true,
         references: {
-          model: 'teams',
+          model: 'documents',
         },
       },
       name: {
@@ -49,6 +56,7 @@ module.exports = {
         allowNull: false,
       },
     });
+    await queryInterface.addIndex('attachments', ['documentId']);
   },
 
   down: async (queryInterface, Sequelize) => {

--- a/server/migrations/20200104233831-attachments.js
+++ b/server/migrations/20200104233831-attachments.js
@@ -1,0 +1,57 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('attachments', {
+      id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        primaryKey: true,
+      },
+      userId: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'users',
+        },
+      },
+      teamId: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'teams',
+        },
+      },
+      name: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      url: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      contentType: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      size: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+      },
+      acl: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('attachments');
+  },
+};

--- a/server/models/Attachment.js
+++ b/server/models/Attachment.js
@@ -35,6 +35,7 @@ const Attachment = sequelize.define('attachment', {
 
 Attachment.associate = models => {
   Attachment.belongsTo(models.Team);
+  Attachment.belongsTo(models.Document);
   Attachment.belongsTo(models.User);
 };
 

--- a/server/models/Attachment.js
+++ b/server/models/Attachment.js
@@ -1,37 +1,48 @@
 // @flow
+import path from 'path';
 import { DataTypes, sequelize } from '../sequelize';
 
-const Attachment = sequelize.define('attachment', {
-  id: {
-    type: DataTypes.UUID,
-    defaultValue: DataTypes.UUIDV4,
-    primaryKey: true,
-  },
-  name: {
-    type: DataTypes.STRING,
-    allowNull: false,
-  },
-  url: {
-    type: DataTypes.STRING,
-    allowNull: false,
-  },
-  contentType: {
-    type: DataTypes.STRING,
-    allowNull: false,
-  },
-  size: {
-    type: DataTypes.BIGINT,
-    allowNull: false,
-  },
-  acl: {
-    type: DataTypes.STRING,
-    allowNull: false,
-    defaultValue: 'public-read',
-    validate: {
-      isIn: [['private', 'public-read']],
+const Attachment = sequelize.define(
+  'attachment',
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    key: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    url: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    contentType: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    size: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    acl: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: 'public-read',
+      validate: {
+        isIn: [['private', 'public-read']],
+      },
     },
   },
-});
+  {
+    getterMethods: {
+      name: function() {
+        return path.parse(this.key).base;
+      },
+    },
+  }
+);
 
 Attachment.associate = models => {
   Attachment.belongsTo(models.Team);

--- a/server/models/Attachment.js
+++ b/server/models/Attachment.js
@@ -1,0 +1,41 @@
+// @flow
+import { DataTypes, sequelize } from '../sequelize';
+
+const Attachment = sequelize.define('attachment', {
+  id: {
+    type: DataTypes.UUID,
+    defaultValue: DataTypes.UUIDV4,
+    primaryKey: true,
+  },
+  name: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  url: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  contentType: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  size: {
+    type: DataTypes.BIGINT,
+    allowNull: false,
+  },
+  acl: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    defaultValue: 'public-read',
+    validate: {
+      isIn: [['private', 'public-read']],
+    },
+  },
+});
+
+Attachment.associate = models => {
+  Attachment.belongsTo(models.Team);
+  Attachment.belongsTo(models.User);
+};
+
+export default Attachment;

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -1,5 +1,6 @@
 // @flow
 import ApiKey from './ApiKey';
+import Attachment from './Attachment';
 import Authentication from './Authentication';
 import Backlink from './Backlink';
 import Collection from './Collection';
@@ -18,6 +19,7 @@ import View from './View';
 
 const models = {
   ApiKey,
+  Attachment,
   Authentication,
   Backlink,
   Collection,
@@ -44,6 +46,7 @@ Object.keys(models).forEach(modelName => {
 
 export {
   ApiKey,
+  Attachment,
   Authentication,
   Backlink,
   Collection,

--- a/server/pages/developers/Api.js
+++ b/server/pages/developers/Api.js
@@ -58,18 +58,18 @@ export default function Api() {
             </Description>
             <Arguments>
               <Argument
-                id="filename"
-                description="Filename of the uploaded file"
+                id="name"
+                description="Name of the uploaded file"
                 required
               />
               <Argument
-                id="kind"
-                description="Mimetype of the document"
+                id="contentType"
+                description="Content-type of the file"
                 required
               />
               <Argument
                 id="size"
-                description="Filesize of the document"
+                description="Size in bytes of the file"
                 required
               />
             </Arguments>

--- a/server/pages/developers/Api.js
+++ b/server/pages/developers/Api.js
@@ -53,7 +53,7 @@ export default function Api() {
             <Description>
               You can upload small files and images as part of your documents.
               All files are stored using Amazon S3. Instead of uploading files
-              to Outline, you need to upload them directly to S3 with special
+              to Outline, you need to upload them directly to S3 with
               credentials which can be obtained through this endpoint.
             </Description>
             <Arguments>
@@ -64,7 +64,7 @@ export default function Api() {
               />
               <Argument
                 id="contentType"
-                description="Content-type of the file"
+                description="Mimetype of the file"
                 required
               />
               <Argument

--- a/server/pages/developers/Api.js
+++ b/server/pages/developers/Api.js
@@ -72,6 +72,10 @@ export default function Api() {
                 description="Size in bytes of the file"
                 required
               />
+              <Argument
+                id="documentId"
+                description="UUID of the associated document"
+              />
             </Arguments>
           </Method>
 


### PR DESCRIPTION
This PR provides the foundation for storing images and other file uploads in a private bucket.

Currently some of the data is stored in the `events` table but this is supposed to be an audit log, not a place to query for active data so it makes sense to create a new table for this concept with it's own schema and validation.

related https://github.com/outline/outline/pull/1137
related https://github.com/outline/outline/issues/1010
related https://github.com/outline/outline/issues/859