### PR TITLE
chore: Remove outline service in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,19 +18,3 @@ services:
       - "127.0.0.1:4569:4569"
     volumes:
       - ./fakes3:/fakes3_root
-  outline:
-    image: outline:v001
-    command: yarn dev
-    build:
-      context: .
-      dockerfile: Dockerfile
-      args:
-        pull: 1
-    ports:
-      - "3000:3000"
-    volumes:
-      - .:/opt/outline
-    depends_on:
-      - postgres
-      - redis
-      - s3


### PR DESCRIPTION
Commit 18cf148bd176d06d760555542bd8784eab5a36d9 made Yarn run locally outside of Docker, so there is no need to mount files into the container. This commit allows hosts without Node.js environment to run Outline with docker-compose.

Depends on #2823.