### PR TITLE
chore: Document and include PGSSLMODE in sample env file

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -20,6 +20,8 @@ UTILS_SECRET=generate_a_new_key
 # should work out of the box.
 DATABASE_URL=postgres://user:pass@localhost:5532/outline
 DATABASE_URL_TEST=postgres://user:pass@localhost:5532/outline-test
+# Uncomment this to disable SSL for connecting to Postgres
+# PGSSLMODE=disable
 REDIS_URL=redis://localhost:6479
 
 # URL should point to the fully qualified, publicly accessible URL. If using a


### PR DESCRIPTION
Our Outline setup uses private Cloud SQL proxy connections so we didn't need to have SSL for our PG connections. I needed to configure this but had to read through the source code to figure out how to do it. Adding the config in the sample config file could make this a lot easier to discover.