### PR TITLE
Allow users to customize the OIDC team name

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -84,6 +84,8 @@ OIDC_CLIENT_SECRET=
 OIDC_AUTH_URI=
 OIDC_TOKEN_URI=
 OIDC_USERINFO_URI=
+# optional, used to set the team that the user belongs to, which will be displayed on the interface.
+OIDC_TEAM_NAME=Wiki
 
 # Display name for OIDC authentication
 OIDC_DISPLAY_NAME=OpenID Connect

--- a/server/routes/auth/providers/oidc.js
+++ b/server/routes/auth/providers/oidc.js
@@ -22,6 +22,9 @@ const OIDC_AUTH_URI = process.env.OIDC_AUTH_URI;
 const OIDC_TOKEN_URI = process.env.OIDC_TOKEN_URI;
 const OIDC_USERINFO_URI = process.env.OIDC_USERINFO_URI;
 const OIDC_SCOPES = process.env.OIDC_SCOPES || "";
+// https://github.com/outline/outline/pull/2388#discussion_r681120223
+const OIDC_TEAM_NAME = process.env.OIDC_TEAM_NAME || "Wiki";
+
 const allowedDomains = getAllowedDomains();
 
 export const config = {
@@ -94,8 +97,7 @@ if (OIDC_CLIENT_ID) {
           const result = await accountProvisioner({
             ip: req.ip,
             team: {
-              // https://github.com/outline/outline/pull/2388#discussion_r681120223
-              name: "Wiki",
+              name: OIDC_TEAM_NAME,
               domain,
               subdomain,
             },


### PR DESCRIPTION
The latest [merged code](https://github.com/outline/outline/pull/2388) I looked at included OIDC support, but the team name was hardly written in the code.

Perhaps, you can use environment variables to allow users to set the team name when customizing OIDC.