### PR TITLE
chore: Change response of shares.info response for unshared document

### DIFF
--- a/app/stores/SharesStore.js
+++ b/app/stores/SharesStore.js
@@ -1,6 +1,6 @@
 // @flow
 import invariant from "invariant";
-import { sortBy, filter, find } from "lodash";
+import { sortBy, filter, find, isUndefined } from "lodash";
 import { action, computed } from "mobx";
 import Share from "models/Share";
 import BaseStore from "./BaseStore";
@@ -47,6 +47,8 @@ export default class SharesStore extends BaseStore<Share> {
 
     try {
       const res = await client.post(`/${this.modelName}s.info`, { documentId });
+      if (isUndefined(res)) return;
+
       invariant(res && res.data, "Data should be available");
 
       this.addPolicies(res.policies);

--- a/app/utils/ApiClient.js
+++ b/app/utils/ApiClient.js
@@ -110,6 +110,8 @@ class ApiClient {
 
       download(blob, trim(fileName, '"'));
       return;
+    } else if (success && response.status === 204) {
+      return;
     } else if (success) {
       return response.json();
     }

--- a/server/api/shares.js
+++ b/server/api/shares.js
@@ -30,7 +30,7 @@ router.post("shares.info", auth(), async (ctx) => {
         },
   });
   if (!share || !share.document) {
-    throw new NotFoundError();
+    return (ctx.response.status = 204);
   }
 
   authorize(user, "read", share);

--- a/server/api/shares.test.js
+++ b/server/api/shares.test.js
@@ -281,7 +281,7 @@ describe("#shares.info", () => {
     const res = await server.post("/api/shares.info", {
       body: { token: user.getJwtToken(), documentId: document.id },
     });
-    expect(res.status).toEqual(404);
+    expect(res.status).toEqual(204);
   });
 
   it("should not find revoked share", async () => {
@@ -295,7 +295,7 @@ describe("#shares.info", () => {
     const res = await server.post("/api/shares.info", {
       body: { token: user.getJwtToken(), documentId: document.id },
     });
-    expect(res.status).toEqual(404);
+    expect(res.status).toEqual(204);
   });
 
   it("should not find share for deleted document", async () => {
@@ -309,7 +309,7 @@ describe("#shares.info", () => {
     const res = await server.post("/api/shares.info", {
       body: { token: user.getJwtToken(), documentId: document.id },
     });
-    expect(res.status).toEqual(404);
+    expect(res.status).toEqual(204);
   });
 
   it("should require authentication", async () => {


### PR DESCRIPTION
This pull request Fixes #1658 

I have updated server/api/share.js to send 204 status for unshared documents.