### PR TITLE
Fix "secret key" variable description

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,8 +8,7 @@
 
 # –––––––––––––––– REQUIRED ––––––––––––––––
 
-# Generate a unique 32 character hexadecimal key. The format is important as this
-# value is fed directly into encryption libraries. You should use `openssl rand -hex 32`
+# Generate a hex-encoded 32-byte random key. You should use `openssl rand -hex 32`
 # in your terminal to generate a random value.
 SECRET_KEY=generate_a_new_key
 


### PR DESCRIPTION
Updated the description of the `SECRET_KEY` variable in the `.env.sample` file to clarify that the key needs to be 32 bytes long and hex-encoded and make the suggested OpenSSL command slightly more prominent.

The previous description of "32 character hexadecimal" was confusing as it left open the possibility of a hex-encoded 16-byte key (see #1267 -- and I made the same mistake a year later).