### PR TITLE
perf: Stop copying attachments when moving documents

### DIFF
--- a/server/commands/documentMover.test.ts
+++ b/server/commands/documentMover.test.ts
@@ -110,45 +110,4 @@ describe("documentMover", () => {
     expect(response.documents[0].collection.id).toEqual(newCollection.id);
     expect(response.documents[1].collection.id).toEqual(newCollection.id);
   });
-
-  it("should move attachments in children to another collection", async () => {
-    const { document, user, collection } = await seed();
-    const newCollection = await buildCollection({
-      teamId: collection.teamId,
-    });
-    const attachment = await buildAttachment({
-      teamId: user.teamId,
-      userId: user.id,
-    });
-    const newDocument = await buildDocument({
-      parentDocumentId: document.id,
-      collectionId: collection.id,
-      teamId: collection.teamId,
-      userId: collection.createdById,
-      title: "Child document",
-      text: `content ![attachment](${attachment.redirectUrl})`,
-    });
-
-    await collection.addDocumentToStructure(newDocument);
-    await documentMover({
-      user,
-      document,
-      collectionId: newCollection.id,
-      parentDocumentId: undefined,
-      index: 0,
-      ip,
-    });
-
-    // check document ids where updated
-    await newDocument.reload();
-    expect(newDocument.collectionId).toBe(newCollection.id);
-
-    // check new attachment was created pointint to same key
-    const attachmentIds = parseAttachmentIds(newDocument.text);
-    const newAttachment = await Attachment.findByPk(attachmentIds[0]);
-    expect(newAttachment?.documentId).toBe(newDocument.id);
-    expect(newAttachment?.key).toBe(attachment.key);
-    await document.reload();
-    expect(document.collectionId).toBe(newCollection.id);
-  });
 });

--- a/server/commands/documentMover.test.ts
+++ b/server/commands/documentMover.test.ts
@@ -1,12 +1,9 @@
-import Attachment from "@server/models/Attachment";
 import {
   buildDocument,
-  buildAttachment,
   buildCollection,
   buildUser,
 } from "@server/test/factories";
 import { flushdb, seed } from "@server/test/support";
-import parseAttachmentIds from "@server/utils/parseAttachmentIds";
 import documentMover from "./documentMover";
 
 beforeEach(() => flushdb());


### PR DESCRIPTION
Towards #3239

This logic to copy attachments when moving documents no longer makes sense as the markdown is no longer the canonical copy of the document since `document.state` was introduced, replacing the attachment urls here will literally be overridden the next time an edit is made.

The better approach is to slightly loosen the attachment permissions so that an attachment can be viewed as long as:

a) you're on the right team
b) you have the attachment id
