### PR TITLE
fix: Hide TOC toggle on publicly shared links if there are no headings

### DIFF
--- a/app/scenes/Document/components/Document.tsx
+++ b/app/scenes/Document/components/Document.tsx
@@ -416,8 +416,10 @@ class DocumentScene extends React.Component<Props> {
         this.editor.current.getHeadings()
       : [];
 
+    const hasHeadings = headings.length > 0;
     const showContents =
-      ui.tocVisible && (readOnly || team?.collaborativeEditing);
+      ui.tocVisible &&
+      ((readOnly && hasHeadings) || team?.collaborativeEditing);
     const collaborativeEditing =
       team?.collaborativeEditing &&
       !document.isArchived &&
@@ -509,6 +511,7 @@ class DocumentScene extends React.Component<Props> {
             )}
             <Header
               document={document}
+              documentHasHeadings={hasHeadings}
               shareId={shareId}
               isRevision={!!revision}
               isDraft={document.isDraft}

--- a/app/scenes/Document/components/Header.tsx
+++ b/app/scenes/Document/components/Header.tsx
@@ -36,6 +36,7 @@ import ShareButton from "./ShareButton";
 
 type Props = {
   document: Document;
+  documentHasHeadings: boolean;
   sharedTree: NavigationNode | undefined;
   shareId: string | null | undefined;
   isDraft: boolean;
@@ -60,6 +61,7 @@ type Props = {
 
 function DocumentHeader({
   document,
+  documentHasHeadings,
   shareId,
   isEditing,
   isDraft,
@@ -175,7 +177,7 @@ function DocumentHeader({
               shareId={shareId}
               sharedTree={sharedTree}
             >
-              {toc}
+              {documentHasHeadings ? toc : null}
             </PublicBreadcrumb>
           )
         }


### PR DESCRIPTION
closes #3006