### PR TITLE
fix: Add PGSSLMODE param to allow unencrypted db access 

### DIFF
--- a/server/sequelize.js
+++ b/server/sequelize.js
@@ -4,6 +4,8 @@ import Sequelize from "sequelize";
 import EncryptedField from "sequelize-encrypted";
 
 const isProduction = process.env.NODE_ENV === "production";
+const isEncryptedConnection =
+  isProduction && process.env.PGSSLMODE !== "disable";
 
 export const encryptedFields = () =>
   EncryptedField(Sequelize, process.env.SECRET_KEY);
@@ -15,7 +17,7 @@ export const sequelize = new Sequelize(process.env.DATABASE_URL, {
   logging: debug("sql"),
   typeValidation: true,
   dialectOptions: {
-    ssl: isProduction
+    ssl: isEncryptedConnection
       ? {
           // Ref.: https://github.com/brianc/node-postgres/issues/2009
           rejectUnauthorized: false,

--- a/server/sequelize.js
+++ b/server/sequelize.js
@@ -4,8 +4,15 @@ import Sequelize from "sequelize";
 import EncryptedField from "sequelize-encrypted";
 
 const isProduction = process.env.NODE_ENV === "production";
-const isEncryptedConnection =
-  isProduction && process.env.PGSSLMODE !== "disable";
+
+const isPGSqlEnabled =
+  typeof process.env.PGSSLMODE === "undefined" ||
+  process.env.PGSSLMODE === null ||
+  process.env.PGSSLMODE !== "disable";
+
+const isEncryptedConnection = isProduction && isPGSqlEnabled;
+
+console.log(isEncryptedConnection);
 
 export const encryptedFields = () =>
   EncryptedField(Sequelize, process.env.SECRET_KEY);


### PR DESCRIPTION
This PR fixes issue #1501 and allows the use of `PGSSLMODE` variable to disable enforced ssl connection to pgsql database