### PR TITLE
feat: Highlight active ListItem in outline.

### DIFF
--- a/app/scenes/Document/components/Contents.js
+++ b/app/scenes/Document/components/Contents.js
@@ -110,6 +110,11 @@ const ListItem = styled("li")`
   line-height: 1.3;
   border-right: 3px solid
     ${(props) => (props.active ? props.theme.divider : "transparent")};
+
+  a {
+    color: ${(props) =>
+      props.active ? props.theme.primary : props.theme.text};
+  }
 `;
 
 const Link = styled("a")`


### PR DESCRIPTION
Hi, I think it would be fantastic if we could highlight the active item in the outline.

Dark theme:

<img src="https://user-images.githubusercontent.com/82504881/141403070-a840e801-6039-47a2-9cc4-fb5a4eeed94a.png" width=500>

Light theme:

<img src="https://user-images.githubusercontent.com/82504881/141403078-78271da3-c614-4407-9e45-c0f4f2283509.png" width=500>

