### PR TITLE
Fix chunks setup

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -79,7 +79,7 @@ window.addEventListener("load", async () => {
   if (!env.GOOGLE_ANALYTICS_ID || !window.ga) return;
 
   // https://github.com/googleanalytics/autotrack/issues/137#issuecomment-305890099
-  await import(/** webpackChunkName "autotrack" */ "autotrack/autotrack.js");
+  await import(/** webpackChunkName: "autotrack" */ "autotrack/autotrack.js");
 
   window.ga("require", "outboundLinkTracker");
   window.ga("require", "urlChangeTracker");

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,6 +97,7 @@ module.exports = {
   optimization: {
     runtimeChunk: 'single',
     moduleIds: 'hashed',
+    chunkIds: 'named',
     splitChunks: {
       cacheGroups: {
         vendor: {


### PR DESCRIPTION
1. make chunkIds deterministic (do not change across builds)
  
  On webpack 4, chunkIds are set by default to `natural` ([non deterministic, based on usage order](https://v4.webpack.js.org/configuration/optimization/#optimizationchunkids)). This is causing hash changes across all chunks when a chunkId is changing:

  ![](https://www.dropbox.com/s/ogrd3bp1otocipr/Screenshot%202021-06-05%20at%2017.54.01.png?raw=1)

  In webpack 5 there is a new  default option ([`deterministic`](https://webpack.js.org/configuration/optimization/#optimizationchunkids)) that will achieve the same behaviour with a smaller size.

2. fix `webpackChunkName` syntax (rel: 082ced3)