### PR TITLE
fix: change `metaDisplay` key to Alt for "Table of contents"

### DIFF
--- a/app/scenes/Document/components/Document.js
+++ b/app/scenes/Document/components/Document.js
@@ -174,7 +174,7 @@ class DocumentScene extends React.Component<Props> {
     this.onSave({ publish: true, done: true });
   }
 
-  @keydown(`${meta}+ctrl+h`)
+  @keydown(`${meta}+alt+h`)
   onToggleTableOfContents(ev) {
     if (!this.props.readOnly) return;
 

--- a/app/scenes/Document/components/Document.js
+++ b/app/scenes/Document/components/Document.js
@@ -174,7 +174,7 @@ class DocumentScene extends React.Component<Props> {
     this.onSave({ publish: true, done: true });
   }
 
-  @keydown(`${meta}+alt+h`)
+  @keydown("ctrl+alt+h")
   onToggleTableOfContents(ev) {
     if (!this.props.readOnly) return;
 

--- a/app/scenes/Document/components/Header.js
+++ b/app/scenes/Document/components/Header.js
@@ -83,7 +83,7 @@ function DocumentHeader({
   const toc = (
     <Tooltip
       tooltip={ui.tocVisible ? t("Hide contents") : t("Show contents")}
-      shortcut={`Ctrl+alt+h`}
+      shortcut="ctrl+alt+h"
       delay={250}
       placement="bottom"
     >

--- a/app/scenes/Document/components/Header.js
+++ b/app/scenes/Document/components/Header.js
@@ -83,7 +83,7 @@ function DocumentHeader({
   const toc = (
     <Tooltip
       tooltip={ui.tocVisible ? t("Hide contents") : t("Show contents")}
-      shortcut={`ctrl+${metaDisplay}+h`}
+      shortcut={`Ctrl+alt+h`}
       delay={250}
       placement="bottom"
     >

--- a/app/scenes/KeyboardShortcuts.js
+++ b/app/scenes/KeyboardShortcuts.js
@@ -33,7 +33,7 @@ function KeyboardShortcuts() {
           {
             shortcut: (
               <>
-                <Key>Ctrl</Key> + <Key>{metaDisplay}</Key> + <Key>h</Key>
+                <Key>Ctrl</Key> + <Key>Alt</Key> + <Key>h</Key>
               </>
             ),
             label: t("Table of contents"),


### PR DESCRIPTION
`metaDisplay` is **Ctrl** on non-Mac systems so this key becomes "Ctrl+ctrl+h" which doesn't work. Changing `metaDisplay` to Alt seems to be a safe choice that should work on Mac too.

I also tried creating `KeyboardShortcuts.test.js` to detect duplicate keys in `KeyboardShortcuts` component's config but somehow can't install `enzyme` with yarn.