### PR TITLE
chore: Specify babelrc specifically for node environment

### DIFF
--- a/server/.babelrc
+++ b/server/.babelrc
@@ -1,0 +1,22 @@
+{
+  "presets": [
+    "@babel/preset-react",
+    "@babel/preset-flow",
+    [
+      "@babel/preset-env",
+      {
+        "corejs": {
+          "version": "2",
+          "proposals": true
+        },
+        "targets": {
+          "node": "12"
+        },
+        "useBuiltIns": "usage"
+      }
+    ]
+  ],
+  "plugins": [
+    "transform-class-properties"
+  ]
+}


### PR DESCRIPTION
This cuts the amount of transpilation that is needed drastically by not treating the server like it has the same feature set as a browser from several years ago. It also cuts the server build time from ~16s -> ~3s

closes #1580 