### PR TITLE
chore: Add Timing-Allow-Origin header

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -185,16 +185,6 @@ app.use(
   })
 );
 
-// In order to report all possible performance metrics to Sentry this header
-// must be provided, see:
-// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Timing-Allow-Origin
-if (env.SENTRY_DSN) {
-  app.use(async (ctx, next) => {
-    ctx.headers["Timing-Allow-Origin"] = "https://sentry.io";
-    await next();
-  });
-}
-
 // Allow DNS prefetching for performance, we do not care about leaking requests
 // to our own CDN's
 app.use(dnsPrefetchControl({ allow: true }));

--- a/server/routes.js
+++ b/server/routes.js
@@ -114,20 +114,15 @@ router.get("*", renderApp);
 // In order to report all possible performance metrics to Sentry this header
 // must be provided when serving the application, see:
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Timing-Allow-Origin
-const timingOrigins = [];
+const timingOrigins = [env.URL];
 if (env.SENTRY_DSN) {
   timingOrigins.push("https://sentry.io");
 }
-if (env.CDN_URL) {
-  timingOrigins.push(env.CDN_URL);
-}
 
-if (timingOrigins.length) {
-  koa.use(async (ctx, next) => {
-    ctx.headers["Timing-Allow-Origin"] = timingOrigins.join(", ");
-    await next();
-  });
-}
+koa.use(async (ctx, next) => {
+  ctx.set("Timing-Allow-Origin", timingOrigins.join(", "));
+  await next();
+});
 
 koa.use(apexRedirect());
 koa.use(router.routes());

--- a/server/utils/prefetchTags.js
+++ b/server/utils/prefetchTags.js
@@ -28,6 +28,7 @@ try {
   // no-op
 }
 
+let index = 0;
 Object.values(manifestData).forEach((filename) => {
   if (typeof filename !== "string") return;
   if (!env.CDN_URL) return;
@@ -40,14 +41,19 @@ Object.values(manifestData).forEach((filename) => {
       filename.includes("/runtime") ||
       filename.includes("/vendors");
 
-    prefetchTags.push(
-      <link
-        rel={shouldPreload ? "preload" : "prefetch"}
-        href={filename}
-        key={filename}
-        as="script"
-      />
-    );
+    // only prefetch the first few javascript chunks or it gets out of hand fast
+    const shouldPrefetch = ++index <= 6;
+
+    if (shouldPreload || shouldPrefetch) {
+      prefetchTags.push(
+        <link
+          rel={shouldPreload ? "preload" : "prefetch"}
+          href={filename}
+          key={filename}
+          as="script"
+        />
+      );
+    }
   } else if (filename.endsWith(".css")) {
     prefetchTags.push(
       <link rel="prefetch" href={filename} key={filename} as="style" />


### PR DESCRIPTION
- Enables collection of detailed performance data by Sentry when the integration is enabled.
- Added cap to script prefetching
- Added additional comments
- Removed unused scriptsrc for Sentry now that we bundle in vendors