### PR TITLE
feat: Default to "recently viewed"

### DIFF
--- a/app/components/Tab.js
+++ b/app/components/Tab.js
@@ -13,7 +13,7 @@ type Props = {
 const NavLinkWithChildrenFunc = ({ to, exact = false, children, ...rest }) => (
   <Route path={to} exact={exact}>
     {({ match }) => (
-      <NavLink to={to} {...rest}>
+      <NavLink to={to} exact={exact} {...rest}>
         {children(match)}
       </NavLink>
     )}

--- a/app/scenes/Home.js
+++ b/app/scenes/Home.js
@@ -5,6 +5,7 @@ import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Switch, Route } from "react-router-dom";
 import { Action } from "components/Actions";
+import Empty from "components/Empty";
 import Heading from "components/Heading";
 import InputSearchPage from "components/InputSearchPage";
 import LanguagePrompt from "components/LanguagePrompt";
@@ -41,19 +42,19 @@ function Home() {
       <Heading>{t("Home")}</Heading>
       <Tabs>
         <Tab to="/home" exact>
-          {t("Recently updated")}
+          {t("Recently viewed")}
         </Tab>
         <Tab to="/home/recent" exact>
-          {t("Recently viewed")}
+          {t("Recently updated")}
         </Tab>
         <Tab to="/home/created">{t("Created by me")}</Tab>
       </Tabs>
       <Switch>
         <Route path="/home/recent">
           <PaginatedDocumentList
-            key="recent"
-            documents={documents.recentlyViewed}
-            fetch={documents.fetchRecentlyViewed}
+            documents={documents.recentlyUpdated}
+            fetch={documents.fetchRecentlyUpdated}
+            empty={<Empty>{t("Weird, this shouldn’t ever be empty")}</Empty>}
             showCollection
           />
         </Route>
@@ -63,13 +64,22 @@ function Home() {
             documents={documents.createdByUser(user)}
             fetch={documents.fetchOwned}
             options={{ user }}
+            empty={<Empty>{t("Weird, this shouldn’t ever be empty")}</Empty>}
             showCollection
           />
         </Route>
         <Route path="/home">
           <PaginatedDocumentList
-            documents={documents.recentlyUpdated}
-            fetch={documents.fetchRecentlyUpdated}
+            key="recent"
+            documents={documents.recentlyViewed}
+            fetch={documents.fetchRecentlyViewed}
+            empty={
+              <Empty>
+                {t(
+                  "Documents you’ve recently viewed will be here for easy access"
+                )}
+              </Empty>
+            }
             showCollection
           />
         </Route>

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -381,6 +381,8 @@
   "Group members": "Group members",
   "Recently viewed": "Recently viewed",
   "Created by me": "Created by me",
+  "Weird, this shouldn’t ever be empty": "Weird, this shouldn’t ever be empty",
+  "Documents you’ve recently viewed will be here for easy access": "Documents you’ve recently viewed will be here for easy access",
   "We sent out your invites!": "We sent out your invites!",
   "Sorry, you can only send {{MAX_INVITES}} invites at a time": "Sorry, you can only send {{MAX_INVITES}} invites at a time",
   "Invite team members or guests to join your knowledge base. Team members can sign in with {{signinMethods}} or use their email address.": "Invite team members or guests to join your knowledge base. Team members can sign in with {{signinMethods}} or use their email address.",


### PR DESCRIPTION
- When joining a team for the first time send the user to the default Collection directly. This improves the smoothness of onboarding experience by automatically expanding the sidebar too
- "Recently viewed" is a much more useful default for the Home screen