### PR TITLE
Use SMTP_SECURE environment variable to force secure parameter of smtp configuration

### DIFF
--- a/server/mailer.js
+++ b/server/mailer.js
@@ -173,7 +173,10 @@ export class Mailer {
       let smtpConfig = {
         host: process.env.SMTP_HOST,
         port: process.env.SMTP_PORT,
-        secure: process.env.NODE_ENV === "production",
+        secure:
+          "SMTP_SECURE" in process.env
+            ? process.env.SMTP_SECURE === "true"
+            : process.env.NODE_ENV === "production",
         auth: undefined,
       };
 


### PR DESCRIPTION
Hello, 

Here is a small pull request to change strategy related to SMTP "secure" configuration, that currently rely on NODE_ENV.

I think it should be overrided by an environment variable, because SMTP configuration is not related to Outline configuration.

Best regards