### PR TITLE
fix: Moving document in private collection returns incorrect policies

### DIFF
--- a/server/api/documents.js
+++ b/server/api/documents.js
@@ -1047,7 +1047,7 @@ router.post("documents.move", auth(), async (ctx) => {
     authorize(user, "update", parent);
   }
 
-  const { documents, collections } = await documentMover({
+  const { documents, collections, collectionChanged } = await documentMover({
     user,
     document,
     collectionId,
@@ -1065,7 +1065,7 @@ router.post("documents.move", auth(), async (ctx) => {
         collections.map((collection) => presentCollection(collection))
       ),
     },
-    policies: presentPolicies(user, documents),
+    policies: collectionChanged ? presentPolicies(user, documents) : [],
   };
 });
 

--- a/server/api/documents.test.js
+++ b/server/api/documents.test.js
@@ -1325,6 +1325,7 @@ describe("#documents.move", () => {
     const body = await res.json();
     expect(res.status).toEqual(200);
     expect(body.data.documents[0].collectionId).toEqual(collection.id);
+    expect(body.policies[0].abilities.move).toEqual(true);
   });
 
   it("should not allow moving the document to a collection the user cannot access", async () => {

--- a/server/commands/documentMover.js
+++ b/server/commands/documentMover.js
@@ -18,8 +18,8 @@ export default async function documentMover({
   ip: string,
 }) {
   let transaction;
-  const result = { collections: [], documents: [] };
   const collectionChanged = collectionId !== document.collectionId;
+  const result = { collections: [], documents: [], collectionChanged };
 
   if (document.template) {
     if (!collectionChanged) {
@@ -72,7 +72,9 @@ export default async function documentMover({
       document.updatedBy = user;
 
       const newCollection: Collection = collectionChanged
-        ? await Collection.findByPk(collectionId, { transaction })
+        ? await Collection.scope({
+            method: ["withMembership", user.id],
+          }).findByPk(collectionId, { transaction })
         : collection;
       await newCollection.addDocumentToStructure(document, toIndex, {
         documentJson,
@@ -104,6 +106,8 @@ export default async function documentMover({
       }
 
       await document.save({ transaction });
+
+      document.collection = newCollection;
       result.documents.push(document);
 
       await transaction.commit();

--- a/server/commands/documentMover.test.js
+++ b/server/commands/documentMover.test.js
@@ -48,6 +48,7 @@ describe("documentMover", () => {
     );
     expect(response.collections.length).toEqual(1);
     expect(response.documents.length).toEqual(1);
+    expect(response.documents[0].collection.id).toEqual(collection.id);
   });
 
   it("should move with children to another collection", async () => {
@@ -89,5 +90,7 @@ describe("documentMover", () => {
     );
     expect(response.collections.length).toEqual(2);
     expect(response.documents.length).toEqual(2);
+    expect(response.documents[0].collection.id).toEqual(newCollection.id);
+    expect(response.documents[1].collection.id).toEqual(newCollection.id);
   });
 });


### PR DESCRIPTION
This fixes an issue where the policies returned from a move operation were overly restrictive, resulting in no further moves being allowed (infact all editing actions were disallowed) until app is reloaded after moving a doc in a private collection.

Glad this was caught before this months release.

closes #1968 