### PR TITLE
chore: Enable automatic generation of email server in non production env

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -18,7 +18,7 @@ PORT=3000
 FORCE_HTTPS=true
 
 ENABLE_UPDATES=true
-DEBUG=cache,presenters,events
+DEBUG=cache,presenters,events,emails,mailer,utils,multiplayer,server,services
 
 # Third party signin credentials (at least one is required)
 SLACK_KEY=get_a_key_from_slack

--- a/server/mailer.js
+++ b/server/mailer.js
@@ -26,6 +26,8 @@ import { baseStyles } from "./emails/components/EmailLayout";
 import { createQueue } from "./utils/queue";
 
 const log = debug("emails");
+const useTestEmailService =
+  process.env.NODE_ENV !== "production" && !process.env.SMTP_USERNAME;
 
 type Emails = "welcome" | "export";
 
@@ -73,7 +75,7 @@ export class Mailer {
 
       try {
         log(`Sending email "${data.title}" to ${data.to}`);
-        await transporter.sendMail({
+        const info = await transporter.sendMail({
           from: process.env.SMTP_FROM_EMAIL,
           replyTo: process.env.SMTP_REPLY_EMAIL || process.env.SMTP_FROM_EMAIL,
           to: data.to,
@@ -82,6 +84,10 @@ export class Mailer {
           text: data.text,
           attachments: data.attachments,
         });
+
+        if (useTestEmailService) {
+          log("Email Preview URL: %s", nodemailer.getTestMessageUrl(info));
+        }
       } catch (err) {
         if (process.env.SENTRY_DSN) {
           Sentry.captureException(err);
@@ -159,6 +165,10 @@ export class Mailer {
   };
 
   constructor() {
+    this.loadTransport();
+  }
+
+  async loadTransport() {
     if (process.env.SMTP_HOST) {
       let smtpConfig = {
         host: process.env.SMTP_HOST,
@@ -173,6 +183,24 @@ export class Mailer {
           pass: process.env.SMTP_PASSWORD,
         };
       }
+
+      this.transporter = nodemailer.createTransport(smtpConfig);
+      return;
+    }
+
+    if (useTestEmailService) {
+      log("SMTP_USERNAME not provided, generating test account…");
+      let testAccount = await nodemailer.createTestAccount();
+
+      const smtpConfig = {
+        host: "smtp.ethereal.email",
+        port: 587,
+        secure: false,
+        auth: {
+          user: testAccount.user,
+          pass: testAccount.pass,
+        },
+      };
 
       this.transporter = nodemailer.createTransport(smtpConfig);
     }


### PR DESCRIPTION
Setting up a test email environment is a pain, this PR means it'll happen automatically if no email server details are set in development.

Unfortunately `ethereal.email` has chosen today to have SSL issues, so leaving this in draft until the service is resolved.