### PR TITLE
feat: Allow unpublishing documents

### DIFF
--- a/app/menus/DocumentMenu.js
+++ b/app/menus/DocumentMenu.js
@@ -106,6 +106,11 @@ class DocumentMenu extends React.Component<Props> {
     this.props.ui.showToast("Document restored");
   };
 
+  handleUnpublish = async (ev: SyntheticEvent<>) => {
+    await this.props.document.unpublish();
+    this.props.ui.showToast("Document unpublished");
+  };
+
   handlePin = (ev: SyntheticEvent<>) => {
     this.props.document.pin();
   };
@@ -174,26 +179,26 @@ class DocumentMenu extends React.Component<Props> {
           {showPin &&
             (document.pinned
               ? can.unpin && (
-                  <DropdownMenuItem onClick={this.handleUnpin}>
-                    Unpin
-                  </DropdownMenuItem>
-                )
-              : can.pin && (
-                  <DropdownMenuItem onClick={this.handlePin}>
-                    Pin to collection
-                  </DropdownMenuItem>
-                ))}
-          {document.isStarred
-            ? can.unstar && (
-                <DropdownMenuItem onClick={this.handleUnstar}>
-                  Unstar
+                <DropdownMenuItem onClick={this.handleUnpin}>
+                  Unpin
                 </DropdownMenuItem>
               )
-            : can.star && (
-                <DropdownMenuItem onClick={this.handleStar}>
-                  Star
+              : can.pin && (
+                <DropdownMenuItem onClick={this.handlePin}>
+                  Pin to collection
                 </DropdownMenuItem>
-              )}
+              ))}
+          {document.isStarred
+            ? can.unstar && (
+              <DropdownMenuItem onClick={this.handleUnstar}>
+                Unstar
+              </DropdownMenuItem>
+            )
+            : can.star && (
+              <DropdownMenuItem onClick={this.handleStar}>
+                Star
+              </DropdownMenuItem>
+            )}
           {canShareDocuments && (
             <DropdownMenuItem
               onClick={this.handleShareLink}
@@ -209,10 +214,10 @@ class DocumentMenu extends React.Component<Props> {
                   Enable embeds
                 </DropdownMenuItem>
               ) : (
-                <DropdownMenuItem onClick={document.disableEmbeds}>
-                  Disable embeds
-                </DropdownMenuItem>
-              )}
+                  <DropdownMenuItem onClick={document.disableEmbeds}>
+                    Disable embeds
+                  </DropdownMenuItem>
+                )}
             </>
           )}
           {!can.restore && <hr />}
@@ -223,6 +228,11 @@ class DocumentMenu extends React.Component<Props> {
               title="Create a nested document inside the current document"
             >
               New nested document
+            </DropdownMenuItem>
+          )}
+          {!document.isArchived && !document.isDeleted && !document.isDraft && (
+            <DropdownMenuItem onClick={this.handleUnpublish}>
+              Unpublish
             </DropdownMenuItem>
           )}
           {can.update && !document.isTemplate && (

--- a/app/menus/DocumentMenu.js
+++ b/app/menus/DocumentMenu.js
@@ -3,7 +3,6 @@ import { observable } from "mobx";
 import { inject, observer } from "mobx-react";
 import * as React from "react";
 import { Redirect } from "react-router-dom";
-
 import AuthStore from "stores/AuthStore";
 import CollectionStore from "stores/CollectionsStore";
 import PoliciesStore from "stores/PoliciesStore";
@@ -15,10 +14,10 @@ import DocumentTemplatize from "scenes/DocumentTemplatize";
 import { DropdownMenu, DropdownMenuItem } from "components/DropdownMenu";
 import Modal from "components/Modal";
 import {
-  documentUrl,
-  documentMoveUrl,
-  editDocumentUrl,
   documentHistoryUrl,
+  documentMoveUrl,
+  documentUrl,
+  editDocumentUrl,
   newDocumentUrl,
 } from "utils/routeHelpers";
 
@@ -230,7 +229,7 @@ class DocumentMenu extends React.Component<Props> {
               New nested document
             </DropdownMenuItem>
           )}
-          {!document.isArchived && !document.isDeleted && !document.isDraft && (
+          {can.unpublish && (
             <DropdownMenuItem onClick={this.handleUnpublish}>
               Unpublish
             </DropdownMenuItem>

--- a/app/menus/DocumentMenu.js
+++ b/app/menus/DocumentMenu.js
@@ -179,26 +179,26 @@ class DocumentMenu extends React.Component<Props> {
           {showPin &&
             (document.pinned
               ? can.unpin && (
-                <DropdownMenuItem onClick={this.handleUnpin}>
-                  Unpin
-                </DropdownMenuItem>
-              )
+                  <DropdownMenuItem onClick={this.handleUnpin}>
+                    Unpin
+                  </DropdownMenuItem>
+                )
               : can.pin && (
-                <DropdownMenuItem onClick={this.handlePin}>
-                  Pin to collection
-                </DropdownMenuItem>
-              ))}
+                  <DropdownMenuItem onClick={this.handlePin}>
+                    Pin to collection
+                  </DropdownMenuItem>
+                ))}
           {document.isStarred
             ? can.unstar && (
-              <DropdownMenuItem onClick={this.handleUnstar}>
-                Unstar
-              </DropdownMenuItem>
-            )
+                <DropdownMenuItem onClick={this.handleUnstar}>
+                  Unstar
+                </DropdownMenuItem>
+              )
             : can.star && (
-              <DropdownMenuItem onClick={this.handleStar}>
-                Star
-              </DropdownMenuItem>
-            )}
+                <DropdownMenuItem onClick={this.handleStar}>
+                  Star
+                </DropdownMenuItem>
+              )}
           {canShareDocuments && (
             <DropdownMenuItem
               onClick={this.handleShareLink}
@@ -214,10 +214,10 @@ class DocumentMenu extends React.Component<Props> {
                   Enable embeds
                 </DropdownMenuItem>
               ) : (
-                  <DropdownMenuItem onClick={document.disableEmbeds}>
-                    Disable embeds
-                  </DropdownMenuItem>
-                )}
+                <DropdownMenuItem onClick={document.disableEmbeds}>
+                  Disable embeds
+                </DropdownMenuItem>
+              )}
             </>
           )}
           {!can.restore && <hr />}

--- a/app/models/Document.js
+++ b/app/models/Document.js
@@ -2,12 +2,12 @@
 import addDays from "date-fns/add_days";
 import invariant from "invariant";
 import { action, computed, observable, set } from "mobx";
-import BaseModel from "models/BaseModel";
-import Revision from "models/Revision";
-import User from "models/User";
 import parseTitle from "shared/utils/parseTitle";
 import unescape from "shared/utils/unescape";
 import DocumentsStore from "stores/DocumentsStore";
+import BaseModel from "models/BaseModel";
+import Revision from "models/Revision";
+import User from "models/User";
 
 type SaveOptions = {
   publish?: boolean,

--- a/app/models/Document.js
+++ b/app/models/Document.js
@@ -1,13 +1,13 @@
 // @flow
 import addDays from "date-fns/add_days";
 import invariant from "invariant";
-import { action, set, observable, computed } from "mobx";
-import parseTitle from "shared/utils/parseTitle";
-import unescape from "shared/utils/unescape";
-import DocumentsStore from "stores/DocumentsStore";
+import { action, computed, observable, set } from "mobx";
 import BaseModel from "models/BaseModel";
 import Revision from "models/Revision";
 import User from "models/User";
+import parseTitle from "shared/utils/parseTitle";
+import unescape from "shared/utils/unescape";
+import DocumentsStore from "stores/DocumentsStore";
 
 type SaveOptions = {
   publish?: boolean,
@@ -143,6 +143,10 @@ export default class Document extends BaseModel {
 
   restore = (revision: Revision) => {
     return this.store.restore(this, revision);
+  };
+
+  unpublish = () => {
+    return this.store.unpublish(this);
   };
 
   @action

--- a/app/stores/DocumentsStore.js
+++ b/app/stores/DocumentsStore.js
@@ -535,6 +535,22 @@ export default class DocumentsStore extends BaseStore<Document> {
     if (collection) collection.refresh();
   };
 
+  @action
+  unpublish = async (document: Document) => {
+    const res = await client.post("/documents.unpublish", {
+      id: document.id,
+    });
+
+    runInAction("Document#unpublish", () => {
+      invariant(res && res.data, "Data should be available");
+      document.updateFromJson(res.data);
+      this.addPolicies(res.policies);
+    });
+
+    const collection = this.getCollectionForDocument(document);
+    if (collection) collection.refresh();
+  };
+
   pin = (document: Document) => {
     return client.post("/documents.pin", { id: document.id });
   };

--- a/server/models/Document.js
+++ b/server/models/Document.js
@@ -12,7 +12,6 @@ import { DataTypes, sequelize } from "../sequelize";
 import slugify from "../utils/slugify";
 import Revision from "./Revision";
 
-
 const Op = Sequelize.Op;
 const URL_REGEX = /^[0-9a-zA-Z-_~]*-([a-zA-Z0-9]{10,15})$/;
 const serializer = new MarkdownSerializer();
@@ -371,19 +370,19 @@ Document.searchForUser = async (
     "teamId" = :teamId AND
     "collectionId" IN(:collectionIds) AND
     ${
-    options.dateFilter ? '"updatedAt" > now() - interval :dateFilter AND' : ""
+      options.dateFilter ? '"updatedAt" > now() - interval :dateFilter AND' : ""
     }
     ${
-    options.collaboratorIds
-      ? '"collaboratorIds" @> ARRAY[:collaboratorIds]::uuid[] AND'
-      : ""
+      options.collaboratorIds
+        ? '"collaboratorIds" @> ARRAY[:collaboratorIds]::uuid[] AND'
+        : ""
     }
     ${options.includeArchived ? "" : '"archivedAt" IS NULL AND'}
     "deletedAt" IS NULL AND
     ${
-    options.includeDrafts
-      ? '("publishedAt" IS NOT NULL OR "createdById" = :userId)'
-      : '"publishedAt" IS NOT NULL'
+      options.includeDrafts
+        ? '("publishedAt" IS NOT NULL OR "createdById" = :userId)'
+        : '"publishedAt" IS NOT NULL'
     }
   ORDER BY
     "searchRanking" DESC,

--- a/server/models/Document.js
+++ b/server/models/Document.js
@@ -556,7 +556,7 @@ Document.prototype.publish = async function (options) {
 };
 
 Document.prototype.unpublish = async function (options) {
-  if (!this.publishedAt) return this.save(options);
+  if (!this.publishedAt) return this;
 
   const collection = await this.getCollection();
   await collection.removeDocumentInStructure(this);

--- a/server/policies/document.js
+++ b/server/policies/document.js
@@ -155,7 +155,15 @@ allow(User, "unpublish", Document, (user, document) => {
 
   if (cannot(user, "update", document.collection)) return false;
 
-  // TODO Block unpublish a document that has nested documents
+  const documentID = document.id;
+  const hasChild = (documents) =>
+    documents.some((doc) => {
+      if (doc.id === documentID) return doc.children.length > 0;
+      return hasChild(doc.children);
+    });
 
-  return user.teamId === document.teamId;
+  return (
+    !hasChild(document.collection.documentStructure) &&
+    user.teamId === document.teamId
+  );
 });

--- a/server/policies/document.js
+++ b/server/policies/document.js
@@ -143,3 +143,19 @@ allow(
   Revision,
   (document, revision) => document.id === revision.documentId
 );
+
+allow(User, "unpublish", Document, (user, document) => {
+  invariant(
+    document.collection,
+    "collection is missing, did you forget to include in the query scope?"
+  );
+
+  if (!document.publishedAt || !!document.deletedAt || !!document.archivedAt)
+    return false;
+
+  if (cannot(user, "update", document.collection)) return false;
+
+  // TODO Block unpublish a document that has nested documents
+
+  return user.teamId === document.teamId;
+});


### PR DESCRIPTION
Implements the action to allow unpublish a document.
This option is only available for a publish document that wasn't archived or deleted.
Should check if the permissions for allowing whom can unpublish are set correctly.