### PR TITLE
fix: fix issue where the title can be modified in read-only mode

### DIFF
--- a/app/components/ContentEditable.js
+++ b/app/components/ContentEditable.js
@@ -5,6 +5,7 @@ import styled from "styled-components";
 
 type Props = {|
   disabled?: boolean,
+  readOnly?: boolean,
   onChange?: (text: string) => void,
   onBlur?: (event: SyntheticInputEvent<>) => void,
   onInput?: (event: SyntheticInputEvent<>) => void,
@@ -33,6 +34,7 @@ function ContentEditable({
   maxLength,
   autoFocus,
   placeholder,
+  readOnly,
   ...rest
 }: Props) {
   const ref = React.useRef<?HTMLSpanElement>();
@@ -72,7 +74,7 @@ function ContentEditable({
   return (
     <div className={className}>
       <Content
-        contentEditable={!disabled}
+        contentEditable={!disabled && !readOnly}
         onInput={wrappedEvent(onInput)}
         onBlur={wrappedEvent(onBlur)}
         onKeyDown={wrappedEvent(onKeyDown)}


### PR DESCRIPTION
The title can be changed (but not saved) when the document is in read only mode.

Before:

<img src="https://user-images.githubusercontent.com/82504881/141443336-f4d81b1a-5130-4e6e-a193-d3e6ec71fece.gif" width=400>

After:

<img src="https://user-images.githubusercontent.com/82504881/141443352-f322b512-9ad0-4ae0-877e-f507da17a819.gif" width=400>


----

By the way, I don't see any use of `disabled` props, perhaps `disabled` might be renamed to `readOnly`?