### PR TITLE
fix: issue-2956 

### DIFF
--- a/app/scenes/Document/components/SharePopover.tsx
+++ b/app/scenes/Document/components/SharePopover.tsx
@@ -165,7 +165,7 @@ function SharePopover({
         <HelpText>{t("Only team members with permission can view")}</HelpText>
       )}
 
-      {canPublish && share?.published && (
+      {canPublish && share?.published && !document.isDraft && (
         <SwitchWrapper>
           <Switch
             id="includeChildDocuments"

--- a/server/models/Collection.ts
+++ b/server/models/Collection.ts
@@ -360,7 +360,7 @@ class Collection extends ParanoidModel {
       direction: "asc",
     };
 
-    let result!: NavigationNode;
+    let result!: NavigationNode | undefined;
 
     const loopChildren = (documents: NavigationNode[]) => {
       if (result) {
@@ -384,6 +384,10 @@ class Collection extends ParanoidModel {
     // but the only place it's used passes straight into an API response
     // so the extra indirection is not worthwhile
     loopChildren(this.documentStructure);
+
+    // if the document is a draft loopChildren will not find it in the structure
+    if (!result) return null;
+
     return {
       ...result,
       children: sortNavigationNodes(result.children, sort),

--- a/server/models/Share.ts
+++ b/server/models/Share.ts
@@ -34,7 +34,7 @@ import Fix from "./decorators/Fix";
     return {
       include: [
         {
-          model: Document,
+          model: Document.scope("withUnpublished"),
           paranoid: true,
           as: "document",
           include: [

--- a/server/policies/share.ts
+++ b/server/policies/share.ts
@@ -10,6 +10,7 @@ allow(User, "update", Share, (user, share) => {
 
   // only the user who can share the document publicly can update the share.
   if (cannot(user, "share", share.document)) return false;
+
   return user.teamId === share.teamId;
 });
 

--- a/server/routes/api/shares.ts
+++ b/server/routes/api/shares.ts
@@ -168,6 +168,7 @@ router.post("shares.update", auth(), async (ctx) => {
   const { user } = ctx.state;
   const team = await Team.findByPk(user.teamId);
   authorize(user, "share", team);
+
   // fetch the share with document and collection.
   const share = await Share.scope({
     method: ["withCollection", user.id],

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -40,6 +40,7 @@
   "Dark": "Dark",
   "Light": "Light",
   "System": "System",
+  "Appearance": "Appearance",
   "Change theme": "Change theme",
   "Change theme to": "Change theme to",
   "Invite people": "Invite people",


### PR DESCRIPTION
fixes #2956 

- when a draft sharing is updated, the auth check failed because it could not locate the draft document when performing an auth check against collections. fixed here

- also uncovers and fixes a related issue: check the "include children" box when sharing a draft document causes an authorization error

- there's an open question on whether we should hide this option from draft shares. this patch make it a safe state but the UX is confusing enough that I think we should remove the option for drafts, so I also hide the secondary checkbox from draft documents