### PR TITLE
feat: nicer gradient mask for hover previews

### DIFF
--- a/app/components/HoverPreview.js
+++ b/app/components/HoverPreview.js
@@ -178,14 +178,15 @@ const Card = styled.div`
     position: absolute;
     pointer-events: none;
     background: linear-gradient(
-      180deg,
+      90deg,
       ${props => transparentize(1, props.theme.background)} 0%,
-      ${props => props.theme.background} 90%
+      ${props => transparentize(1, props.theme.background)} 70%,
+      ${props => props.theme.background} 100%
     );
     bottom: 0;
     left: 0;
     right: 0;
-    height: 4em;
+    height: 1.7em;
     border-bottom: 16px solid ${props => props.theme.background};
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;

--- a/app/components/HoverPreview.js
+++ b/app/components/HoverPreview.js
@@ -180,8 +180,8 @@ const Card = styled.div`
     background: linear-gradient(
       90deg,
       ${props => transparentize(1, props.theme.background)} 0%,
-      ${props => transparentize(1, props.theme.background)} 70%,
-      ${props => props.theme.background} 100%
+      ${props => transparentize(1, props.theme.background)} 75%,
+      ${props => props.theme.background} 90%
     );
     bottom: 0;
     left: 0;


### PR DESCRIPTION
For previews that do not use all the available space, it's nicer when we don't mask any of the content

---
![image](https://user-images.githubusercontent.com/427579/87864387-82444180-c91c-11ea-9643-bd68d9a82727.png)

For previews that use all of the space, mask only the last part of the last line for readability and implied continuation

---
![image](https://user-images.githubusercontent.com/427579/87864370-5759ed80-c91c-11ea-9058-872be5d2949c.png)

This is similar to what Wikipedia does

---
![image](https://user-images.githubusercontent.com/427579/87864381-680a6380-c91c-11ea-9270-0888a195e822.png)
 