### PR TITLE
fix: Single share record per document

### DIFF
--- a/server/api/shares.js
+++ b/server/api/shares.js
@@ -25,7 +25,7 @@ router.post("shares.info", auth(), async (ctx) => {
         }
       : {
           documentId,
-          userId: user.id,
+          teamId: user.teamId,
           revokedAt: { [Op.eq]: null },
         },
   });
@@ -134,9 +134,11 @@ router.post("shares.create", auth(), async (ctx) => {
   const [share, isCreated] = await Share.findOrCreate({
     where: {
       documentId,
-      userId: user.id,
       teamId: user.teamId,
       revokedAt: null,
+    },
+    defaults: {
+      userId: user.id,
     },
   });
 

--- a/server/api/shares.test.js
+++ b/server/api/shares.test.js
@@ -277,12 +277,12 @@ describe("#shares.info", () => {
     expect(body.data.published).toBe(true);
   });
 
-  it("should not find share for different user", async () => {
+  it("should find share created by another user", async () => {
     const { admin, document } = await seed();
     const user = await buildUser({
       teamId: admin.teamId,
     });
-    await buildShare({
+    const share = await buildShare({
       documentId: document.id,
       teamId: admin.teamId,
       userId: admin.id,
@@ -290,7 +290,11 @@ describe("#shares.info", () => {
     const res = await server.post("/api/shares.info", {
       body: { token: user.getJwtToken(), documentId: document.id },
     });
-    expect(res.status).toEqual(204);
+    const body = await res.json();
+
+    expect(res.status).toEqual(200);
+    expect(body.data.id).toBe(share.id);
+    expect(body.data.published).toBe(true);
   });
 
   it("should not find revoked share", async () => {
@@ -353,6 +357,23 @@ describe("#shares.info", () => {
 });
 
 describe("#shares.update", () => {
+  it("should allow user to update a share", async () => {
+    const { user, document } = await seed();
+    const share = await buildShare({
+      documentId: document.id,
+      teamId: user.teamId,
+    });
+
+    const res = await server.post("/api/shares.update", {
+      body: { token: user.getJwtToken(), id: share.id, published: true },
+    });
+    const body = await res.json();
+
+    expect(res.status).toEqual(200);
+    expect(body.data.id).toBe(share.id);
+    expect(body.data.published).toBe(true);
+  });
+
   it("should allow author to update a share", async () => {
     const { user, document } = await seed();
     const share = await buildShare({

--- a/server/policies/share.js
+++ b/server/policies/share.js
@@ -5,8 +5,14 @@ import policy from "./policy";
 
 const { allow } = policy;
 
-allow(User, ["read"], Share, (user, share) => user.teamId === share.teamId);
-allow(User, ["update", "revoke"], Share, (user, share) => {
+allow(
+  User,
+  ["read", "update"],
+  Share,
+  (user, share) => user.teamId === share.teamId
+);
+
+allow(User, "revoke", Share, (user, share) => {
   if (!share || user.teamId !== share.teamId) return false;
   if (user.id === share.userId) return true;
   if (user.isAdmin) return true;


### PR DESCRIPTION
Currently multiple share records are created per-document – one per-user, this makes it hard to reason about and understand whether a document is truly shared publicly or not without checking in the admin interface.

This change makes it so that there is a single canonical share record per document.