### PR TITLE
fix: Link copied to clipboard takes dark mode styles

### DIFF
--- a/app/components/CopyToClipboard.js
+++ b/app/components/CopyToClipboard.js
@@ -15,6 +15,7 @@ class CopyToClipboard extends React.PureComponent<Props> {
     const elem = React.Children.only(children);
     copy(text, {
       debug: process.env.NODE_ENV !== "production",
+      format: "text/plain",
     });
 
     if (onCopy) onCopy();

--- a/flow-typed/npm/copy-to-clipboard_v3.x.x.js
+++ b/flow-typed/npm/copy-to-clipboard_v3.x.x.js
@@ -1,10 +1,12 @@
 // flow-typed signature: 350413ab85bd03f3d1450c0ae307d106
 // flow-typed version: c6154227d1/copy-to-clipboard_v3.x.x/flow_>=v0.104.x
 
-declare module 'copy-to-clipboard' {
+// @flow
+declare module "copy-to-clipboard" {
   declare export type Options = {|
     debug?: boolean,
     message?: string,
+    format?: "text/plain" | "text/html",
   |};
 
   declare module.exports: (text: string, options?: Options) => boolean;

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "cancan": "3.1.0",
     "chalk": "^4.1.0",
     "compressorjs": "^1.0.7",
-    "copy-to-clipboard": "^3.0.6",
+    "copy-to-clipboard": "^3.3.1",
     "core-js": "^3.10.2",
     "date-fns": "2.22.1",
     "dd-trace": "^0.32.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4138,7 +4138,7 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-copy-to-clipboard@^3.0.6, copy-to-clipboard@^3.0.8:
+copy-to-clipboard@^3.0.8, copy-to-clipboard@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz#115aa1a9998ffab6196f93076ad6da3b913662ae"
   integrity sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==


### PR DESCRIPTION
Upgrade `copy-to-clipboard` dep

closes #2207