### PR TITLE
fix: Add UTILS_SECRET to .env.sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,6 +4,7 @@
 #
 # Please use `openssl rand -hex 32` to create SECRET_KEY
 SECRET_KEY=generate_a_new_key
+UTILS_SECRET=generate_a_new_key
 
 DATABASE_URL=postgres://user:pass@postgres:5432/outline
 DATABASE_URL_TEST=postgres://user:pass@postgres:5432/outline-test


### PR DESCRIPTION
When running tests, `server/api/utils.test.js` would fail:

```
Summary of all failing tests
 FAIL  server/api/utils.test.js
  ● #utils.gc › should require authentication

    expect(received).toEqual(expected)

    Expected value to equal:
      401
    Received:
      200

      70 |   it('should require authentication', async () => {
      71 |     const res = await server.post('/api/utils.gc');
    > 72 |     expect(res.status).toEqual(401);
      73 |   });
      74 | });
      75 | 

      at _callee3$ (server/api/utils.test.js:72:24)
      at tryCatch (node_modules/regenerator-runtime/runtime.js:45:40)
      at Generator.invoke [as _invoke] (node_modules/regenerator-runtime/runtime.js:271:22)
      at Generator.prototype.<computed> [as next] (node_modules/regenerator-runtime/runtime.js:97:21)
      at step (server/api/utils.test.js:25:191)
      at server/api/utils.test.js:25:361
          at runMicrotasks (<anonymous>)
```

This is due to the fact that the [check for UTILS_SECRET versus token](https://github.com/outline/outline/blob/master/server/api/utils.js#L13-L15) depended on a value set for `UTILS_SECRET` in `.env`. Since I couldn't find any additional reference of this environment variable and no paths leading to this endpoint, I thought it would be good to hint to add this in `.env.sample`.