### PR TITLE
Add support for authentication with Telegram.

### DIFF
--- a/app/components/AuthLogo/TelegramLogo.js
+++ b/app/components/AuthLogo/TelegramLogo.js
@@ -1,0 +1,31 @@
+// @flow
+import * as React from "react";
+
+type Props = {
+  size?: number,
+  fill?: string,
+  className?: string,
+};
+
+function TelegramLogo({ size = 34, fill = "#FFF", className }: Props) {
+  return (
+    <svg
+      width={240}
+      height={240}
+      viewBox="50 50 160 160"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <defs>
+        <linearGradient id="a" x1=".667" x2=".417" y1=".167" y2=".75"><stop offset="0" stopColor="#37aee2"/><stop offset="1" stopColor="#1e96c8"/></linearGradient>
+        <linearGradient id="b" x1=".66" x2=".851" y1=".437" y2=".802"><stop offset="0" stopColor="#eff7fc"/><stop offset="1" stopColor="#fff"/></linearGradient>
+      </defs>
+      {/* <circle cx="120" cy="120" r="120" fill="url(#a)"/> */}
+      <path fill="#c8daea" d="M98 175c-3.888 0-3.227-1.468-4.568-5.17L82 132.207 170 80"/>
+      <path fill="#a9c9dd" d="M98 175c3 0 4.325-1.372 6-3l16-15.558-19.958-12.035"/>
+      <path fill="url(#b)" d="M100.04 144.41l48.36 35.729c5.519 3.045 9.501 1.468 10.876-5.123l19.685-92.763c2.015-8.08-3.08-11.746-8.36-9.349l-115.59 44.571c-7.89 3.165-7.843 7.567-1.438 9.528l29.663 9.259 68.673-43.325c3.242-1.966 6.218-.91 3.776 1.258"/>
+    </svg>
+  );
+}
+
+export default TelegramLogo;

--- a/app/components/AuthLogo/index.js
+++ b/app/components/AuthLogo/index.js
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import GoogleLogo from "./GoogleLogo";
 import MicrosoftLogo from "./MicrosoftLogo";
 import SlackLogo from "./SlackLogo";
+import TelegramLogo from "./TelegramLogo";
 
 type Props = {|
   providerName: string,
@@ -30,6 +31,12 @@ function AuthLogo({ providerName, size = 16 }: Props) {
           <MicrosoftLogo size={size} />
         </Logo>
       );
+      case "telegram":
+        return (
+          <Logo>
+            <TelegramLogo size={size} />
+          </Logo>
+        );
     default:
       return null;
   }

--- a/app/scenes/Login/Provider.js
+++ b/app/scenes/Login/Provider.js
@@ -7,11 +7,13 @@ import AuthLogo from "components/AuthLogo";
 import ButtonLarge from "components/ButtonLarge";
 import InputLarge from "components/InputLarge";
 import { client } from "utils/ApiClient";
+import TelegramLoginButton from './TelegramLogin'
 
 type Props = {
   id: string,
   name: string,
   authUrl: string,
+  data: string,
   isCreate: boolean,
   onEmailSuccess: (email: string) => void,
   t: TFunction,
@@ -58,7 +60,7 @@ class Provider extends React.Component<Props, State> {
   };
 
   render() {
-    const { isCreate, id, name, authUrl, t } = this.props;
+    const { isCreate, id, name, authUrl, data, t } = this.props;
 
     if (id === "email") {
       if (isCreate) {
@@ -99,8 +101,19 @@ class Provider extends React.Component<Props, State> {
       );
     }
 
-    return (
-      <Wrapper key={id}>
+    if (id == "telegram") {
+      return (
+        <Wrapper key={id}>
+          <TelegramLoginButton
+          bot_id={parseInt(data)}
+          icon={<AuthLogo providerName={id} />}
+          />
+          </Wrapper>
+      );
+
+    } else {
+      return (
+        <Wrapper key={id}>
         <ButtonLarge
           onClick={() => (window.location.href = authUrl)}
           icon={<AuthLogo providerName={id} />}
@@ -110,8 +123,9 @@ class Provider extends React.Component<Props, State> {
             authProviderName: name,
           })}
         </ButtonLarge>
-      </Wrapper>
-    );
+        </Wrapper>
+        );
+     }
   }
 }
 

--- a/app/scenes/Login/TelegramLogin.js
+++ b/app/scenes/Login/TelegramLogin.js
@@ -1,0 +1,79 @@
+import * as React from "react";
+import ButtonLarge from "components/ButtonLarge";
+
+type Props = {
+  bot_id: int,
+  icon: object,
+};
+
+type State = {
+  telegramLoaded: boolean,
+};
+
+class TelegramLoginButton extends React.Component<Props, State> {
+  state = {
+    telegramLoaded: false,
+  };
+
+  handleTelegramLoaded = (e)=>{
+    this.setState({
+      telegramLoaded:true
+    })
+  }
+
+  render() {
+    const { bot_id, icon } = this.props;
+    var _this = this;
+      
+    var TelegramLoginScript = function TelegramLoginScript(props) {
+      // https://stackoverflow.com/a/63593384
+
+      var ref = React.useRef(null);
+      React.useEffect(function () {
+        if (ref.current === null) return;
+        if (!_this.state.telegramLoaded) {
+          var script = document.createElement('script');
+          script.src = 'https://telegram.org/js/telegram-widget.js';
+          script.onload =() => {
+            // script has been loaded
+            _this.handleTelegramLoaded();
+          };
+          ref.current.appendChild(script);
+        }
+      }, [ref]);
+      return React.createElement("div", {
+        ref: ref,
+      });
+    };
+
+    var telegramLogin = function telegramLogin(bot_name) {
+      console.log("Telegram login with: " + bot_name);
+      window.Telegram.Login.auth(
+        { bot_id: bot_name, request_access: true },
+        (data) => {
+          if (!data) {
+            // console.log("Login Failed");
+            location.href=`/?notice=auth-error`;
+          }
+          // console.log("Login Success: " + data);
+          location.href=`/auth/telegram?id=${data.id}&first_name=${data.first_name}&last_name=${data.last_name}&username=${data.username}&auth_date=${data.auth_date}&hash=${data.hash}`;
+        });
+    };
+
+    return (
+        <>
+        <ButtonLarge
+          onClick={() => (telegramLogin(bot_id))}
+          icon={icon}
+          disabled={!this.state.telegramLoaded}
+          fullwidth
+        >
+          Continue with Telegram
+        </ButtonLarge>
+        <TelegramLoginScript />
+        </>
+    );
+  };
+}
+
+export default TelegramLoginButton;

--- a/app/stores/AuthStore.js
+++ b/app/stores/AuthStore.js
@@ -24,6 +24,7 @@ type Provider = {|
   id: string,
   name: string,
   authUrl: string,
+  data: string,
 |};
 
 type Config = {|

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "passport": "^0.4.1",
     "passport-google-oauth2": "^0.2.0",
     "passport-slack-oauth2": "^1.1.0",
+    "passport-telegram-official": "^1.1.0",
     "pg": "^8.5.1",
     "pg-hstore": "^2.3.3",
     "polished": "3.6.5",

--- a/server/api/auth.js
+++ b/server/api/auth.js
@@ -29,6 +29,7 @@ function filterProviders(team) {
       id: provider.id,
       name: provider.name,
       authUrl: provider.authUrl,
+      data: provider.data,
     }));
 }
 

--- a/server/app.js
+++ b/server/app.js
@@ -31,6 +31,7 @@ const scriptSrc = [
   "'unsafe-inline'",
   "'unsafe-eval'",
   "gist.github.com",
+  "telegram.org",
 ];
 
 if (env.GOOGLE_ANALYTICS_ID) {

--- a/server/auth/providers/index.js
+++ b/server/auth/providers/index.js
@@ -29,6 +29,7 @@ requireDirectory(__dirname).forEach(([module, id]) => {
       name: config.name,
       enabled: config.enabled,
       authUrl: signin(id),
+      data: config.data,
       router: router,
     });
   }

--- a/server/auth/providers/telegram.js
+++ b/server/auth/providers/telegram.js
@@ -1,0 +1,91 @@
+// @flow
+import passport from "@outlinewiki/koa-passport";
+import { TelegramStrategy } from "passport-telegram-official";
+
+import fetch from "fetch-with-proxy";
+import jwt from "jsonwebtoken";
+import Router from "koa-router";
+import accountProvisioner from "../../commands/accountProvisioner";
+import env from "../../env";
+import { TelegramError } from "../../errors";
+import passportMiddleware from "../../middlewares/passport";
+import { getAllowedDomains } from "../../utils/authentication";
+import { StateStore } from "../../utils/passport";
+
+const router = new Router();
+const providerName = "telegram";
+const TELEGRAM_BOT_NAME = process.env.TELEGRAM_BOT_NAME;
+const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
+const allowedDomains = getAllowedDomains();
+
+export const config = {
+  name: 'Telegram',
+  enabled: !!TELEGRAM_BOT_TOKEN,
+  data: (TELEGRAM_BOT_TOKEN.split(':')[0]),
+};
+
+if (TELEGRAM_BOT_TOKEN) {
+  const strategy = new TelegramStrategy(
+    {
+      botToken: TELEGRAM_BOT_TOKEN,
+      passReqToCallback: true,
+    },
+    async function (req, profile, done) {
+      try {
+          // console.log(profile); 
+          // console.log("allowedDomains: " + allowedDomains);
+          var team = allowedDomains[0];
+          var result = result = await accountProvisioner({
+            ip: req.ip,
+            team: {
+              name: team,
+              domain: team,
+            },
+            user: {
+              name: profile.username,
+              email: profile.first_name + " " + profile.last_name,
+            },
+            authenticationProvider: {
+              name: providerName,
+              providerId: providerName,
+            },
+            authentication: {
+              providerId: profile.id,
+            },
+          });
+          done(null, result.user, result);
+      } catch (err) {
+        return done(err, null);
+      }
+    }
+  );
+
+  // TelegramStrategy assumes that a POST request will not have the query in the args,
+  // But koa-passport always seems to forward requests on as POST.
+
+  function override(object, methodName, callback) {
+    object[methodName] = callback(object[methodName])
+  }
+
+  override(strategy, 'authenticate', function(original) {
+    return function(req, options) {
+      if (req.body.auth_date) {
+        req.method = 'POST';
+      }
+      if (req.query.auth_date) {
+        req.method = 'GET';
+      }  
+      return original.apply(this, arguments);
+    }
+  })
+
+  strategy.error = function(err) {
+    console.log(err);
+    throw new new Error(err);
+  }
+  
+  passport.use(strategy);
+  router.get("telegram", passportMiddleware(providerName));
+}
+
+export default router;


### PR DESCRIPTION
This PR add support for Telegram authentication, automatically enrolling the user in the first of the "allowed" teams.

Telegram auth integration was much harder / messier than Discord (https://github.com/outline/outline/pull/2470) as they don't provide a real oauth2 workflow. Typically you need to use their js library which creates a button automatically in an iframe (in their theme, white background, specific size) which will run your callback on auth, similar to oauth2 but not quite fully compatible.

Thankfully their library has a function to handle the same auth workflow with your own button, but getting the right data for it took a bit more plumbing in.

There's probably a cleaner way this could have been done, but it's my first time using React so had to figure it out as I went. Either way it's working pretty well for me as it stands!