### PR TITLE
fix: Add 'sort' parameter validation

### DIFF
--- a/server/api/documents.js
+++ b/server/api/documents.js
@@ -128,6 +128,8 @@ router.post("documents.list", auth(), pagination(), async (ctx) => {
     sort = "updatedAt";
   }
 
+  ctx.assertSort(sort, Document);
+
   // add the users starred state to the response by default
   const starredScope = { method: ["withStarred", user.id] };
   const collectionScope = { method: ["withCollection", user.id] };
@@ -170,6 +172,7 @@ router.post("documents.pinned", auth(), pagination(), async (ctx) => {
   let direction = ctx.body.direction;
   if (direction !== "ASC") direction = "DESC";
   ctx.assertUuid(collectionId, "collectionId is required");
+  ctx.assertSort(sort, Document);
 
   const user = ctx.state.user;
   const collection = await Collection.scope({
@@ -214,6 +217,8 @@ router.post("documents.pinned", auth(), pagination(), async (ctx) => {
 
 router.post("documents.archived", auth(), pagination(), async (ctx) => {
   const { sort = "updatedAt" } = ctx.body;
+  ctx.assertSort(sort, Document);
+
   let direction = ctx.body.direction;
   if (direction !== "ASC") direction = "DESC";
 
@@ -254,6 +259,8 @@ router.post("documents.archived", auth(), pagination(), async (ctx) => {
 
 router.post("documents.deleted", auth(), pagination(), async (ctx) => {
   const { sort = "deletedAt" } = ctx.body;
+  ctx.assertSort(sort, Document);
+
   let direction = ctx.body.direction;
   if (direction !== "ASC") direction = "DESC";
 
@@ -295,6 +302,8 @@ router.post("documents.deleted", auth(), pagination(), async (ctx) => {
 
 router.post("documents.viewed", auth(), pagination(), async (ctx) => {
   let { sort = "updatedAt", direction } = ctx.body;
+  ctx.assertSort(sort, Document);
+
   if (direction !== "ASC") direction = "DESC";
 
   const user = ctx.state.user;
@@ -344,6 +353,8 @@ router.post("documents.viewed", auth(), pagination(), async (ctx) => {
 
 router.post("documents.starred", auth(), pagination(), async (ctx) => {
   let { sort = "updatedAt", direction } = ctx.body;
+  ctx.assertSort(sort, Document);
+
   if (direction !== "ASC") direction = "DESC";
 
   const user = ctx.state.user;
@@ -395,6 +406,8 @@ router.post("documents.starred", auth(), pagination(), async (ctx) => {
 
 router.post("documents.drafts", auth(), pagination(), async (ctx) => {
   let { collectionId, dateFilter, sort = "updatedAt", direction } = ctx.body;
+  ctx.assertSort(sort, Document);
+
   if (direction !== "ASC") direction = "DESC";
 
   const user = ctx.state.user;

--- a/server/api/events.js
+++ b/server/api/events.js
@@ -22,6 +22,7 @@ router.post("events.list", auth(), pagination(), async (ctx) => {
     auditLog = false,
   } = ctx.body;
   if (direction !== "ASC") direction = "DESC";
+  ctx.assertSort(sort, Event);
 
   let where = {
     name: Event.ACTIVITY_EVENTS,

--- a/server/api/groups.js
+++ b/server/api/groups.js
@@ -18,9 +18,10 @@ const { authorize } = policy;
 const router = new Router();
 
 router.post("groups.list", auth(), pagination(), async (ctx) => {
-  const { sort = "updatedAt" } = ctx.body;
-  let direction = ctx.body.direction;
+  let { sort = "updatedAt", direction } = ctx.body;
   if (direction !== "ASC") direction = "DESC";
+  ctx.assertSort(sort, Group);
+
   const user = ctx.state.user;
 
   let groups = await Group.findAll({

--- a/server/api/integrations.js
+++ b/server/api/integrations.js
@@ -13,6 +13,7 @@ const router = new Router();
 router.post("integrations.list", auth(), pagination(), async (ctx) => {
   let { sort = "updatedAt", direction } = ctx.body;
   if (direction !== "ASC") direction = "DESC";
+  ctx.assertSort(sort, Integration);
 
   const user = ctx.state.user;
   const integrations = await Integration.findAll({

--- a/server/api/revisions.js
+++ b/server/api/revisions.js
@@ -34,6 +34,7 @@ router.post("revisions.info", auth(), async (ctx) => {
 router.post("revisions.list", auth(), pagination(), async (ctx) => {
   let { documentId, sort = "updatedAt", direction } = ctx.body;
   if (direction !== "ASC") direction = "DESC";
+  ctx.assertSort(sort, Revision);
   ctx.assertPresent(documentId, "documentId is required");
 
   const user = ctx.state.user;

--- a/server/api/shares.js
+++ b/server/api/shares.js
@@ -44,6 +44,7 @@ router.post("shares.info", auth(), async (ctx) => {
 router.post("shares.list", auth(), pagination(), async (ctx) => {
   let { sort = "updatedAt", direction } = ctx.body;
   if (direction !== "ASC") direction = "DESC";
+  ctx.assertSort(sort, Share);
 
   const user = ctx.state.user;
   const where = {

--- a/server/api/users.js
+++ b/server/api/users.js
@@ -13,9 +13,15 @@ const { authorize } = policy;
 const router = new Router();
 
 router.post("users.list", auth(), pagination(), async (ctx) => {
-  const { sort = "createdAt", query, includeSuspended = false } = ctx.body;
-  let direction = ctx.body.direction;
+  let {
+    sort = "createdAt",
+    query,
+    direction,
+    includeSuspended = false,
+  } = ctx.body;
   if (direction !== "ASC") direction = "DESC";
+  ctx.assertSort(sort, User);
+
   const user = ctx.state.user;
 
   let where = {

--- a/server/middlewares/validation.js
+++ b/server/middlewares/validation.js
@@ -18,6 +18,12 @@ export default function validation() {
       }
     };
 
+    ctx.assertSort = (value, model, message = "Invalid sort parameter") => {
+      if (!Object.keys(model.rawAttributes).includes(value)) {
+        throw new ValidationError(message);
+      }
+    };
+
     ctx.assertNotEmpty = (value, message) => {
       if (value === "") {
         throw new ValidationError(message);


### PR DESCRIPTION
We've seen some errors where API clients submit an invalid value for the `sort` parameter, it must be a column in the database. Added a new validation to ensure this and return a more useful error to the API consumer.