### PR TITLE
feat: Signup query params tracking

### DIFF
--- a/app/scenes/Login/index.js
+++ b/app/scenes/Login/index.js
@@ -45,7 +45,11 @@ function Login({ location }: Props) {
 
   React.useEffect(() => {
     const entries = Object.fromEntries(query.entries());
-    if (Object.keys(entries).length) {
+
+    // We don't want to override this cookie if we're viewing an error notice
+    // sent back from the server via query string (notice=), or if there are no
+    // query params at all.
+    if (Object.keys(entries).length && !query.get("notice")) {
       setCookie("signupQueryParams", JSON.stringify(entries));
     }
   }, [query]);

--- a/app/scenes/Login/index.js
+++ b/app/scenes/Login/index.js
@@ -5,6 +5,7 @@ import { BackIcon, EmailIcon } from "outline-icons";
 import * as React from "react";
 import { Redirect, Link, type Location } from "react-router-dom";
 import styled from "styled-components";
+import { setCookie } from "tiny-cookie";
 import ButtonLarge from "components/ButtonLarge";
 import Fade from "components/Fade";
 import Flex from "components/Flex";
@@ -16,6 +17,7 @@ import TeamLogo from "components/TeamLogo";
 import Notices from "./Notices";
 import Provider from "./Provider";
 import env from "env";
+import useQuery from "hooks/useQuery";
 import useStores from "hooks/useStores";
 
 type Props = {|
@@ -23,6 +25,7 @@ type Props = {|
 |};
 
 function Login({ location }: Props) {
+  const query = useQuery();
   const { auth } = useStores();
   const { config } = auth;
   const [emailLinkSentTo, setEmailLinkSentTo] = React.useState("");
@@ -39,6 +42,13 @@ function Login({ location }: Props) {
   React.useEffect(() => {
     auth.fetchConfig();
   }, [auth]);
+
+  React.useEffect(() => {
+    const entries = Object.fromEntries(query.entries());
+    if (Object.keys(entries).length) {
+      setCookie("signupQueryParams", JSON.stringify(entries));
+    }
+  }, [query]);
 
   if (auth.authenticated) {
     return <Redirect to="/home" />;

--- a/server/auth/providers/email.js
+++ b/server/auth/providers/email.js
@@ -101,7 +101,7 @@ router.get("email.callback", async (ctx) => {
     await user.update({ lastActiveAt: new Date() });
 
     // set cookies on response and redirect to team subdomain
-    signIn(ctx, user, user.team, "email", false, false);
+    await signIn(ctx, user, user.team, "email", false, false);
   } catch (err) {
     ctx.redirect(`/?notice=expired-token`);
   }

--- a/server/auth/providers/email.js
+++ b/server/auth/providers/email.js
@@ -101,7 +101,7 @@ router.get("email.callback", async (ctx) => {
     await user.update({ lastActiveAt: new Date() });
 
     // set cookies on response and redirect to team subdomain
-    signIn(ctx, user, user.team, "email", false);
+    signIn(ctx, user, user.team, "email", false, false);
   } catch (err) {
     ctx.redirect(`/?notice=expired-token`);
   }

--- a/server/middlewares/passport.js
+++ b/server/middlewares/passport.js
@@ -9,7 +9,7 @@ export default function createMiddleware(providerName: string) {
     return passport.authorize(
       providerName,
       { session: false },
-      (err, _, result: AccountProvisionerResult) => {
+      async (err, _, result: AccountProvisionerResult) => {
         if (err) {
           console.error(err);
 
@@ -39,7 +39,7 @@ export default function createMiddleware(providerName: string) {
           return ctx.redirect("/?notice=suspended");
         }
 
-        signIn(
+        await signIn(
           ctx,
           result.user,
           result.team,

--- a/server/middlewares/passport.js
+++ b/server/middlewares/passport.js
@@ -39,7 +39,14 @@ export default function createMiddleware(providerName: string) {
           return ctx.redirect("/?notice=suspended");
         }
 
-        signIn(ctx, result.user, result.team, providerName, result.isNewUser);
+        signIn(
+          ctx,
+          result.user,
+          result.team,
+          providerName,
+          result.isNewUser,
+          result.isNewTeam
+        );
       }
     )(ctx);
   };

--- a/server/migrations/20210430024222-marketing-tracking.js
+++ b/server/migrations/20210430024222-marketing-tracking.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+     await queryInterface.addColumn("teams", "signupQueryParams", {
+      type: Sequelize.JSONB,
+      allowNull: true,
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn("teams", "signupQueryParams");
+  }
+};

--- a/server/models/Team.js
+++ b/server/models/Team.js
@@ -55,6 +55,10 @@ const Team = sequelize.define(
     googleId: { type: DataTypes.STRING, allowNull: true },
     avatarUrl: { type: DataTypes.STRING, allowNull: true },
     sharing: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+    signupQueryParams: {
+      type: DataTypes.JSONB,
+      allowNull: true,
+    },
     guestSignin: {
       type: DataTypes.BOOLEAN,
       allowNull: false,


### PR DESCRIPTION
In order to know where new teams are coming from we want to add minimal tracking so that we can quantify the value of different traffic sources.

This doesn't have any use that I can think of for self-hosted installations as it only applies to team creation, which will only happen once for these folks.