### PR TITLE
fix: Prevent accessToken leakage on subdomain redirect

### DIFF
--- a/server/auth/index.js
+++ b/server/auth/index.js
@@ -22,16 +22,20 @@ router.use('/', email.routes());
 router.get('/redirect', auth(), async ctx => {
   const user = ctx.state.user;
 
-  // transfer access token cookie from root to subdomain
-  ctx.cookies.set('accessToken', undefined, {
-    httpOnly: true,
-    domain: stripSubdomain(ctx.request.hostname),
-  });
+  // transfer access token cookie from root to subdomain,
+  // only if it exists already. Otherwise we would
+  // convert an api-token to an access-token.
+  if (ctx.cookies.get('accessToken') !== '') {
+    ctx.cookies.set('accessToken', undefined, {
+      httpOnly: true,
+      domain: stripSubdomain(ctx.request.hostname),
+    });
 
-  ctx.cookies.set('accessToken', user.getJwtToken(), {
-    httpOnly: false,
-    expires: addMonths(new Date(), 3),
-  });
+    ctx.cookies.set('accessToken', user.getJwtToken(), {
+      httpOnly: false,
+      expires: addMonths(new Date(), 3),
+    });
+  }
 
   const team = await Team.findByPk(user.teamId);
   ctx.redirect(`${team.url}/home`);


### PR DESCRIPTION
### Possible Priviledge Escalation using API Token 
I filed the following vulnerability report:
> The subdomain cookie translation route at /auth/redirect
https://github.com/outline/outline/blob/d914ecb603bbd72c7fd1e56e63693f317f5257bc/server/auth/index.js#L22
creates an accessToken cookie, even if it did not exist before (it does not exist if the requester authenticated with an apiToken). If the requester now intercepts the response to redirect, he is able to obtain the accessToken.
> Because there are no (not that many?) accessibility differences between an apiToken and an accessToken (besides websocket connectivity), exploiting this issue does not yield more capabilities. But in case there are per-token policies implemented in the future, relying on the current redirect code will yield power to exploiters, namely priviledge escalation.

@tommoor wrote:
> Thanks for reporting in a responsible manner. I've taken a look at your example and whilst as you mentioned I can't see any way that this would result in privilege escalation _today_ (the API token and access token are always identical) it does seem like a weak point in the architecture that would be nice to shore up.
> I'd be happy to accept the PR, given that neither of us can see ways to directly exploit It should be fine to submit that against the public repo?

### Fix
Only set the `accessToken` cookie if it exists already. https://github.com/outline/outline/commit/19e7daaf2c555c58eb95bc4b0654e2c7d543ffc0