### PR TITLE
fix: Aligned images do not load in publicly shared documents

### DIFF
--- a/server/utils/parseAttachmentIds.js
+++ b/server/utils/parseAttachmentIds.js
@@ -1,5 +1,5 @@
 // @flow
-const attachmentRegex = /!\[.*?\]\(\/api\/attachments\.redirect\?id=(?<id>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\)/gi;
+const attachmentRegex = /\/api\/attachments\.redirect\?id=(?<id>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/gi;
 
 export default function parseAttachmentIds(text: any): string[] {
   return [...text.matchAll(attachmentRegex)].map(

--- a/server/utils/parseAttachmentIds.test.js
+++ b/server/utils/parseAttachmentIds.test.js
@@ -1,0 +1,95 @@
+// @flow
+import { expect } from "@jest/globals";
+import { v4 as uuidv4 } from "uuid";
+import parseAttachmentIds from "./parseAttachmentIds";
+
+it("should return an empty array with no matches", () => {
+  expect(parseAttachmentIds(`some random text`).length).toBe(0);
+});
+
+it("should not return orphaned UUID's", () => {
+  const uuid = uuidv4();
+  expect(
+    parseAttachmentIds(`some random text with a uuid ${uuid}
+
+![caption](/images/${uuid}.png)`).length
+  ).toBe(0);
+});
+
+it("should parse attachment ID from markdown", () => {
+  const uuid = uuidv4();
+  const results = parseAttachmentIds(
+    `![caption text](/api/attachments.redirect?id=${uuid})`
+  );
+
+  expect(results.length).toBe(1);
+  expect(results[0]).toBe(uuid);
+});
+
+it("should parse attachment ID from markdown with additional query params", () => {
+  const uuid = uuidv4();
+  const results = parseAttachmentIds(
+    `![caption text](/api/attachments.redirect?id=${uuid}&size=2)`
+  );
+
+  expect(results.length).toBe(1);
+  expect(results[0]).toBe(uuid);
+});
+
+it("should parse attachment ID from markdown with fully qualified url", () => {
+  const uuid = uuidv4();
+  const results = parseAttachmentIds(
+    `![caption text](${process.env.URL}/api/attachments.redirect?id=${uuid})`
+  );
+
+  expect(process.env.URL).toBeTruthy();
+  expect(results.length).toBe(1);
+  expect(results[0]).toBe(uuid);
+});
+
+it("should parse attachment ID from markdown with title", () => {
+  const uuid = uuidv4();
+  const results = parseAttachmentIds(
+    `![caption text](/api/attachments.redirect?id=${uuid} "align-left")`
+  );
+
+  expect(results.length).toBe(1);
+  expect(results[0]).toBe(uuid);
+});
+
+it("should parse multiple attachment IDs from markdown", () => {
+  const uuid = uuidv4();
+  const uuid2 = uuidv4();
+  const results = parseAttachmentIds(
+    `![caption text](/api/attachments.redirect?id=${uuid})
+
+some text
+
+![another caption](/api/attachments.redirect?id=${uuid2})`
+  );
+
+  expect(results.length).toBe(2);
+  expect(results[0]).toBe(uuid);
+  expect(results[1]).toBe(uuid2);
+});
+
+it("should parse attachment ID from html", () => {
+  const uuid = uuidv4();
+  const results = parseAttachmentIds(
+    `<img src="/api/attachments.redirect?id=${uuid}" />`
+  );
+
+  expect(results.length).toBe(1);
+  expect(results[0]).toBe(uuid);
+});
+
+it("should parse attachment ID from html with fully qualified url", () => {
+  const uuid = uuidv4();
+  const results = parseAttachmentIds(
+    `<img src="${process.env.URL}/api/attachments.redirect?id=${uuid}" />`
+  );
+
+  expect(process.env.URL).toBeTruthy();
+  expect(results.length).toBe(1);
+  expect(results[0]).toBe(uuid);
+});


### PR DESCRIPTION
Fun coincidence, I was already updating this logic for the work over in https://github.com/outline/outline/pull/2239 – the regex did not account for markdown image tags containing titles.

closes #2247 