### PR TITLE
fix: Content Security Policy font-src

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -137,6 +137,7 @@ app.use(
       ],
       styleSrc: ["'self'", "'unsafe-inline'", 'github.githubassets.com'],
       imgSrc: ['*', 'data:', 'blob:'],
+      fontSrc: ['*', 'data:'],
       frameSrc: ['*'],
       connectSrc: compact([
         "'self'",


### PR DESCRIPTION
Because `font-src` CSP was not defined, it was falling back to `default-src` which only allowed loading fonts from the same origin. The proposed rule allows loading fonts from any origin and inline `data:`.