### PR TITLE
fix: Document icon overflow in ReferenceListItem

### DIFF
--- a/app/scenes/Document/components/ReferenceListItem.tsx
+++ b/app/scenes/Document/components/ReferenceListItem.tsx
@@ -31,14 +31,13 @@ const DocumentLink = styled(Link)`
   }
 `;
 
-const Title = styled.h3`
-  display: flex;
-  align-items: center;
+const Title = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
   font-size: 14px;
-  margin-top: 0;
-  margin-bottom: 0.25em;
+  font-weight: 500;
+  line-height: 1.25;
+  padding-top: 3px;
   white-space: nowrap;
   color: ${(props) => props.theme.text};
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
@@ -78,16 +77,18 @@ function ReferenceListItem({
       }}
       {...rest}
     >
-      <Title dir="auto">
+      <div style={{ display: "flex" }}>
         {document instanceof Document && document.emoji ? (
           <Emoji>{document.emoji}</Emoji>
         ) : (
           <StyledDocumentIcon color="currentColor" />
-        )}{" "}
-        {document instanceof Document && document.emoji
-          ? document.title.replace(new RegExp(`^${document.emoji}`), "")
-          : document.title}
-      </Title>
+        )}
+        <Title dir="auto">
+          {document instanceof Document && document.emoji
+            ? document.title.replace(new RegExp(`^${document.emoji}`), "")
+            : document.title}
+        </Title>
+      </div>
       {document instanceof Document && document.updatedBy && (
         <DocumentMeta document={document} showCollection={showCollection} />
       )}

--- a/app/scenes/Document/components/ReferenceListItem.tsx
+++ b/app/scenes/Document/components/ReferenceListItem.tsx
@@ -47,6 +47,7 @@ const Title = styled.div`
 const StyledDocumentIcon = styled(DocumentIcon)`
   margin-left: -4px;
   color: ${(props) => props.theme.textSecondary};
+  flex-shrink: 0;
 `;
 
 const Emoji = styled.span`

--- a/app/scenes/Document/components/ReferenceListItem.tsx
+++ b/app/scenes/Document/components/ReferenceListItem.tsx
@@ -5,6 +5,7 @@ import { Link } from "react-router-dom";
 import styled from "styled-components";
 import Document from "~/models/Document";
 import DocumentMeta from "~/components/DocumentMeta";
+import Flex from "~/components/Flex";
 import { NavigationNode } from "~/types";
 
 type Props = {
@@ -78,18 +79,18 @@ function ReferenceListItem({
       }}
       {...rest}
     >
-      <div style={{ display: "flex" }}>
+      <Flex gap={4} dir="auto">
         {document instanceof Document && document.emoji ? (
           <Emoji>{document.emoji}</Emoji>
         ) : (
           <StyledDocumentIcon color="currentColor" />
         )}
-        <Title dir="auto">
+        <Title>
           {document instanceof Document && document.emoji
             ? document.title.replace(new RegExp(`^${document.emoji}`), "")
             : document.title}
         </Title>
-      </div>
+      </Flex>
       {document instanceof Document && document.updatedBy && (
         <DocumentMeta document={document} showCollection={showCollection} />
       )}


### PR DESCRIPTION
Related to https://github.com/outline/outline/issues/2810.

Now:
<img src="https://user-images.githubusercontent.com/82504881/143984896-080bad62-f623-49b7-9b3b-b8854c6c4dde.png" width=400>

Fixed:

<img src="https://user-images.githubusercontent.com/82504881/143988386-1e4cfb6e-a53b-4e95-9c7b-9287aec76a25.png" width=400>


<img src="https://user-images.githubusercontent.com/82504881/143992273-0858d98c-3d78-4c4d-a7ec-511b9dd6ed46.png" width=600>

-------

We can deduce the cause of the overflow problem from this stackoverflow answer. We can do some tricks to achieve `text-overflow: ellipsis`. The solution is `width: calc(100%)`. We also need to change the display to inline block and add the line`vertical-align: middle` to align the svg and h3 vertically.


Reference:
https://stackoverflow.com/questions/17779293/css-text-overflow-ellipsis-not-working
https://stackoverflow.com/questions/9670469/css-vertical-alignment-of-inline-inline-block-elements
