### PR TITLE
fix: nested link positions for RTL titles in sidebar

### DIFF
--- a/app/components/Sidebar/components/EditableTitle.js
+++ b/app/components/Sidebar/components/EditableTitle.js
@@ -65,6 +65,7 @@ function EditableTitle({ title, onSubmit, canUpdate }: Props) {
       {isEditing ? (
         <form onSubmit={handleSave}>
           <Input
+            dir="auto"
             type="text"
             value={value}
             onKeyDown={handleKeyDown}

--- a/app/components/Sidebar/components/SidebarLink.js
+++ b/app/components/Sidebar/components/SidebarLink.js
@@ -84,7 +84,7 @@ function SidebarLink(
         ref={ref}
       >
         {icon && <IconWrapper>{icon}</IconWrapper>}
-        <Label dir="auto">{label}</Label>
+        <Label>{label}</Label>
       </Link>
       {menu && <Actions showActions={showActions}>{menu}</Actions>}
     </>
@@ -176,6 +176,9 @@ const Label = styled.div`
   width: 100%;
   max-height: 4.8em;
   line-height: 1.6;
+  * {
+    unicode-bidi: plaintext;
+  }
 `;
 
 export default withRouter(withTheme(React.forwardRef(SidebarLink)));


### PR DESCRIPTION
Hey, @tommoor.

I wanted to patch outline regarding RTL titles and sidebars, then I noticed you already worked on it. Thanks!
However, I found some small issues with the side bar regarding nested positions and edit mode, which I tried to address in this PR.

### Before the fix
1. Nested documents appear flat.
<img width="325" alt="before-read-only" src="https://user-images.githubusercontent.com/8026878/124391743-4cec5b80-dd07-11eb-870c-fac24b457c49.png">
2. Wrong input direction during edit.
<img width="340" alt="before-editable" src="https://user-images.githubusercontent.com/8026878/124391750-54ac0000-dd07-11eb-949c-8f80823a4c99.png">

### With the fix
1. Even though the text are aligned to left, the direction is correct and nesting is preserved. Since direction of app (regardless of the content) is LTR, this is acceptable even if texts are RTL.
<img width="331" alt="after-read-only" src="https://user-images.githubusercontent.com/8026878/124391813-87ee8f00-dd07-11eb-8896-b718c1f44015.png">

2. Input direction is correct during edit.
<img width="319" alt="after-editable" src="https://user-images.githubusercontent.com/8026878/124391868-d865ec80-dd07-11eb-8c17-0b395428923b.png">

