### PR TITLE
fix: Clicking the share link from a context menu navigates to document

### DIFF
--- a/app/components/DocumentPreview/DocumentPreview.js
+++ b/app/components/DocumentPreview/DocumentPreview.js
@@ -9,6 +9,7 @@ import Document from "models/Document";
 import Badge from "components/Badge";
 import Button from "components/Button";
 import DocumentMeta from "components/DocumentMeta";
+import EventBoundary from "components/EventBoundary";
 import Flex from "components/Flex";
 import Highlight from "components/Highlight";
 import Tooltip from "components/Tooltip";
@@ -123,7 +124,9 @@ class DocumentPreview extends React.Component<Props> {
                 </Button>
               )}
             &nbsp;
-            <DocumentMenu document={document} showPin={showPin} />
+            <EventBoundary>
+              <DocumentMenu document={document} showPin={showPin} />
+            </EventBoundary>
           </SecondaryActions>
         </Heading>
 

--- a/app/components/EventBoundary.js
+++ b/app/components/EventBoundary.js
@@ -1,0 +1,16 @@
+// @flow
+
+import * as React from "react";
+
+type Props = {
+  children: React.Node,
+};
+
+export default function EventBoundary({ children }: Props) {
+  const handleClick = React.useCallback((event: SyntheticEvent<>) => {
+    event.preventDefault();
+    event.stopPropagation();
+  }, []);
+
+  return <span onClick={handleClick}>{children}</span>;
+}


### PR DESCRIPTION
This bug affects the three places modals exist within the document dropdowns:

- Share link
- Create template
- Delete document

closes #1642