### PR TITLE
fix: miro - use the incoming domain to ensure access to logged in boards works

### DIFF
--- a/app/embeds/Miro.js
+++ b/app/embeds/Miro.js
@@ -18,7 +18,7 @@ export default class RealtimeBoard extends React.Component<Props> {
     const { matches } = this.props.attrs;
     const domain = matches[1];
     const boardId = matches[2];
-    const titleName = domain === 'realtimeboard' ? `RealtimeBoard` : `Miro`;
+    const titleName = domain === "realtimeboard" ? "RealtimeBoard" : "Miro";
 
     return (
       <Frame

--- a/app/embeds/Miro.js
+++ b/app/embeds/Miro.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 import Frame from "./components/Frame";
 
-const URL_REGEX = /^https:\/\/(?:realtimeboard|miro).com\/app\/board\/(.*)$/;
+const URL_REGEX = /^https:\/\/(realtimeboard|miro).com\/app\/board\/(.*)$/;
 
 type Props = {|
   attrs: {|
@@ -16,13 +16,15 @@ export default class RealtimeBoard extends React.Component<Props> {
 
   render() {
     const { matches } = this.props.attrs;
-    const boardId = matches[1];
+    const domain = matches[1];
+    const boardId = matches[2];
+    const titleName = domain === 'realtimeboard' ? `RealtimeBoard` : `Miro`;
 
     return (
       <Frame
         {...this.props}
-        src={`https://realtimeboard.com/app/embed/${boardId}`}
-        title={`RealtimeBoard (${boardId})`}
+        src={`https://${domain}.com/app/embed/${boardId}`}
+        title={`${titleName} (${boardId})`}
       />
     );
   }

--- a/app/embeds/Miro.test.js
+++ b/app/embeds/Miro.test.js
@@ -16,7 +16,7 @@ describe("Miro", () => {
   test("to extract the domain as part of the match for later use", () => {
     expect(
       "https://realtimeboard.com/app/board/o9J_k0fwiss=".match(match)[1]
-    ).toBe('realtimeboard');
+    ).toBe("realtimeboard");
   });
 
   test("to not be enabled elsewhere", () => {

--- a/app/embeds/Miro.test.js
+++ b/app/embeds/Miro.test.js
@@ -13,6 +13,12 @@ describe("Miro", () => {
     expect("https://miro.com/app/board/o9J_k0fwiss=".match(match)).toBeTruthy();
   });
 
+  test("to extract the domain as part of the match for later use", () => {
+    expect(
+      "https://realtimeboard.com/app/board/o9J_k0fwiss=".match(match)[1]
+    ).toBe('realtimeboard');
+  });
+
   test("to not be enabled elsewhere", () => {
     expect("https://miro.com".match(match)).toBe(null);
     expect("https://realtimeboard.com".match(match)).toBe(null);


### PR DESCRIPTION
I've started trying to use Outline (it's great and has huge potential - thanks!), and we use Miro a lot.  I notice that the embed forces the embed url to `realtimeboard.com` - which breaks access to logged in boards, as we login via miro.com.  This change uses the incoming url domain to generate the iframe src url domain.