### PR TITLE
fix: Share popover incorrectly displays draft as publicly shared

### DIFF
--- a/app/scenes/Document/components/ShareButton.tsx
+++ b/app/scenes/Document/components/ShareButton.tsx
@@ -20,7 +20,8 @@ function ShareButton({ document }: Props) {
   const share = shares.getByDocumentId(document.id);
   const sharedParent = shares.getByDocumentParents(document.id);
   const isPubliclyShared =
-    (share && share.published) || (sharedParent && sharedParent.published);
+    (share && share.published) ||
+    (sharedParent && sharedParent.published && !document.isDraft);
 
   const popover = usePopoverState({
     gutter: 0,

--- a/app/scenes/Document/components/SharePopover.tsx
+++ b/app/scenes/Document/components/SharePopover.tsx
@@ -46,7 +46,9 @@ function SharePopover({
     !document.isTemplate &&
     auth.team?.sharing &&
     documentAbilities.share;
-  const isPubliclyShared = (share && share.published) || sharedParent;
+  const isPubliclyShared =
+    (share && share.published) ||
+    (sharedParent && sharedParent.published && !document.isDraft);
 
   useKeyDown("Escape", onRequestClose);
 
@@ -117,7 +119,7 @@ function SharePopover({
         {t("Share this document")}
       </Heading>
 
-      {sharedParent && (
+      {sharedParent && !document.isDraft && (
         <Notice>
           <Trans
             defaults="This document is shared because the parent <em>{{ documentTitle }}</em> is publicly shared"


### PR DESCRIPTION
closes #2978