### PR TITLE
fix: Remove double separator in collection menu

### DIFF
--- a/app/menus/CollectionMenu.js
+++ b/app/menus/CollectionMenu.js
@@ -160,7 +160,6 @@ function CollectionMenu({
             },
             {
               type: "separator",
-              visible: !!(collection && can.delete),
             },
             {
               title: `${t("Delete")}…`,

--- a/app/menus/CollectionMenu.js
+++ b/app/menus/CollectionMenu.js
@@ -160,9 +160,7 @@ function CollectionMenu({
             },
             {
               type: "separator",
-            },
-            {
-              type: "separator",
+              visible: !!(collection && can.delete),
             },
             {
               title: `${t("Delete")}…`,


### PR DESCRIPTION
fixes #1947 