### PR TITLE
fix: Do not load Analytics if env is empty

### DIFF
--- a/app/components/Analytics.js
+++ b/app/components/Analytics.js
@@ -8,8 +8,6 @@ type Props = {
 
 export default class Analytics extends React.Component<Props> {
   componentDidMount() {
-    if (!process.env.GOOGLE_ANALYTICS_ID) return;
-
     // standard Google Analytics script
     window.ga =
       window.ga ||

--- a/app/components/Layout.js
+++ b/app/components/Layout.js
@@ -103,7 +103,7 @@ class Layout extends React.Component<Props> {
             content="width=device-width, initial-scale=1.0"
           />
         </Helmet>
-        <Analytics />
+        {process.env.GOOGLE_ANALYTICS_ID && <Analytics />}
 
         {this.props.ui.progressBarVisible && <LoadingIndicatorBar />}
         {this.props.notifications}


### PR DESCRIPTION
Avoid loading a script unnecessarily