### PR TITLE
fix: sync the correct collection with edit action

### DIFF
--- a/app/actions/index.ts
+++ b/app/actions/index.ts
@@ -95,7 +95,7 @@ export function actionToKBar(
       name: resolvedName,
       section: resolvedSection,
       placeholder: resolvedPlaceholder,
-      keywords: `${action.keywords}`,
+      keywords: action.keywords ?? "",
       shortcut: action.shortcut || [],
       icon: resolvedIcon,
       perform: action.perform

--- a/app/hooks/useCommandBarActions.ts
+++ b/app/hooks/useCommandBarActions.ts
@@ -11,7 +11,10 @@ import useActionContext from "./useActionContext";
  *
  * @param actions actions to make available
  */
-export default function useCommandBarActions(actions: Action[]) {
+export default function useCommandBarActions(
+  actions: Action[],
+  additionalDeps: string[] = []
+) {
   const location = useLocation();
   const context = useActionContext({
     isCommandBar: true,
@@ -24,5 +27,6 @@ export default function useCommandBarActions(actions: Action[]) {
   useRegisterActions(registerable, [
     registerable.map((r) => r.id).join(""),
     location.pathname,
+    ...additionalDeps,
   ]);
 }

--- a/app/hooks/useCommandBarActions.ts
+++ b/app/hooks/useCommandBarActions.ts
@@ -13,7 +13,7 @@ import useActionContext from "./useActionContext";
  */
 export default function useCommandBarActions(
   actions: Action[],
-  additionalDeps: string[] = []
+  additionalDeps: React.DependencyList = []
 ) {
   const location = useLocation();
   const context = useActionContext({

--- a/app/scenes/Collection.tsx
+++ b/app/scenes/Collection.tsx
@@ -91,7 +91,10 @@ function CollectionScene() {
     load();
   }, [collections, isFetching, collection, error, id, can]);
 
-  useCommandBarActions([editCollection]);
+  useCommandBarActions(
+    [editCollection],
+    ui.activeCollectionId ? [ui.activeCollectionId] : undefined
+  );
 
   if (!collection && error) {
     return <Search notFound />;


### PR DESCRIPTION
The edit collection action was always happening with the previous collection. 