### PR TITLE
feat: preview draft location in collections tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ npm-debug.log
 stats.json
 .DS_Store
 fakes3/*
+.idea

--- a/app/components/Sidebar/components/CollectionLink.js
+++ b/app/components/Sidebar/components/CollectionLink.js
@@ -1,6 +1,7 @@
 // @flow
 import { observable } from "mobx";
 import { observer } from "mobx-react";
+import { EditIcon } from "outline-icons";
 import * as React from "react";
 import DocumentsStore from "stores/DocumentsStore";
 import UiStore from "stores/UiStore";
@@ -31,9 +32,14 @@ class CollectionLink extends React.Component<Props> {
       documents,
       activeDocument,
       prefetchDocument,
+      // activeDocumentRef,
       ui,
     } = this.props;
     const expanded = collection.id === ui.activeCollectionId;
+    const draftDocuments = documents
+      .draftsInCollection(collection.id)
+      .filter((document) => !document.parentDocumentId);
+    const hasDraftDocuments = !!draftDocuments.length;
 
     return (
       <DropToImport
@@ -61,6 +67,18 @@ class CollectionLink extends React.Component<Props> {
           }
         >
           <Flex column>
+            {hasDraftDocuments &&
+              draftDocuments.map((document) => (
+                <SidebarLink
+                  // ref={!!activeDocument && activeDocument.id === document.id ? activeDocumentRef : undefined}
+                  key={document.id}
+                  to={document.url}
+                  icon={<EditIcon color="currentColor" />}
+                  label={document.title}
+                  active={!!activeDocument && activeDocument.id === document.id}
+                  exact
+                />
+              ))}
             {collection.documents.map((node) => (
               <DocumentLink
                 key={node.id}

--- a/app/components/Sidebar/components/DocumentLink.js
+++ b/app/components/Sidebar/components/DocumentLink.js
@@ -1,6 +1,7 @@
 // @flow
 import { observable } from "mobx";
 import { observer } from "mobx-react";
+import { EditIcon } from "outline-icons";
 import * as React from "react";
 import styled from "styled-components";
 import DocumentsStore from "stores/DocumentsStore";
@@ -57,7 +58,7 @@ class DocumentLink extends React.Component<Props> {
   };
 
   hasChildDocuments = () => {
-    return !!this.props.node.children.length;
+    return !!this.props.node.children?.length;
   };
 
   render() {
@@ -81,6 +82,14 @@ class DocumentLink extends React.Component<Props> {
         this.isActiveDocument())
     );
     const document = documents.get(node.id);
+
+    const draftDocuments = documents
+      .draftsInCollection(collection.id)
+      .filter(
+        (_document) =>
+          !!_document.parentDocumentId && _document.parentDocumentId === node.id
+      );
+    const hasDraftDocuments = !!draftDocuments.length;
 
     return (
       <Flex
@@ -113,8 +122,23 @@ class DocumentLink extends React.Component<Props> {
               ) : undefined
             }
           >
-            {this.hasChildDocuments() && (
+            {(this.hasChildDocuments(draftDocuments) || hasDraftDocuments) && (
               <DocumentChildren column>
+                {hasDraftDocuments &&
+                  draftDocuments.map((document) => (
+                    <SidebarLink
+                      // ref={!!activeDocument && activeDocument.id === document.id ? activeDocumentRef : undefined}
+                      key={document.id}
+                      to={document.url}
+                      icon={<EditIcon color="currentColor" />}
+                      label={document.title}
+                      depth={depth + 1}
+                      active={
+                        !!activeDocument && activeDocument.id === document.id
+                      }
+                      exact
+                    />
+                  ))}
                 {node.children.map((childNode) => (
                   <DocumentLink
                     key={childNode.id}

--- a/app/scenes/Collection.js
+++ b/app/scenes/Collection.js
@@ -84,6 +84,10 @@ class CollectionScene extends React.Component<Props> {
       await this.props.documents.fetchPinned({
         collectionId: id,
       });
+
+      await this.props.documents.fetchDrafts({
+        collectionId: id,
+      });
     }
 
     this.isFetching = false;
@@ -250,8 +254,20 @@ class CollectionScene extends React.Component<Props> {
                   <Tab to={collectionUrl(collection.id, "alphabetical")} exact>
                     A–Z
                   </Tab>
+                  <Tab to={collectionUrl(collection.id, "drafts")} exact>
+                    Drafts
+                  </Tab>
                 </Tabs>
                 <Switch>
+                  <Route path={collectionUrl(collection.id, "drafts")}>
+                    <PaginatedDocumentList
+                      key="drafts"
+                      documents={documents.draftsInCollection(collection.id)}
+                      fetch={documents.fetchDrafts}
+                      options={{ collectionId: collection.id }}
+                      showPin
+                    />
+                  </Route>
                   <Route path={collectionUrl(collection.id, "alphabetical")}>
                     <PaginatedDocumentList
                       key="alphabetical"

--- a/app/scenes/Document/components/ReferenceListItem.js
+++ b/app/scenes/Document/components/ReferenceListItem.js
@@ -5,6 +5,8 @@ import { Link } from "react-router-dom";
 import styled from "styled-components";
 import Document from "models/Document";
 import DocumentMeta from "components/DocumentMeta";
+import Badge from "../../../components/Badge";
+import Tooltip from "../../../components/Tooltip";
 import type { NavigationNode } from "types";
 
 type Props = {
@@ -58,7 +60,15 @@ class ReferenceListItem extends React.Component<Props> {
         }}
         {...rest}
       >
-        <Title>{document.title}</Title>
+        <Title>
+          {document.title}
+          {document.isDraft && (
+            <Tooltip tooltip="Only visible to you" delay={500} placement="top">
+              <Badge>Draft</Badge>
+            </Tooltip>
+          )}
+        </Title>
+
         {document.updatedBy && (
           <DocumentMeta document={document} showCollection={showCollection} />
         )}

--- a/app/stores/DocumentsStore.js
+++ b/app/stores/DocumentsStore.js
@@ -100,6 +100,14 @@ export default class DocumentsStore extends BaseStore<Document> {
     );
   }
 
+  draftsInCollection(collectionId: string): Document[] {
+    return filter(
+      this.all,
+      (document) =>
+        document.collectionId === collectionId && !document.publishedAt
+    );
+  }
+
   publishedInCollection(collectionId: string): Document[] {
     return filter(
       this.all,


### PR DESCRIPTION
Show draft files in collections tree, previewing where the document will be when published.
Also, add new tab inside a collection, showing all drafts, and highlight nested drafts in a document