### PR TITLE
build: Webpack config - allow package.json module field usage

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,9 +45,12 @@ module.exports = {
       path.resolve(__dirname, 'app'),
       'node_modules'
     ],
-    mainFields: ["browser",  "main"],
     alias: {
       shared: path.resolve(__dirname, 'shared'),
+      'boundless-arrow-key-navigation': 'boundless-arrow-key-navigation/build',
+      'boundless-popover': 'boundless-popover/build',
+      'boundless-utils-omit-keys': 'boundless-utils-omit-keys/build',
+      'boundless-utils-uuid': 'boundless-utils-uuid/build'
     }
   },
   plugins: [


### PR DESCRIPTION
- revert resolve.mainFields to [default](https://webpack.js.org/configuration/resolve/#resolvemainfields)
- revert boundless-* package aliases to commonjs folder to avoid transpiling

rel: https://github.com/outline/outline/pull/507/commits/fe00e1f76d080107bf7f0c4ec40e24c754efc521

@tommoor I pushed the config change to see the impact. There are many changes across the modules, please consider merging only if you don't see any side-effects.