### PR TITLE
fix: Pass credentials with API requests when required to work with Cloudflare Access

### DIFF
--- a/app/utils/ApiClient.js
+++ b/app/utils/ApiClient.js
@@ -1,9 +1,9 @@
 // @flow
 import invariant from "invariant";
 import { map, trim } from "lodash";
+import { getCookie } from "tiny-cookie";
 import stores from "stores";
 import download from "./download";
-import { getCookie } from "tiny-cookie";
 import {
   AuthorizationError,
   BadRequestError,

--- a/app/utils/ApiClient.js
+++ b/app/utils/ApiClient.js
@@ -3,6 +3,7 @@ import invariant from "invariant";
 import { map, trim } from "lodash";
 import stores from "stores";
 import download from "./download";
+import { getCookie } from "tiny-cookie";
 import {
   AuthorizationError,
   BadRequestError,
@@ -17,6 +18,11 @@ import {
 type Options = {
   baseUrl?: string,
 };
+
+// authorization cookie set by a Cloudflare Access proxy
+const CF_AUTHORIZATION = getCookie("CF_Authorization");
+// if the cookie is set, we must pass it with all ApiClient requests
+const CREDENTIALS = CF_AUTHORIZATION ? "same-origin" : "omit";
 
 class ApiClient {
   baseUrl: string;
@@ -91,7 +97,7 @@ class ApiClient {
         body,
         headers,
         redirect: "follow",
-        credentials: "omit",
+        credentials: CREDENTIALS,
         cache: "no-cache",
       });
     } catch (err) {

--- a/server/static/index.html
+++ b/server/static/index.html
@@ -12,7 +12,7 @@
       href="/favicon-32.png"
       sizes="32x32"
     />
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />
     <link
       rel="search"
       type="application/opensearchdescription+xml"


### PR DESCRIPTION
Makes Outline work correctly behind Cloudflare Access proxies which require passing credentials (cookies) with API requests.

Fixes #1866
Fixes #1850