### PR TITLE
feat: Enforce single team when self-hosted

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -71,7 +71,7 @@ DEBUG=cache,presenters,events,emails,mailer,utils,multiplayer,server,services
 
 # Comma separated list of domains to be allowed to signin to the wiki. If not
 # set, all domains are allowed by default when using Google OAuth to signin
-GOOGLE_ALLOWED_DOMAINS=
+ALLOWED_DOMAINS=
 
 # For a complete Slack integration with search and posting to channels the 
 # following configs are also needed, some more details

--- a/app.json
+++ b/app.json
@@ -55,7 +55,7 @@
       "description": "",
       "required": false
     },
-    "GOOGLE_ALLOWED_DOMAINS": {
+    "ALLOWED_DOMAINS": {
       "description": "Comma separated list of domains to be allowed (optional). If not set, all Google apps domains are allowed by default",
       "required": false
     },

--- a/app/scenes/Login/Notices.js
+++ b/app/scenes/Login/Notices.js
@@ -17,8 +17,8 @@ export default function Notices({ notice }: Props) {
       )}
       {notice === "maximum-teams" && (
         <NoticeAlert>
-          The team you authenticated with is not authorized on this installation.
-          Try another?
+          The team you authenticated with is not authorized on this
+          installation. Try another?
         </NoticeAlert>
       )}
       {notice === "hd-not-allowed" && (

--- a/app/scenes/Login/Notices.js
+++ b/app/scenes/Login/Notices.js
@@ -17,7 +17,7 @@ export default function Notices({ notice }: Props) {
       )}
       {notice === "maximum-teams" && (
         <NoticeAlert>
-          The team you authenticated with is not allowed on this installation.
+          The team you authenticated with is not authorized on this installation.
           Try another?
         </NoticeAlert>
       )}

--- a/app/scenes/Login/Notices.js
+++ b/app/scenes/Login/Notices.js
@@ -15,6 +15,12 @@ export default function Notices({ notice }: Props) {
           signing in with your Google Workspace account.
         </NoticeAlert>
       )}
+      {notice === "maximum-teams" && (
+        <NoticeAlert>
+          The team you authenticated with is not allowed on this installation.
+          Try another?
+        </NoticeAlert>
+      )}
       {notice === "hd-not-allowed" && (
         <NoticeAlert>
           Sorry, your Google apps domain is not allowed. Please try again with

--- a/server/auth/google.js
+++ b/server/auth/google.js
@@ -11,14 +11,14 @@ import {
 } from "../errors";
 import auth from "../middlewares/authentication";
 import passportMiddleware from "../middlewares/passport";
+import { getAllowedDomains } from "../utils/authentication";
 import { StateStore } from "../utils/passport";
 
 const router = new Router();
 const providerName = "google";
 const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
 const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET;
-const allowedDomainsEnv = process.env.GOOGLE_ALLOWED_DOMAINS;
-const allowedDomains = allowedDomainsEnv ? allowedDomainsEnv.split(",") : [];
+const allowedDomains = getAllowedDomains();
 
 const scopes = [
   "https://www.googleapis.com/auth/userinfo.profile",

--- a/server/commands/teamCreator.js
+++ b/server/commands/teamCreator.js
@@ -1,5 +1,6 @@
 // @flow
 import debug from "debug";
+import { MaximumTeamsError } from "../errors";
 import { Team, AuthenticationProvider } from "../models";
 import { sequelize } from "../sequelize";
 import { generateAvatarUrl } from "../utils/avatars";
@@ -62,6 +63,16 @@ export default async function teamCreator({
   // This team has never been seen before, time to create all the new stuff
   let transaction = await sequelize.transaction();
   let team;
+
+  if (process.env.DEPLOYMENT !== "hosted") {
+    const teams = await Team.count();
+    if (teams >= 1) {
+      throw new MaximumTeamsError(
+        "The team you attempted to login with does not exist on this installation."
+      );
+    }
+  }
+
   try {
     team = await Team.create(
       {

--- a/server/commands/teamCreator.js
+++ b/server/commands/teamCreator.js
@@ -71,9 +71,7 @@ export default async function teamCreator({
     }
 
     if (teamCount >= 1) {
-      throw new MaximumTeamsError(
-        "The team you attempted to login with does not exist on this installation."
-      );
+      throw new MaximumTeamsError();
     }
   }
 

--- a/server/commands/teamCreator.test.js
+++ b/server/commands/teamCreator.test.js
@@ -55,6 +55,31 @@ describe("teamCreator", () => {
     expect(error).toBeTruthy();
   });
 
+  it("should return existing team when within allowed domains", async () => {
+    const existing = await buildTeam();
+
+    const result = await teamCreator({
+      name: "Updated name",
+      subdomain: "example",
+      domain: "allowed-domain.com",
+      authenticationProvider: {
+        name: "google",
+        providerId: "allowed-domain.com",
+      },
+    });
+
+    const { team, authenticationProvider, isNewTeam } = result;
+
+    expect(team.id).toEqual(existing.id);
+    expect(team.name).toEqual(existing.name);
+    expect(authenticationProvider.name).toEqual("google");
+    expect(authenticationProvider.providerId).toEqual("allowed-domain.com");
+    expect(isNewTeam).toEqual(false);
+
+    const providers = await team.getAuthenticationProviders();
+    expect(providers.length).toEqual(2);
+  });
+
   it("should return exising team", async () => {
     const authenticationProvider = {
       name: "google",

--- a/server/commands/teamCreator.test.js
+++ b/server/commands/teamCreator.test.js
@@ -34,6 +34,27 @@ describe("teamCreator", () => {
     expect(isNewTeam).toEqual(true);
   });
 
+  it("should now allow creating multiple teams in installation", async () => {
+    await buildTeam();
+    let error;
+
+    try {
+      await teamCreator({
+        name: "Test team",
+        subdomain: "example",
+        avatarUrl: "http://example.com/logo.png",
+        authenticationProvider: {
+          name: "google",
+          providerId: "example.com",
+        },
+      });
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error).toBeTruthy();
+  });
+
   it("should return exising team", async () => {
     const authenticationProvider = {
       name: "google",

--- a/server/errors.js
+++ b/server/errors.js
@@ -69,6 +69,12 @@ export function OAuthStateMismatchError(
   return httpErrors(400, message, { id: "state_mismatch" });
 }
 
+export function MaximumTeamsError(
+  message: string = "The maximum number of teams has been reached"
+) {
+  return httpErrors(400, message, { id: "max_teams" });
+}
+
 export function EmailAuthenticationRequiredError(
   message: string = "User must authenticate with email",
   redirectUrl: string = env.URL

--- a/server/errors.js
+++ b/server/errors.js
@@ -72,7 +72,7 @@ export function OAuthStateMismatchError(
 export function MaximumTeamsError(
   message: string = "The maximum number of teams has been reached"
 ) {
-  return httpErrors(400, message, { id: "max_teams" });
+  return httpErrors(400, message, { id: "maximum_teams" });
 }
 
 export function EmailAuthenticationRequiredError(

--- a/server/test/helper.js
+++ b/server/test/helper.js
@@ -7,6 +7,7 @@ process.env.NODE_ENV = "test";
 process.env.GOOGLE_CLIENT_ID = "123";
 process.env.SLACK_KEY = "123";
 process.env.DEPLOYMENT = "";
+process.env.ALLOWED_DOMAINS = "allowed-domain.com";
 
 // This is needed for the relative manual mock to be picked up
 jest.mock("../events");

--- a/server/test/helper.js
+++ b/server/test/helper.js
@@ -6,6 +6,7 @@ process.env.DATABASE_URL = process.env.DATABASE_URL_TEST;
 process.env.NODE_ENV = "test";
 process.env.GOOGLE_CLIENT_ID = "123";
 process.env.SLACK_KEY = "123";
+process.env.DEPLOYMENT = "";
 
 // This is needed for the relative manual mock to be picked up
 jest.mock("../events");

--- a/server/utils/authentication.js
+++ b/server/utils/authentication.js
@@ -1,0 +1,7 @@
+// @flow
+
+export function getAllowedDomains(): string[] {
+  // GOOGLE_ALLOWED_DOMAINS included here for backwards compatability
+  const env = process.env.ALLOWED_DOMAINS || process.env.GOOGLE_ALLOWED_DOMAINS;
+  return env ? env.split(",") : [];
+}


### PR DESCRIPTION
Behavior is as follows:

- On first install signup is open (apart from `ALLOWED_DOMAINS` restriction)
- After first team is registered no other teams can be created
- If attempting to signin with another google hd that's within `ALLOWED_DOMAINS` it will be assigned to the existing team, otherwise an error will be returned
- The addition of https://github.com/outline/outline/issues/1945 will enable adding multiple authentication methods in the future.

closes #862 