### PR TITLE
fix: truncate a very long team name with ellipses

### DIFF
--- a/app/components/Sidebar/components/TeamButton.tsx
+++ b/app/components/Sidebar/components/TeamButton.tsx
@@ -58,6 +58,10 @@ const TeamName = styled.div`
   white-space: nowrap;
   text-decoration: none;
   font-size: 16px;
+
+  text-overflow: ellipsis;
+  overflow: hidden;
+  width: 100%;
 `;
 
 const Wrapper = styled.div`


### PR DESCRIPTION
result
![image](https://user-images.githubusercontent.com/427579/150402042-8fcd6e95-4a4a-48cf-9c83-e86504b1d1b5.png)
fixes #2952