### PR TITLE
fix: Various extra scrollbars when not using mac-style overlaying scrollbars

### DIFF
--- a/app/components/DocumentHistory/DocumentHistory.js
+++ b/app/components/DocumentHistory/DocumentHistory.js
@@ -133,7 +133,8 @@ const Wrapper = styled(Flex)`
   right: 0;
   z-index: 1;
   min-width: ${props => props.theme.sidebarWidth};
-  overflow: scroll;
+  height: 100%;
+  overflow-y: auto;
   overscroll-behavior: none;
 `;
 
@@ -141,8 +142,6 @@ const Sidebar = styled(Flex)`
   background: ${props => props.theme.background};
   min-width: ${props => props.theme.sidebarWidth};
   border-left: 1px solid ${props => props.theme.divider};
-  overflow: scroll;
-  overscroll-behavior: none;
   z-index: 1;
 `;
 

--- a/app/components/InputRich.js
+++ b/app/components/InputRich.js
@@ -76,7 +76,7 @@ const StyledOutline = styled(Outline)`
   padding: 8px 12px;
   min-height: ${({ minHeight }) => (minHeight ? `${minHeight}px` : '0')};
   max-height: ${({ maxHeight }) => (maxHeight ? `${maxHeight}px` : 'auto')};
-  overflow: scroll;
+  overflow-y: auto;
 
   > * {
     display: block;

--- a/app/components/Layout.js
+++ b/app/components/Layout.js
@@ -142,7 +142,7 @@ const Container = styled(Flex)`
   background: ${props => props.theme.background};
   transition: ${props => props.theme.backgroundTransition};
   position: relative;
-  width: 100vw;
+  width: 100%;
   min-height: 100%;
 `;
 

--- a/app/components/Sidebar/Sidebar.js
+++ b/app/components/Sidebar/Sidebar.js
@@ -97,7 +97,7 @@ const Container = styled(Flex)`
     left: ${props => (props.editMode ? `-${props.theme.sidebarWidth}` : 0)};
     width: ${props => props.theme.sidebarWidth};
     margin: 0;
-    z-index: 2;
+    z-index: 3;
   `};
 `;
 

--- a/server/pages/developers/index.js
+++ b/server/pages/developers/index.js
@@ -146,7 +146,7 @@ const Pre = styled.pre`
   background: #f9fbfc;
   border-radius: 4px;
   border: 1px solid #e8ebed;
-  overflow: scroll;
+  overflow: auto;
 `;
 
 const Code = styled.code`


### PR DESCRIPTION
According to [caniuse](https://caniuse.com/#feat=viewport-units) 100vw not considering scrollbars is considered a layout bug in the browsers:

![image](https://user-images.githubusercontent.com/380914/80268107-af54c100-8659-11ea-88d4-e750b21feded.png)

closes #1241