### PR TITLE
fix: Restore ability to disable embeds on a document

### DIFF
--- a/app/menus/DocumentMenu.js
+++ b/app/menus/DocumentMenu.js
@@ -123,6 +123,7 @@ class DocumentMenu extends React.Component<Props> {
       document,
       position,
       className,
+      showToggleEmbeds,
       showPrint,
       showPin,
       auth,
@@ -176,6 +177,19 @@ class DocumentMenu extends React.Component<Props> {
           >
             Share link…
           </DropdownMenuItem>
+        )}
+        {showToggleEmbeds && (
+          <React.Fragment>
+            {document.embedsDisabled ? (
+              <DropdownMenuItem onClick={document.enableEmbeds}>
+                Enable embeds
+              </DropdownMenuItem>
+            ) : (
+              <DropdownMenuItem onClick={document.disableEmbeds}>
+                Disable embeds
+              </DropdownMenuItem>
+            )}
+          </React.Fragment>
         )}
         {canViewHistory && (
           <React.Fragment>

--- a/app/models/Document.js
+++ b/app/models/Document.js
@@ -1,5 +1,5 @@
 // @flow
-import { action, set, computed } from 'mobx';
+import { action, set, observable, computed } from 'mobx';
 import pkg from 'rich-markdown-editor/package.json';
 import addDays from 'date-fns/add_days';
 import invariant from 'invariant';
@@ -15,7 +15,8 @@ import DocumentsStore from 'stores/DocumentsStore';
 type SaveOptions = { publish?: boolean, done?: boolean, autosave?: boolean };
 
 export default class Document extends BaseModel {
-  isSaving: boolean;
+  @observable isSaving: boolean = false;
+  @observable embedsDisabled: boolean = false;
   store: DocumentsStore;
 
   collaborators: User[];
@@ -108,6 +109,17 @@ export default class Document extends BaseModel {
 
   restore = (revision: Revision) => {
     return this.store.restore(this, revision);
+  };
+
+  @action
+  enableEmbeds = () => {
+    this.embedsDisabled = false;
+  };
+
+  @action
+  disableEmbeds = () => {
+    this.embedsDisabled = true;
+    debugger;
   };
 
   @action

--- a/app/scenes/Document/components/Document.js
+++ b/app/scenes/Document/components/Document.js
@@ -275,7 +275,8 @@ class DocumentScene extends React.Component<Props> {
       return <Loading location={location} />;
     }
 
-    const disableEmbeds = team && team.documentEmbeds === false;
+    const disableEmbeds =
+      (team && team.documentEmbeds === false) || document.embedsDisabled;
 
     return (
       <ErrorBoundary>


### PR DESCRIPTION
closes #1237