### PR TITLE
fix: correct GoogleSheets component class name

### DIFF
--- a/app/embeds/GoogleSheets.js
+++ b/app/embeds/GoogleSheets.js
@@ -12,7 +12,7 @@ type Props = {|
   |},
 |};
 
-export default class GoogleSlides extends React.Component<Props> {
+export default class GoogleSheets extends React.Component<Props> {
   static ENABLED = [URL_REGEX];
 
   render() {


### PR DESCRIPTION
The GoogleSheets component has an incorrect name which is "GoogleSlides". Its probably result of a copy/paste mistake.