### PR TITLE
fix: Do not parse :smile: style emoji in Markdown paste handler

### DIFF
--- a/app/editor/index.tsx
+++ b/app/editor/index.tsx
@@ -500,7 +500,7 @@ export class Editor extends React.PureComponent<
   createPasteParser() {
     return this.extensions.parser({
       schema: this.schema,
-      rules: { linkify: true },
+      rules: { linkify: true, emoji: false },
       plugins: this.rulePlugins,
     });
   }

--- a/shared/editor/rules/emoji.ts
+++ b/shared/editor/rules/emoji.ts
@@ -4,7 +4,7 @@ import emojiPlugin from "markdown-it-emoji";
 
 export default function emoji(md: MarkdownIt) {
   return emojiPlugin(md, {
-    defs: nameToEmoji,
+    defs: (md.options as any).emoji === false ? {} : nameToEmoji,
     shortcuts: {},
   });
 }


### PR DESCRIPTION
There is far more chance of a false positive than someone actually wanting :v: to convert to an emoji ✌️ when pasting Markdown.