### PR TITLE
fix: Support uppercase letters in gist link

### DIFF
--- a/shared/embeds/Gist.js
+++ b/shared/embeds/Gist.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 
 const URL_REGEX = new RegExp(
-  "^https://gist.github.com/([a-z\\d](?:[a-z\\d]|-(?=[a-z\\d])){0,38})/(.*)$"
+  "^https://gist.github.com/([a-zA-Z\\d](?:[a-zA-Z\\d]|-(?=[a-zA-Z\\d])){0,38})/(.*)$"
 );
 
 type Props = {|

--- a/shared/embeds/Gist.test.js
+++ b/shared/embeds/Gist.test.js
@@ -15,6 +15,12 @@ describe("Gist", () => {
         match
       )
     ).toBeTruthy();
+
+    expect(
+      "https://gist.github.com/ShubhanjanMedhi-dev/900c9c14093611898a4a085938bb90d9".match(
+        match
+      )
+    ).toBeTruthy();
   });
 
   test("to not be enabled elsewhere", () => {


### PR DESCRIPTION
Hello, I discovered an issue while embedding a gist link with capital letters, I tried to embed gists into the document by picking a random gist link, but it didn't work, and I got the error `Sorry, that link won’t work for this embed type`.

<img src="https://user-images.githubusercontent.com/82504881/139013903-6f36f3b7-24c6-4c85-a275-b73894dc389e.png" width=600>

So I read the source code and I believe the regex may be adjusted to accommodate capital letters.

