### PR TITLE
fix: Adds support for VirtualHost style AWS S3 buckets

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@tippy.js/react": "^2.2.2",
     "@tommoor/remove-markdown": "0.3.1",
     "autotrack": "^2.4.1",
-    "aws-sdk": "^2.135.0",
+    "aws-sdk": "^2.831.0",
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-styled-components": "^1.11.1",
     "babel-plugin-transform-class-properties": "^6.24.1",

--- a/server/utils/s3.js
+++ b/server/utils/s3.js
@@ -88,7 +88,7 @@ export const publicS3Endpoint = (isServerUpload?: boolean) => {
   // for the bucket name in the endpoint url before appending.
   const isVirtualHost = host.includes(AWS_S3_UPLOAD_BUCKET_NAME);
 
-  if (isVirtualHost && !AWS_S3_FORCE_PATH_STYLE) {
+  if (isVirtualHost) {
     return host;
   }
 

--- a/server/utils/s3.js
+++ b/server/utils/s3.js
@@ -16,7 +16,7 @@ const s3 = new AWS.S3({
   s3ForcePathStyle: AWS_S3_FORCE_PATH_STYLE,
   accessKeyId: AWS_ACCESS_KEY_ID,
   secretAccessKey: AWS_SECRET_ACCESS_KEY,
-  endpoint: new AWS.Endpoint(process.env.AWS_S3_UPLOAD_BUCKET_URL),
+  region: AWS_REGION,
   signatureVersion: "v4",
 });
 
@@ -88,8 +88,8 @@ export const publicS3Endpoint = (isServerUpload?: boolean) => {
   // for the bucket name in the endpoint url before appending.
   const isVirtualHost = host.includes(AWS_S3_UPLOAD_BUCKET_NAME);
 
-  if (isVirtualHost) {
-    return `${host}/`;
+  if (isVirtualHost && !AWS_S3_FORCE_PATH_STYLE) {
+    return host;
   }
 
   return `${host}/${

--- a/server/utils/s3.js
+++ b/server/utils/s3.js
@@ -84,6 +84,14 @@ export const publicS3Endpoint = (isServerUpload?: boolean) => {
     "localhost:"
   ).replace(/\/$/, "");
 
+  // support old path-style S3 uploads and new virtual host uploads by checking
+  // for the bucket name in the endpoint url before appending.
+  const isVirtualHost = host.includes(AWS_S3_UPLOAD_BUCKET_NAME);
+
+  if (isVirtualHost) {
+    return `${host}/`;
+  }
+
   return `${host}/${
     isServerUpload && isDocker ? "s3/" : ""
   }${AWS_S3_UPLOAD_BUCKET_NAME}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2296,10 +2296,10 @@ autotrack@^2.4.1:
     rollup-plugin-node-resolve "^3.0.0"
     source-map "^0.5.6"
 
-aws-sdk@^2.135.0:
-  version "2.791.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.791.0.tgz#a85bedd46c97e0d262edb055651075c3171a171c"
-  integrity sha512-oIWu0hLKmDS+rOmjud2Z1CaDXtmxKSJF4937dSNLf/vNkxxjJA/6HapSfKqsraLnekI9DLP8uop5HnCHC++Abw==
+aws-sdk@^2.831.0:
+  version "2.831.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.831.0.tgz#02607cc911a2136e5aabe624c1282e821830aef2"
+  integrity sha512-lrOjbGFpjk2xpESyUx2PGsTZgptCy5xycZazPeakNbFO19cOoxjHx3xyxOHsMCYb3pQwns35UvChQT60B4u6cw==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"


### PR DESCRIPTION
Changes from the discussion here: https://github.com/outline/outline/discussions/1813

✅  Tested with old pre 2020 buckets (`AWS_S3_FORCE_PATH_STYLE=true`)
✅  Tested with new 2021 buckets (`AWS_S3_FORCE_PATH_STYLE=false`)
✅  Tested with new 2021 buckets