### PR TITLE
pref: JS bundling improvements

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,30 +10,30 @@ require('dotenv').config({ silent: true });
 module.exports = {
   output: {
     path: path.join(__dirname, 'dist'),
-    filename: 'bundle.js',
+    filename: '[name].[contenthash].js',
     publicPath: '/static/',
   },
   module: {
     rules: [
       {
-        test: /\.js$/,
-        loader: 'babel-loader',
-        exclude: [
-          path.join(__dirname, 'node_modules')
-        ],
-        include: [
-          path.join(__dirname, 'app'),
-          path.join(__dirname, 'shared'),
-        ],
-        options: {
-          cacheDirectory: true
-        }
+       test: /\.js$/,
+       loader: 'babel-loader',
+       exclude: [
+         path.join(__dirname, 'node_modules')
+       ],
+       include: [
+         path.join(__dirname, 'app'),
+         path.join(__dirname, 'shared'),
+       ],
+       options: {
+         cacheDirectory: true
+       }
       },
       // inline base64 URLs for <=8k images, direct URLs for the rest
       { test: /\.(png|jpg|svg)$/, loader: 'url-loader' },
       {
-        test: /\.woff$/,
-        loader: 'url-loader?limit=1&mimetype=application/font-woff&name=public/fonts/[name].[ext]',
+       test: /\.woff$/,
+       loader: 'url-loader?limit=1&mimetype=application/font-woff&name=public/fonts/[name].[ext]',
       },
       { test: /\.md/, loader: 'raw-loader' },
     ]
@@ -64,4 +64,17 @@ module.exports = {
   stats: {
     assets: false,
   },
+  optimization: {
+    runtimeChunk: 'single',
+    moduleIds: 'hashed',
+    splitChunks: {
+      cacheGroups: {
+        vendor: {
+          test: /[\\/]node_modules[\\/]/,
+          name: 'vendors',
+          chunks: 'all',
+        },
+      },
+    },
+  }
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,7 @@ require('dotenv').config({ silent: true });
 module.exports = {
   output: {
     path: path.join(__dirname, 'dist'),
-    filename: '[name].[contenthash].js',
+    filename: '[name].[hash].js',
     publicPath: '/static/',
   },
   module: {
@@ -72,7 +72,7 @@ module.exports = {
         vendor: {
           test: /[\\/]node_modules[\\/]/,
           name: 'vendors',
-          chunks: 'all',
+          chunks: 'initial',
         },
       },
     },

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -7,6 +7,11 @@ const TerserPlugin = require('terser-webpack-plugin');
 commonWebpackConfig = require('./webpack.config');
 
 productionWebpackConfig = Object.assign(commonWebpackConfig, {
+  output: {
+    path: path.join(__dirname, 'dist'),
+    filename: '[name].[contenthash].js',
+    publicPath: '/static/',
+  },
   cache: true,
   mode: "production",
   devtool: 'source-map',

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -11,13 +11,9 @@ productionWebpackConfig = Object.assign(commonWebpackConfig, {
   mode: "production",
   devtool: 'source-map',
   entry: ['./app/index'],
-  output: {
-    path: path.join(__dirname, 'dist'),
-    filename: 'bundle.[hash].js',
-    publicPath: '/static/',
-  },
   stats: "normal",
   optimization: {
+    ...commonWebpackConfig.optimization,
     minimizer: [
       new TerserPlugin({
         terserOptions: {


### PR DESCRIPTION
Both of these updates do not change the initial download size, but they should massively reduce subsequent downloads when new deploys of the app go out.

- Split initial vendors and runtime into their own bundles
- Correctly hash bundles based on content so they don't need reloading on every deploy

closes #1460 