### PR TITLE
fix: Moving documents between collections does not update attachment permissions

### DIFF
--- a/server/commands/documentMover.test.js
+++ b/server/commands/documentMover.test.js
@@ -1,6 +1,13 @@
 // @flow
-import { buildDocument, buildCollection, buildUser } from "../test/factories";
+import { Attachment } from "../models";
+import {
+  buildDocument,
+  buildAttachment,
+  buildCollection,
+  buildUser,
+} from "../test/factories";
 import { flushdb, seed } from "../test/support";
+import parseAttachmentIds from "../utils/parseAttachmentIds";
 import documentMover from "./documentMover";
 
 beforeEach(() => flushdb());
@@ -109,5 +116,47 @@ describe("documentMover", () => {
     expect(response.documents.length).toEqual(2);
     expect(response.documents[0].collection.id).toEqual(newCollection.id);
     expect(response.documents[1].collection.id).toEqual(newCollection.id);
+  });
+
+  it("should move attachments in children to another collection", async () => {
+    const { document, user, collection } = await seed();
+    const newCollection = await buildCollection({
+      teamId: collection.teamId,
+    });
+    const attachment = await buildAttachment({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const newDocument = await buildDocument({
+      parentDocumentId: document.id,
+      collectionId: collection.id,
+      teamId: collection.teamId,
+      userId: collection.createdById,
+      title: "Child document",
+      text: `content ![attachment](${attachment.redirectUrl})`,
+    });
+    await collection.addDocumentToStructure(newDocument);
+
+    await documentMover({
+      user,
+      document,
+      collectionId: newCollection.id,
+      parentDocumentId: undefined,
+      index: 0,
+      ip,
+    });
+
+    // check document ids where updated
+    await newDocument.reload();
+    expect(newDocument.collectionId).toBe(newCollection.id);
+
+    // check new attachment was created pointint to same key
+    const attachmentIds = parseAttachmentIds(newDocument.text);
+    const newAttachment = await Attachment.findByPk(attachmentIds[0]);
+    expect(newAttachment.documentId).toBe(newDocument.id);
+    expect(newAttachment.key).toBe(attachment.key);
+
+    await document.reload();
+    expect(document.collectionId).toBe(newCollection.id);
   });
 });

--- a/server/test/factories.js
+++ b/server/test/factories.js
@@ -242,11 +242,6 @@ export async function buildAttachment(overrides: Object = {}) {
     overrides.userId = user.id;
   }
 
-  if (!overrides.collectionId) {
-    const collection = await buildCollection(overrides);
-    overrides.collectionId = collection.id;
-  }
-
   if (!overrides.documentId) {
     const document = await buildDocument(overrides);
     overrides.documentId = document.id;


### PR DESCRIPTION
closes #2107