### PR TITLE
feat: Add PWA support to subdomains

### DIFF
--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -94,6 +94,11 @@ const Title = styled(Flex)`
   ${breakpoint("tablet")`	
     flex-grow: 1;
   `};
+
+  @media (display-mode: standalone) {
+    overflow: hidden;
+    flex-grow: 0 !important;
+  }
 `;
 
 const Actions = styled(Flex)`

--- a/shared/styles/globals.js
+++ b/shared/styles/globals.js
@@ -31,7 +31,7 @@ export default createGlobalStyle`
     font-size: 16px;
     line-height: 1.5;
     color: ${(props) => props.theme.text};
-
+    overscroll-behavior-y: none;
     -moz-osx-font-smoothing: grayscale;
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,7 +66,8 @@ module.exports = {
       short_name: "Outline",
       background_color: "#fff",
       theme_color: "#fff",
-      start_url: process.env.URL,
+      start_url: "/",
+      publicPath: "/static/",
       display: "standalone",
       icons: [
         {


### PR DESCRIPTION
PWA support was added for self hosted installations in `0.53.0` however it hasn't yet worked for the cloud hosted version due to the reliance on a single domain. These changes add support for multiple subdomains and clean up the styling a little.

closes #1892 