### PR TITLE
fix: gist not support username contains numbers

### DIFF
--- a/app/embeds/Gist.js
+++ b/app/embeds/Gist.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 
 const URL_REGEX = new RegExp(
-  "^https://gist.github.com/([a-zd](?:[a-zd]|-(?=[a-zd])){0,38})/(.*)$"
+  "^https://gist.github.com/([a-z\\d](?:[a-z\\d]|-(?=[a-z\\d])){0,38})/(.*)$"
 );
 
 type Props = {|

--- a/app/embeds/Gist.test.js
+++ b/app/embeds/Gist.test.js
@@ -9,6 +9,12 @@ describe("Gist", () => {
         match
       )
     ).toBeTruthy();
+
+    expect(
+      "https://gist.github.com/n3n/eb51ada6308b539d388c8ff97711adfa".match(
+        match
+      )
+    ).toBeTruthy();
   });
 
   test("to not be enabled elsewhere", () => {


### PR DESCRIPTION
Problem REGEX: https://regex101.com/r/Tm3EFc/1/

Fixed REGEX: https://regex101.com/r/3es1Mf/2