### PR TITLE
feat: Dynamic site title and description

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -136,3 +136,8 @@ SMTP_REPLY_EMAIL=
 # The default interface language. See translate.getoutline.com for a list of 
 # available language codes and their rough percentage translated.
 DEFAULT_LANGUAGE=en_US
+
+# Site name and description (optional)
+# these will be added to meta tags
+SITE_NAME=
+SITE_DESCRIPTION=

--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
     "db:migrate": "sequelize db:migrate",
     "db:rollback": "sequelize db:migrate:undo",
     "upgrade": "git fetch && git pull && yarn install && yarn heroku-postbuild",
-    "test": "yarn test:app && yarn test:server",
+    "test": "yarn test:app && yarn test:server && test:env",
     "test:app": "jest",
     "test:server": "jest --config=server/.jestconfig.json --runInBand --forceExit",
+    "test:env": "jest --config=server/env.jestconfig.json env.test.js --runInBand --forceExit",
     "test:watch": "jest --config=server/.jestconfig.json --runInBand --forceExit --watchAll"
   },
   "funding": {

--- a/server/.jestconfig.json
+++ b/server/.jestconfig.json
@@ -9,5 +9,10 @@
     "<rootDir>/__mocks__/console.js",
     "./server/test/helper.js"
   ],
-  "testEnvironment": "node"
+  "testEnvironment": "node",
+  "testMatch": [
+    "**/__tests__/**/*.[jt]s?(x)",
+    "**/?(*.)+(spec|test).[jt]s?(x)",
+    "!**/server/env.test.js"
+  ]
 }

--- a/server/env.jestconfig.json
+++ b/server/env.jestconfig.json
@@ -1,0 +1,14 @@
+{
+  "verbose": false,
+  "rootDir": "..",
+  "roots": [
+    "<rootDir>/server",
+    "<rootDir>/shared"
+  ],
+  "setupFiles": [
+    "<rootDir>/__mocks__/console.js",
+    "./server/test/helper.js",
+    "./server/env.test.config.js"
+  ],
+  "testEnvironment": "node"
+}

--- a/server/env.js
+++ b/server/env.js
@@ -15,4 +15,7 @@ export default {
   SUBDOMAINS_ENABLED: process.env.SUBDOMAINS_ENABLED === "true",
   GOOGLE_ANALYTICS_ID: process.env.GOOGLE_ANALYTICS_ID,
   RELEASE: process.env.SOURCE_COMMIT || process.env.SOURCE_VERSION || undefined,
+  SITE_NAME: "Outline",
+  SITE_DESCRIPTION: `A modern team knowledge base for your 
+ internal documentation, product specs, support answers, meeting notes, onboarding, &amp; more…`,
 };

--- a/server/env.js
+++ b/server/env.js
@@ -15,7 +15,8 @@ export default {
   SUBDOMAINS_ENABLED: process.env.SUBDOMAINS_ENABLED === "true",
   GOOGLE_ANALYTICS_ID: process.env.GOOGLE_ANALYTICS_ID,
   RELEASE: process.env.SOURCE_COMMIT || process.env.SOURCE_VERSION || undefined,
-  SITE_NAME: "Outline",
-  SITE_DESCRIPTION: `A modern team knowledge base for your 
- internal documentation, product specs, support answers, meeting notes, onboarding, &amp; more…`,
+  SITE_NAME: process.env.SITE_NAME || "Outline",
+  SITE_DESCRIPTION:
+    process.env.SITE_DESCRIPTION ||
+    "A modern team knowledge base for your internal documentation, product specs, support answers, meeting notes, onboarding, &amp; more…",
 };

--- a/server/env.test.config.js
+++ b/server/env.test.config.js
@@ -1,0 +1,6 @@
+// @flow
+export const SITE_NAME = "Another Outline";
+export const SITE_DESCRIPTION = "Another Description";
+
+process.env.SITE_NAME = SITE_NAME;
+process.env.SITE_DESCRIPTION = SITE_DESCRIPTION;

--- a/server/env.test.js
+++ b/server/env.test.js
@@ -1,0 +1,65 @@
+// @flow
+import TestServer from "fetch-test-server";
+import app from "./app";
+import { SITE_NAME, SITE_DESCRIPTION } from "./env.test.config";
+import { buildShare, buildDocument } from "./test/factories";
+import { flushdb } from "./test/support";
+
+const server = new TestServer(app.callback());
+
+beforeEach(() => flushdb());
+afterAll(() => server.close());
+
+describe("/share/:id", () => {
+  it("should return standard title in html when loading share", async () => {
+    const share = await buildShare({ published: false });
+
+    const res = await server.get(`/share/${share.id}`);
+    const body = await res.text();
+
+    expect(res.status).toEqual(200);
+    expect(body).toContain(`<title>${SITE_NAME}</title>`);
+    expect(body).toContain(
+      `<meta name="description" content="${SITE_DESCRIPTION}"/>`
+    );
+  });
+
+  it("should return standard title in html when share does not exist", async () => {
+    const res = await server.get(`/share/junk`);
+    const body = await res.text();
+
+    expect(res.status).toEqual(200);
+    expect(body).toContain(`<title>${SITE_NAME}</title>`);
+    expect(body).toContain(
+      `<meta name="description" content="${SITE_DESCRIPTION}"/>`
+    );
+  });
+
+  it("should return document title in html when loading published share", async () => {
+    const document = await buildDocument();
+    const share = await buildShare({ documentId: document.id });
+
+    const res = await server.get(`/share/${share.id}`);
+    const body = await res.text();
+
+    expect(res.status).toEqual(200);
+    expect(body).toContain(`<title>${document.title}</title>`);
+    expect(body).toContain(
+      `<meta name="description" content="${SITE_DESCRIPTION}"/>`
+    );
+  });
+
+  it("should return document title in html when loading published share with nested doc route", async () => {
+    const document = await buildDocument();
+    const share = await buildShare({ documentId: document.id });
+
+    const res = await server.get(`/share/${share.id}/doc/test-Cl6g1AgPYn`);
+    const body = await res.text();
+
+    expect(res.status).toEqual(200);
+    expect(body).toContain(`<title>${document.title}</title>`);
+    expect(body).toContain(
+      `<meta name="description" content="${SITE_DESCRIPTION}"/>`
+    );
+  });
+});

--- a/server/routes.js
+++ b/server/routes.js
@@ -46,7 +46,7 @@ const readIndexFile = async (ctx) => {
   });
 };
 
-const renderApp = async (ctx, next, title = "Outline") => {
+const renderApp = async (ctx, next, title = null) => {
   if (ctx.request.path === "/realtime/") {
     return next();
   }
@@ -55,10 +55,11 @@ const renderApp = async (ctx, next, title = "Outline") => {
   const environment = `
     window.env = ${JSON.stringify(env)};
   `;
+
   ctx.body = page
     .toString()
     .replace(/\/\/inject-env\/\//g, environment)
-    .replace(/\/\/inject-meta-tags\/\//g, metaTags)
+    .replace(/\/\/inject-meta-tags\/\//g, metaTags(title))
     .replace(/\/\/inject-prefetch\/\//g, prefetchTags)
     .replace(/\/\/inject-slack-app-id\/\//g, process.env.SLACK_APP_ID || "");
 };

--- a/server/routes.js
+++ b/server/routes.js
@@ -11,6 +11,7 @@ import { languages } from "../shared/i18n";
 import env from "./env";
 import apexRedirect from "./middlewares/apexRedirect";
 import Share from "./models/Share";
+import metaTags from "./utils/metaTags";
 import { opensearchResponse } from "./utils/opensearch";
 import prefetchTags from "./utils/prefetchTags";
 import { robotsResponse } from "./utils/robots";
@@ -57,7 +58,7 @@ const renderApp = async (ctx, next, title = "Outline") => {
   ctx.body = page
     .toString()
     .replace(/\/\/inject-env\/\//g, environment)
-    .replace(/\/\/inject-title\/\//g, title)
+    .replace(/\/\/inject-meta-tags\/\//g, metaTags)
     .replace(/\/\/inject-prefetch\/\//g, prefetchTags)
     .replace(/\/\/inject-slack-app-id\/\//g, process.env.SLACK_APP_ID || "");
 };

--- a/server/static/index.html
+++ b/server/static/index.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>//inject-title//</title>
     <meta name="theme-color" content="#FFF" />
     <meta name="slack-app-id" content="//inject-slack-app-id//" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="description" content="A modern team knowledge base for your internal documentation, product specs, support answers, meeting notes, onboarding, &amp; more…">
+    //inject-meta-tags//
     //inject-prefetch//
     <link
       rel="shortcut icon"
@@ -20,12 +19,6 @@
       type="image/png"
       href="/apple-touch-icon.png"
       sizes="192x192"
-    />
-    <link
-      rel="search"
-      type="application/opensearchdescription+xml"
-      href="/opensearch.xml"
-      title="Outline"
     />
     <style>
       body,

--- a/server/utils/metaTags.js
+++ b/server/utils/metaTags.js
@@ -3,7 +3,7 @@ import * as React from "react";
 import ReactDOMServer from "react-dom/server";
 import env from "../env";
 
-export default function metaTags(title = null) {
+export default function metaTags(title: string = null) {
   return ReactDOMServer.renderToStaticMarkup([
     <meta name="description" content={env.SITE_DESCRIPTION} />,
     <title>{title || env.SITE_NAME}</title>,

--- a/server/utils/metaTags.js
+++ b/server/utils/metaTags.js
@@ -3,7 +3,7 @@ import * as React from "react";
 import ReactDOMServer from "react-dom/server";
 import env from "../env";
 
-export default function metaTags(title: string = null) {
+export default function metaTags(title: string | null = null) {
   return ReactDOMServer.renderToStaticMarkup([
     <meta name="description" content={env.SITE_DESCRIPTION} />,
     <title>{title || env.SITE_NAME}</title>,

--- a/server/utils/metaTags.js
+++ b/server/utils/metaTags.js
@@ -3,19 +3,15 @@ import * as React from "react";
 import ReactDOMServer from "react-dom/server";
 import env from "../env";
 
-const metaTags = [];
-
-metaTags.push(<meta name="description" content={env.SITE_DESCRIPTION} />);
-
-metaTags.push(<title>{env.SITE_NAME}</title>);
-
-metaTags.push(
-  <link
-    rel="search"
-    type="application/opensearchdescription+xml"
-    href="/opensearch.xml"
-    title={env.SITE_NAME}
-  />
-);
-
-export default ReactDOMServer.renderToString(metaTags);
+export default function metaTags(title = null) {
+  return ReactDOMServer.renderToStaticMarkup([
+    <meta name="description" content={env.SITE_DESCRIPTION} />,
+    <title>{title || env.SITE_NAME}</title>,
+    <link
+      rel="search"
+      type="application/opensearchdescription+xml"
+      href="/opensearch.xml"
+      title={env.SITE_NAME}
+    />,
+  ]);
+}

--- a/server/utils/metaTags.js
+++ b/server/utils/metaTags.js
@@ -1,0 +1,21 @@
+// @flow
+import * as React from "react";
+import ReactDOMServer from "react-dom/server";
+import env from "../env";
+
+const metaTags = [];
+
+metaTags.push(<meta name="description" content={env.SITE_DESCRIPTION} />);
+
+metaTags.push(<title>{env.SITE_NAME}</title>);
+
+metaTags.push(
+  <link
+    rel="search"
+    type="application/opensearchdescription+xml"
+    href="/opensearch.xml"
+    title={env.SITE_NAME}
+  />
+);
+
+export default ReactDOMServer.renderToString(metaTags);


### PR DESCRIPTION
With this PR it is possible to define SITE_NAME and SITE_DESCRIPTION env variables to override the default values.

I realized a second ago, when I was rebasing you guys just added `//inject-title//`, but since this was already done and also allow changing the description I thought I would send it anyways