### PR TITLE
feat: Attachment of Files to Documents using S3

### DIFF
--- a/app/components/Editor.js
+++ b/app/components/Editor.js
@@ -29,7 +29,7 @@ type PropsWithRef = Props & {
 };
 
 class Editor extends React.Component<PropsWithRef> {
-  onUploadImage = async (file: File) => {
+  onUpload = async (file: File) => {
     const result = await uploadFile(file, { documentId: this.props.id });
     return result.url;
   };
@@ -72,7 +72,8 @@ class Editor extends React.Component<PropsWithRef> {
       <ErrorBoundary reloadOnChunkMissing>
         <StyledEditor
           ref={this.props.forwardedRef}
-          uploadImage={this.onUploadImage}
+          uploadImage={this.onUpload}
+          uploadFile={this.onUpload}
           onClickLink={this.onClickLink}
           onShowToast={this.onShowToast}
           embeds={this.props.disableEmbeds ? EMPTY_ARRAY : embeds}


### PR DESCRIPTION
Background:
At Qure.ai we have been using the self-hosted outline and its feature for maintaining our internal documentation and knowledge base.

Problem:
We have been having a hard time uploading and maintaining files except for images on the outline that we are using.

Solution:

So we have built a draft of the files attachment using the original image upload feature and supported all kinds of files to be upload in the outline.
We understand that this isssue has been already requested.
The above issue requested Google Drive and Dropbox integration. However, we believe it is not a great direction to integrate third party for a feature as simple as file upload.
S3 is a files service provider over the cloud and is already an integral part of the outline service.
So we thought why not use the already existing S3 upload integration and support all kinds of files to be stored inside a document.

What does this PR do:
- I have already raised a PR for the changes in rich-markdown-editior : [Editor PR](https://github.com/outline/rich-markdown-editor/pull/280).
- This is the support PR for passing upload file function callback (It uses the same upload file function which is used in upload image).

Attaching Demo: 


![File-Upload-Demo](https://user-images.githubusercontent.com/23118273/95451933-21aa2b00-0986-11eb-83a0-a044cd1d5f10.gif)
