### PR TITLE
fix: Two restore options when an archived document is deleted

### DIFF
--- a/app/menus/DocumentMenu.js
+++ b/app/menus/DocumentMenu.js
@@ -218,12 +218,7 @@ function DocumentMenu({
           items={[
             {
               title: t("Restore"),
-              visible: !!can.unarchive,
-              onClick: handleRestore,
-            },
-            {
-              title: t("Restore"),
-              visible: !!(collection && can.restore),
+              visible: (!!collection && can.restore) || can.unarchive,
               onClick: handleRestore,
             },
             {

--- a/server/api/documents.test.js
+++ b/server/api/documents.test.js
@@ -1588,7 +1588,7 @@ describe("#documents.restore", () => {
     const body = await res.json();
 
     expect(res.status).toEqual(200);
-    expect(body.data.parentDocumentId).toEqual(undefined);
+    expect(body.data.parentDocumentId).toEqual(null);
     expect(body.data.archivedAt).toEqual(null);
   });
 

--- a/server/models/Document.js
+++ b/server/models/Document.js
@@ -637,7 +637,7 @@ Document.prototype.unarchive = async function (userId: string) {
         },
       },
     });
-    if (!parent) this.parentDocumentId = undefined;
+    if (!parent) this.parentDocumentId = null;
   }
 
   if (!this.template) {

--- a/server/policies/document.js
+++ b/server/policies/document.js
@@ -149,6 +149,7 @@ allow(User, "unarchive", Document, (user, document) => {
   if (cannot(user, "update", document.collection)) return false;
 
   if (!document.archivedAt) return false;
+  if (document.deletedAt) return false;
 
   return user.teamId === document.teamId;
 });


### PR DESCRIPTION
This PR fixes the bug of two restore options showing in the document menu when an archived document is deleted. 