### PR TITLE
Revert "feat: Add hosted domain hint when signing in through Google SSO from subdomain"

### DIFF
--- a/server/api/auth.js
+++ b/server/api/auth.js
@@ -25,19 +25,11 @@ function filterProviders(team) {
         find(team.authenticationProviders, { name: provider.id, enabled: true })
       );
     })
-    .map((provider) => {
-      const authProvider = team
-        ? find(team.authenticationProviders, {
-            name: provider.id,
-          })
-        : undefined;
-
-      return {
-        id: provider.id,
-        name: provider.name,
-        authUrl: `${provider.authUrl}?authProviderId=${authProvider?.id || ""}`,
-      };
-    });
+    .map((provider) => ({
+      id: provider.id,
+      name: provider.name,
+      authUrl: provider.authUrl,
+    }));
 }
 
 router.post("auth.config", async (ctx) => {

--- a/server/api/auth.test.js
+++ b/server/api/auth.test.js
@@ -56,7 +56,7 @@ describe("#auth.config", () => {
   it("should return available providers for team subdomain", async () => {
     process.env.URL = "http://localoutline.com";
 
-    const team = await buildTeam({
+    await buildTeam({
       guestSignin: false,
       subdomain: "example",
       authenticationProviders: [
@@ -74,9 +74,6 @@ describe("#auth.config", () => {
     expect(res.status).toEqual(200);
     expect(body.data.providers.length).toBe(1);
     expect(body.data.providers[0].name).toBe("Slack");
-    expect(body.data.providers[0].authUrl).toContain(
-      `?authProviderId=${team.authenticationProviders[0].id}`
-    );
   });
 
   it("should return available providers for team custom domain", async () => {

--- a/server/auth/providers/google.js
+++ b/server/auth/providers/google.js
@@ -10,7 +10,6 @@ import {
   GoogleWorkspaceInvalidError,
 } from "../../errors";
 import passportMiddleware from "../../middlewares/passport";
-import { AuthenticationProvider } from "../../models";
 import { getAllowedDomains } from "../../utils/authentication";
 import { StateStore } from "../../utils/passport";
 
@@ -87,28 +86,13 @@ if (GOOGLE_CLIENT_ID) {
     )
   );
 
-  router.get("google", async (ctx) => {
-    const { authProviderId } = ctx.request.query;
-
-    if (authProviderId) {
-      ctx.assertUuid(authProviderId, "authProviderId must be a UUID");
-    }
-
-    const authProvider = authProviderId
-      ? await AuthenticationProvider.findOne({
-          where: {
-            id: authProviderId,
-            name: providerName,
-          },
-        })
-      : undefined;
-
-    return passport.authenticate(providerName, {
+  router.get(
+    "google",
+    passport.authenticate(providerName, {
       accessType: "offline",
       prompt: "select_account consent",
-      hd: authProvider?.providerId,
-    })(ctx);
-  });
+    })
+  );
 
   router.get("google.callback", passportMiddleware(providerName));
 }


### PR DESCRIPTION
Reverts outline/outline#2458 because it is confusing when team has multiple Google SSO, need to account for this case.