### PR TITLE
fix: allow one part domains in links

### DIFF
--- a/app/models/Document.js
+++ b/app/models/Document.js
@@ -118,7 +118,6 @@ export default class Document extends BaseModel {
   @action
   disableEmbeds = () => {
     this.embedsDisabled = true;
-    debugger;
   };
 
   @action

--- a/app/utils/isInternalUrl.js
+++ b/app/utils/isInternalUrl.js
@@ -6,6 +6,7 @@ export default function isInternalUrl(href: string) {
 
   const outline = parseDomain(window.location.href);
   const parsed = parseDomain(href);
+
   if (
     parsed &&
     outline &&

--- a/shared/utils/domains.js
+++ b/shared/utils/domains.js
@@ -44,7 +44,7 @@ export function parseDomain(url: string): ?Domain {
     return {
       subdomain: "",
       domain: cleanTLD(parts.slice(0).join()),
-      tld: cleanTLD(parts.slice(0).join()),
+      tld: "",
     };
   }
 

--- a/shared/utils/domains.js
+++ b/shared/utils/domains.js
@@ -39,6 +39,15 @@ export function parseDomain(url: string): ?Domain {
     };
   }
 
+  // one-part domain handler for things like localhost
+  if (parts.length === 1) {
+    return {
+      subdomain: "",
+      domain: cleanTLD(parts.slice(0).join()),
+      tld: cleanTLD(parts.slice(0).join()),
+    };
+  }
+
   return null;
 }
 

--- a/shared/utils/domains.js
+++ b/shared/utils/domains.js
@@ -12,6 +12,7 @@ type Domain = {
 // unneccessarily for our usecase of trusted input.
 export function parseDomain(url: string): ?Domain {
   if (typeof url !== "string") return null;
+  if (url === "") return null;
 
   // strip extermeties and whitespace from input
   const normalizedDomain = trim(url.replace(/(https?:)?\/\//, ""));


### PR DESCRIPTION
adds a case in `util/domains` to account for one-part domains like `localhost:3000`