### PR TITLE
fix: 'Post to channel' functionality does not work unless Slack SSO used

### DIFF
--- a/server/api/hooks.js
+++ b/server/api/hooks.js
@@ -8,7 +8,6 @@ import {
   Document,
   User,
   Team,
-  Collection,
   SearchQuery,
   Integration,
   IntegrationAuthentication,
@@ -87,7 +86,7 @@ router.post("hooks.interactive", async (ctx) => {
     throw new InvalidRequestError("Invalid callback_id");
   }
 
-  const team = await Collection.findByPk(document.teamId);
+  const team = await Team.findByPk(document.teamId);
 
   // respond with a public message that will be posted in the original channel
   ctx.body = {

--- a/server/api/hooks.js
+++ b/server/api/hooks.js
@@ -79,49 +79,27 @@ router.post("hooks.interactive", async (ctx) => {
     throw new AuthenticationError("Invalid verification token");
   }
 
-  const authProvider = await AuthenticationProvider.findOne({
-    where: {
-      name: "slack",
-      providerId: data.team.id,
-    },
-    include: [
-      {
-        model: Team,
-        as: "team",
-        required: true,
-      },
-    ],
-  });
-
-  if (!authProvider) {
-    ctx.body = {
-      text:
-        "Sorry, we couldn’t find an integration for your team. Head to your Outline settings to set one up.",
-      response_type: "ephemeral",
-      replace_original: false,
-    };
-    return;
+  // we find the document based on the users teamId to ensure access
+  const document = await Document.scope("withCollection").findByPk(
+    data.callback_id
+  );
+  if (!document) {
+    throw new InvalidRequestError("Invalid callback_id");
   }
 
-  const { team } = authProvider;
-
-  // we find the document based on the users teamId to ensure access
-  const document = await Document.findOne({
-    where: {
-      id: data.callback_id,
-      teamId: team.id,
-    },
-  });
-  if (!document) throw new InvalidRequestError("Invalid document");
-
-  const collection = await Collection.findByPk(document.collectionId);
+  const team = await Collection.findByPk(document.teamId);
 
   // respond with a public message that will be posted in the original channel
   ctx.body = {
     response_type: "in_channel",
     replace_original: false,
     attachments: [
-      presentSlackAttachment(document, collection, team, document.getSummary()),
+      presentSlackAttachment(
+        document,
+        document.collection,
+        team,
+        document.getSummary()
+      ),
     ],
   };
 });


### PR DESCRIPTION
Removes redundant checks that prevent "post to slack" functionality from being used without Slack SSO (authentication provider matching teamId being present).

Note to self: We need to upgrade to use the new signed requests soon, verification token approach is deprecated due to the theoretical ability to tamper with the payload