### PR TITLE
fix: Remove duplicate translation key

### DIFF
--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -219,7 +219,6 @@
   "Contents": "Contents",
   "Headings you add to the document will appear here": "Headings you add to the document will appear here",
   "Table of contents": "Table of contents",
-  "Contents": "Contents",
   "By {{ author }}": "By {{ author }}",
   "Are you sure you want to make {{ userName }} an admin? Admins can modify team and billing information.": "Are you sure you want to make {{ userName }} an admin? Admins can modify team and billing information.",
   "Are you sure you want to make {{ userName }} a member?": "Are you sure you want to make {{ userName }} a member?",


### PR DESCRIPTION
#2307 introduced a duplicate `"Contents"` key in [`shared/i18n/locales/en_US/translations.json`](https://github.com/outline/outline/commit/959697999383bf5643813ae9ec00edfe0cc2c8dc#diff-16efc6d9ffa448721d7d5d26405b78774523868c4a2bfeb7e602f23918070a99R222)