### PR TITLE
WIP: fix: Color the label to be white to contrast

### DIFF
--- a/app/components/DocumentHistory/components/Revision.js
+++ b/app/components/DocumentHistory/components/Revision.js
@@ -43,7 +43,7 @@ class RevisionListItem extends React.Component<Props> {
           <StyledRevisionMenu
             document={document}
             revision={revision}
-            label={<MoreIcon color={theme.white} />}
+            label={<MoreIcon />}
           />
         )}
       </StyledNavLink>
@@ -68,6 +68,15 @@ const StyledNavLink = styled(NavLink)`
   padding: 8px 16px;
   font-size: 15px;
   position: relative;
+
+  &:focus,
+  &:active {
+    ${StyledRevisionMenu} {
+      svg {
+        fill: ${props => props.theme.white};
+      }
+    }
+  }
 `;
 
 const Author = styled(Flex)`


### PR DESCRIPTION
Closes #1140.

---

![hover inconsistencies](https://user-images.githubusercontent.com/4522043/72981167-fe583500-3d90-11ea-87bb-3901fea873a4.gif)

Currently, this PR changes the color of the icon to fill with white when the revision is considered active.

It doesn't, however, work well in cases of:
- [ ] clicking directly on the icon (the icon turns white, and then fills back to normal)
- [ ] click-holding onto another revision (the icon turns white before the revision is highlighted)
- [ ] clicking anywhere else in the UI asides from `RevisionList` (the icon fills back to gray)

At this rate, it makes me feel like another approach should be taken, like passing some status (`active`?) down to `Revision`, and then using a specifically styled `MoreIcon` and swap based on that condition. Any thoughts?