### PR TITLE
fix: Cleanup totally empty drafts on leave

### DIFF
--- a/app/models/Document.ts
+++ b/app/models/Document.ts
@@ -173,6 +173,11 @@ export default class Document extends BaseModel {
   }
 
   @computed
+  get hasEmptyTitle(): boolean {
+    return this.title === "";
+  }
+
+  @computed
   get titleWithDefault(): string {
     return this.title || "Untitled";
   }

--- a/app/scenes/Document/components/Document.tsx
+++ b/app/scenes/Document/components/Document.tsx
@@ -102,6 +102,16 @@ class DocumentScene extends React.Component<Props> {
     this.updateIsDirty();
   }
 
+  componentWillUnmount() {
+    if (
+      this.isEmpty &&
+      this.props.document.isDraft &&
+      this.props.document.title === ""
+    ) {
+      this.props.document.delete();
+    }
+  }
+
   componentDidUpdate(prevProps: Props) {
     const { auth, document, t } = this.props;
 
@@ -341,7 +351,8 @@ class DocumentScene extends React.Component<Props> {
     this.isEditorDirty = editorText !== document.text.trim();
 
     // a single hash is a doc with just an empty title
-    this.isEmpty = (!editorText || editorText === "#") && !this.title;
+    this.isEmpty =
+      (!editorText || editorText === "#" || editorText === "\\") && !this.title;
   };
 
   updateIsDirtyDebounced = debounce(this.updateIsDirty, 500);

--- a/app/scenes/Document/components/Document.tsx
+++ b/app/scenes/Document/components/Document.tsx
@@ -102,16 +102,6 @@ class DocumentScene extends React.Component<Props> {
     this.updateIsDirty();
   }
 
-  componentWillUnmount() {
-    if (
-      this.isEmpty &&
-      this.props.document.isDraft &&
-      this.props.document.title === ""
-    ) {
-      this.props.document.delete();
-    }
-  }
-
   componentDidUpdate(prevProps: Props) {
     const { auth, document, t } = this.props;
 
@@ -145,6 +135,18 @@ class DocumentScene extends React.Component<Props> {
           }
         );
       }
+    }
+  }
+
+  componentWillUnmount() {
+    if (
+      this.isEmpty &&
+      this.props.document.createdBy.id === this.props.auth.user?.id &&
+      this.props.document.isDraft &&
+      this.props.document.isActive &&
+      this.props.document.hasEmptyTitle
+    ) {
+      this.props.document.delete();
     }
   }
 

--- a/app/scenes/Document/components/Document.tsx
+++ b/app/scenes/Document/components/Document.tsx
@@ -144,7 +144,8 @@ class DocumentScene extends React.Component<Props> {
       this.props.document.createdBy.id === this.props.auth.user?.id &&
       this.props.document.isDraft &&
       this.props.document.isActive &&
-      this.props.document.hasEmptyTitle
+      this.props.document.hasEmptyTitle &&
+      this.props.document.isPersistedOnce
     ) {
       this.props.document.delete();
     }


### PR DESCRIPTION
I looked at doing this from the side of the collaboration server but I feel like it introduces more race conditions honestly. There are two edge cases for client-side that I can see but neither feels terrible considering the current behavior:

1. two people are looking at a totally empty doc and the creator leaves causing it to be deleted, in this case it can be restored.
2. close tab with totally empty doc means it won't have a chance to cleanup so draft is left

closes #3179