### PR TITLE
fix: Allow admin edit/update access to all collections

### DIFF
--- a/server/policies/collection.ts
+++ b/server/policies/collection.ts
@@ -43,6 +43,9 @@ allow(User, ["read", "star", "unstar"], Collection, (user, collection) => {
   if (!collection || user.teamId !== collection.teamId) {
     return false;
   }
+  if (user.isAdmin) {
+    return true;
+  }
 
   if (!collection.permission) {
     invariant(
@@ -71,6 +74,9 @@ allow(User, "share", Collection, (user, collection) => {
   if (!collection.sharing) {
     return false;
   }
+  if (user.isAdmin) {
+    return true;
+  }
 
   if (collection.permission !== "read_write") {
     invariant(
@@ -95,6 +101,9 @@ allow(User, ["publish", "update"], Collection, (user, collection) => {
   }
   if (!collection || user.teamId !== collection.teamId) {
     return false;
+  }
+  if (user.isAdmin) {
+    return true;
   }
 
   if (collection.permission !== "read_write") {
@@ -121,6 +130,9 @@ allow(User, "delete", Collection, (user, collection) => {
   if (!collection || user.teamId !== collection.teamId) {
     return false;
   }
+  if (user.isAdmin) {
+    return true;
+  }
 
   if (collection.permission !== "read_write") {
     invariant(
@@ -136,9 +148,6 @@ allow(User, "delete", Collection, (user, collection) => {
     );
   }
 
-  if (user.isAdmin) {
-    return true;
-  }
   if (user.id === collection.createdById) {
     return true;
   }

--- a/server/routes/api/collections.test.ts
+++ b/server/routes/api/collections.test.ts
@@ -270,14 +270,14 @@ describe("#collections.move", () => {
 
 describe("#collections.export", () => {
   it("should not allow export of private collection not a member", async () => {
-    const { admin } = await seed();
+    const { user } = await seed();
     const collection = await buildCollection({
       permission: null,
-      teamId: admin.teamId,
+      teamId: user.teamId,
     });
     const res = await server.post("/api/collections.export", {
       body: {
-        token: admin.getJwtToken(),
+        token: user.getJwtToken(),
         id: collection.id,
       },
     });


### PR DESCRIPTION
Admins should always be able to update and delete collections that they can view, regardless of it's other permissions.

Note: This does not change the list of collections visible in the sidebar.

closes #3331