### PR TITLE
feat: add document events log menu

### DIFF
--- a/app/components/DocumentEvents.js
+++ b/app/components/DocumentEvents.js
@@ -1,0 +1,166 @@
+// @flow
+import { action, observable } from "mobx";
+import { inject, observer } from "mobx-react";
+import { CloseIcon } from "outline-icons";
+import * as React from "react";
+import { type Match, Redirect, type RouterHistory } from "react-router-dom";
+import { Waypoint } from "react-waypoint";
+import styled from "styled-components";
+
+import { DEFAULT_PAGINATION_LIMIT } from "stores/BaseStore";
+import EventListItem from "scenes/Settings/components/EventListItem";
+import Button from "components/Button";
+import Flex from "components/Flex";
+import { ListPlaceholder } from "components/LoadingPlaceholder";
+import CollectionsStore from "../stores/CollectionsStore";
+import DocumentsStore from "../stores/DocumentsStore";
+import EventsStore from "../stores/EventsStore";
+import { documentUrl } from "utils/routeHelpers";
+
+type Props = {
+  match: Match,
+  events: EventsStore,
+  documents: DocumentsStore,
+  collections: CollectionsStore,
+  history: RouterHistory,
+};
+
+@observer
+class DocumentEvents extends React.Component<Props> {
+  @observable isLoaded: boolean = false;
+  @observable isFetching: boolean = false;
+  @observable offset: number = 0;
+  @observable allowLoadMore: boolean = true;
+  @observable redirectTo: ?string;
+
+  componentDidMount() {
+    this.fetchResults();
+  }
+
+  fetchResults = async () => {
+    this.isFetching = true;
+
+    const results = await this.props.events.fetchPage({
+      limit: DEFAULT_PAGINATION_LIMIT,
+      offset: this.offset,
+      auditLog: true,
+      documentId: this.props.match.params.documentSlug,
+    });
+
+    if (
+      results &&
+      (results.length === 0 || results.length < DEFAULT_PAGINATION_LIMIT)
+    ) {
+      this.allowLoadMore = false;
+    } else {
+      this.offset += DEFAULT_PAGINATION_LIMIT;
+    }
+
+    this.isLoaded = true;
+    this.isFetching = false;
+  };
+
+  @action
+  loadMoreResults = async () => {
+    // Don't paginate if there aren't more results or we’re in the middle of fetching
+    if (!this.allowLoadMore || this.isFetching) return;
+    await this.fetchResults();
+  };
+
+  onClose = () => {
+    const document = this.props.documents.getByUrl(
+      this.props.match.params.documentSlug
+    );
+    if (!document) return;
+    this.redirectTo = documentUrl(document);
+  };
+
+  render() {
+    if (this.redirectTo) return <Redirect to={this.redirectTo} push />;
+    const { events, documents, collections } = this.props;
+    const showLoading = events.isFetching && !events.orderedData.length;
+
+    return (
+      <Sidebar>
+        <Wrapper column>
+          <Header justify={"center"}>
+            <Title>Events</Title>
+            <CloseButton
+              icon={<CloseIcon />}
+              onClick={this.onClose}
+              neutral
+              borderOnHover
+            />
+          </Header>
+          {showLoading ? (
+            <ListPlaceholder count={5} />
+          ) : (
+            <>
+              {events.orderedData.map((event) => (
+                <EventListItem
+                  key={event.id}
+                  event={event}
+                  documents={documents}
+                  collections={collections}
+                />
+              ))}
+              {this.allowLoadMore && (
+                <Waypoint key={this.offset} onEnter={this.loadMoreResults} />
+              )}
+            </>
+          )}
+        </Wrapper>
+      </Sidebar>
+    );
+  }
+}
+
+// const Loading = styled.div`
+//   margin: 0 16px;
+// `;
+
+const Wrapper = styled(Flex)`
+  position: fixed;
+  top: 0;
+  right: 0;
+  z-index: 1;
+  width: ${(props) => props.theme.sidebarWidth};
+  padding: 5px;
+  height: 100%;
+  overflow-y: auto;
+  overscroll-behavior: none;
+`;
+
+const Sidebar = styled(Flex)`
+  background: ${(props) => props.theme.background};
+  min-width: ${(props) => props.theme.sidebarWidth};
+  border-left: 1px solid ${(props) => props.theme.divider};
+  z-index: 1;
+`;
+
+const Title = styled.h3`
+  max-width: 90%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 20px;
+  margin-top: 0;
+  margin-bottom: 0.25em;
+  white-space: nowrap;
+  color: ${(props) => props.theme.text};
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
+    Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+`;
+
+const Header = styled(Flex)`
+  position: relative;
+  padding: 20px;
+  border-bottom: 1px solid ${(props) => props.theme.divider};
+`;
+
+const CloseButton = styled(Button)`
+  position: absolute;
+  top: 10px;
+  right: 10px;
+`;
+
+export default inject("documents", "collections", "events")(DocumentEvents);

--- a/app/components/DocumentEvents.js
+++ b/app/components/DocumentEvents.js
@@ -7,6 +7,7 @@ import { type Match, Redirect, type RouterHistory } from "react-router-dom";
 import { Waypoint } from "react-waypoint";
 import styled from "styled-components";
 
+import breakpoint from "styled-components-breakpoint";
 import { DEFAULT_PAGINATION_LIMIT } from "stores/BaseStore";
 import EventListItem from "scenes/Settings/components/EventListItem";
 import Button from "components/Button";
@@ -83,7 +84,7 @@ class DocumentEvents extends React.Component<Props> {
     return (
       <Sidebar>
         <Wrapper column>
-          <Header justify={"center"}>
+          <Header>
             <Title>Events</Title>
             <CloseButton
               icon={<CloseIcon />}
@@ -92,23 +93,25 @@ class DocumentEvents extends React.Component<Props> {
               borderOnHover
             />
           </Header>
-          {showLoading ? (
-            <ListPlaceholder count={5} />
-          ) : (
-            <>
-              {events.orderedData.map((event) => (
-                <EventListItem
-                  key={event.id}
-                  event={event}
-                  documents={documents}
-                  collections={collections}
-                />
-              ))}
-              {this.allowLoadMore && (
-                <Waypoint key={this.offset} onEnter={this.loadMoreResults} />
-              )}
-            </>
-          )}
+          <EventWrapper>
+            {showLoading ? (
+              <ListPlaceholder count={5} />
+            ) : (
+              <>
+                {events.orderedData.map((event) => (
+                  <EventListItem
+                    key={event.id}
+                    event={event}
+                    documents={documents}
+                    collections={collections}
+                  />
+                ))}
+                {this.allowLoadMore && (
+                  <Waypoint key={this.offset} onEnter={this.loadMoreResults} />
+                )}
+              </>
+            )}
+          </EventWrapper>
         </Wrapper>
       </Sidebar>
     );
@@ -125,7 +128,6 @@ const Wrapper = styled(Flex)`
   right: 0;
   z-index: 1;
   width: ${(props) => props.theme.sidebarWidth};
-  padding: 5px;
   height: 100%;
   overflow-y: auto;
   overscroll-behavior: none;
@@ -138,22 +140,27 @@ const Sidebar = styled(Flex)`
   z-index: 1;
 `;
 
-const Title = styled.h3`
-  max-width: 90%;
-  overflow: hidden;
+const Title = styled.div`
+  font-size: 16px;
+  font-weight: 600;
+  text-align: center;
+  align-items: center;
+  justify-content: flex-start;
   text-overflow: ellipsis;
-  font-size: 20px;
-  margin-top: 0;
-  margin-bottom: 0.25em;
   white-space: nowrap;
-  color: ${(props) => props.theme.text};
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
-    Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+  overflow: hidden;
+  display: none;
+  width: 0;
+
+  ${breakpoint("tablet")`	
+    display: flex;
+    flex-grow: 1;
+  `};
 `;
 
 const Header = styled(Flex)`
   position: relative;
-  padding: 20px;
+  padding: 15.8px;
   border-bottom: 1px solid ${(props) => props.theme.divider};
 `;
 
@@ -161,6 +168,10 @@ const CloseButton = styled(Button)`
   position: absolute;
   top: 10px;
   right: 10px;
+`;
+
+const EventWrapper = styled.div`
+  padding: 5px;
 `;
 
 export default inject("documents", "collections", "events")(DocumentEvents);

--- a/app/components/Layout.js
+++ b/app/components/Layout.js
@@ -21,6 +21,7 @@ import { LoadingIndicatorBar } from "components/LoadingIndicator";
 import Modal from "components/Modal";
 import Sidebar from "components/Sidebar";
 import SettingsSidebar from "components/Sidebar/Settings";
+import DocumentEvents from "./DocumentEvents";
 import {
   homeUrl,
   searchUrl,
@@ -124,6 +125,7 @@ class Layout extends React.Component<Props> {
               path={`/doc/${slug}/history/:revisionId?`}
               component={DocumentHistory}
             />
+            <Route path={`/doc/${slug}/events`} component={DocumentEvents} />
           </Switch>
         </Container>
         <Modal

--- a/app/menus/DocumentMenu.js
+++ b/app/menus/DocumentMenu.js
@@ -20,6 +20,7 @@ import {
   editDocumentUrl,
   documentHistoryUrl,
   newDocumentUrl,
+  documentEventsUrl,
 } from "utils/routeHelpers";
 
 type Props = {
@@ -66,6 +67,10 @@ class DocumentMenu extends React.Component<Props> {
     } else {
       this.redirectTo = documentHistoryUrl(this.props.document);
     }
+  };
+
+  handleDocumentEvents = () => {
+    this.redirectTo = documentEventsUrl(this.props.document);
   };
 
   handleMove = (ev: SyntheticEvent<>) => {
@@ -256,6 +261,13 @@ class DocumentMenu extends React.Component<Props> {
             <>
               <DropdownMenuItem onClick={this.handleDocumentHistory}>
                 History
+              </DropdownMenuItem>
+            </>
+          )}
+          {can.update && (
+            <>
+              <DropdownMenuItem onClick={this.handleDocumentEvents}>
+                Events
               </DropdownMenuItem>
             </>
           )}

--- a/app/routes/authenticated.js
+++ b/app/routes/authenticated.js
@@ -54,6 +54,7 @@ export default function AuthenticatedRoutes() {
             path={`/doc/${slug}/history/:revisionId?`}
             component={KeyedDocument}
           />
+          <Route exact path={`/doc/${slug}/events`} component={KeyedDocument} />
           <Route exact path={`/doc/${slug}/edit`} component={KeyedDocument} />
           <Route path={`/doc/${slug}`} component={KeyedDocument} />
           <Route exact path="/search" component={Search} />

--- a/app/scenes/Document/components/Header.js
+++ b/app/scenes/Document/components/Header.js
@@ -1,14 +1,14 @@
 // @flow
 import { throttle } from "lodash";
 import { observable } from "mobx";
-import { observer, inject } from "mobx-react";
+import { inject, observer } from "mobx-react";
 import {
-  TableOfContentsIcon,
   EditIcon,
   GlobeIcon,
   PlusIcon,
+  TableOfContentsIcon,
 } from "outline-icons";
-import { transparentize, darken } from "polished";
+import { transparentize } from "polished";
 import * as React from "react";
 import { Redirect } from "react-router-dom";
 import styled from "styled-components";
@@ -33,7 +33,7 @@ import DocumentMenu from "menus/DocumentMenu";
 import NewChildDocumentMenu from "menus/NewChildDocumentMenu";
 import TemplatesMenu from "menus/TemplatesMenu";
 import { meta } from "utils/keyboard";
-import { newDocumentUrl, editDocumentUrl } from "utils/routeHelpers";
+import { editDocumentUrl, newDocumentUrl } from "utils/routeHelpers";
 
 type Props = {
   auth: AuthStore,
@@ -379,10 +379,7 @@ const Actions = styled(Flex)`
   z-index: 2;
   background: ${(props) => transparentize(0.2, props.theme.background)};
   box-shadow: 0 1px 0
-    ${(props) =>
-      props.isCompact
-        ? darken(0.05, props.theme.sidebarBackground)
-        : "transparent"};
+    ${(props) => (props.isCompact ? props.theme.divider : "transparent")};
   padding: 12px;
   transition: all 100ms ease-out;
   transform: translate3d(0, 0, 0);

--- a/app/scenes/Settings/components/EventListItem.js
+++ b/app/scenes/Settings/components/EventListItem.js
@@ -7,12 +7,16 @@ import Event from "models/Event";
 import Avatar from "components/Avatar";
 import ListItem from "components/List/Item";
 import Time from "components/Time";
+import CollectionsStore from "../../../stores/CollectionsStore";
+import DocumentsStore from "../../../stores/DocumentsStore";
 
 type Props = {
   event: Event,
+  collections?: ?CollectionsStore,
+  documents?: ?DocumentsStore,
 };
 
-const description = (event) => {
+const description = (event, collections, documents) => {
   switch (event.name) {
     case "api_keys.create":
       return (
@@ -157,6 +161,37 @@ const description = (event) => {
         </>
       );
     }
+    if (event.name === "documents.move") {
+      const moveFromCollection = event.data.collectionIds?.length > 1;
+
+      let source, target;
+      if (moveFromCollection) {
+        source = collections.get(event.data.collectionIds[0]).name;
+        target = collections.get(event.data.collectionIds[1]).name;
+      }
+
+      return (
+        <>
+          {capitalize(event.verbPastTense)} the{" "}
+          <Link to={`/doc/${event.documentId}`}>
+            {event.data.title || "Untitled"}
+          </Link>{" "}
+          document{" "}
+          {moveFromCollection && (
+            <>
+              from{" "}
+              <Link to={`/collections/${event.data.collectionIds[0]}`}>
+                {source}
+              </Link>{" "}
+              to{" "}
+              <Link to={`/collections/${event.data.collectionIds[1]}`}>
+                {target}
+              </Link>
+            </>
+          )}
+        </>
+      );
+    }
     return (
       <>
         {capitalize(event.verbPastTense)} the{" "}
@@ -195,7 +230,7 @@ const description = (event) => {
   return "";
 };
 
-const EventListItem = ({ event }: Props) => {
+const EventListItem = ({ event, collections, documents }: Props) => {
   return (
     <ListItem
       key={event.id}
@@ -203,7 +238,8 @@ const EventListItem = ({ event }: Props) => {
       image={<Avatar src={event.actor.avatarUrl} size={32} />}
       subtitle={
         <>
-          {description(event)} <Time dateTime={event.createdAt} /> ago &middot;{" "}
+          {description(event, collections, documents)}{" "}
+          <Time dateTime={event.createdAt} /> ago &middot;{" "}
           <strong>{event.name}</strong>
         </>
       }

--- a/app/utils/routeHelpers.js
+++ b/app/utils/routeHelpers.js
@@ -32,6 +32,10 @@ export function documentMoveUrl(doc: Document): string {
   return `${doc.url}/move`;
 }
 
+export function documentEventsUrl(doc: Document): string {
+  return `${doc.url}/events`;
+}
+
 export function documentHistoryUrl(doc: Document, revisionId?: string): string {
   let base = `${doc.url}/history`;
   if (revisionId) base += `/${revisionId}`;

--- a/server/api/events.js
+++ b/server/api/events.js
@@ -2,7 +2,7 @@
 import Router from "koa-router";
 import Sequelize from "sequelize";
 import auth from "../middlewares/authentication";
-import { Event, Team, User } from "../models";
+import { Document, Event, Team, User } from "../models";
 import policy from "../policies";
 import { presentEvent } from "../presenters";
 import pagination from "./middlewares/pagination";
@@ -12,16 +12,32 @@ const { authorize } = policy;
 const router = new Router();
 
 router.post("events.list", auth(), pagination(), async (ctx) => {
-  let { sort = "createdAt", direction, auditLog = false } = ctx.body;
+  let {
+    documentId,
+    sort = "createdAt",
+    direction,
+    auditLog = false,
+  } = ctx.body;
   if (direction !== "ASC") direction = "DESC";
 
   const user = ctx.state.user;
+
+  if (!!documentId) {
+    ctx.assertPresent(documentId, "documentId is required");
+
+    const document = await Document.findByPk(documentId, { userId: user.id });
+    authorize(user, "read", document);
+    documentId = document.id;
+  }
+
   const paranoid = false;
   const collectionIds = await user.collectionIds(paranoid);
+
 
   let where = {
     name: Event.ACTIVITY_EVENTS,
     teamId: user.teamId,
+    documentId: documentId,
     [Op.or]: [
       { collectionId: collectionIds },
       {
@@ -36,6 +52,8 @@ router.post("events.list", auth(), pagination(), async (ctx) => {
     authorize(user, "auditLog", Team);
     where.name = Event.AUDIT_EVENTS;
   }
+
+  if (!documentId) delete where.documentId;
 
   const events = await Event.findAll({
     where,

--- a/server/api/events.js
+++ b/server/api/events.js
@@ -33,7 +33,6 @@ router.post("events.list", auth(), pagination(), async (ctx) => {
   const paranoid = false;
   const collectionIds = await user.collectionIds(paranoid);
 
-
   let where = {
     name: Event.ACTIVITY_EVENTS,
     teamId: user.teamId,


### PR DESCRIPTION
Add events menu to a document, allowing us to see it events.
![Screen Shot 2020-08-21 at 22 31 13](https://user-images.githubusercontent.com/64857365/90948298-854aba00-e413-11ea-86ba-4c893177fbee.png)
![Screen Shot 2020-08-21 at 22 31 24](https://user-images.githubusercontent.com/64857365/90948301-87147d80-e413-11ea-9055-f674e41d54d9.png)

