### PR TITLE
fix: No reserving space in sidebar for overflow

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -25,5 +25,17 @@
     "@babel/plugin-transform-destructuring",
     "@babel/plugin-transform-regenerator",
     "transform-class-properties"
-  ]
+  ],
+  "env": {
+    "production": {
+      "plugins": [
+        [
+          "styled-components",
+          {
+            "displayName": false
+          }
+        ]
+      ]
+    }
+  }
 }

--- a/app/components/Sidebar/components/DocumentLink.tsx
+++ b/app/components/Sidebar/components/DocumentLink.tsx
@@ -7,7 +7,6 @@ import { MAX_TITLE_LENGTH } from "@shared/constants";
 import Collection from "~/models/Collection";
 import Document from "~/models/Document";
 import Fade from "~/components/Fade";
-import NudeButton from "~/components/NudeButton";
 import useBoolean from "~/hooks/useBoolean";
 import useStores from "~/hooks/useStores";
 import DocumentMenu from "~/menus/DocumentMenu";
@@ -227,7 +226,7 @@ function DocumentLink(
         >
           <div ref={dropToReparent}>
             <DropToImport documentId={node.id} activeClassName="activeDropZone">
-              <StyledSidebarLink
+              <SidebarLink
                 onMouseEnter={handleMouseEnter}
                 to={{
                   pathname: node.url,
@@ -307,20 +306,6 @@ const Relative = styled.div`
 const Draggable = styled.div<{ $isDragging?: boolean; $isMoving?: boolean }>`
   opacity: ${(props) => (props.$isDragging || props.$isMoving ? 0.5 : 1)};
   pointer-events: ${(props) => (props.$isMoving ? "none" : "all")};
-`;
-
-const StyledSidebarLink = styled(SidebarLink)`
-  & + * {
-    ${NudeButton} {
-      background: ${(props) => props.theme.sidebarBackground};
-    }
-  }
-
-  &[aria-current="page"] + * {
-    ${NudeButton} {
-      background: ${(props) => props.theme.sidebarItemBackground};
-    }
-  }
 `;
 
 const ObservedDocumentLink = observer(React.forwardRef(DocumentLink));

--- a/app/components/Sidebar/components/DocumentLink.tsx
+++ b/app/components/Sidebar/components/DocumentLink.tsx
@@ -7,6 +7,7 @@ import { MAX_TITLE_LENGTH } from "@shared/constants";
 import Collection from "~/models/Collection";
 import Document from "~/models/Document";
 import Fade from "~/components/Fade";
+import NudeButton from "~/components/NudeButton";
 import useBoolean from "~/hooks/useBoolean";
 import useStores from "~/hooks/useStores";
 import DocumentMenu from "~/menus/DocumentMenu";
@@ -226,7 +227,7 @@ function DocumentLink(
         >
           <div ref={dropToReparent}>
             <DropToImport documentId={node.id} activeClassName="activeDropZone">
-              <SidebarLink
+              <StyledSidebarLink
                 onMouseEnter={handleMouseEnter}
                 to={{
                   pathname: node.url,
@@ -250,9 +251,8 @@ function DocumentLink(
                     />
                   </>
                 }
-                // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'match' implicitly has an 'any' type.
                 isActive={(match, location) =>
-                  match && location.search !== "?starred"
+                  !!match && location.search !== "?starred"
                 }
                 isActiveDrop={isOverReparent && canDropToReparent}
                 depth={depth}
@@ -307,6 +307,20 @@ const Relative = styled.div`
 const Draggable = styled.div<{ $isDragging?: boolean; $isMoving?: boolean }>`
   opacity: ${(props) => (props.$isDragging || props.$isMoving ? 0.5 : 1)};
   pointer-events: ${(props) => (props.$isMoving ? "none" : "all")};
+`;
+
+const StyledSidebarLink = styled(SidebarLink)`
+  & + * {
+    ${NudeButton} {
+      background: ${(props) => props.theme.sidebarBackground};
+    }
+  }
+
+  &[aria-current="page"] + * {
+    ${NudeButton} {
+      background: ${(props) => props.theme.sidebarItemBackground};
+    }
+  }
 `;
 
 const ObservedDocumentLink = observer(React.forwardRef(DocumentLink));

--- a/app/components/Sidebar/components/NavLink.tsx
+++ b/app/components/Sidebar/components/NavLink.tsx
@@ -4,7 +4,11 @@
 // it avoids recalculating the link match again.
 import { Location, createLocation } from "history";
 import * as React from "react";
-import { __RouterContext as RouterContext, matchPath } from "react-router";
+import {
+  __RouterContext as RouterContext,
+  matchPath,
+  match,
+} from "react-router";
 import { Link } from "react-router-dom";
 import scrollIntoView from "smooth-scroll-into-view-if-needed";
 
@@ -32,7 +36,7 @@ export type Props = React.HTMLAttributes<HTMLAnchorElement> & {
   className?: string;
   scrollIntoViewIfNeeded?: boolean;
   exact?: boolean;
-  isActive?: any;
+  isActive?: (match: match | null, location: Location) => boolean;
   location?: Location;
   strict?: boolean;
   style?: React.CSSProperties;

--- a/app/components/Sidebar/components/SidebarLink.tsx
+++ b/app/components/Sidebar/components/SidebarLink.tsx
@@ -154,7 +154,7 @@ const Link = styled(NavLink)<{ $isActiveDrop?: boolean }>`
   }
 
   ${breakpoint("tablet")`
-    padding: 4px 32px 4px 16px;
+    padding: 4px 8px 4px 16px;
     font-size: 15px;
   `}
 

--- a/app/components/Sidebar/components/SidebarLink.tsx
+++ b/app/components/Sidebar/components/SidebarLink.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import styled, { useTheme } from "styled-components";
 import breakpoint from "styled-components-breakpoint";
 import EventBoundary from "~/components/EventBoundary";
+import NudeButton from "~/components/NudeButton";
 import { NavigationNode } from "~/types";
 import NavLink, { Props as NavLinkProps } from "./NavLink";
 
@@ -151,6 +152,25 @@ const Link = styled(NavLink)<{ $isActiveDrop?: boolean }>`
     color: ${(props) => props.theme.text};
     background: ${(props) =>
       transparentize("0.25", props.theme.sidebarItemBackground)};
+  }
+
+  & + ${Actions} {
+    ${NudeButton} {
+      background: ${(props) => props.theme.sidebarBackground};
+    }
+  }
+
+  &:focus + ${Actions} {
+    ${NudeButton} {
+      background: ${(props) =>
+        transparentize("0.25", props.theme.sidebarItemBackground)};
+    }
+  }
+
+  &[aria-current="page"] + ${Actions} {
+    ${NudeButton} {
+      background: ${(props) => props.theme.sidebarItemBackground};
+    }
   }
 
   ${breakpoint("tablet")`

--- a/app/components/Sidebar/components/StarredLink.tsx
+++ b/app/components/Sidebar/components/StarredLink.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { MAX_TITLE_LENGTH } from "@shared/constants";
 import Fade from "~/components/Fade";
+import NudeButton from "~/components/NudeButton";
 import useBoolean from "~/hooks/useBoolean";
 import useStores from "~/hooks/useStores";
 import DocumentMenu from "~/menus/DocumentMenu";
@@ -72,12 +73,11 @@ function StarredLink({ depth, title, to, documentId, collectionId }: Props) {
   return (
     <>
       <Relative>
-        <SidebarLink
+        <StyledSidebarLink
           depth={depth}
           to={`${to}?starred`}
-          // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'match' implicitly has an 'any' type.
           isActive={(match, location) =>
-            match && location.search === "?starred"
+            !!match && location.search === "?starred"
           }
           label={
             <>
@@ -127,6 +127,20 @@ function StarredLink({ depth, title, to, documentId, collectionId }: Props) {
 
 const Relative = styled.div`
   position: relative;
+`;
+
+const StyledSidebarLink = styled(SidebarLink)`
+  & + * {
+    ${NudeButton} {
+      background: ${(props) => props.theme.sidebarBackground};
+    }
+  }
+
+  &[aria-current="page"] + * {
+    ${NudeButton} {
+      background: ${(props) => props.theme.sidebarItemBackground};
+    }
+  }
 `;
 
 const ObserveredStarredLink = observer(StarredLink);

--- a/app/components/Sidebar/components/StarredLink.tsx
+++ b/app/components/Sidebar/components/StarredLink.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { MAX_TITLE_LENGTH } from "@shared/constants";
 import Fade from "~/components/Fade";
-import NudeButton from "~/components/NudeButton";
 import useBoolean from "~/hooks/useBoolean";
 import useStores from "~/hooks/useStores";
 import DocumentMenu from "~/menus/DocumentMenu";
@@ -73,7 +72,7 @@ function StarredLink({ depth, title, to, documentId, collectionId }: Props) {
   return (
     <>
       <Relative>
-        <StyledSidebarLink
+        <SidebarLink
           depth={depth}
           to={`${to}?starred`}
           isActive={(match, location) =>
@@ -127,20 +126,6 @@ function StarredLink({ depth, title, to, documentId, collectionId }: Props) {
 
 const Relative = styled.div`
   position: relative;
-`;
-
-const StyledSidebarLink = styled(SidebarLink)`
-  & + * {
-    ${NudeButton} {
-      background: ${(props) => props.theme.sidebarBackground};
-    }
-  }
-
-  &[aria-current="page"] + * {
-    ${NudeButton} {
-      background: ${(props) => props.theme.sidebarItemBackground};
-    }
-  }
 `;
 
 const ObserveredStarredLink = observer(StarredLink);


### PR DESCRIPTION
closes #2486

based on #2741 – this PR was half way there but it drilled an `isOverlay` prop down through several components that don't need it and also didn't handle the background color correctly when the sidebar item is highlighted.