### PR TITLE
fix: Images no longer in original document not included in export 

### DIFF
--- a/server/utils/zip.ts
+++ b/server/utils/zip.ts
@@ -7,6 +7,7 @@ import Collection from "@server/models/Collection";
 import Document from "@server/models/Document";
 import { NavigationNode } from "~/types";
 import { serializeFilename } from "./fs";
+import parseAttachmentIds from "./parseAttachmentIds";
 import { getFileByKey } from "./s3";
 
 async function addToArchive(zip: JSZip, documents: NavigationNode[]) {
@@ -20,7 +21,8 @@ async function addToArchive(zip: JSZip, documents: NavigationNode[]) {
     let text = document.toMarkdown();
     const attachments = await Attachment.findAll({
       where: {
-        documentId: document.id,
+        teamId: document.teamId,
+        id: parseAttachmentIds(document.text),
       },
     });
 


### PR DESCRIPTION
Previously this was querying attachments that have been uploaded at some point for a document rather than attachments that are _currently_ referenced from the document.

closes #2578