### PR TITLE
feat: DocumentMenu button overlay style

### DIFF
--- a/app/components/ContextMenu/OverflowMenuButton.js
+++ b/app/components/ContextMenu/OverflowMenuButton.js
@@ -4,11 +4,17 @@ import * as React from "react";
 import { MenuButton } from "reakit/Menu";
 import NudeButton from "components/NudeButton";
 
+type Props = {
+  iconColor?: string,
+  className?: string,
+  isOverlay?: boolean,
+};
+
 export default function OverflowMenuButton({
   iconColor,
   className,
   ...rest
-}: any) {
+}: Props) {
   return (
     <MenuButton {...rest}>
       {(props) => (

--- a/app/components/NudeButton.js
+++ b/app/components/NudeButton.js
@@ -5,7 +5,12 @@ import styled from "styled-components";
 const Button = styled.button`
   width: ${(props) => props.width || props.size}px;
   height: ${(props) => props.height || props.size}px;
-  background: none;
+  background: ${(props) =>
+    props.isOverlay ? props.theme.menuBackground : "none"};
+  ${(props) =>
+    props.isOverlay
+      ? `box-shadow: rgba(0, 0, 0, 0.07) 0px 1px 2px, ${props.theme.buttonNeutralBorder} 0 0 0 1px inset;`
+      : ""}
   border-radius: 4px;
   line-height: 0;
   border: 0;

--- a/app/components/Sidebar/components/DocumentLink.js
+++ b/app/components/Sidebar/components/DocumentLink.js
@@ -263,6 +263,7 @@ function DocumentLink(
                         document={document}
                         onOpen={handleMenuOpen}
                         onClose={handleMenuClose}
+                        isOverlay
                       />
                     </Fade>
                   ) : undefined

--- a/app/components/Sidebar/components/SidebarLink.js
+++ b/app/components/Sidebar/components/SidebarLink.js
@@ -152,7 +152,7 @@ const Link = styled(NavLink)`
   }
 
   ${breakpoint("tablet")`
-    padding: 4px 32px 4px 16px;
+    padding: 4px 8px 4px 16px;
     font-size: 15px;
   `}
 

--- a/app/menus/DocumentMenu.js
+++ b/app/menus/DocumentMenu.js
@@ -56,6 +56,7 @@ type Props = {|
   modal?: boolean,
   showToggleEmbeds?: boolean,
   showPin?: boolean,
+  isOverlay?: boolean,
   label?: (any) => React.Node,
   onOpen?: () => void,
   onClose?: () => void,
@@ -66,6 +67,7 @@ function DocumentMenu({
   isRevision,
   className,
   modal = true,
+  isOverlay = false,
   showToggleEmbeds,
   showPrint,
   showPin,
@@ -256,6 +258,7 @@ function DocumentMenu({
         <MenuButton {...menu}>{label}</MenuButton>
       ) : (
         <OverflowMenuButton
+          isOverlay={isOverlay}
           className={className}
           aria-label={t("Show menu")}
           {...menu}


### PR DESCRIPTION
Following on from #2486, I've added a style to the action buttons that display alongside the sidebar links to allow them to 'overlay' the text of the sidebar link—rather than reserving 24px of space to the right of the link for the button (see screenshots below).

These styles should only apply to the sidebar links—not to any other document link actions across the application.

I've also added some type annotations for the `OverflowMenuButton`'s props. They're not complete but they cover all of the props used by `OverflowMenuButton` directly.

## Testing
1. Spin up the test site and create a child document under **Welcome**. Give it a long title, preferably one that wraps onto multiple lines.
2. Hover over that document's name in the sidebar; the 'actions' button should overlay the text on hover.
3. Click into the **Welcome** document; your new document should appear in the list of child documents.
4. Hovering over the title of your document here should show the original style—the three `MoreInfo` dots with no background.

## Screenshots

#### Before:
![The sidebar actions button pushes the text over, even when not displayed](https://user-images.githubusercontent.com/20623195/140609271-4696d844-32d5-4a5e-bf94-ed71ceadac79.gif)

#### After:
![The sidebar actions button overlays the text when the text is hovered](https://user-images.githubusercontent.com/20623195/140609314-52c360ee-8701-4e18-899a-34120d614302.gif)

![The sidebar actions button overlays the text when the text is hovered in dark mode, as well](https://user-images.githubusercontent.com/20623195/140609322-910dd3cd-5325-44d9-a230-2d084197d818.gif)

