### PR TITLE
refactor: Fix updater's use of the UPDATES_KEY constant

### DIFF
--- a/server/utils/updates.js
+++ b/server/utils/updates.js
@@ -45,7 +45,7 @@ export default async () => {
     },
   });
 
-  await client.del("UPDATES_KEY");
+  await client.del(UPDATES_KEY);
 
   try {
     const response = await fetch(UPDATES_URL, {


### PR DESCRIPTION
Was taking a peek at the file and noticed that this literal was probably supposed to be the `UPDATES_KEY` constant instead.