### PR TITLE
chore: Move 'templates' to bottom of sidebar

### DIFF
--- a/app/components/Sidebar/Main.js
+++ b/app/components/Sidebar/Main.js
@@ -116,17 +116,6 @@ function MainSidebar() {
               />
               {can.createDocument && (
                 <SidebarLink
-                  to="/templates"
-                  icon={<ShapesIcon color="currentColor" />}
-                  exact={false}
-                  label={t("Templates")}
-                  active={
-                    documents.active ? documents.active.template : undefined
-                  }
-                />
-              )}
-              {can.createDocument && (
-                <SidebarLink
                   to="/drafts"
                   icon={<EditIcon color="currentColor" />}
                   label={
@@ -151,26 +140,40 @@ function MainSidebar() {
               />
             </Section>
             <Section>
-              <SidebarLink
-                to="/archive"
-                icon={<ArchiveIcon color="currentColor" />}
-                exact={false}
-                label={t("Archive")}
-                active={
-                  documents.active
-                    ? documents.active.isArchived && !documents.active.isDeleted
-                    : undefined
-                }
-              />
-              <SidebarLink
-                to="/trash"
-                icon={<TrashIcon color="currentColor" />}
-                exact={false}
-                label={t("Trash")}
-                active={
-                  documents.active ? documents.active.isDeleted : undefined
-                }
-              />
+              {can.createDocument && (
+                <>
+                  <SidebarLink
+                    to="/templates"
+                    icon={<ShapesIcon color="currentColor" />}
+                    exact={false}
+                    label={t("Templates")}
+                    active={
+                      documents.active ? documents.active.template : undefined
+                    }
+                  />
+                  <SidebarLink
+                    to="/archive"
+                    icon={<ArchiveIcon color="currentColor" />}
+                    exact={false}
+                    label={t("Archive")}
+                    active={
+                      documents.active
+                        ? documents.active.isArchived &&
+                          !documents.active.isDeleted
+                        : undefined
+                    }
+                  />
+                  <SidebarLink
+                    to="/trash"
+                    icon={<TrashIcon color="currentColor" />}
+                    exact={false}
+                    label={t("Trash")}
+                    active={
+                      documents.active ? documents.active.isDeleted : undefined
+                    }
+                  />
+                </>
+              )}
               <SidebarLink
                 to="/settings"
                 icon={<SettingsIcon color="currentColor" />}


### PR DESCRIPTION
- Move 'templates' to bottom of sidebar – we expose the ability to create a document from a template as part of the new doc flow, so the list of templates doesn't need to be so prominently positioned 
- Hide trash and archive for read-only users, they can never use them

cc @iamsaumya there will be a small conflict with your drag and drop PR here.