### PR TITLE
feat: Add hosted domain hint when signing in through Google SSO from subdomain

### DIFF
--- a/server/api/auth.js
+++ b/server/api/auth.js
@@ -25,11 +25,23 @@ function filterProviders(team) {
         find(team.authenticationProviders, { name: provider.id, enabled: true })
       );
     })
-    .map((provider) => ({
-      id: provider.id,
-      name: provider.name,
-      authUrl: provider.authUrl,
-    }));
+    .map((provider) => {
+      const authProvider = team
+        ? find(team.authenticationProviders, {
+            name: provider.id,
+          })
+        : undefined;
+
+      return {
+        id: provider.id,
+        name: provider.name,
+        authUrl: `${provider.authUrl}${
+          authProvider && authProvider.name === "google"
+            ? "?hd=" + authProvider.providerId
+            : ""
+        }`,
+      };
+    });
 }
 
 router.post("auth.config", async (ctx) => {

--- a/server/api/auth.js
+++ b/server/api/auth.js
@@ -35,11 +35,7 @@ function filterProviders(team) {
       return {
         id: provider.id,
         name: provider.name,
-        authUrl: `${provider.authUrl}${
-          authProvider && authProvider.name === "google"
-            ? "?hd=" + authProvider.providerId
-            : ""
-        }`,
+        authUrl: `${provider.authUrl}?authProviderId=${authProvider?.id || ""}`,
       };
     });
 }

--- a/server/api/auth.test.js
+++ b/server/api/auth.test.js
@@ -76,6 +76,30 @@ describe("#auth.config", () => {
     expect(body.data.providers[0].name).toBe("Slack");
   });
 
+  it("should return hosted domain hint for Google provider for team subdomain", async () => {
+    process.env.URL = "http://localoutline.com";
+
+    await buildTeam({
+      guestSignin: false,
+      subdomain: "example",
+      authenticationProviders: [
+        {
+          name: "google",
+          providerId: "example.com",
+        },
+      ],
+    });
+    const res = await server.post("/api/auth.config", {
+      headers: { host: `example.localoutline.com` },
+    });
+    const body = await res.json();
+
+    expect(res.status).toEqual(200);
+    expect(body.data.providers.length).toBe(1);
+    expect(body.data.providers[0].name).toBe("Google");
+    expect(body.data.providers[0].authUrl).toContain("?hd=example.com");
+  });
+
   it("should return available providers for team custom domain", async () => {
     await buildTeam({
       guestSignin: false,

--- a/server/api/auth.test.js
+++ b/server/api/auth.test.js
@@ -56,7 +56,7 @@ describe("#auth.config", () => {
   it("should return available providers for team subdomain", async () => {
     process.env.URL = "http://localoutline.com";
 
-    await buildTeam({
+    const team = await buildTeam({
       guestSignin: false,
       subdomain: "example",
       authenticationProviders: [
@@ -74,30 +74,9 @@ describe("#auth.config", () => {
     expect(res.status).toEqual(200);
     expect(body.data.providers.length).toBe(1);
     expect(body.data.providers[0].name).toBe("Slack");
-  });
-
-  it("should return hosted domain hint for Google provider for team subdomain", async () => {
-    process.env.URL = "http://localoutline.com";
-
-    await buildTeam({
-      guestSignin: false,
-      subdomain: "example",
-      authenticationProviders: [
-        {
-          name: "google",
-          providerId: "example.com",
-        },
-      ],
-    });
-    const res = await server.post("/api/auth.config", {
-      headers: { host: `example.localoutline.com` },
-    });
-    const body = await res.json();
-
-    expect(res.status).toEqual(200);
-    expect(body.data.providers.length).toBe(1);
-    expect(body.data.providers[0].name).toBe("Google");
-    expect(body.data.providers[0].authUrl).toContain("?hd=example.com");
+    expect(body.data.providers[0].authUrl).toContain(
+      `?authProviderId=${team.authenticationProviders[0].id}`
+    );
   });
 
   it("should return available providers for team custom domain", async () => {

--- a/server/auth/providers/google.js
+++ b/server/auth/providers/google.js
@@ -10,6 +10,7 @@ import {
   GoogleWorkspaceInvalidError,
 } from "../../errors";
 import passportMiddleware from "../../middlewares/passport";
+import { AuthenticationProvider } from "../../models";
 import { getAllowedDomains } from "../../utils/authentication";
 import { StateStore } from "../../utils/passport";
 
@@ -86,13 +87,28 @@ if (GOOGLE_CLIENT_ID) {
     )
   );
 
-  router.get("google", (ctx) =>
-    passport.authenticate(providerName, {
+  router.get("google", async (ctx) => {
+    const { authProviderId } = ctx.request.query;
+
+    if (authProviderId) {
+      ctx.assertUuid(authProviderId, "authProviderId must be a UUID");
+    }
+
+    const authProvider = authProviderId
+      ? await AuthenticationProvider.findOne({
+          where: {
+            id: authProviderId,
+            name: providerName,
+          },
+        })
+      : undefined;
+
+    return passport.authenticate(providerName, {
       accessType: "offline",
       prompt: "select_account consent",
-      hd: ctx.request.query?.hd,
-    })(ctx)
-  );
+      hd: authProvider?.providerId,
+    })(ctx);
+  });
 
   router.get("google.callback", passportMiddleware(providerName));
 }

--- a/server/auth/providers/google.js
+++ b/server/auth/providers/google.js
@@ -86,12 +86,12 @@ if (GOOGLE_CLIENT_ID) {
     )
   );
 
-  router.get(
-    "google",
+  router.get("google", (ctx) =>
     passport.authenticate(providerName, {
       accessType: "offline",
       prompt: "select_account consent",
-    })
+      hd: ctx.request.query?.hd,
+    })(ctx)
   );
 
   router.get("google.callback", passportMiddleware(providerName));


### PR DESCRIPTION
> The `hd` parameter streamlines the login process for G Suite hosted accounts. By including the domain of the G Suite user (for example, mycollege.edu), you can indicate that the account selection UI should be optimized for accounts at that domain

To be very clear – it is just a hint and can be bypassed or modified by the client, it provides no security – just a push in the right direction and some reassurance that they are at the right Outline subdomain.

closes #2454

ref: https://developers.google.com/identity/protocols/oauth2/openid-connect#hd-param
