### PR TITLE
fix: Update package.json build script to use yarn instead of npm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "lint": "eslint app server shared",
     "flow": "flow",
     "deploy": "git push heroku master",
-    "heroku-postbuild": "npm run build && npm run sequelize:migrate",
+    "heroku-postbuild": "yarn build && yarn sequelize:migrate",
     "sequelize:create-migration": "sequelize migration:create",
     "sequelize:migrate": "sequelize db:migrate",
-    "test": "npm run test:app && npm run test:server",
+    "test": "yarn test:app && yarn test:server",
     "test:app": "jest",
     "test:server": "jest --config=server/.jestconfig.json --runInBand --forceExit",
     "test:watch": "jest --config=server/.jestconfig.json --runInBand --forceExit --watchAll"


### PR DESCRIPTION
Update package.json build script to use yarn instead of npm to maintain consistency with the rest of scripts. I was running into an issue with the Dockerfile when using nvm with yarn and this fixed the issue.