### PR TITLE
perf: Remove collaborators from documents.list response

### DIFF
--- a/app/models/Document.js
+++ b/app/models/Document.js
@@ -24,6 +24,7 @@ export default class Document extends BaseModel {
   @observable lastViewedAt: ?string;
   store: DocumentsStore;
 
+  collaboratorIds: string[];
   collectionId: string;
   createdAt: string;
   createdBy: User;

--- a/app/models/Document.js
+++ b/app/models/Document.js
@@ -24,7 +24,6 @@ export default class Document extends BaseModel {
   @observable lastViewedAt: ?string;
   store: DocumentsStore;
 
-  collaborators: User[];
   collectionId: string;
   createdAt: string;
   createdBy: User;

--- a/server/presenters/document.js
+++ b/server/presenters/document.js
@@ -52,6 +52,7 @@ export default async function present(document: Document, options: ?Options) {
     teamId: document.teamId,
     template: document.template,
     templateId: document.templateId,
+    collaboratorIds: [],
     starred: document.starred ? !!document.starred.length : undefined,
     revision: document.revisionCount,
     pinned: undefined,
@@ -70,6 +71,7 @@ export default async function present(document: Document, options: ?Options) {
     data.parentDocumentId = document.parentDocumentId;
     data.createdBy = presentUser(document.createdBy);
     data.updatedBy = presentUser(document.updatedBy);
+    data.collaboratorIds = document.collaboratorIds;
   }
 
   return data;

--- a/server/presenters/document.js
+++ b/server/presenters/document.js
@@ -1,6 +1,5 @@
 // @flow
-import { takeRight } from "lodash";
-import { Attachment, Document, User } from "../models";
+import { Attachment, Document } from "../models";
 import parseAttachmentIds from "../utils/parseAttachmentIds";
 import { getSignedImageUrl } from "../utils/s3";
 import presentUser from "./user";

--- a/server/presenters/document.js
+++ b/server/presenters/document.js
@@ -53,7 +53,6 @@ export default async function present(document: Document, options: ?Options) {
     teamId: document.teamId,
     template: document.template,
     templateId: document.templateId,
-    collaborators: [],
     starred: document.starred ? !!document.starred.length : undefined,
     revision: document.revisionCount,
     pinned: undefined,
@@ -72,15 +71,6 @@ export default async function present(document: Document, options: ?Options) {
     data.parentDocumentId = document.parentDocumentId;
     data.createdBy = presentUser(document.createdBy);
     data.updatedBy = presentUser(document.updatedBy);
-
-    // TODO: This could be further optimized
-    data.collaborators = (
-      await User.findAll({
-        where: {
-          id: takeRight(document.collaboratorIds, 10) || [],
-        },
-      })
-    ).map(presentUser);
   }
 
   return data;


### PR DESCRIPTION
This data was unused by the frontend and the cause of a non-negligible portion of the API request time, this removal will make all document list actions more performant.

closes #2037 