### PR TITLE
chore: Add revisions.create backfill script

### DIFF
--- a/server/scripts/20210716000000-backfill-revisions.js
+++ b/server/scripts/20210716000000-backfill-revisions.js
@@ -1,0 +1,59 @@
+// @flow
+import "./bootstrap";
+import debug from "debug";
+import { Revision, Document, Event } from "../models";
+
+const log = debug("server");
+let page = 0;
+let limit = 100;
+
+export default async function main(exit = false) {
+  const work = async (page: number) => {
+    log(`Backfill revision events… page ${page}`);
+
+    const revisions = await Revision.findAll({
+      limit,
+      offset: page * limit,
+      order: [["createdAt", "DESC"]],
+      include: [
+        {
+          model: Document,
+          as: "document",
+          required: true,
+          paranoid: false,
+        },
+      ],
+    });
+
+    for (const revision of revisions) {
+      try {
+        await Event.findOrCreate({
+          where: {
+            name: "revisions.create",
+            modelId: revision.id,
+            documentId: revision.documentId,
+            actorId: revision.userId,
+            teamId: revision.document.teamId,
+          },
+        });
+      } catch (err) {
+        console.error(`Failed at ${revision.id}:`, err);
+        continue;
+      }
+    }
+
+    return revisions.length === limit ? work(page + 1) : undefined;
+  };
+
+  await work(page);
+
+  if (exit) {
+    log("Backfill complete");
+    process.exit(0);
+  }
+}
+
+// In the test suite we import the script rather than run via node CLI
+if (process.env.NODE_ENV !== "test") {
+  main(true);
+}

--- a/server/scripts/20210716000000-backfill-revisions.js
+++ b/server/scripts/20210716000000-backfill-revisions.js
@@ -35,6 +35,9 @@ export default async function main(exit = false) {
             actorId: revision.userId,
             teamId: revision.document.teamId,
           },
+          defaults: {
+            createdAt: revision.createdAt,
+          },
         });
       } catch (err) {
         console.error(`Failed at ${revision.id}:`, err);

--- a/server/scripts/20210716000000-backfill-revisions.test.js
+++ b/server/scripts/20210716000000-backfill-revisions.test.js
@@ -1,0 +1,50 @@
+// @flow
+import { Revision, Event } from "../models";
+import { buildDocument } from "../test/factories";
+import { flushdb } from "../test/support";
+import script from "./20210716000000-backfill-revisions";
+
+beforeEach(() => flushdb());
+
+describe("#work", () => {
+  it("should create events for revisions", async () => {
+    const document = await buildDocument();
+    const revision = await Revision.createFromDocument(document);
+
+    await script();
+
+    const event = await Event.findOne();
+
+    expect(event.name).toEqual("revisions.create");
+    expect(event.modelId).toEqual(revision.id);
+    expect(event.documentId).toEqual(document.id);
+    expect(event.teamId).toEqual(document.teamId);
+  });
+
+  it("should create events for revisions of deleted documents", async () => {
+    const document = await buildDocument();
+    const revision = await Revision.createFromDocument(document);
+
+    await document.destroy();
+
+    await script();
+
+    const event = await Event.findOne();
+
+    expect(event.name).toEqual("revisions.create");
+    expect(event.modelId).toEqual(revision.id);
+    expect(event.documentId).toEqual(document.id);
+    expect(event.teamId).toEqual(document.teamId);
+  });
+
+  it("should be idempotent", async () => {
+    const document = await buildDocument();
+    await Revision.createFromDocument(document);
+
+    await script();
+    await script();
+
+    const count = await Event.count();
+    expect(count).toEqual(1);
+  });
+});

--- a/server/scripts/20210716000000-backfill-revisions.test.js
+++ b/server/scripts/20210716000000-backfill-revisions.test.js
@@ -19,6 +19,7 @@ describe("#work", () => {
     expect(event.modelId).toEqual(revision.id);
     expect(event.documentId).toEqual(document.id);
     expect(event.teamId).toEqual(document.teamId);
+    expect(event.createdAt).toEqual(revision.createdAt);
   });
 
   it("should create events for revisions of deleted documents", async () => {
@@ -35,6 +36,7 @@ describe("#work", () => {
     expect(event.modelId).toEqual(revision.id);
     expect(event.documentId).toEqual(document.id);
     expect(event.teamId).toEqual(document.teamId);
+    expect(event.createdAt).toEqual(revision.createdAt);
   });
 
   it("should be idempotent", async () => {


### PR DESCRIPTION
Final piece of the puzzle to allow document history sidebar to be driven from events table.

Towards #2230