### PR TITLE
feat: Support IAM role authentication for S3

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@tippy.js/react": "^2.2.2",
     "@tommoor/remove-markdown": "^0.3.2",
     "autotrack": "^2.4.1",
-    "aws-sdk": "^2.831.0",
+    "aws-sdk": "^2.1044.0",
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-styled-components": "^1.11.1",
     "babel-plugin-transform-class-properties": "^6.24.1",

--- a/server/commands/accountProvisioner.test.ts
+++ b/server/commands/accountProvisioner.test.ts
@@ -7,6 +7,7 @@ import accountProvisioner from "./accountProvisioner";
 jest.mock("../mailer");
 jest.mock("aws-sdk", () => {
   const mS3 = {
+    createPresignedPost: jest.fn(),
     putObject: jest.fn().mockReturnThis(),
     promise: jest.fn(),
   };

--- a/server/commands/documentPermanentDeleter.test.ts
+++ b/server/commands/documentPermanentDeleter.test.ts
@@ -6,6 +6,7 @@ import documentPermanentDeleter from "./documentPermanentDeleter";
 
 jest.mock("aws-sdk", () => {
   const mS3 = {
+    createPresignedPost: jest.fn(),
     deleteObject: jest.fn().mockReturnThis(),
     promise: jest.fn(),
   };

--- a/server/commands/fileOperationDeleter.test.ts
+++ b/server/commands/fileOperationDeleter.test.ts
@@ -5,6 +5,7 @@ import fileOperationDeleter from "./fileOperationDeleter";
 
 jest.mock("aws-sdk", () => {
   const mS3 = {
+    createPresignedPost: jest.fn(),
     deleteObject: jest.fn().mockReturnThis(),
     promise: jest.fn(),
   };

--- a/server/commands/teamCreator.test.ts
+++ b/server/commands/teamCreator.test.ts
@@ -4,6 +4,7 @@ import teamCreator from "./teamCreator";
 
 jest.mock("aws-sdk", () => {
   const mS3 = {
+    createPresignedPost: jest.fn(),
     putObject: jest.fn().mockReturnThis(),
     promise: jest.fn(),
   };

--- a/server/commands/teamPermanentDeleter.test.ts
+++ b/server/commands/teamPermanentDeleter.test.ts
@@ -11,6 +11,7 @@ import teamPermanentDeleter from "./teamPermanentDeleter";
 
 jest.mock("aws-sdk", () => {
   const mS3 = {
+    createPresignedPost: jest.fn(),
     deleteObject: jest.fn().mockReturnThis(),
     promise: jest.fn(),
   };

--- a/server/routes/api/attachments.test.ts
+++ b/server/routes/api/attachments.test.ts
@@ -15,6 +15,7 @@ const app = webService();
 const server = new TestServer(app.callback());
 jest.mock("aws-sdk", () => {
   const mS3 = {
+    createPresignedPost: jest.fn(),
     deleteObject: jest.fn().mockReturnThis(),
     promise: jest.fn(),
   };

--- a/server/routes/api/fileOperations.test.ts
+++ b/server/routes/api/fileOperations.test.ts
@@ -15,6 +15,7 @@ const app = webService();
 const server = new TestServer(app.callback());
 jest.mock("aws-sdk", () => {
   const mS3 = {
+    createPresignedPost: jest.fn(),
     deleteObject: jest.fn().mockReturnThis(),
     promise: jest.fn(),
   };

--- a/server/routes/api/utils.test.ts
+++ b/server/routes/api/utils.test.ts
@@ -11,6 +11,7 @@ const app = webService();
 const server = new TestServer(app.callback());
 jest.mock("aws-sdk", () => {
   const mS3 = {
+    createPresignedPost: jest.fn(),
     deleteObject: jest.fn().mockReturnThis(),
     promise: jest.fn(),
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4060,10 +4060,10 @@ autotrack@^2.4.1:
     rollup-plugin-node-resolve "^3.0.0"
     source-map "^0.5.6"
 
-aws-sdk@^2.831.0:
-  version "2.831.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.831.0.tgz#02607cc911a2136e5aabe624c1282e821830aef2"
-  integrity sha512-lrOjbGFpjk2xpESyUx2PGsTZgptCy5xycZazPeakNbFO19cOoxjHx3xyxOHsMCYb3pQwns35UvChQT60B4u6cw==
+aws-sdk@^2.1044.0:
+  version "2.1044.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1044.0.tgz#0708eaf48daf8d961b414e698d84e8cd1f82c4ad"
+  integrity sha512-n55uGUONQGXteGGG1QlZ1rKx447KSuV/x6jUGNf2nOl41qMI8ZgLUhNUt0uOtw3qJrCTanzCyR/JKBq2PMiqEQ==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"


### PR DESCRIPTION
With an asynchronous credential provider like EC2 IAM roles, `createPresignedPost()` should always be called with an asynchronous callback.

closes #2829

Note: This implementation has not been tested against S3-compatible storage.