### PR TITLE
fix: document publishing

### DIFF
--- a/app/models/Document.ts
+++ b/app/models/Document.ts
@@ -305,6 +305,8 @@ export default class Document extends BaseModel {
           },
           {
             lastRevision: options.lastRevision,
+            publish: options?.publish,
+            done: options?.done,
           }
         );
       }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "yarn clean && yarn build:webpack && yarn build:i18n && yarn build:server",
     "start": "node ./build/server/index.js",
     "dev": "NODE_ENV=development yarn concurrently -n api,collaboration  -c \"blue,magenta\" \"node --inspect=0.0.0.0 build/server/index.js --services=collaboration,websockets,admin,web,worker\"",
-    "dev:watch": "nodemon --exec \"yarn build:server && yarn build:i18n && yarn dev\" -e js --ignore build/ --ignore app/",
+    "dev:watch": "nodemon --exec \"yarn build:server && yarn build:i18n && yarn dev\" -e js,ts --ignore build/ --ignore app/",
     "lint": "eslint app server shared",
     "deploy": "git push heroku master",
     "prepare": "yarn yarn-deduplicate yarn.lock",


### PR DESCRIPTION
adds `done` and `publish` options to document.update - these got removed during the switchover to ts