### PR TITLE
Fix: consistently check allowed domains

### DIFF
--- a/server/commands/teamCreator.ts
+++ b/server/commands/teamCreator.ts
@@ -1,7 +1,7 @@
 import invariant from "invariant";
 import Logger from "@server/logging/logger";
 import { Team, AuthenticationProvider } from "@server/models";
-import { getAllowedDomains } from "@server/utils/authentication";
+import { isDomainAllowed } from "@server/utils/authentication";
 import { generateAvatarUrl } from "@server/utils/avatars";
 import { MaximumTeamsError } from "../errors";
 
@@ -59,7 +59,7 @@ export default async function teamCreator({
     // If the self-hosted installation has a single team and the domain for the
     // new team matches one in the allowed domains env variable then assign the
     // authentication provider to the existing team
-    if (teamCount === 1 && domain && getAllowedDomains().includes(domain)) {
+    if (teamCount === 1 && domain && isDomainAllowed(domain)) {
       const team = await Team.findOne();
       invariant(team, "Team should exist");
 

--- a/server/commands/teamCreator.ts
+++ b/server/commands/teamCreator.ts
@@ -57,8 +57,8 @@ export default async function teamCreator({
     const teamCount = await Team.count();
 
     // If the self-hosted installation has a single team and the domain for the
-    // new team matches one in the allowed domains env variable then assign the
-    // authentication provider to the existing team
+    // new team is allowed then assign the authentication provider to the
+    // existing team
     if (teamCount === 1 && domain && isDomainAllowed(domain)) {
       const team = await Team.findOne();
       invariant(team, "Team should exist");

--- a/server/routes/auth/providers/google.ts
+++ b/server/routes/auth/providers/google.ts
@@ -10,14 +10,13 @@ import {
   GoogleWorkspaceInvalidError,
 } from "@server/errors";
 import passportMiddleware from "@server/middlewares/passport";
-import { getAllowedDomains } from "@server/utils/authentication";
+import { isDomainAllowed } from "@server/utils/authentication";
 import { StateStore } from "@server/utils/passport";
 
 const router = new Router();
 const providerName = "google";
 const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
 const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET;
-const allowedDomains = getAllowedDomains();
 const scopes = [
   "https://www.googleapis.com/auth/userinfo.profile",
   "https://www.googleapis.com/auth/userinfo.email",
@@ -48,7 +47,7 @@ if (GOOGLE_CLIENT_ID) {
             throw GoogleWorkspaceRequiredError();
           }
 
-          if (allowedDomains.length && !allowedDomains.includes(domain)) {
+          if (!isDomainAllowed(domain)) {
             throw GoogleWorkspaceInvalidError();
           }
 

--- a/server/routes/auth/providers/oidc.ts
+++ b/server/routes/auth/providers/oidc.ts
@@ -9,7 +9,7 @@ import {
   AuthenticationError,
 } from "@server/errors";
 import passportMiddleware from "@server/middlewares/passport";
-import { getAllowedDomains } from "@server/utils/authentication";
+import { isDomainAllowed } from "@server/utils/authentication";
 import { StateStore, request } from "@server/utils/passport";
 
 const router = new Router();
@@ -23,7 +23,6 @@ const OIDC_USERINFO_URI = process.env.OIDC_USERINFO_URI || "";
 const OIDC_SCOPES = process.env.OIDC_SCOPES || "";
 const OIDC_USERNAME_CLAIM =
   process.env.OIDC_USERNAME_CLAIM || "preferred_username";
-const allowedDomains = getAllowedDomains();
 
 export const config = {
   name: OIDC_DISPLAY_NAME,
@@ -84,7 +83,7 @@ if (OIDC_CLIENT_ID) {
             throw OIDCMalformedUserInfoError();
           }
 
-          if (allowedDomains.length && !allowedDomains.includes(domain)) {
+          if (!isDomainAllowed(domain)) {
             throw AuthenticationError(
               `Domain ${domain} is not on the whitelist`
             );

--- a/server/utils/authentication.ts
+++ b/server/utils/authentication.ts
@@ -12,6 +12,11 @@ export function getAllowedDomains(): string[] {
   return env ? env.split(",") : [];
 }
 
+export function isDomainAllowed(domain: string): boolean {
+  const allowedDomains = getAllowedDomains();
+  return allowedDomains.includes(domain) || allowedDomains.length === 0;
+}
+
 export async function signIn(
   ctx: Context,
   user: User,


### PR DESCRIPTION
### Context
Currently the way allowed domains are checked is (just an example): https://github.com/outline/outline/blob/390a1343b788af56ad52f9bb267edf82e65920bf/server/routes/auth/providers/oidc.ts#L87-L92
Notice that empty `ALLOWED_DOMAINS` will result into this error never being thrown thus allowing all domains. This is desired behavior. 

### Problem
In this piece of code introduced in #1954 we forgot to check the length of `ALLOWED_DOMAINS`. As a result empty `ALLOWED_DOMAINS` in self-hosted installations will be equivalent to all domains being invalid. As a workaround new users' domains have to be explicitly whitelisted (which is a big pain as we can't even wildcard it or smth).
https://github.com/outline/outline/blob/390a1343b788af56ad52f9bb267edf82e65920bf/server/commands/teamCreator.ts#L59-L75

### Solution
Add function that checks if domain is allowed and consistently use it across application. The original function is preserved in case we ever need it, but I guess we could just put it into new one as well. 