### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/server/routes/api/hooks.ts
+++ b/server/routes/api/hooks.ts
@@ -57,7 +57,7 @@ router.post("hooks.unfurl", async (ctx) => {
   const unfurls = {};
 
   for (const link of event.links) {
-    const id = link.url.substr(link.url.lastIndexOf("/") + 1);
+    const id = link.url.slice(link.url.lastIndexOf("/") + 1);
     const doc = await Document.findByPk(id);
     if (!doc || doc.teamId !== user.teamId) {
       continue;


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.