### PR TITLE
feat: Split up check for Slack environment variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,15 +29,23 @@ if (process.env.AWS_ACCESS_KEY_ID) {
 }
 
 if (process.env.SLACK_KEY) {
-  ['SLACK_SECRET', 'SLACK_VERIFICATION_TOKEN', 'SLACK_APP_ID'].forEach(key => {
-    if (!process.env[key]) {
-      console.error(
-        `The ${key} env variable must be set when using the Slack integration`
-      );
-      // $FlowFixMe
-      process.exit(1);
-    }
-  });
+  if (!process.env.SLACK_SECRET) {
+    console.error(
+      `The SLACK_SECRET env variable must be set when using Slack Sign In`
+    );
+    // $FlowFixMe
+    process.exit(1);
+  }
+}
+
+if (process.env.SLACK_APP_ID) {
+  if (!process.env.SLACK_VERIFICATION_TOKEN) {
+    console.error(
+      `The SLACK_VERIFICATION_TOKEN env variable must be set when using the Slack slash command`
+    );
+    // $FlowFixMe
+    process.exit(1);
+  }
 }
 
 if (!process.env.URL) {

--- a/index.js
+++ b/index.js
@@ -38,16 +38,6 @@ if (process.env.SLACK_KEY) {
   }
 }
 
-if (process.env.SLACK_APP_ID) {
-  if (!process.env.SLACK_VERIFICATION_TOKEN) {
-    console.error(
-      `The SLACK_VERIFICATION_TOKEN env variable must be set when using the Slack slash command`
-    );
-    // $FlowFixMe
-    process.exit(1);
-  }
-}
-
 if (!process.env.URL) {
   console.error(
     'The URL env variable must be set to the externally accessible URL, e.g (https://www.getoutline.com)'


### PR DESCRIPTION
This allows for the Slack slash command to be used without
needing Slack sign in enabled.

connects to #1199