### PR TITLE
feat: Adding an env variable for Google auth prompts

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -74,4 +74,3 @@ SMTP_REPLY_EMAIL=
 # TEAM_LOGO=https://example.com/images/logo.png
 
 DEFAULT_LANGUAGE=en_US
-

--- a/.env.sample
+++ b/.env.sample
@@ -74,3 +74,4 @@ SMTP_REPLY_EMAIL=
 # TEAM_LOGO=https://example.com/images/logo.png
 
 DEFAULT_LANGUAGE=en_US
+

--- a/.env.sample
+++ b/.env.sample
@@ -36,6 +36,13 @@ GOOGLE_CLIENT_SECRET=
 # If not set, all Google apps domains are allowed by default
 GOOGLE_ALLOWED_DOMAINS=
 
+# Type of OAuth prompt to show. Values are (consent|select_account|none)
+# select_account forces the user to choose an account and can avoid a 403
+# when the user is e.g. only signed in to their personal Gmail on their phone.
+# You can also use "select_account consent" to both select an account explicitly
+# and require the auth server to ask the user's permission every time. See https://developers.google.com/identity/protocols/oauth2/openid-connect#authenticationuriparameters
+GOOGLE_AUTH_PROMPT=
+
 # Third party credentials (optional)
 SLACK_VERIFICATION_TOKEN=PLxk6OlXXXXXVj3YYYY
 SLACK_APP_ID=A0XXXXXXX

--- a/server/auth/google.js
+++ b/server/auth/google.js
@@ -27,7 +27,7 @@ router.get("google", async (ctx) => {
       "https://www.googleapis.com/auth/userinfo.profile",
       "https://www.googleapis.com/auth/userinfo.email",
     ],
-    prompt: "consent",
+    prompt: process.env.GOOGLE_AUTH_PROMPT || "consent",
   });
   ctx.redirect(authorizeUrl);
 });


### PR DESCRIPTION
Hey, great project! We have it deployed and are starting to use it for our team knowledge base.

Our team members have a variety of challenges/journeys when it comes to using technology so want to break everything I can ahead of time :).

Here's one issue I noticed and how to reproduce it:

**Setup**
- Let's say the user has a personal and a work Gmail account
- the installation defines `GOOGLE_ALLOWED_DOMAINS` to allow only the work domain to log in to Outline
- On the user's browser, they're only logged into their personal Gmail by default (even if, say, the mail app is logged in to both)
- The OAuth prompt is hard-coded to `consent` in: https://github.com/outline/outline/blob/308d4bd797dd4b600add492ac94d922a1f4a8d17/server/auth/google.js#L22-L33

**The issue**
- After Outline has redirected to the auth URL, Google throws a 403, "org_internal: This client is restricted to users within this organization" and displays some opaque-looking OAuth request details.
- It's not clear to the user what they need to do. Hitting back, clearing the cache, etc. will not solve the main issue, which is that they need to log in to their work account on the browser they're using.

**Proposed fix**
This answer may not be the right for all use cases, so left it as an option for the deployment without changing the default, but the issue I described can be handled by using a prompt type of `select_account`, which will force account selection every time (or the best of both worlds, `select_account consent`).

More info on the options here: https://developers.google.com/identity/protocols/oauth2/openid-connect#authenticationuriparameters

Happy to accept another solution. I just know that's going to be a stumbling block for our folks.