### PR TITLE
fix: touch up UI for compact breadcrumbs

### DIFF
--- a/app/components/Breadcrumb.js
+++ b/app/components/Breadcrumb.js
@@ -169,10 +169,13 @@ const SmallPadlockIcon = styled(PadlockIcon)`
 `;
 
 const SmallSlash = styled(GoToIcon)`
-  width: 15px;
-  height: 10px;
+  width: 12px;
+  height: 12px;
+  vertical-align: middle;
   flex-shrink: 0;
-  opacity: 0.25;
+
+  fill: ${(props) => props.theme.slate};
+  opacity: 0.5;
 `;
 
 const Crumb = styled(Link)`

--- a/app/components/DocumentMeta.js
+++ b/app/components/DocumentMeta.js
@@ -18,6 +18,11 @@ const Container = styled(Flex)`
   min-width: 0;
 `;
 
+const Viewed = styled.span`
+  text-overflow: ellipsis;
+  overflow: hidden;
+`;
+
 const Modified = styled.span`
   color: ${(props) => props.theme.textTertiary};
   font-weight: ${(props) => (props.highlight ? "600" : "400")};
@@ -112,16 +117,16 @@ function DocumentMeta({
     }
     if (!lastViewedAt) {
       return (
-        <>
+        <Viewed>
           •&nbsp;<Modified highlight>{t("Never viewed")}</Modified>
-        </>
+        </Viewed>
       );
     }
 
     return (
-      <span>
+      <Viewed>
         •&nbsp;{t("Viewed")} <Time dateTime={lastViewedAt} addSuffix shorten />
-      </span>
+      </Viewed>
     );
   };
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/427579/111240907-59627200-85b9-11eb-88a7-57263fbb1ec1.png)
![image](https://user-images.githubusercontent.com/427579/111240712-f7097180-85b8-11eb-9563-16e4516dac87.png)

1. adds ellipses to last segment of list item metadata
2. makes the slashes more visible, especially in dark mode and fixes vertical alignment