### PR TITLE
docs: Add note to .env.sample about Google OAuth URI

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -24,6 +24,11 @@ DEBUG=cache,presenters,events
 SLACK_KEY=get_a_key_from_slack
 SLACK_SECRET=get_the_secret_of_above_key
 
+# To configure Google auth, you'll need to create an OAuth Client ID at
+# => https://console.cloud.google.com/apis/credentials
+#
+# When configuring the Client ID, add an Authorized redirect URI:
+# https://<your Outline URL>/auth/google.callback
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 


### PR DESCRIPTION
Just adding a bit more context around the required information for setting up Google auth.