### PR TITLE
fix: Clickable area for docs in sidebar is obstructed

### DIFF
--- a/app/components/Sidebar/components/Collections.tsx
+++ b/app/components/Sidebar/components/Collections.tsx
@@ -26,9 +26,6 @@ function Collections() {
   const isPreloaded = !!collections.orderedData.length;
   const { t } = useTranslation();
   const orderedCollections = collections.orderedData;
-  const [isDraggingAnyCollection, setIsDraggingAnyCollection] = React.useState(
-    false
-  );
 
   React.useEffect(() => {
     async function load() {
@@ -85,8 +82,6 @@ function Collections() {
           activeDocument={documents.active}
           prefetchDocument={documents.prefetchDocument}
           canUpdate={policies.abilities(collection.id).update}
-          isDraggingAnyCollection={isDraggingAnyCollection}
-          onChangeDragging={setIsDraggingAnyCollection}
           belowCollection={orderedCollections[index + 1]}
         />
       ))}

--- a/app/components/Sidebar/components/DocumentLink.tsx
+++ b/app/components/Sidebar/components/DocumentLink.tsx
@@ -197,7 +197,7 @@ function DocumentLink(
   });
 
   // Drop to reorder
-  const [{ isOverReorder }, dropToReorder] = useDrop({
+  const [{ isOverReorder, isDraggingAnyDocument }, dropToReorder] = useDrop({
     accept: "document",
     drop: (item: DragObject) => {
       if (!collection) return;
@@ -212,6 +212,7 @@ function DocumentLink(
     },
     collect: (monitor) => ({
       isOverReorder: !!monitor.isOver(),
+      isDraggingAnyDocument: !!monitor.canDrop(),
     }),
   });
 
@@ -275,7 +276,7 @@ function DocumentLink(
             </DropToImport>
           </div>
         </Draggable>
-        {manualSort && (
+        {manualSort && isDraggingAnyDocument && (
           <DropCursor isActiveDrop={isOverReorder} innerRef={dropToReorder} />
         )}
       </Relative>


### PR DESCRIPTION
Also simplifies the logic for collapsing collections when dragging by avoiding sending state out to the parent component and relying on the `useDrop` `monitor` instead.

This is so much nicer now, no "dead" areas in the sidebar when hovering over docs in manually sorted collections.

closes #2808