### PR TITLE
fix: Unable to view all possible locations when moving document

### DIFF
--- a/app/components/PathToDocument.js
+++ b/app/components/PathToDocument.js
@@ -42,6 +42,7 @@ class PathToDocument extends React.Component<Props> {
     return (
       <Component ref={ref} onClick={this.handleClick} href="" selectable>
         {collection && <CollectionIcon collection={collection} />}
+        &nbsp;
         {result.path
           .map((doc) => <Title key={doc.id}>{doc.title}</Title>)
           .reduce((prev, curr) => [prev, <StyledGoToIcon />, curr])}

--- a/app/components/PathToDocument.js
+++ b/app/components/PathToDocument.js
@@ -47,15 +47,17 @@ class PathToDocument extends React.Component<Props> {
           .map((doc) => <Title key={doc.id}>{doc.title}</Title>)
           .reduce((prev, curr) => [prev, <StyledGoToIcon />, curr])}
         {document && (
-          <Flex>
+          <DocumentTitle>
             {" "}
             <StyledGoToIcon /> <Title>{document.title}</Title>
-          </Flex>
+          </DocumentTitle>
         )}
       </Component>
     );
   }
 }
+
+const DocumentTitle = styled(Flex)``;
 
 const Title = styled.span`
   white-space: nowrap;
@@ -80,13 +82,20 @@ const ResultWrapper = styled.div`
 const ResultWrapperLink = styled(ResultWrapper.withComponent("a"))`
   margin: 0 -8px;
   padding: 8px 4px;
-  border-radius: 8px;
+
+  ${DocumentTitle} {
+    display: none;
+  }
 
   &:hover,
   &:active,
   &:focus {
     background: ${(props) => props.theme.listItemHoverBackground};
     outline: none;
+
+    ${DocumentTitle} {
+      display: flex;
+    }
   }
 `;
 

--- a/app/scenes/Document/components/DocumentMove.js
+++ b/app/scenes/Document/components/DocumentMove.js
@@ -34,14 +34,19 @@ class DocumentMove extends React.Component<Props> {
 
   @computed
   get searchIndex() {
-    const { collections } = this.props;
+    const { collections, documents } = this.props;
     const paths = collections.pathsToDocuments;
     const index = new Search("id");
     index.addIndex("title");
 
     // Build index
     const indexeableDocuments = [];
-    paths.forEach((path) => indexeableDocuments.push(path));
+    paths.forEach((path) => {
+      const doc = documents.get(path.id);
+      if (!doc || !doc.isTemplate) {
+        indexeableDocuments.push(path);
+      }
+    });
     index.addDocuments(indexeableDocuments);
 
     return index;

--- a/app/scenes/Document/components/DocumentMove.js
+++ b/app/scenes/Document/components/DocumentMove.js
@@ -13,12 +13,10 @@ import DocumentsStore from "stores/DocumentsStore";
 import UiStore from "stores/UiStore";
 import Document from "models/Document";
 import Flex from "components/Flex";
-import Input from "components/Input";
+import { Outline } from "components/Input";
 import Labeled from "components/Labeled";
 import Modal from "components/Modal";
 import PathToDocument from "components/PathToDocument";
-
-const MAX_RESULTS = 8;
 
 type Props = {|
   document: Document,
@@ -136,35 +134,41 @@ class DocumentMove extends React.Component<Props> {
             </Section>
 
             <Section column>
-              <Labeled label="Choose a new location">
-                <Input
-                  type="search"
-                  placeholder="Search collections & documents…"
-                  onKeyDown={this.handleKeyDown}
-                  onChange={this.handleFilter}
-                  required
-                  autoFocus
-                />
-              </Labeled>
-              <Flex column>
-                <StyledArrowKeyNavigation
-                  mode={ArrowKeyNavigation.mode.VERTICAL}
-                  defaultActiveChildIndex={0}
-                >
-                  {this.results.slice(0, MAX_RESULTS).map((result, index) => (
-                    <PathToDocument
-                      key={result.id}
-                      result={result}
-                      document={document}
-                      collection={collections.get(result.collectionId)}
-                      ref={(ref) =>
-                        index === 0 && this.setFirstDocumentRef(ref)
-                      }
-                      onSuccess={this.handleSuccess}
-                    />
-                  ))}
-                </StyledArrowKeyNavigation>
-              </Flex>
+              <Labeled label="Choose a new location" />
+              <NewLocation>
+                <InputWrapper>
+                  <Input
+                    type="search"
+                    placeholder="Search collections & documents…"
+                    onKeyDown={this.handleKeyDown}
+                    onChange={this.handleFilter}
+                    required
+                    autoFocus
+                  />
+                </InputWrapper>
+
+                <Results>
+                  <Flex column>
+                    <StyledArrowKeyNavigation
+                      mode={ArrowKeyNavigation.mode.VERTICAL}
+                      defaultActiveChildIndex={0}
+                    >
+                      {this.results.map((result, index) => (
+                        <PathToDocument
+                          key={result.id}
+                          result={result}
+                          document={document}
+                          collection={collections.get(result.collectionId)}
+                          ref={(ref) =>
+                            index === 0 && this.setFirstDocumentRef(ref)
+                          }
+                          onSuccess={this.handleSuccess}
+                        />
+                      ))}
+                    </StyledArrowKeyNavigation>
+                  </Flex>
+                </Results>
+              </NewLocation>
             </Section>
           </Flex>
         )}
@@ -172,6 +176,37 @@ class DocumentMove extends React.Component<Props> {
     );
   }
 }
+
+const InputWrapper = styled("div")`
+  padding: 8px;
+  width: 100%;
+`;
+
+const Input = styled("input")`
+  width: 100%;
+  outline: none;
+  background: none;
+  border-radius: 4px;
+  height: 30px;
+  border: 0;
+  color: ${(props) => props.theme.text};
+
+  &::placeholder {
+    color: ${(props) => props.theme.placeholder};
+  }
+`;
+
+const NewLocation = styled(Outline)`
+  flex-direction: column;
+`;
+
+const Results = styled(Flex)`
+  display: block;
+  width: 100%;
+  max-height: 40vh;
+  overflow-y: auto;
+  padding: 8px;
+`;
 
 const Section = styled(Flex)`
   margin-bottom: 24px;


### PR DESCRIPTION
This PR includes a number of improvements to the document move dialog to improve the experience:

![image](https://user-images.githubusercontent.com/380914/91127669-92f28080-e65b-11ea-92bf-67fdc503218e.png)

- There is no longer an artificial cap on results, instead the UI is scrollable. closes #1410 
- The original document name only shows in the path on hover now to reduce visual clutter and add clarity to the end desination.
- Fixed a number of visual and spacing bugs
- Fixed templates should not appear here as an option to move