### PR TITLE
perf: Don't load CRDT state from database by default

### DIFF
--- a/server/collaboration/persistence.ts
+++ b/server/collaboration/persistence.ts
@@ -20,7 +20,11 @@ export default class Persistence {
       return;
     }
 
-    const document = await Document.findByPk(documentId);
+    const document = await Document.scope("withState").findOne({
+      where: {
+        id: documentId,
+      },
+    });
     invariant(document, "Document not found");
 
     if (document.state) {

--- a/server/commands/documentPermanentDeleter.ts
+++ b/server/commands/documentPermanentDeleter.ts
@@ -52,7 +52,7 @@ export default async function documentPermanentDeleter(documents: Document[]) {
     }
   }
 
-  return Document.scope("withUnpublished").destroy({
+  return Document.scope("withDrafts").destroy({
     where: {
       id: documents.map((document) => document.id),
     },

--- a/server/commands/documentUpdater.ts
+++ b/server/commands/documentUpdater.ts
@@ -15,7 +15,7 @@ export default async function documentUpdater({
   ydoc: Y.Doc;
   userId?: string;
 }) {
-  const document = await Document.findByPk(documentId);
+  const document = await Document.scope("withState").findByPk(documentId);
   invariant(document, "document not found");
 
   const state = Y.encodeStateAsUpdate(ydoc);
@@ -34,7 +34,7 @@ export default async function documentUpdater({
   const existingIds = document.collaboratorIds;
   const collaboratorIds = uniq([...pudIds, ...existingIds]);
 
-  await Document.scope("withUnpublished").update(
+  await Document.scope(["withDrafts", "withState"]).update(
     {
       text,
       state: Buffer.from(state),

--- a/server/models/Document.ts
+++ b/server/models/Document.ts
@@ -69,6 +69,9 @@ const serializer = new MarkdownSerializer();
 export const DOCUMENT_VERSION = 2;
 
 @DefaultScope(() => ({
+  attributes: {
+    exclude: ["state"],
+  },
   include: [
     {
       model: User,
@@ -112,7 +115,18 @@ export const DOCUMENT_VERSION = 2;
       ],
     };
   },
-  withUnpublished: {
+  withoutState: {
+    attributes: {
+      exclude: ["state"],
+    },
+  },
+  withState: {
+    attributes: {
+      // resets to include the state column
+      exclude: [],
+    },
+  },
+  withDrafts: {
     include: [
       {
         model: User,
@@ -370,7 +384,8 @@ class Document extends ParanoidModel {
     // allow default preloading of collection membership if `userId` is passed in find options
     // almost every endpoint needs the collection membership to determine policy permissions.
     const scope = this.scope([
-      "withUnpublished",
+      "withoutState",
+      "withDrafts",
       {
         method: ["withCollection", options.userId, options.paranoid],
       },

--- a/server/models/Share.ts
+++ b/server/models/Share.ts
@@ -34,7 +34,7 @@ import Fix from "./decorators/Fix";
     return {
       include: [
         {
-          model: Document.scope("withUnpublished"),
+          model: Document.scope("withDrafts"),
           paranoid: true,
           as: "document",
           include: [

--- a/server/routes/api/utils.ts
+++ b/server/routes/api/utils.ts
@@ -20,7 +20,7 @@ router.post("utils.gc", async (ctx) => {
     "utils",
     `Permanently destroying upto ${limit} documents older than 30 days…`
   );
-  const documents = await Document.scope("withUnpublished").findAll({
+  const documents = await Document.scope("withDrafts").findAll({
     attributes: ["id", "teamId", "text", "deletedAt"],
     where: {
       deletedAt: {


### PR DESCRIPTION
Excludes `state` from default columns, renamed `withUnpublished` -> `withDrafts`