### PR TITLE
feat: Improved search results when finding links in document editor

### DIFF
--- a/app/scenes/Document/components/DataLoader.js
+++ b/app/scenes/Document/components/DataLoader.js
@@ -1,6 +1,7 @@
 // @flow
 import distanceInWordsToNow from "date-fns/distance_in_words_to_now";
 import invariant from "invariant";
+import { deburr, sortBy } from "lodash";
 import { observable } from "mobx";
 import { observer, inject } from "mobx-react";
 import * as React from "react";
@@ -73,6 +74,8 @@ class DataLoader extends React.Component<Props> {
   }
 
   onSearchLink = async (term: string) => {
+    term = term.trim();
+
     if (isInternalUrl(term)) {
       // search for exact internal document
       const slug = parseDocumentSlug(term);
@@ -97,20 +100,26 @@ class DataLoader extends React.Component<Props> {
     }
 
     // default search for anything that doesn't look like a URL
-    const results = await this.props.documents.search(term);
+    const results = await this.props.documents.searchTitles(term);
 
-    return results
-      .filter((result) => result.document.title)
-      .map((result) => {
-        const time = distanceInWordsToNow(result.document.updatedAt, {
+    return sortBy(
+      results.map((document) => {
+        const time = distanceInWordsToNow(document.updatedAt, {
           addSuffix: true,
         });
         return {
-          title: result.document.title,
+          title: document.title,
           subtitle: `Updated ${time}`,
-          url: result.document.url,
+          url: document.url,
         };
-      });
+      }),
+      (document) =>
+        deburr(document.title)
+          .toLowerCase()
+          .startsWith(deburr(term).toLowerCase())
+          ? -1
+          : 1
+    );
   };
 
   onCreateLink = async (title: string) => {

--- a/app/scenes/Document/components/DataLoader.js
+++ b/app/scenes/Document/components/DataLoader.js
@@ -74,8 +74,6 @@ class DataLoader extends React.Component<Props> {
   }
 
   onSearchLink = async (term: string) => {
-    term = term.trim();
-
     if (isInternalUrl(term)) {
       // search for exact internal document
       const slug = parseDocumentSlug(term);

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "react-portal": "^4.0.0",
     "react-router-dom": "^5.1.2",
     "react-waypoint": "^9.0.2",
-    "rich-markdown-editor": "^11.0.0-8",
+    "rich-markdown-editor": "^11.0.0-9",
     "semver": "^7.3.2",
     "sequelize": "^6.3.4",
     "sequelize-cli": "^6.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9887,10 +9887,10 @@ retry-as-promised@^3.2.0:
   dependencies:
     any-promise "^1.3.0"
 
-rich-markdown-editor@^11.0.0-8:
-  version "11.0.0-8"
-  resolved "https://registry.yarnpkg.com/rich-markdown-editor/-/rich-markdown-editor-11.0.0-8.tgz#542a33963147077a3c01ba2f689f67714056bbb9"
-  integrity sha512-TTMVMr33CFlk+AkHKE2/nOZ4VRSwq0aOLodCYotztSwGAQ1a01znZmue1gn/VbIrF7/AtxZ/cnIs3p2hJr82bw==
+rich-markdown-editor@^11.0.0-9:
+  version "11.0.0-9"
+  resolved "https://registry.yarnpkg.com/rich-markdown-editor/-/rich-markdown-editor-11.0.0-9.tgz#a7a4bfa09fca3cdf3168027e11fd9af46c708680"
+  integrity sha512-B1q6VbRF/6yjHsYMQEXjgjwPJCSU3mNEmLGsJOF+PZACII5ojg8bV51jGd4W1rTvbIzqnLK4iPWlAbn+hrMtXw==
   dependencies:
     copy-to-clipboard "^3.0.8"
     lodash "^4.17.11"


### PR DESCRIPTION
Moves searching for a document via the link editor to it's own endpoint. There are a couple of reasons for this:

- We're now recording search queries and these shouldn't be mixed in with link searches, it will improve the signal to noise ratio.
- Returning results that match based on content of the document doesn't make much sense for this context
- Faster!