### PR TITLE
feat: Optimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ WORKDIR $APP_PATH
 ENV NODE_ENV production
 
 COPY --from=builder $APP_PATH/build ./build
+COPY --from=builder $APP_PATH/server ./server
+COPY --from=builder $APP_PATH/.sequelizerc ./.sequelizerc
 COPY --from=deps-prod $APP_PATH/node_modules ./node_modules
 COPY --from=builder $APP_PATH/package.json ./package.json
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 # syntax=docker/dockerfile:1.2
+ARG APP_PATH=/opt/outline
 FROM node:14-alpine AS deps-common
 
-ARG APP_PATH /opt/outline
+ARG APP_PATH
 WORKDIR $APP_PATH
 COPY ./package.json ./yarn.lock ./
 
@@ -17,6 +18,8 @@ RUN yarn install --production=true --frozen-lockfile && \
 
 # ---
 FROM node:14-alpine AS builder
+
+ARG APP_PATH
 WORKDIR $APP_PATH
 
 COPY . .
@@ -26,6 +29,7 @@ RUN yarn build
 # ---
 FROM node:14-alpine AS runner
 
+ARG APP_PATH
 WORKDIR $APP_PATH
 ENV NODE_ENV production
 

--- a/package.json
+++ b/package.json
@@ -165,8 +165,7 @@
     "turndown": "^7.1.1",
     "utf8": "^3.0.0",
     "uuid": "^8.3.2",
-    "validator": "5.2.0",
-    "yarn-deduplicate": "^3.1.0"
+    "validator": "5.2.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",
@@ -204,7 +203,8 @@
     "webpack-cli": "^3.3.12",
     "webpack-manifest-plugin": "^3.0.0",
     "webpack-pwa-manifest": "^4.3.0",
-    "workbox-webpack-plugin": "^6.1.0"
+    "workbox-webpack-plugin": "^6.1.0",
+    "yarn-deduplicate": "^3.1.0"
   },
   "resolutions": {
     "prosemirror-view": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -165,7 +165,8 @@
     "turndown": "^7.1.1",
     "utf8": "^3.0.0",
     "uuid": "^8.3.2",
-    "validator": "5.2.0"
+    "validator": "5.2.0",
+    "yarn-deduplicate": "^3.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",
@@ -203,8 +204,7 @@
     "webpack-cli": "^3.3.12",
     "webpack-manifest-plugin": "^3.0.0",
     "webpack-pwa-manifest": "^4.3.0",
-    "workbox-webpack-plugin": "^6.1.0",
-    "yarn-deduplicate": "^3.1.0"
+    "workbox-webpack-plugin": "^6.1.0"
   },
   "resolutions": {
     "prosemirror-view": "1.18.1",


### PR DESCRIPTION
## Dockerfile Improvements
* Use new BuildKit dockerfile syntaxes
* Leverage multi-stage build steps for faster builds
* Strip Yarn install cache from image, reducing final size
* Use a stricter version of `yarn install` such that it will fail with an invalid lockfile
* Run as a non-root user for security

## Notes
* `yarn-deduplicate` was moved to a required dependency, otherwise running `yarn install --production` will fail on fresh installs.
* In my testing the image sizes were reduced from ~1.4GB to ~450MB