### PR TITLE
fix: added missing call to onOpen

### DIFF
--- a/app/components/IconPicker.js
+++ b/app/components/IconPicker.js
@@ -171,6 +171,7 @@ class IconPicker extends React.Component<Props> {
           <LabelText>Icon</LabelText>
         </label>
         <DropdownMenu
+          onOpen={this.handleOpen}
           label={
             <LabelButton>
               <Component role="button" color={this.props.color} size={30} />


### PR DESCRIPTION
closes https://github.com/outline/outline/issues/1377

handleOpen was already defined just not wired through
```ts
  handleNameChange = (ev: SyntheticInputEvent<*>) => {
    this.name = ev.target.value;

    // If the user hasn't picked an icon yet, go ahead and suggest one based on
    // the name of the collection. It's the little things sometimes.
    if (!this.hasOpenedIconPicker) {
      const keys = Object.keys(icons);
      for (const key of keys) {
        const icon = icons[key];
        const keywords = icon.keywords.split(" ");
        const namewords = this.name.toLowerCase().split(" ");
        const matches = intersection(namewords, keywords);

        if (matches.length > 0) {
          this.icon = key;
          return;
        }
      }

      this.icon = "collection";
    }
  };

  handleIconPickerOpen = () => {
    this.hasOpenedIconPicker = true;
  };
```
...
```ts
  handleOpen = () => {
    this.isOpen = true;

    if (this.props.onOpen) {
      this.props.onOpen();
    }
  };
```

