### PR TITLE
chore: Refactor authentication pass between subdomains

### DIFF
--- a/app/components/Authenticated.js
+++ b/app/components/Authenticated.js
@@ -21,9 +21,14 @@ const Authenticated = observer(({ auth, children }: Props) => {
       return <LoadingIndicator />;
     }
 
-    // If we're authenticated but viewing a subdomain that doesn't match the
-    // currently authenticated team then kick the user to the teams subdomain.
-    if (
+    // If we're authenticated but viewing a domain that doesn't match the
+    // current team then kick the user to the teams correct domain.
+    if (team.domain) {
+      if (team.domain !== hostname) {
+        window.location.href = `${team.url}${window.location.pathname}`;
+        return <LoadingIndicator />;
+      }
+    } else if (
       env.SUBDOMAINS_ENABLED &&
       team.subdomain &&
       isCustomSubdomain(hostname) &&

--- a/app/models/Team.js
+++ b/app/models/Team.js
@@ -12,6 +12,7 @@ class Team extends BaseModel {
   documentEmbeds: boolean;
   guestSignin: boolean;
   subdomain: ?string;
+  domain: ?string;
   url: string;
 
   @computed

--- a/server/api/auth.js
+++ b/server/api/auth.js
@@ -1,15 +1,12 @@
 // @flow
 import Router from "koa-router";
 import { reject } from "lodash";
-import {
-  parseDomain,
-  isCustomDomain,
-  isCustomSubdomain,
-} from "../../shared/utils/domains";
+import { parseDomain, isCustomSubdomain } from "../../shared/utils/domains";
 import { signin } from "../../shared/utils/routeHelpers";
 import auth from "../middlewares/authentication";
 import { Team } from "../models";
 import { presentUser, presentTeam, presentPolicies } from "../presenters";
+import { isCustomDomain } from "../utils/domains";
 
 const router = new Router();
 

--- a/server/auth/index.js
+++ b/server/auth/index.js
@@ -3,10 +3,10 @@ import addMonths from "date-fns/add_months";
 import Koa from "koa";
 import bodyParser from "koa-body";
 import Router from "koa-router";
+import { AuthenticationError } from "../errors";
 import auth from "../middlewares/authentication";
 import validation from "../middlewares/validation";
 import { Team } from "../models";
-import { getCookieDomain } from "../utils/domains";
 
 import email from "./email";
 import google from "./google";
@@ -21,22 +21,16 @@ router.use("/", email.routes());
 
 router.get("/redirect", auth(), async (ctx) => {
   const user = ctx.state.user;
-
-  // transfer access token cookie from root to subdomain
-  const rootToken = ctx.cookies.get("accessToken");
   const jwtToken = user.getJwtToken();
 
-  if (rootToken === jwtToken) {
-    ctx.cookies.set("accessToken", undefined, {
-      httpOnly: true,
-      domain: getCookieDomain(ctx.request.hostname),
-    });
-
-    ctx.cookies.set("accessToken", jwtToken, {
-      httpOnly: false,
-      expires: addMonths(new Date(), 3),
-    });
+  if (jwtToken === ctx.params.token) {
+    throw new AuthenticationError("Cannot extend token");
   }
+
+  ctx.cookies.set("accessToken", jwtToken, {
+    httpOnly: false,
+    expires: addMonths(new Date(), 3),
+  });
 
   const team = await Team.findByPk(user.teamId);
   ctx.redirect(`${team.url}/home`);

--- a/server/auth/index.js
+++ b/server/auth/index.js
@@ -27,6 +27,9 @@ router.get("/redirect", auth(), async (ctx) => {
     throw new AuthenticationError("Cannot extend token");
   }
 
+  // ensure that the lastActiveAt on user is updated to prevent replay requests
+  await user.updateActiveAt(ctx.request.ip, true);
+
   ctx.cookies.set("accessToken", jwtToken, {
     httpOnly: false,
     expires: addMonths(new Date(), 3),

--- a/server/middlewares/authentication.js
+++ b/server/middlewares/authentication.js
@@ -1,6 +1,6 @@
 // @flow
+import addMinutes from "date-fns/add_minutes";
 import addMonths from "date-fns/add_months";
-import addSeconds from "date-fns/add_seconds";
 import JWT from "jsonwebtoken";
 import { AuthenticationError, UserSuspendedError } from "../errors";
 import { User, Team, ApiKey } from "../models";
@@ -144,7 +144,7 @@ export default function auth(options?: { required?: boolean } = {}) {
 
         ctx.redirect(
           `${team.url}/auth/redirect?token=${user.getJwtToken(
-            addSeconds(new Date(), 30)
+            addMinutes(new Date(), 1)
           )}`
         );
       } else {

--- a/server/middlewares/authentication.js
+++ b/server/middlewares/authentication.js
@@ -1,5 +1,4 @@
 // @flow
-import addMinutes from "date-fns/add_minutes";
 import addMonths from "date-fns/add_months";
 import JWT from "jsonwebtoken";
 import { AuthenticationError, UserSuspendedError } from "../errors";
@@ -143,9 +142,7 @@ export default function auth(options?: { required?: boolean } = {}) {
         });
 
         ctx.redirect(
-          `${team.url}/auth/redirect?token=${user.getJwtToken(
-            addMinutes(new Date(), 1)
-          )}`
+          `${team.url}/auth/redirect?token=${user.getTransferToken()}`
         );
       } else {
         ctx.cookies.set("accessToken", user.getJwtToken(), {

--- a/server/migrations/20201103050534-custom-domains.js
+++ b/server/migrations/20201103050534-custom-domains.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('teams', 'domain', {
+      type: Sequelize.STRING,
+      allowNull: true,
+      unique: true
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('teams', 'domain');
+  }
+};

--- a/server/models/Team.js
+++ b/server/models/Team.js
@@ -47,6 +47,11 @@ const Team = sequelize.define(
       },
       unique: true,
     },
+    domain: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      unique: true,
+    },
     slackId: { type: DataTypes.STRING, allowNull: true },
     googleId: { type: DataTypes.STRING, allowNull: true },
     avatarUrl: { type: DataTypes.STRING, allowNull: true },
@@ -66,6 +71,9 @@ const Team = sequelize.define(
   {
     getterMethods: {
       url() {
+        if (this.domain) {
+          return `https://${this.domain}`;
+        }
         if (!this.subdomain || process.env.SUBDOMAINS_ENABLED !== "true") {
           return process.env.URL;
         }

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -109,8 +109,11 @@ User.prototype.updateSignedIn = function (ip) {
   return this.save({ hooks: false });
 };
 
-User.prototype.getJwtToken = function () {
-  return JWT.sign({ id: this.id }, this.jwtSecret);
+User.prototype.getJwtToken = function (expiresAt?: Date) {
+  return JWT.sign(
+    { id: this.id, expiresAt: expiresAt ? expiresAt.toISOString() : undefined },
+    this.jwtSecret
+  );
 };
 
 User.prototype.getEmailSigninToken = function () {

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -1,5 +1,6 @@
 // @flow
 import crypto from "crypto";
+import addMinutes from "date-fns/add_minutes";
 import subMinutes from "date-fns/sub_minutes";
 import JWT from "jsonwebtoken";
 import uuid from "uuid";
@@ -91,12 +92,12 @@ User.prototype.collectionIds = async function (options = {}) {
     .map((c) => c.id);
 };
 
-User.prototype.updateActiveAt = function (ip) {
+User.prototype.updateActiveAt = function (ip, force = false) {
   const fiveMinutesAgo = subMinutes(new Date(), 5);
 
   // ensure this is updated only every few minutes otherwise
   // we'll be constantly writing to the DB as API requests happen
-  if (this.lastActiveAt < fiveMinutesAgo) {
+  if (this.lastActiveAt < fiveMinutesAgo || force) {
     this.lastActiveAt = new Date();
     this.lastActiveIp = ip;
     return this.save({ hooks: false });
@@ -109,20 +110,42 @@ User.prototype.updateSignedIn = function (ip) {
   return this.save({ hooks: false });
 };
 
+// Returns a session token that is used to make API requests and is stored
+// in the client browser cookies to remain logged in.
 User.prototype.getJwtToken = function (expiresAt?: Date) {
   return JWT.sign(
-    { id: this.id, expiresAt: expiresAt ? expiresAt.toISOString() : undefined },
+    {
+      id: this.id,
+      expiresAt: expiresAt ? expiresAt.toISOString() : undefined,
+      type: "session",
+    },
     this.jwtSecret
   );
 };
 
+// Returns a temporary token that is only used for transferring a session
+// between subdomains or domains. It has a short expiry and can only be used once
+User.prototype.getTransferToken = function () {
+  return JWT.sign(
+    {
+      id: this.id,
+      createdAt: new Date().toISOString(),
+      expiresAt: addMinutes(new Date(), 1).toISOString(),
+      type: "transfer",
+    },
+    this.jwtSecret
+  );
+};
+
+// Returns a temporary token that is only used for logging in from an email
+// It can only be used to sign in once and has a medium length expiry
 User.prototype.getEmailSigninToken = function () {
   if (this.service && this.service !== "email") {
     throw new Error("Cannot generate email signin token for OAuth user");
   }
 
   return JWT.sign(
-    { id: this.id, createdAt: new Date().toISOString() },
+    { id: this.id, createdAt: new Date().toISOString(), type: "email-signin" },
     this.jwtSecret
   );
 };

--- a/server/presenters/team.js
+++ b/server/presenters/team.js
@@ -12,6 +12,7 @@ export default function present(team: Team) {
     documentEmbeds: team.documentEmbeds,
     guestSignin: team.guestSignin,
     subdomain: team.subdomain,
+    domain: team.domain,
     url: team.url,
   };
 }

--- a/server/utils/domains.js
+++ b/server/utils/domains.js
@@ -1,8 +1,16 @@
 // @flow
-import { stripSubdomain } from "../../shared/utils/domains";
+import { parseDomain, stripSubdomain } from "../../shared/utils/domains";
 
 export function getCookieDomain(domain: string) {
   return process.env.SUBDOMAINS_ENABLED === "true"
     ? stripSubdomain(domain)
     : domain;
+}
+
+export function isCustomDomain(hostname: string) {
+  const parsed = parseDomain(hostname);
+  const main = parseDomain(process.env.URL);
+  return (
+    parsed && main && (main.domain !== parsed.domain || main.tld !== parsed.tld)
+  );
 }

--- a/server/utils/jwt.js
+++ b/server/utils/jwt.js
@@ -20,6 +20,14 @@ function getJWTPayload(token) {
 
 export async function getUserForJWT(token: string): Promise<User> {
   const payload = getJWTPayload(token);
+
+  // check the token is within it's expiration time
+  if (payload.expiresAt) {
+    if (new Date(payload.expiresAt) < new Date()) {
+      throw new AuthenticationError("Expired token");
+    }
+  }
+
   const user = await User.findByPk(payload.id);
 
   try {

--- a/shared/utils/domains.js
+++ b/shared/utils/domains.js
@@ -73,14 +73,6 @@ export function isCustomSubdomain(hostname: string) {
   return true;
 }
 
-export function isCustomDomain(hostname: string) {
-  const parsed = parseDomain(hostname);
-  const main = parseDomain(process.env.URL);
-  return (
-    parsed && main && (main.domain !== parsed.domain || main.tld !== parsed.tld)
-  );
-}
-
 export const RESERVED_SUBDOMAINS = [
   "about",
   "account",

--- a/shared/utils/domains.js
+++ b/shared/utils/domains.js
@@ -73,6 +73,14 @@ export function isCustomSubdomain(hostname: string) {
   return true;
 }
 
+export function isCustomDomain(hostname: string) {
+  const parsed = parseDomain(hostname);
+  const main = parseDomain(process.env.URL);
+  return (
+    parsed && main && (main.domain !== parsed.domain || main.tld !== parsed.tld)
+  );
+}
+
 export const RESERVED_SUBDOMAINS = [
   "about",
   "account",


### PR DESCRIPTION
In order to support custom domains, the way authentication is passed between subdomains on signin is changing from a cross-subdomain cookie to a single-use token.

_Note_: For self-hosted installations this change has no impact.