### PR TITLE
fix: spotify widget wrong size

### DIFF
--- a/app/embeds/Spotify.js
+++ b/app/embeds/Spotify.js
@@ -25,11 +25,21 @@ export default class Spotify extends React.Component<Props> {
   render() {
     const normalizedPath = this.pathname.replace(/^\/embed/, "/");
 
+    var height;
+
+    if (normalizedPath.includes("episode") || normalizedPath.includes("show")) {
+      height = 232;
+    } else if (normalizedPath.includes("track")) {
+      height = 80;
+    } else {
+      height = 380;
+    }
+
     return (
       <Frame
         {...this.props}
-        width="300px"
-        height="380px"
+        width="100%"
+        height={`${height}px`}
         src={`https://open.spotify.com/embed${normalizedPath}`}
         title="Spotify Embed"
         allow="encrypted-media"


### PR DESCRIPTION
Hello, while using outline I noticed the spotify iframe elements were using a wrong size. The spotify widgets are all using the same size either for tracks, playlist, album and podcast. This results in a lot of wasted space on the wiki page.

This fix allows to create widgets with specific size depending if it's a podcast episode, a song track, a playlist or an album following [the spotify recommandations](https://developer.spotify.com/documentation/widgets/).

Feel free to comment 👍  

## Before
![before](https://user-images.githubusercontent.com/2095991/94455045-edc74c80-01b2-11eb-8e77-d939e216b9f5.png)

## After
![after](https://user-images.githubusercontent.com/2095991/94455078-f91a7800-01b2-11eb-9730-7728d8f55b28.png)

