### PR TITLE
feat: Ensure that editorVersion is saved with document/revisions

### DIFF
--- a/app/models/Document.js
+++ b/app/models/Document.js
@@ -1,5 +1,6 @@
 // @flow
 import { action, set, computed } from 'mobx';
+import pkg from 'rich-markdown-editor/package.json';
 import addDays from 'date-fns/add_days';
 import invariant from 'invariant';
 import { client } from 'utils/ApiClient';
@@ -180,6 +181,7 @@ export default class Document extends BaseModel {
     try {
       if (isCreating) {
         return await this.store.create({
+          editorVersion: pkg.version,
           parentDocumentId: this.parentDocumentId,
           collectionId: this.collectionId,
           title: this.title,
@@ -193,6 +195,7 @@ export default class Document extends BaseModel {
         title: this.title,
         text: this.text,
         lastRevision: this.revision,
+        editorVersion: pkg.version,
         ...options,
       });
     } finally {

--- a/server/api/documents.js
+++ b/server/api/documents.js
@@ -688,6 +688,7 @@ router.post('documents.create', auth(), async ctx => {
   const {
     title = '',
     text = '',
+    editorVersion,
     publish,
     collectionId,
     parentDocumentId,
@@ -726,6 +727,7 @@ router.post('documents.create', auth(), async ctx => {
 
   let document = await Document.create({
     parentDocumentId,
+    editorVersion,
     collectionId: collection.id,
     teamId: user.teamId,
     userId: user.id,
@@ -781,6 +783,7 @@ router.post('documents.update', auth(), async ctx => {
     publish,
     autosave,
     done,
+    editorVersion,
     lastRevision,
     append,
   } = ctx.body;
@@ -798,6 +801,7 @@ router.post('documents.update', auth(), async ctx => {
 
   // Update document
   if (title) document.title = title;
+  if (editorVersion) document.editorVersion = editorVersion;
 
   if (append) {
     document.text += text;

--- a/server/migrations/20200316040755-document-editor-version.js
+++ b/server/migrations/20200316040755-document-editor-version.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('documents', 'editorVersion', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+    await queryInterface.addColumn('revisions', 'editorVersion', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('documents', 'editorVersion');
+    await queryInterface.removeColumn('revisions', 'editorVersion');
+  }
+};

--- a/server/models/Document.js
+++ b/server/models/Document.js
@@ -37,6 +37,7 @@ const createRevision = (doc, options = {}) => {
       title: doc.title,
       text: doc.text,
       userId: doc.lastModifiedById,
+      editorVersion: doc.editorVersion,
       documentId: doc.id,
     },
     {
@@ -91,6 +92,7 @@ const Document = sequelize.define(
         },
       },
     },
+    editorVersion: DataTypes.STRING,
     text: DataTypes.TEXT,
     isWelcome: { type: DataTypes.BOOLEAN, defaultValue: false },
     revisionCount: { type: DataTypes.INTEGER, defaultValue: 0 },

--- a/server/models/Revision.js
+++ b/server/models/Revision.js
@@ -7,6 +7,7 @@ const Revision = sequelize.define('revision', {
     defaultValue: DataTypes.UUIDV4,
     primaryKey: true,
   },
+  editorVersion: DataTypes.STRING,
   title: DataTypes.STRING,
   text: DataTypes.TEXT,
 });


### PR DESCRIPTION
As we migrate to a brand new editor this will be useful to track and debug issues.

closes #1209 