### PR TITLE
fix: changing the title and body content in quick succession would trigger unsaved changes warning prompt

### DIFF
--- a/app/scenes/Document/components/Document.tsx
+++ b/app/scenes/Document/components/Document.tsx
@@ -38,6 +38,7 @@ import { isCustomDomain } from "~/utils/domains";
 import { emojiToUrl } from "~/utils/emoji";
 import { isModKey } from "~/utils/keyboard";
 import {
+  editDocumentUrl,
   documentMoveUrl,
   documentHistoryUrl,
   editDocumentUrl,
@@ -471,14 +472,14 @@ class DocumentScene extends React.Component<Props> {
                       // a URL replace matching the current document indicates a title change
                       // no guard is needed for this transition
                       action === "REPLACE" &&
-                      location.pathname.includes(document.url)
+                      location.pathname === editDocumentUrl(document)
                     ) {
                       return true;
                     }
 
                     return t(
                       `You have unsaved changes.\nAre you sure you want to discard them?`
-                    ).toString();
+                    ) as string;
                   }}
                 />
                 <Prompt

--- a/app/scenes/Document/components/Document.tsx
+++ b/app/scenes/Document/components/Document.tsx
@@ -38,7 +38,6 @@ import { isCustomDomain } from "~/utils/domains";
 import { emojiToUrl } from "~/utils/emoji";
 import { isModKey } from "~/utils/keyboard";
 import {
-  editDocumentUrl,
   documentMoveUrl,
   documentHistoryUrl,
   editDocumentUrl,

--- a/app/scenes/Document/components/Document.tsx
+++ b/app/scenes/Document/components/Document.tsx
@@ -466,9 +466,20 @@ class DocumentScene extends React.Component<Props> {
                     !this.isUploading &&
                     !team?.collaborativeEditing
                   }
-                  message={t(
-                    `You have unsaved changes.\nAre you sure you want to discard them?`
-                  )}
+                  message={(location, action) => {
+                    if (
+                      // a URL replace matching the current document indicates a title change
+                      // no guard is needed for this transition
+                      action === "REPLACE" &&
+                      location.pathname.includes(document.url)
+                    ) {
+                      return true;
+                    }
+
+                    return t(
+                      `You have unsaved changes.\nAre you sure you want to discard them?`
+                    ).toString();
+                  }}
                 />
                 <Prompt
                   when={this.isUploading && !this.isEditorDirty}

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -40,6 +40,7 @@
   "Dark": "Dark",
   "Light": "Light",
   "System": "System",
+  "Appearance": "Appearance",
   "Change theme": "Change theme",
   "Change theme to": "Change theme to",
   "Invite people": "Invite people",


### PR DESCRIPTION
fixes #2949 