### PR TITLE
fix: Server error when listing memberships for group with deleted user

### DIFF
--- a/server/api/groups.js
+++ b/server/api/groups.js
@@ -40,9 +40,12 @@ router.post('groups.list', auth(), pagination(), async ctx => {
     data: {
       groups: groups.map(presentGroup),
       groupMemberships: groups
-        .map(g => g.groupMemberships.slice(0, MAX_AVATAR_DISPLAY))
+        .map(g =>
+          g.groupMemberships
+            .filter(membership => !!membership.user)
+            .slice(0, MAX_AVATAR_DISPLAY)
+        )
         .flat()
-        .filter(gM => gM.user)
         .map(presentGroupMembership),
     },
     policies: presentPolicies(user, groups),

--- a/server/api/groups.js
+++ b/server/api/groups.js
@@ -42,6 +42,7 @@ router.post('groups.list', auth(), pagination(), async ctx => {
       groupMemberships: groups
         .map(g => g.groupMemberships.slice(0, MAX_AVATAR_DISPLAY))
         .flat()
+        .filter(gM => gM.user)
         .map(presentGroupMembership),
     },
     policies: presentPolicies(user, groups),


### PR DESCRIPTION
Ideally this would be solved at the query level, but adding `required: true` on the GroupUser association causes us to bump into [this old Sequelize bug](https://github.com/sequelize/sequelize/issues/9869) – it generates an invalid query.

closes https://github.com/outline/outline/issues/1287