### PR TITLE
feat: Retrieve AWS credentials from IAM role in ECS & EC2

### DIFF
--- a/server/utils/s3.js
+++ b/server/utils/s3.js
@@ -1,77 +1,73 @@
 // @flow
-import crypto from "crypto";
-import * as Sentry from "@sentry/node";
-import AWS from "aws-sdk";
-import addHours from "date-fns/add_hours";
-import format from "date-fns/format";
-import fetch from "isomorphic-fetch";
+import crypto from 'crypto';
+import * as Sentry from '@sentry/node';
+import AWS from 'aws-sdk';
+import addHours from 'date-fns/add_hours';
+import format from 'date-fns/format';
+import fetch from 'isomorphic-fetch';
 
+const AWS_REGION = process.env.AWS_REGION;
+const AWS_S3_UPLOAD_BUCKET_NAME = process.env.AWS_S3_UPLOAD_BUCKET_NAME || '';
+const AWS_S3_FORCE_PATH_STYLE = process.env.AWS_S3_FORCE_PATH_STYLE !== 'false';
 const AWS_SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY;
 const AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID;
-const AWS_REGION = process.env.AWS_REGION;
-const AWS_S3_UPLOAD_BUCKET_NAME = process.env.AWS_S3_UPLOAD_BUCKET_NAME || "";
-const AWS_S3_FORCE_PATH_STYLE = process.env.AWS_S3_FORCE_PATH_STYLE !== "false";
+
+if (process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI || process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI) {
+  AWS.config.credentials = new AWS.ECSCredentials({
+    httpOptions: { timeout: 5000 },
+    maxRetries: 3,
+    retryDelayOptions: { base: 200 },
+  });
+}
+
+AWS.config.credentials.get(function () {
+  var accessKeyId = AWS.config.credentials.accessKeyId || AWS_ACCESS_KEY_ID;
+  var secretAccessKey = AWS.config.credentials.secretAccessKey || AWS_SECRET_ACCESS_KEY;
+});
 
 const s3 = new AWS.S3({
   s3ForcePathStyle: AWS_S3_FORCE_PATH_STYLE,
-  accessKeyId: AWS_ACCESS_KEY_ID,
-  secretAccessKey: AWS_SECRET_ACCESS_KEY,
   endpoint: new AWS.Endpoint(process.env.AWS_S3_UPLOAD_BUCKET_URL),
-  signatureVersion: "v4",
+  signatureVersion: 'v4',
 });
 
 const hmac = (key: string, message: string, encoding: any) => {
-  return crypto
-    .createHmac("sha256", key)
-    .update(message, "utf8")
-    .digest(encoding);
+  return crypto.createHmac('sha256', key).update(message, 'utf8').digest(encoding);
 };
 
 export const makeCredential = () => {
   const credential =
-    AWS_ACCESS_KEY_ID +
-    "/" +
-    format(new Date(), "YYYYMMDD") +
-    "/" +
-    AWS_REGION +
-    "/s3/aws4_request";
+    AWS.config.credentials.accessKeyId + '/' + format(new Date(), 'YYYYMMDD') + '/' + AWS_REGION + '/s3/aws4_request';
   return credential;
 };
 
-export const makePolicy = (
-  credential: string,
-  longDate: string,
-  acl: string
-) => {
+export const makePolicy = (credential: string, longDate: string, acl: string) => {
   const tomorrow = addHours(new Date(), 24);
   const policy = {
     conditions: [
       { bucket: process.env.AWS_S3_UPLOAD_BUCKET_NAME },
-      ["starts-with", "$key", ""],
+      ['starts-with', '$key', ''],
       { acl },
-      ["content-length-range", 0, +process.env.AWS_S3_UPLOAD_MAX_SIZE],
-      ["starts-with", "$Content-Type", "image"],
-      ["starts-with", "$Cache-Control", ""],
-      { "x-amz-algorithm": "AWS4-HMAC-SHA256" },
-      { "x-amz-credential": credential },
-      { "x-amz-date": longDate },
+      ['content-length-range', 0, +process.env.AWS_S3_UPLOAD_MAX_SIZE],
+      ['starts-with', '$Content-Type', 'image'],
+      ['starts-with', '$Cache-Control', ''],
+      { 'x-amz-algorithm': 'AWS4-HMAC-SHA256' },
+      { 'x-amz-credential': credential },
+      { 'x-amz-date': longDate },
     ],
-    expiration: format(tomorrow, "YYYY-MM-DDTHH:mm:ss\\Z"),
+    expiration: format(tomorrow, 'YYYY-MM-DDTHH:mm:ss\\Z'),
   };
 
-  return new Buffer(JSON.stringify(policy)).toString("base64");
+  return new Buffer(JSON.stringify(policy)).toString('base64');
 };
 
 export const getSignature = (policy: any) => {
-  const kDate = hmac(
-    "AWS4" + AWS_SECRET_ACCESS_KEY,
-    format(new Date(), "YYYYMMDD")
-  );
+  const kDate = hmac('AWS4' + AWS_SECRET_ACCESS_KEY, format(new Date(), 'YYYYMMDD'));
   const kRegion = hmac(kDate, AWS_REGION);
-  const kService = hmac(kRegion, "s3");
-  const kCredentials = hmac(kService, "aws4_request");
+  const kService = hmac(kRegion, 's3');
+  const kCredentials = hmac(kService, 'aws4_request');
 
-  const signature = hmac(kCredentials, policy, "hex");
+  const signature = hmac(kCredentials, policy, 'hex');
   return signature;
 };
 
@@ -79,22 +75,12 @@ export const publicS3Endpoint = (isServerUpload?: boolean) => {
   // lose trailing slash if there is one and convert fake-s3 url to localhost
   // for access outside of docker containers in local development
   const isDocker = process.env.AWS_S3_UPLOAD_BUCKET_URL.match(/http:\/\/s3:/);
-  const host = process.env.AWS_S3_UPLOAD_BUCKET_URL.replace(
-    "s3:",
-    "localhost:"
-  ).replace(/\/$/, "");
+  const host = process.env.AWS_S3_UPLOAD_BUCKET_URL.replace('s3:', 'localhost:').replace(/\/$/, '');
 
-  return `${host}/${
-    isServerUpload && isDocker ? "s3/" : ""
-  }${AWS_S3_UPLOAD_BUCKET_NAME}`;
+  return `${host}/${isServerUpload && isDocker ? 's3/' : ''}${AWS_S3_UPLOAD_BUCKET_NAME}`;
 };
 
-export const uploadToS3FromBuffer = async (
-  buffer: Buffer,
-  contentType: string,
-  key: string,
-  acl: string
-) => {
+export const uploadToS3FromBuffer = async (buffer: Buffer, contentType: string, key: string, acl: string) => {
   await s3
     .putObject({
       ACL: acl,
@@ -102,7 +88,7 @@ export const uploadToS3FromBuffer = async (
       Key: key,
       ContentType: contentType,
       ContentLength: buffer.length,
-      ServerSideEncryption: "AES256",
+      ServerSideEncryption: 'AES256',
       Body: buffer,
     })
     .promise();
@@ -111,11 +97,7 @@ export const uploadToS3FromBuffer = async (
   return `${endpoint}/${key}`;
 };
 
-export const uploadToS3FromUrl = async (
-  url: string,
-  key: string,
-  acl: string
-) => {
+export const uploadToS3FromUrl = async (url: string, key: string, acl: string) => {
   try {
     // $FlowIssue https://github.com/facebook/flow/issues/2171
     const res = await fetch(url);
@@ -125,9 +107,9 @@ export const uploadToS3FromUrl = async (
         ACL: acl,
         Bucket: AWS_S3_UPLOAD_BUCKET_NAME,
         Key: key,
-        ContentType: res.headers["content-type"],
-        ContentLength: res.headers["content-length"],
-        ServerSideEncryption: "AES256",
+        ContentType: res.headers['content-type'],
+        ContentLength: res.headers['content-length'],
+        ServerSideEncryption: 'AES256',
         Body: buffer,
       })
       .promise();
@@ -161,9 +143,7 @@ export const getSignedImageUrl = async (key: string) => {
     Expires: 60,
   };
 
-  return isDocker
-    ? `${publicS3Endpoint()}/${key}`
-    : s3.getSignedUrl("getObject", params);
+  return isDocker ? `${publicS3Endpoint()}/${key}` : s3.getSignedUrl('getObject', params);
 };
 
 export const getImageByKey = async (key: string) => {

--- a/server/utils/s3.js
+++ b/server/utils/s3.js
@@ -17,8 +17,6 @@ AWS.config.getCredentials(function (err) {
 
 const s3 = new AWS.S3({
   s3ForcePathStyle: AWS_S3_FORCE_PATH_STYLE,
-  //accessKeyId: AWS.config.credentials.accessKeyId,
-  //secretAccessKey: AWS.config.credentials.secretAccessKey,
   endpoint: new AWS.Endpoint(process.env.AWS_S3_UPLOAD_BUCKET_URL),
   signatureVersion: "v4",
 });

--- a/server/utils/s3.js
+++ b/server/utils/s3.js
@@ -9,8 +9,8 @@ import fetch from "isomorphic-fetch";
 const AWS_REGION = process.env.AWS_REGION;
 const AWS_S3_UPLOAD_BUCKET_NAME = process.env.AWS_S3_UPLOAD_BUCKET_NAME || "";
 const AWS_S3_FORCE_PATH_STYLE = process.env.AWS_S3_FORCE_PATH_STYLE !== "false";
-var AWS_ACCESS_KEY_ID = undefined;
-var AWS_SECRET_ACCESS_KEY = undefined;
+var AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID;
+var AWS_SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY;
 
 AWS.CredentialProviderChain.defaultProviders = [
   function () {


### PR DESCRIPTION
This PR adds support for retrieving AWS Credentials from more sources than just the environment.

It will search for credentials is:
- The environment 
- ECS IAM Role
- EC2 IAM Role

The advantage of this is that no hardcoded environment variables (either directly or via the Parameter Store) have to be provided to the ECS Task and that the credentials in this case are rotated automatically thus increasing security.