### PR TITLE
fix: Match search requests from Slack using Integration for non-Slack teams

### DIFF
--- a/server/auth/slack.js
+++ b/server/auth/slack.js
@@ -188,7 +188,7 @@ router.get("slack.commands", auth({ required: false }), async (ctx) => {
     teamId: user.teamId,
     authenticationId: authentication.id,
     settings: {
-      teamId: data.team_id,
+      serviceTeamId: data.team_id,
     },
   });
 

--- a/server/auth/slack.js
+++ b/server/auth/slack.js
@@ -151,7 +151,7 @@ router.get("slack.commands", auth({ required: false }), async (ctx) => {
   }
 
   // this code block accounts for the root domain being unable to
-  // access authentcation for subdomains. We must forward to the appropriate
+  // access authentication for subdomains. We must forward to the appropriate
   // subdomain to complete the oauth flow
   if (!user) {
     if (state) {
@@ -187,6 +187,9 @@ router.get("slack.commands", auth({ required: false }), async (ctx) => {
     userId: user.id,
     teamId: user.teamId,
     authenticationId: authentication.id,
+    settings: {
+      teamId: data.team_id,
+    },
   });
 
   ctx.redirect("/settings/integrations/slack");

--- a/server/test/factories.js
+++ b/server/test/factories.js
@@ -10,6 +10,8 @@ import {
   Group,
   GroupUser,
   Attachment,
+  Authentication,
+  Integration,
 } from "../models";
 
 let count = 0;
@@ -64,6 +66,33 @@ export async function buildUser(overrides: Object = {}) {
     serviceId: uuid.v4(),
     createdAt: new Date("2018-01-01T00:00:00.000Z"),
     lastActiveAt: new Date("2018-01-01T00:00:00.000Z"),
+    ...overrides,
+  });
+}
+
+export async function buildIntegration(overrides: Object = {}) {
+  if (!overrides.teamId) {
+    const team = await buildTeam();
+    overrides.teamId = team.id;
+  }
+
+  const user = await buildUser({ teamId: overrides.teamId });
+
+  const authentication = await Authentication.create({
+    service: "slack",
+    userId: user.id,
+    teamId: user.teamId,
+    token: "fake-access-token",
+    scopes: ["example", "scopes", "here"],
+  });
+
+  return Integration.create({
+    type: "post",
+    service: "slack",
+    settings: {
+      serviceTeamId: "slack_team_id",
+    },
+    authenticationId: authentication.id,
     ...overrides,
   });
 }


### PR DESCRIPTION
Allows searching from inside of Slack for Google-authed teams.

closes #1315 