### PR TITLE
feat: Add GitPod config for dev deployments thru Gitpod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ npm-debug.log
 stats.json
 .DS_Store
 fakes3/*
+package-lock.json

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,6 @@
+FROM gitpod/workspace-postgres
+                    
+USER gitpod
+
+## Install Nodejs 13.x
+RUN curl https://gitlab.com/MadeByThePinsTeam-DevLabs/bash-scripts-temps/-/raw/master/templates/nodejs/deb_install_13x.sh | bash -

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,3 +3,10 @@ tasks:
     command: npm run dev
 image:
   file: .gitpod.Dockerfile
+ports:
+  - port: 3000
+    onOpen: open-preview
+  - port: 6379
+    onOpen: ignore
+  - port: 5432
+    onOpen: ignore

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,5 @@
+tasks:
+  - init: npm install && npm run build:webpack && npm run sequelize:migrate
+    command: npm run dev
+image:
+  file: .gitpod.Dockerfile

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/outline/outline) 
+
 <p align="center">
   <img src="https://user-images.githubusercontent.com/31465/34380645-bd67f474-eb0b-11e7-8d03-0151c1730654.png" height="29" />
 </p>

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "mobx": "4.6.0",
     "mobx-react": "^5.4.2",
     "natural-sort": "^1.0.0",
+    "node": "^13.10.1",
     "nodemailer": "^4.4.0",
     "outline-icons": "^1.10.0",
     "oy-vey": "^0.10.0",


### PR DESCRIPTION
This merge request (pull request on GitHub) adds support for Gitpod.io, a free automated
dev environment that makes contributing and generally working on GitHub
projects much easier. It allows anyone to start a ready-to-code dev
environment for any branch, issue and pull request with a single click.

Feel free to test the config on your own and make suggestions. Feedback is welcome!