### PR TITLE
chore: Refactor backlinks and revisions

### DIFF
--- a/app/scenes/Document/components/DataLoader.js
+++ b/app/scenes/Document/components/DataLoader.js
@@ -64,7 +64,11 @@ class DataLoader extends React.Component<Props> {
 
     // Also need to load the revision if it changes
     const { revisionId } = this.props.match.params;
-    if (prevProps.match.params.revisionId !== revisionId && revisionId) {
+    if (
+      prevProps.match.params.revisionId !== revisionId &&
+      revisionId &&
+      revisionId !== "latest"
+    ) {
       this.loadRevision();
     }
   }
@@ -152,7 +156,7 @@ class DataLoader extends React.Component<Props> {
         shareId,
       });
 
-      if (revisionId) {
+      if (revisionId && revisionId !== "latest") {
         await this.loadRevision();
       } else {
         this.revision = undefined;

--- a/app/stores/RevisionsStore.js
+++ b/app/stores/RevisionsStore.js
@@ -16,7 +16,31 @@ export default class RevisionsStore extends BaseStore<Revision> {
   }
 
   getDocumentRevisions(documentId: string): Revision[] {
-    return filter(this.orderedData, { documentId });
+    let revisions = filter(this.orderedData, { documentId });
+    const latestRevision = revisions[0];
+    const document = this.rootStore.documents.get(documentId);
+
+    // There is no guarantee that we have a revision that represents the latest
+    // state of the document. This pushes a fake revision in at the top if there
+    // isn't one
+    if (
+      latestRevision &&
+      document &&
+      latestRevision.createdAt !== document.updatedAt
+    ) {
+      revisions.unshift(
+        new Revision({
+          id: "latest",
+          documentId: document.id,
+          title: document.title,
+          text: document.text,
+          createdAt: document.updatedAt,
+          createdBy: document.createdBy,
+        })
+      );
+    }
+
+    return revisions;
   }
 
   @action

--- a/server/api/documents.js
+++ b/server/api/documents.js
@@ -870,6 +870,8 @@ router.post("documents.update", auth(), async (ctx) => {
     throw new InvalidRequestError("Document has changed since last revision");
   }
 
+  const previousTitle = document.title;
+
   // Update document
   if (title) document.title = title;
   if (editorVersion) document.editorVersion = editorVersion;
@@ -920,6 +922,21 @@ router.post("documents.update", auth(), async (ctx) => {
       data: {
         autosave,
         done,
+        title: document.title,
+      },
+      ip: ctx.request.ip,
+    });
+  }
+
+  if (document.title !== previousTitle) {
+    Event.add({
+      name: "documents.title_change",
+      documentId: document.id,
+      collectionId: document.collectionId,
+      teamId: document.teamId,
+      actorId: user.id,
+      data: {
+        previousTitle,
         title: document.title,
       },
       ip: ctx.request.ip,

--- a/server/events.js
+++ b/server/events.js
@@ -64,6 +64,13 @@ export type DocumentEvent =
       },
     };
 
+export type RevisionEvent = {
+  name: "revisions.create",
+  documentId: string,
+  collectionId: string,
+  teamId: string,
+};
+
 export type CollectionEvent =
   | {
   name: | 'collections.create' // eslint-disable-line
@@ -120,7 +127,8 @@ export type Event =
   | DocumentEvent
   | CollectionEvent
   | IntegrationEvent
-  | GroupEvent;
+  | GroupEvent
+  | RevisionEvent;
 
 const globalEventsQueue = createQueue("global events");
 const serviceEventsQueue = createQueue("service events");

--- a/server/migrations/20201028043021-reverse-document-id-index.js
+++ b/server/migrations/20201028043021-reverse-document-id-index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addIndex("backlinks", ["reverseDocumentId"]);
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeIndex("backlinks", ["reverseDocumentId"]);
+  }
+};

--- a/server/models/Document.js
+++ b/server/models/Document.js
@@ -19,32 +19,6 @@ const serializer = new MarkdownSerializer();
 
 export const DOCUMENT_VERSION = 2;
 
-const createRevision = async (doc, options = {}) => {
-  // we don't create revisions for autosaves
-  if (options.autosave) return;
-
-  const previous = await Revision.findLatest(doc.id);
-
-  // we don't create revisions if identical to previous
-  if (previous && doc.text === previous.text && doc.title === previous.title) {
-    return;
-  }
-
-  return Revision.create(
-    {
-      title: doc.title,
-      text: doc.text,
-      userId: doc.lastModifiedById,
-      editorVersion: doc.editorVersion,
-      version: doc.version,
-      documentId: doc.id,
-    },
-    {
-      transaction: options.transaction,
-    }
-  );
-};
-
 const createUrlId = (doc) => {
   return (doc.urlId = doc.urlId || randomstring.generate(10));
 };
@@ -118,8 +92,6 @@ const Document = sequelize.define(
       beforeValidate: createUrlId,
       beforeCreate: beforeCreate,
       beforeUpdate: beforeSave,
-      afterCreate: createRevision,
-      afterUpdate: createRevision,
     },
     getterMethods: {
       url: function () {

--- a/server/models/Document.test.js
+++ b/server/models/Document.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
-import { Document, Revision } from "../models";
+import { Document } from "../models";
 import {
   buildDocument,
   buildCollection,
@@ -10,37 +10,6 @@ import { flushdb } from "../test/support";
 
 beforeEach(() => flushdb());
 beforeEach(jest.resetAllMocks);
-
-describe("#createRevision", () => {
-  test("should create revision on document creation", async () => {
-    const document = await buildDocument();
-
-    document.title = "Changed";
-    await document.save({ autosave: true });
-
-    const amount = await Revision.count({ where: { documentId: document.id } });
-    expect(amount).toBe(1);
-  });
-
-  test("should create revision on document update identical to previous autosave", async () => {
-    const document = await buildDocument();
-
-    document.title = "Changed";
-    await document.save({ autosave: true });
-
-    document.title = "Changed";
-    await document.save();
-
-    const amount = await Revision.count({ where: { documentId: document.id } });
-    expect(amount).toBe(2);
-  });
-
-  test("should not create revision if autosave", async () => {
-    const document = await buildDocument();
-    const amount = await Revision.count({ where: { documentId: document.id } });
-    expect(amount).toBe(1);
-  });
-});
 
 describe("#getSummary", () => {
   test("should strip markdown", async () => {

--- a/server/models/Event.js
+++ b/server/models/Event.js
@@ -48,6 +48,12 @@ Event.afterCreate((event) => {
   events.add(event, { removeOnComplete: true });
 });
 
+// add can be used to send events into the event system without recording them
+// in the database / audit trail
+Event.add = (event) => {
+  events.add(Event.build(event), { removeOnComplete: true });
+};
+
 Event.ACTIVITY_EVENTS = [
   "users.create",
   "documents.publish",

--- a/server/models/Revision.js
+++ b/server/models/Revision.js
@@ -49,6 +49,21 @@ Revision.findLatest = function (documentId) {
   });
 };
 
+Revision.createFromDocument = function (document) {
+  return Revision.create({
+    title: document.title,
+    text: document.text,
+    userId: document.lastModifiedById,
+    editorVersion: document.editorVersion,
+    version: document.version,
+    documentId: document.id,
+
+    // revision time is set to the last time document was touched as this
+    // handler can be debounced in the case of an update
+    createdAt: document.updatedAt,
+  });
+};
+
 Revision.prototype.migrateVersion = function () {
   let migrated = false;
 

--- a/server/models/Revision.test.js
+++ b/server/models/Revision.test.js
@@ -12,12 +12,15 @@ describe("#findLatest", () => {
       title: "Title",
       text: "Content",
     });
+    await Revision.createFromDocument(document);
 
     document.title = "Changed 1";
     await document.save();
+    await Revision.createFromDocument(document);
 
     document.title = "Changed 2";
     await document.save();
+    await Revision.createFromDocument(document);
 
     const revision = await Revision.findLatest(document.id);
 

--- a/server/services/backlinks.js
+++ b/server/services/backlinks.js
@@ -32,13 +32,14 @@ export default class Backlinks {
         break;
       }
       case "documents.update": {
-        // no-op for drafts
+        // backlinks are only created for published documents
         const document = await Document.findByPk(event.documentId);
         if (!document.publishedAt) return;
 
         const linkIds = parseDocumentIds(document.text);
         const linkedDocumentIds = [];
 
+        // create or find existing backlink records for referenced docs
         await Promise.all(
           linkIds.map(async (linkId) => {
             const linkedDocument = await Document.findByPk(linkId);

--- a/server/services/backlinks.js
+++ b/server/services/backlinks.js
@@ -1,6 +1,6 @@
 // @flow
 import type { DocumentEvent, RevisionEvent } from "../events";
-import { Revision, Document, Backlink } from "../models";
+import { Document, Backlink } from "../models";
 import { Op } from "../sequelize";
 import parseDocumentIds from "../utils/parseDocumentIds";
 import slugify from "../utils/slugify";
@@ -10,6 +10,8 @@ export default class Backlinks {
     switch (event.name) {
       case "documents.publish": {
         const document = await Document.findByPk(event.documentId);
+        if (!document) return;
+
         const linkIds = parseDocumentIds(document.text);
 
         await Promise.all(
@@ -32,8 +34,10 @@ export default class Backlinks {
         break;
       }
       case "documents.update": {
-        // backlinks are only created for published documents
         const document = await Document.findByPk(event.documentId);
+        if (!document) return;
+
+        // backlinks are only created for published documents
         if (!document.publishedAt) return;
 
         const linkIds = parseDocumentIds(document.text);
@@ -71,27 +75,13 @@ export default class Backlinks {
         });
         break;
       }
-      case "revisions.create": {
+      case "documents.title_change": {
         const document = await Document.findByPk(event.documentId);
-        const [currentRevision, previousRevision] = await Revision.findAll({
-          where: { documentId: event.documentId },
-          order: [["createdAt", "desc"]],
-          limit: 2,
-        });
+        if (!document) return;
 
-        // before parsing document text we must make sure it's been migrated to
-        // the latest version or the parser may fail on version differences
-        await currentRevision.migrateVersion();
-        if (previousRevision) {
-          await previousRevision.migrateVersion();
-        }
-
-        if (
-          !previousRevision ||
-          currentRevision.title === previousRevision.title
-        ) {
-          break;
-        }
+        // might as well check
+        const { title, previousTitle } = event.data;
+        if (!previousTitle || title === previousTitle) break;
 
         // update any link titles in documents that lead to this one
         const backlinks = await Backlink.findAll({
@@ -103,7 +93,7 @@ export default class Backlinks {
 
         await Promise.all(
           backlinks.map(async (backlink) => {
-            const previousUrl = `/doc/${slugify(previousRevision.title)}-${
+            const previousUrl = `/doc/${slugify(previousTitle)}-${
               document.urlId
             }`;
 
@@ -111,8 +101,8 @@ export default class Backlinks {
             // the old title as anchor text. Go ahead and update those to the
             // new title automatically
             backlink.reverseDocument.text = backlink.reverseDocument.text.replace(
-              `[${previousRevision.title}](${previousUrl})`,
-              `[${document.title}](${document.url})`
+              `[${previousTitle}](${previousUrl})`,
+              `[${title}](${document.url})`
             );
             await backlink.reverseDocument.save({
               silent: true,

--- a/server/services/backlinks.test.js
+++ b/server/services/backlinks.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
-import Backlink from "../models/Backlink";
+import { Backlink } from "../models";
 import { buildDocument } from "../test/factories";
 import { flushdb } from "../test/support";
 import BacklinksService from "./backlinks";
@@ -149,11 +149,12 @@ describe("documents.delete", () => {
   });
 });
 
-describe("revisions.create", () => {
+describe("documents.title_change", () => {
   test("should update titles in backlinked documents", async () => {
     const newTitle = "test";
     const document = await buildDocument();
     const otherDocument = await buildDocument();
+    const previousTitle = otherDocument.title;
 
     // create a doc with a link back
     document.text = `[${otherDocument.title}](${otherDocument.url})`;
@@ -174,11 +175,15 @@ describe("revisions.create", () => {
 
     // does the text get updated with the new title
     await Backlinks.on({
-      name: "revisions.create",
+      name: "documents.title_change",
       documentId: otherDocument.id,
       collectionId: otherDocument.collectionId,
       teamId: otherDocument.teamId,
       actorId: otherDocument.createdById,
+      data: {
+        previousTitle,
+        title: newTitle,
+      },
     });
     await document.reload();
 

--- a/server/services/debouncer.js
+++ b/server/services/debouncer.js
@@ -1,0 +1,44 @@
+// @flow
+import events, { type Event } from "../events";
+import { Document } from "../models";
+
+export default class Debouncer {
+  async on(event: Event) {
+    switch (event.name) {
+      case "documents.update": {
+        events.add(
+          {
+            ...event,
+            name: "documents.update.delayed",
+          },
+          {
+            delay: 5 * 60 * 1000,
+            removeOnComplete: true,
+          }
+        );
+        break;
+      }
+      case "documents.update.delayed": {
+        const document = await Document.findByPk(event.documentId);
+
+        // If the document has been deleted then prevent further processing
+        if (!document) return;
+
+        // If the document has been updated since we initially queued the delayed
+        // event then abort, there must be another updated event in the queue –
+        // this functions as a simple distributed debounce.
+        if (document.updatedAt > new Date(event.createdAt)) return;
+
+        events.add(
+          {
+            ...event,
+            name: "documents.update.debounced",
+          },
+          { removeOnComplete: true }
+        );
+        break;
+      }
+      default:
+    }
+  }
+}

--- a/server/services/notifications.test.js
+++ b/server/services/notifications.test.js
@@ -60,4 +60,28 @@ describe("documents.update.debounced", () => {
 
     expect(mailer.documentNotification).not.toHaveBeenCalled();
   });
+
+  test("should not send a notification to last editor", async () => {
+    const user = await buildUser();
+    const document = await buildDocument({
+      teamId: user.teamId,
+      lastModifiedById: user.id,
+    });
+
+    await NotificationSetting.create({
+      userId: user.id,
+      teamId: user.teamId,
+      event: "documents.update",
+    });
+
+    await Notifications.on({
+      name: "documents.update.debounced",
+      documentId: document.id,
+      collectionId: document.collectionId,
+      teamId: document.teamId,
+      actorId: document.createdById,
+    });
+
+    expect(mailer.documentNotification).not.toHaveBeenCalled();
+  });
 });

--- a/server/services/notifications.test.js
+++ b/server/services/notifications.test.js
@@ -1,0 +1,63 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+import mailer from "../mailer";
+import { View, NotificationSetting } from "../models";
+import { buildDocument, buildUser } from "../test/factories";
+import { flushdb } from "../test/support";
+import NotificationsService from "./notifications";
+
+jest.mock("../mailer");
+
+const Notifications = new NotificationsService();
+
+beforeEach(() => flushdb());
+beforeEach(jest.resetAllMocks);
+
+describe("documents.update.debounced", () => {
+  test("should send a notification to other collaborator", async () => {
+    const document = await buildDocument();
+    const collaborator = await buildUser({ teamId: document.teamId });
+    document.collaboratorIds = [collaborator.id];
+    await document.save();
+
+    await NotificationSetting.create({
+      userId: collaborator.id,
+      teamId: collaborator.teamId,
+      event: "documents.update",
+    });
+
+    await Notifications.on({
+      name: "documents.update.debounced",
+      documentId: document.id,
+      collectionId: document.collectionId,
+      teamId: document.teamId,
+      actorId: document.createdById,
+    });
+
+    expect(mailer.documentNotification).toHaveBeenCalled();
+  });
+
+  test("should not send a notification if viewed since update", async () => {
+    const document = await buildDocument();
+    const collaborator = await buildUser({ teamId: document.teamId });
+    document.collaboratorIds = [collaborator.id];
+    await document.save();
+
+    await NotificationSetting.create({
+      userId: collaborator.id,
+      teamId: collaborator.teamId,
+      event: "documents.update",
+    });
+
+    await View.touch(document.id, collaborator.id, true);
+
+    await Notifications.on({
+      name: "documents.update.debounced",
+      documentId: document.id,
+      collectionId: document.collectionId,
+      teamId: document.teamId,
+      actorId: document.createdById,
+    });
+
+    expect(mailer.documentNotification).not.toHaveBeenCalled();
+  });
+});

--- a/server/services/revisions.js
+++ b/server/services/revisions.js
@@ -1,0 +1,32 @@
+// @flow
+import type { DocumentEvent, RevisionEvent } from "../events";
+import { Revision, Document } from "../models";
+
+export default class Revisions {
+  async on(event: DocumentEvent | RevisionEvent) {
+    switch (event.name) {
+      case "documents.publish":
+      case "documents.update.debounced": {
+        const document = await Document.findByPk(event.documentId);
+        if (!document) return;
+
+        const previous = await Revision.findLatest(document.id);
+
+        // we don't create revisions if identical to previous revision, this can
+        // happen if a manual revision was created from another service or user.
+        if (
+          previous &&
+          document.text === previous.text &&
+          document.title === previous.title
+        ) {
+          return;
+        }
+
+        await Revision.createFromDocument(document);
+
+        break;
+      }
+      default:
+    }
+  }
+}

--- a/server/services/revisions.test.js
+++ b/server/services/revisions.test.js
@@ -1,0 +1,61 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+import { Revision } from "../models";
+import { buildDocument } from "../test/factories";
+import { flushdb } from "../test/support";
+import RevisionsService from "./revisions";
+
+const Revisions = new RevisionsService();
+
+beforeEach(() => flushdb());
+beforeEach(jest.resetAllMocks);
+
+describe("documents.publish", () => {
+  test("should create a revision", async () => {
+    const document = await buildDocument();
+
+    await Revisions.on({
+      name: "documents.publish",
+      documentId: document.id,
+      collectionId: document.collectionId,
+      teamId: document.teamId,
+      actorId: document.createdById,
+    });
+
+    const amount = await Revision.count({ where: { documentId: document.id } });
+    expect(amount).toBe(1);
+  });
+});
+
+describe("documents.update.debounced", () => {
+  test("should create a revision", async () => {
+    const document = await buildDocument();
+
+    await Revisions.on({
+      name: "documents.update.debounced",
+      documentId: document.id,
+      collectionId: document.collectionId,
+      teamId: document.teamId,
+      actorId: document.createdById,
+    });
+
+    const amount = await Revision.count({ where: { documentId: document.id } });
+    expect(amount).toBe(1);
+  });
+
+  test("should not create a revision if identical to previous", async () => {
+    const document = await buildDocument();
+
+    await Revision.createFromDocument(document);
+
+    await Revisions.on({
+      name: "documents.update.debounced",
+      documentId: document.id,
+      collectionId: document.collectionId,
+      teamId: document.teamId,
+      actorId: document.createdById,
+    });
+
+    const amount = await Revision.count({ where: { documentId: document.id } });
+    expect(amount).toBe(1);
+  });
+});

--- a/server/services/slack.js
+++ b/server/services/slack.js
@@ -7,7 +7,7 @@ export default class Slack {
   async on(event: Event) {
     switch (event.name) {
       case "documents.publish":
-      case "documents.update":
+      case "documents.update.debounced":
         return this.documentUpdated(event);
       case "integrations.create":
         return this.integrationCreated(event);
@@ -55,20 +55,6 @@ export default class Slack {
   }
 
   async documentUpdated(event: DocumentEvent) {
-    // lets not send a notification on every autosave update
-    if (
-      event.name === "documents.update" &&
-      event.data &&
-      event.data.autosave
-    ) {
-      return;
-    }
-
-    // lets not send a notification on every CMD+S update
-    if (event.name === "documents.update" && event.data && !event.data.done) {
-      return;
-    }
-
     const document = await Document.findByPk(event.documentId);
     if (!document) return;
 
@@ -87,10 +73,10 @@ export default class Slack {
 
     const team = await Team.findByPk(document.teamId);
 
-    let text = `${document.createdBy.name} published a new document`;
+    let text = `${document.updatedBy.name} updated a document`;
 
-    if (event.name === "documents.update") {
-      text = `${document.updatedBy.name} updated a document`;
+    if (event.name === "documents.publish") {
+      text = `${document.createdBy.name} published a new document`;
     }
 
     await fetch(integration.settings.url, {


### PR DESCRIPTION
- Removes the dependency on revisions for updating backlinks and titles on documents
- Refactors debouncing out of notifications to it's own service
- Debounced revision creation (create a revision only if there has been no activity for X period of time)
- Debounced slack notifications (create a post only if there has been no activity for X period of time)
- Ensure there is always an item in document history for the current state
- Adds missing index to backlinks
- Suppress email notifications if document already viewed

closes #1607
closes #1608 