### PR TITLE
fix: issue 3030 HelpText layout

### DIFF
--- a/app/components/HelpText.ts
+++ b/app/components/HelpText.ts
@@ -4,6 +4,8 @@ const HelpText = styled.p<{ small?: boolean }>`
   margin-top: 0;
   color: ${(props) => props.theme.textSecondary};
   font-size: ${(props) => (props.small ? "14px" : "inherit")};
+  word-break: break-all;
+  white-space: normal;
 `;
 
 export default HelpText;

--- a/app/components/HelpText.ts
+++ b/app/components/HelpText.ts
@@ -4,7 +4,6 @@ const HelpText = styled.p<{ small?: boolean }>`
   margin-top: 0;
   color: ${(props) => props.theme.textSecondary};
   font-size: ${(props) => (props.small ? "14px" : "inherit")};
-  word-break: break-all;
   white-space: normal;
 `;
 


### PR DESCRIPTION
## What I have done:
- [x] add work-break and whitespace in HelpText component style
- [x] roughly check if there is any regression in the application layout (I would be grateful if you can help me double check this too) 

## Result screenshots:
PC version (1440x789 screen size)
![image](https://user-images.githubusercontent.com/72560298/151731517-fe2a41cc-0a5a-4a5a-b398-d67f442e2357.png)

Tablet version (768x1024 screen size)
![image](https://user-images.githubusercontent.com/72560298/151731654-49b075ed-2a40-4939-a082-b9c691b4150f.png)

Smartphone version
![image](https://user-images.githubusercontent.com/72560298/151731737-3a5a112b-ee51-429c-82b9-0e8f0c1b9580.png)

Please take a look and let me know if there is any other issues.
Thanks