### PR TITLE
Let redis, pgsql and s3 listen on localhost only. (docker-compose)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,11 @@ services:
   redis:
     image: redis
     ports:
-      - "6479:6379"
+      - "127.0.0.1:6479:6379"
   postgres:
     image: postgres
     ports:
-      - "5532:5432"
+      - "127.0.0.1:5532:5432"
     environment:
       POSTGRES_USER: user
       POSTGRES_PASSWORD: pass
@@ -15,7 +15,7 @@ services:
   s3:
     image: lphoward/fake-s3
     ports:
-      - "4569:4569"
+      - "127.0.0.1:4569:4569"
     volumes:
       - ./fakes3:/fakes3_root
   outline:


### PR DESCRIPTION
If you open such services publicly, that might cause some security issues (i.e. every one can access those services). No matter it's on production or development.
