### PR TITLE
fix: Archived documents should be filtered from `getChildDocumentIds`

### DIFF
--- a/server/models/Document.ts
+++ b/server/models/Document.ts
@@ -8,6 +8,7 @@ import {
   QueryTypes,
   FindOptions,
   ScopeOptions,
+  WhereOptions,
 } from "sequelize";
 import {
   ForeignKey,
@@ -473,7 +474,11 @@ class Document extends ParanoidModel {
       const sharedDocument = await options.share.$get("document");
       invariant(sharedDocument, "Cannot find document for share");
 
-      const childDocumentIds = await sharedDocument.getChildDocumentIds();
+      const childDocumentIds = await sharedDocument.getChildDocumentIds({
+        archivedAt: {
+          [Op.is]: null,
+        },
+      });
       documentIds = [sharedDocument.id, ...childDocumentIds];
     }
 
@@ -737,6 +742,7 @@ class Document extends ParanoidModel {
    * @returns A promise that resolves to a list of document ids
    */
   getChildDocumentIds = async (
+    where?: Omit<WhereOptions<Document>, "parentDocumentId">,
     options?: FindOptions<Document>
   ): Promise<string[]> => {
     const getChildDocumentIds = async (
@@ -747,6 +753,7 @@ class Document extends ParanoidModel {
         attributes: ["id"],
         where: {
           parentDocumentId,
+          ...where,
         },
         ...options,
       });

--- a/server/routes/api/documents.ts
+++ b/server/routes/api/documents.ts
@@ -489,13 +489,17 @@ async function loadDocument({
 
     // If we're attempting to load a document that isn't the document originally
     // shared then includeChildDocuments must be enabled and the document must
-    // still be nested within the shared document
+    // still be active and nested within the shared document
     if (share.document.id !== document.id) {
       if (!share.includeChildDocuments) {
         throw AuthorizationError();
       }
 
-      const childDocumentIds = await share.document.getChildDocumentIds();
+      const childDocumentIds = await share.document.getChildDocumentIds({
+        archivedAt: {
+          [Op.is]: null,
+        },
+      });
       if (!childDocumentIds.includes(document.id)) {
         throw AuthorizationError();
       }


### PR DESCRIPTION
closes #3343