### PR TITLE
[draft] Add cloudflare access as an authentication provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "outline-icons": "^1.30.0",
     "oy-vey": "^0.10.0",
     "passport": "^0.4.1",
+    "passport-cloudflare": "https://github.com/pratheekrebala/passport-cloudflare.git",
     "passport-google-oauth2": "^0.2.0",
     "passport-slack-oauth2": "^1.1.0",
     "pg": "^8.5.1",

--- a/server/auth/providers/cloudflare.js
+++ b/server/auth/providers/cloudflare.js
@@ -1,0 +1,74 @@
+// @flow
+import passport from "@outlinewiki/koa-passport";
+import Router from "koa-router";
+
+import { Strategy as CloudflareStrategy } from "passport-cloudflare";
+import debug from "debug";
+
+import passportMiddleware from "../../middlewares/passport";
+import accountProvisioner from "../../commands/accountProvisioner";
+
+const router = new Router();
+
+const providerName = 'cloudflare';
+
+const audienceId = process.env.CLOUDFLARE_AUDIENCE;
+const displayName = process.env.CLOUDFLARE_TEAM_DISPLAY_NAME;
+const teamName = process.env.CLOUDFLARE_TEAM_NAME;
+const teamDomainName = `${CLOUDFLARE_TEAM_NAME}.cloudflareaccess.com`;
+
+const providerEnabled = !!teamName;
+
+export const config = {
+    name: providerName,
+    enabled: providerEnabled
+}
+
+const strategy = new CloudflareStrategy({
+    teamName: teamName,
+    audience: audienceId,
+
+    verifyAudience: true,
+    verifyIssuer: true,
+
+    passReqToCallback: true
+}, async function (req, response, done) {
+
+    try {
+        const { payload, identity } = response;
+
+        const result = await accountProvisioner({
+            ip: identity.ip,
+            team: {
+                name: displayName,
+                domain: teamDomainName,
+                subdomain: teamName
+            },
+            user: {
+                name: identity.name,
+                email: identity.email
+            },
+            authenticationProvider: {
+                name: providerName,
+                providerId: teamDomainName
+            },
+            authentication: {
+                providerId: identity.account_id
+            }
+        });
+    
+        return done(null, result.user, result);
+    } catch (err) {
+        return done(err, null);
+    }
+});
+
+strategy.name = providerName;
+passport.use(strategy);
+
+router.get(
+    providerName, 
+    passportMiddleware(providerName)
+);
+
+export default router;

--- a/server/auth/providers/cloudflare.js
+++ b/server/auth/providers/cloudflare.js
@@ -15,7 +15,7 @@ const providerName = 'cloudflare';
 const audienceId = process.env.CLOUDFLARE_AUDIENCE;
 const displayName = process.env.CLOUDFLARE_TEAM_DISPLAY_NAME;
 const teamName = process.env.CLOUDFLARE_TEAM_NAME;
-const teamDomainName = `${CLOUDFLARE_TEAM_NAME}.cloudflareaccess.com`;
+const teamDomainName = `${teamName}.cloudflareaccess.com`;
 
 const providerEnabled = !!teamName;
 


### PR DESCRIPTION
I am working on integrating Cloudflare as an authentication provider for our deployment. The strategy is located here: https://github.com/pratheekrebala/passport-cloudflare.

It is currently working but still needs more testing and documentation.