### PR TITLE
fix: Unknown mimetype should fallback to Markdown parsing if .md

### DIFF
--- a/server/commands/documentImporter.js
+++ b/server/commands/documentImporter.js
@@ -1,5 +1,6 @@
 // @flow
 import fs from "fs";
+import path from "path";
 import File from "formidable/lib/file";
 import { strikethrough, tables } from "joplin-turndown-plugin-gfm";
 import mammoth from "mammoth";
@@ -139,7 +140,16 @@ export default async function documentImporter({
   file: File,
   ip: string,
 }): Promise<{ text: string, title: string }> {
-  const fileInfo = importMapping.filter((item) => item.type === file.type)[0];
+  const fileInfo = importMapping.filter((item) => {
+    if (item.type === file.type) {
+      return true;
+    }
+    if (item.type === "text/markdown" && path.extname(file.name) === ".md") {
+      return true;
+    }
+    return false;
+  })[0];
+
   if (!fileInfo) {
     throw new InvalidRequestError(`File type ${file.type} not supported`);
   }

--- a/server/commands/documentImporter.test.js
+++ b/server/commands/documentImporter.test.js
@@ -94,9 +94,28 @@ describe("documentImporter", () => {
     expect(response.title).toEqual("Heading 1");
   });
 
-  it("should error with unknown file type", async () => {
+  it("should fallback to extension if mimetype unknown", async () => {
     const user = await buildUser();
     const name = "markdown.md";
+    const file = new File({
+      name,
+      type: "application/octet-stream",
+      path: path.resolve(__dirname, "..", "test", "fixtures", name),
+    });
+
+    const response = await documentImporter({
+      user,
+      file,
+      ip,
+    });
+
+    expect(response.text).toContain("This is a test paragraph");
+    expect(response.title).toEqual("Heading 1");
+  });
+
+  it("should error with unknown file type", async () => {
+    const user = await buildUser();
+    const name = "files.zip";
     const file = new File({
       name,
       type: "executable/zip",


### PR DESCRIPTION
closes #1675