### PR TITLE
perf: Optimized Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ COPY . $APP_PATH
 RUN yarn install --pure-lockfile
 RUN cp -r /opt/outline/node_modules /opt/node_modules
 
-CMD yarn build && yarn start
+RUN yarn build 
+
+CMD yarn start
 
 EXPOSE 3000


### PR DESCRIPTION
Previously "yarn build" was running on every container restart, making the container restart extremely slow. The build process should be part of the Docker build process, not the run process.