### PR TITLE
feat: Support custom CDN in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ WORKDIR $APP_PATH
 
 COPY . .
 COPY --from=deps-dev $APP_PATH/node_modules ./node_modules
+ARG CDN_URL
 RUN yarn build
 
 # ---


### PR DESCRIPTION
`process.env.CDN_URL` is evaluated during compile time in `webpack.config.prod.js`, so it has to be passed to `yarn build` to work.