### PR TITLE
fix: Move notifications to be revision driven

### DIFF
--- a/server/queues/processors/notifications.test.js
+++ b/server/queues/processors/notifications.test.js
@@ -93,8 +93,8 @@ describe("documents.publish", () => {
   });
 });
 
-describe("documents.update.debounced", () => {
-  test("should send a notification to other collaborator", async () => {
+describe("revisions.create", () => {
+  test("should send a notification to other collaborators", async () => {
     const document = await buildDocument();
     const collaborator = await buildUser({ teamId: document.teamId });
     document.collaboratorIds = [collaborator.id];
@@ -107,7 +107,7 @@ describe("documents.update.debounced", () => {
     });
 
     await Notifications.on({
-      name: "documents.update.debounced",
+      name: "revisions.create",
       documentId: document.id,
       collectionId: document.collectionId,
       teamId: document.teamId,
@@ -132,7 +132,7 @@ describe("documents.update.debounced", () => {
     await View.touch(document.id, collaborator.id, true);
 
     await Notifications.on({
-      name: "documents.update.debounced",
+      name: "revisions.create",
       documentId: document.id,
       collectionId: document.collectionId,
       teamId: document.teamId,
@@ -156,7 +156,7 @@ describe("documents.update.debounced", () => {
     });
 
     await Notifications.on({
-      name: "documents.update.debounced",
+      name: "revisions.create",
       documentId: document.id,
       collectionId: document.collectionId,
       teamId: document.teamId,

--- a/server/routes/api/documents.js
+++ b/server/routes/api/documents.js
@@ -1048,6 +1048,7 @@ router.post("documents.update", auth(), async (ctx) => {
 
   document.lastModifiedById = user.id;
   const { collection } = document;
+  const changed = document.changed();
 
   let transaction;
   try {
@@ -1066,30 +1067,32 @@ router.post("documents.update", auth(), async (ctx) => {
     throw err;
   }
 
-  if (publish) {
-    await Event.create({
-      name: "documents.publish",
-      documentId: document.id,
-      collectionId: document.collectionId,
-      teamId: document.teamId,
-      actorId: user.id,
-      data: { title: document.title },
-      ip: ctx.request.ip,
-    });
-  } else {
-    await Event.create({
-      name: "documents.update",
-      documentId: document.id,
-      collectionId: document.collectionId,
-      teamId: document.teamId,
-      actorId: user.id,
-      data: {
-        autosave,
-        done,
-        title: document.title,
-      },
-      ip: ctx.request.ip,
-    });
+  if (changed) {
+    if (publish) {
+      await Event.create({
+        name: "documents.publish",
+        documentId: document.id,
+        collectionId: document.collectionId,
+        teamId: document.teamId,
+        actorId: user.id,
+        data: { title: document.title },
+        ip: ctx.request.ip,
+      });
+    } else {
+      await Event.create({
+        name: "documents.update",
+        documentId: document.id,
+        collectionId: document.collectionId,
+        teamId: document.teamId,
+        actorId: user.id,
+        data: {
+          autosave,
+          done,
+          title: document.title,
+        },
+        ip: ctx.request.ip,
+      });
+    }
   }
 
   if (document.title !== previousTitle) {


### PR DESCRIPTION
Kind of thought I did this already 🤷  – because revisions are only created when the text actually changes this protects against sending notifications that are unneccessary 

closes #2703