### PR TITLE
chore: change the way that share permissions are checked on child docs

### DIFF
--- a/server/models/Collection.test.ts
+++ b/server/models/Collection.test.ts
@@ -85,56 +85,6 @@ describe("getDocumentTree", () => {
   });
 });
 
-describe("isChildDocument", () => {
-  test("should return false with unexpected data", async () => {
-    const document = await buildDocument();
-    const collection = await buildCollection({
-      documentStructure: [document.toJSON()],
-    });
-    expect(collection.isChildDocument(document.id, document.id)).toEqual(false);
-    expect(collection.isChildDocument(document.id, undefined)).toEqual(false);
-    expect(collection.isChildDocument(undefined, document.id)).toEqual(false);
-  });
-
-  test("should return false if sibling", async () => {
-    const one = await buildDocument();
-    const document = await buildDocument();
-    const collection = await buildCollection({
-      documentStructure: [one.toJSON(), document.toJSON()],
-    });
-    expect(collection.isChildDocument(one.id, document.id)).toEqual(false);
-    expect(collection.isChildDocument(document.id, one.id)).toEqual(false);
-  });
-
-  test("should return true if direct child of parent", async () => {
-    const parent = await buildDocument();
-    const document = await buildDocument();
-    const collection = await buildCollection({
-      documentStructure: [
-        { ...parent.toJSON(), children: [document.toJSON()] },
-      ],
-    });
-    expect(collection.isChildDocument(parent.id, document.id)).toEqual(true);
-    expect(collection.isChildDocument(document.id, parent.id)).toEqual(false);
-  });
-
-  test("should return true if nested child of parent", async () => {
-    const parent = await buildDocument();
-    const nested = await buildDocument();
-    const document = await buildDocument();
-    const collection = await buildCollection({
-      documentStructure: [
-        {
-          ...parent.toJSON(),
-          children: [{ ...nested.toJSON(), children: [document.toJSON()] }],
-        },
-      ],
-    });
-    expect(collection.isChildDocument(parent.id, document.id)).toEqual(true);
-    expect(collection.isChildDocument(document.id, parent.id)).toEqual(false);
-  });
-});
-
 describe("#addDocumentToStructure", () => {
   test("should add as last element without index", async () => {
     const { collection } = await seed();

--- a/server/models/Collection.ts
+++ b/server/models/Collection.ts
@@ -506,33 +506,6 @@ class Collection extends ParanoidModel {
     return result;
   };
 
-  isChildDocument = function (
-    parentDocumentId?: string,
-    documentId?: string
-  ): boolean {
-    let result = false;
-
-    const loopChildren = (documents: NavigationNode[], input: string[]) => {
-      if (result) {
-        return;
-      }
-
-      documents.forEach((document) => {
-        const parents = [...input];
-
-        if (document.id === documentId && parentDocumentId) {
-          result = parents.includes(parentDocumentId);
-        } else {
-          parents.push(document.id);
-          loopChildren(document.children, parents);
-        }
-      });
-    };
-
-    loopChildren(this.documentStructure, []);
-    return result;
-  };
-
   /**
    * Update document's title and url in the documentStructure
    */

--- a/server/routes/api/documents.ts
+++ b/server/routes/api/documents.ts
@@ -542,10 +542,12 @@ async function loadDocument({
     // shared then includeChildDocuments must be enabled and the document must
     // still be nested within the shared document
     if (share.document.id !== document.id) {
-      if (
-        !share.includeChildDocuments ||
-        !collection.isChildDocument(share.document.id, document.id)
-      ) {
+      if (!share.includeChildDocuments) {
+        throw AuthorizationError();
+      }
+
+      const childDocumentIds = await share.document.getChildDocumentIds();
+      if (!childDocumentIds.includes(document.id)) {
         throw AuthorizationError();
       }
     }


### PR DESCRIPTION
use the new method on server document model that checks via traversing parent ids rather than using the collection structure json