### PR TITLE
fix: Allow TOC to scroll when larger than browser height

### DIFF
--- a/app/scenes/Document/components/Contents.js
+++ b/app/scenes/Document/components/Contents.js
@@ -70,11 +70,13 @@ const Wrapper = styled("div")`
   display: none;
   position: sticky;
   top: 80px;
+  max-height: calc(100vh - 80px);
 
   box-shadow: 1px 0 0 ${(props) => props.theme.divider};
   margin-top: 40px;
   margin-right: 2em;
   min-height: 40px;
+  overflow-y: auto;
 
   ${breakpoint("desktopLarge")`
     margin-left: -16em;


### PR DESCRIPTION
closes https://github.com/outline/outline/issues/2240