### PR TITLE
WIP: Group assignment from JWT claims

### DIFF
--- a/server/commands/groupCreator.js
+++ b/server/commands/groupCreator.js
@@ -1,0 +1,111 @@
+// @flow
+import Sequelize from "sequelize";
+import { Event, Group, GroupUser, User } from "../models";
+import { sequelize } from "../sequelize";
+
+const Op = Sequelize.Op;
+
+type GroupCreatorResult = {|
+  group: Group,
+  membership: GroupUser,
+  isNewGroup: boolean,
+|};
+
+export default async function groupCreator({
+  name,
+  ip,
+  user,
+}: {|
+  name: string,
+  ip: string,
+  user: User,
+|}): Promise<GroupCreatorResult> {
+  let isNewGroup = false;
+  let group = await Group.findOne({
+    where: {
+      name: { [Op.iLike]: name },
+    },
+  });
+
+  // The group does not already exist so we should create it
+  if (!group) {
+    let transaction = await sequelize.transaction();
+
+    try {
+      group = await Group.create(
+        {
+          name,
+          teamId: user.teamId,
+          createdById: user.id,
+        },
+        {
+          transaction,
+        }
+      );
+
+      await Event.create(
+        {
+          name: "groups.create",
+          actorId: user.id,
+          teamId: user.teamId,
+          modelId: group.id,
+          data: { name },
+          ip,
+        },
+        {
+          transaction,
+        }
+      );
+
+      await transaction.commit();
+
+      // reload to get default scope
+      group = await Group.findByPk(group.id);
+      isNewGroup = true;
+    } catch (err) {
+      await transaction.rollback();
+      throw err;
+    }
+  }
+
+  // Check for an existing group membership
+  let membership = await GroupUser.findOne({
+    where: {
+      groupId: group.id,
+      userId: user.id,
+    },
+  });
+
+  // User is not a member of the group, so we should add them
+  if (!membership) {
+    await group.addUser(user, {
+      through: { createdById: user.id },
+    });
+
+    membership = await GroupUser.findOne({
+      where: {
+        groupId: group.id,
+        userId: user.id,
+      },
+    });
+
+    await Event.create({
+      name: "groups.add_user",
+      userId: user.id,
+      teamId: user.teamId,
+      modelId: group.id,
+      actorId: user.id,
+      data: { name: user.name },
+      ip,
+    });
+
+    // reload to get default scope
+    group = await Group.findByPk(group.id);
+  }
+
+  return {
+    isNewGroup,
+    group,
+    membership,
+  };
+}

--- a/server/routes/auth/providers/oidc.js
+++ b/server/routes/auth/providers/oidc.js
@@ -21,6 +21,7 @@ const OIDC_CLIENT_SECRET = process.env.OIDC_CLIENT_SECRET;
 const OIDC_AUTH_URI = process.env.OIDC_AUTH_URI;
 const OIDC_TOKEN_URI = process.env.OIDC_TOKEN_URI;
 const OIDC_USERINFO_URI = process.env.OIDC_USERINFO_URI;
+const OIDC_GROUPS_CLAIM = process.env.OIDC_GROUPS_CLAIM || "groups";
 const OIDC_SCOPES = process.env.OIDC_SCOPES || "";
 const allowedDomains = getAllowedDomains();
 
@@ -90,6 +91,12 @@ if (OIDC_CLIENT_ID) {
           }
 
           const subdomain = domain.split(".")[0];
+          let groups = profile[OIDC_GROUPS_CLAIM] || [];
+
+          // Ensure groups is an array
+          if (typeof groups === "string") {
+            groups = groups.split(",");
+          }
 
           const result = await accountProvisioner({
             ip: req.ip,
@@ -104,6 +111,7 @@ if (OIDC_CLIENT_ID) {
               email: profile.email,
               avatarUrl: profile.picture,
             },
+            groups,
             authenticationProvider: {
               name: providerName,
               providerId: domain,


### PR DESCRIPTION
This is a natural follow-on from #2388 and was initially floated in discussions #2205 and #2206. This PR is a WIP with some pretty obviously missing pieces, specifically error handling, `.env.sample` examples, and tests, which I will gladly add but wanted to be sure that _how_ I'm going about this is acceptable before adding the polish.

#### Additions

1. The provider passes a configurable groups claim to the `accountProvisioner`. If no claim is present then there is no effect.
2. The claim name is configurable by specifying an environment variable. This accounts for multiple IdPs that might use a claim named `roles` instead of `groups` or anything similar.
3. The claim content can either be a JSON array, or a string of comma-separated group names. This, once again, accounts for the majority of ways identity providers will provide roles/group names.
4. The `accountProvisioner` will pass the groups to a new `groupCreator` file in `/commands`.
5. The `groupCreator` first ensures that the group exists, and if not will create it.
6. The `groupCreator` will then ensure that the user is a part of the group, and if not will add them.
7. The `accountProvisioner` will then remove any GroupUser records that are not present in the current list of groups passed to it; currently this includes groups that were assigned manually, however if no groups are passed to the `accountProvisioner` then it will not remove any group assignments, and therefore should not interfere with existing setups. It will also _not_ delete any group, even if there are no members.

#### Configuration

- `OIDC_GROUPS_CLAIM` &mdash; The name of the claim provided that contains the list of groups a user belongs to. Currently defaults to `groups` although we may wish to have it default to a disabled state to guarantee that existing deployments will not be affected by stray configuration.

Further configuration will be necessary from the IdP side; as this likely requires additional scopes that will add the required claim referenced in the env variable above. For example, on Keycloak this would require creating a "mapper" that has that effect.
