### PR TITLE
fix: Suppress notifications for suspended users

### DIFF
--- a/server/services/notifications.js
+++ b/server/services/notifications.js
@@ -63,7 +63,7 @@ export default class Notifications {
       event.name === "documents.publish" ? "published" : "updated";
 
     for (const setting of notificationSettings) {
-      // Supress notifications for suspended users
+      // Suppress notifications for suspended users
       if (setting.user.isSuspended) {
         continue;
       }
@@ -147,7 +147,10 @@ export default class Notifications {
     });
 
     notificationSettings.forEach((setting) => {
-      if (setting.user.isSuspended) return;
+      // Suppress notifications for suspended users
+      if (setting.user.isSuspended) {
+        return;
+      }
 
       mailer.collectionNotification({
         to: setting.user.email,

--- a/server/services/notifications.js
+++ b/server/services/notifications.js
@@ -63,6 +63,11 @@ export default class Notifications {
       event.name === "documents.publish" ? "published" : "updated";
 
     for (const setting of notificationSettings) {
+      // Supress notifications for suspended users
+      if (setting.user.isSuspended) {
+        continue;
+      }
+
       // For document updates we only want to send notifications if
       // the document has been edited by the user with this notification setting
       // This could be replaced with ability to "follow" in the future
@@ -141,14 +146,16 @@ export default class Notifications {
       ],
     });
 
-    notificationSettings.forEach((setting) =>
+    notificationSettings.forEach((setting) => {
+      if (setting.user.isSuspended) return;
+
       mailer.collectionNotification({
         to: setting.user.email,
         eventName: "created",
         collection,
         actor: collection.user,
         unsubscribeUrl: setting.unsubscribeUrl,
-      })
-    );
+      });
+    });
   }
 }


### PR DESCRIPTION
Notifications from the application are currently being sent to a user even when the user is suspended. This PR implements a change that suppresses notifications for suspended users.