### PR TITLE
feat: Always show share button

### DIFF
--- a/app/scenes/Document/components/Header.js
+++ b/app/scenes/Document/components/Header.js
@@ -79,7 +79,6 @@ function DocumentHeader({
   const isNew = document.isNewDocument;
   const isTemplate = document.isTemplate;
   const can = policies.abilities(document.id);
-  const canShareDocument = auth.team && auth.team.sharing && can.share;
   const canToggleEmbeds = auth.team && auth.team.documentEmbeds;
   const canEdit = can.update && !isEditing;
 
@@ -171,7 +170,7 @@ function DocumentHeader({
                 <TemplatesMenu document={document} />
               </Action>
             )}
-            {!isEditing && canShareDocument && (!isMobile || !isTemplate) && (
+            {!isEditing && (!isMobile || !isTemplate) && (
               <Action>
                 <ShareButton document={document} />
               </Action>

--- a/app/scenes/Document/components/SharePopover.js
+++ b/app/scenes/Document/components/SharePopover.js
@@ -27,12 +27,17 @@ type Props = {|
 
 function SharePopover({ document, share, sharedParent, onSubmit }: Props) {
   const { t } = useTranslation();
-  const { policies, shares } = useStores();
+  const { policies, shares, auth } = useStores();
   const { showToast } = useToasts();
   const [isCopied, setIsCopied] = React.useState(false);
   const timeout = React.useRef<?TimeoutID>();
   const can = policies.abilities(share ? share.id : "");
-  const canPublish = can.update && !document.isTemplate;
+  const documentAbilities = policies.abilities(document.id);
+  const canPublish =
+    can.update &&
+    !document.isTemplate &&
+    auth.team?.sharing &&
+    documentAbilities.share;
   const isPubliclyShared = (share && share.published) || sharedParent;
 
   React.useEffect(() => {
@@ -102,7 +107,7 @@ function SharePopover({ document, share, sharedParent, onSubmit }: Props) {
         </Notice>
       )}
 
-      {canPublish && (
+      {canPublish ? (
         <SwitchWrapper>
           <Switch
             id="published"
@@ -132,8 +137,11 @@ function SharePopover({ document, share, sharedParent, onSubmit }: Props) {
             </SwitchText>
           </SwitchLabel>
         </SwitchWrapper>
+      ) : (
+        <HelpText>{t("Only team members with permission can view")}</HelpText>
       )}
-      {share && share.published && (
+
+      {canPublish && share?.published && (
         <SwitchWrapper>
           <Switch
             id="includeChildDocuments"

--- a/server/api/documents.test.js
+++ b/server/api/documents.test.js
@@ -235,6 +235,27 @@ describe("#documents.info", () => {
     expect(res.status).toEqual(403);
   });
 
+  it("should return document from shareId if public sharing is disabled but the user has permission to read", async () => {
+    const { document, collection, team, user } = await seed();
+    const share = await buildShare({
+      documentId: document.id,
+      teamId: document.teamId,
+      userId: user.id,
+    });
+
+    team.sharing = false;
+    await team.save();
+
+    collection.sharing = false;
+    await collection.save();
+
+    const res = await server.post("/api/documents.info", {
+      body: { token: user.getJwtToken(), shareId: share.id },
+    });
+
+    expect(res.status).toEqual(200);
+  });
+
   it("should not return document from revoked shareId", async () => {
     const { document, user } = await seed();
     const share = await buildShare({


### PR DESCRIPTION
Show the share button even when public sharing is disabled in the security settings.
It basically checks if the person who opens the share link is logged in and has read access. If that's the case it will display the document.

Let me know if there's anything that need to be changed or if there's other feedback!

closes #2443 
closes #2444