### PR TITLE
feat: make ioredis configurable via environment variables

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -16,7 +16,15 @@ DATABASE_CONNECTION_POOL_MIN=
 DATABASE_CONNECTION_POOL_MAX=
 # Uncomment this to disable SSL for connecting to Postgres
 # PGSSLMODE=disable
-REDIS_URL=redis://localhost:6379
+
+# For redis you can either specify an ioredis compatible url like this
+REDIS_URL=redis://localhost:6479
+# or alternatively, if you would like to provide addtional connection options,
+# use a base64 encoded JSON connection option object. Refer to the ioredis documentation
+# for a list of available options.
+# Example: Use Redis Sentinel for high availability
+# {"sentinels":[{"host":"sentinel-0","port":26379},{"host":"sentinel-1","port":26379}],"name":"mymaster"}
+# REDIS_URL=ioredis://eyJzZW50aW5lbHMiOlt7Imhvc3QiOiJzZW50aW5lbC0wIiwicG9ydCI6MjYzNzl9LHsiaG9zdCI6InNlbnRpbmVsLTEiLCJwb3J0IjoyNjM3OX1dLCJuYW1lIjoibXltYXN0ZXIifQ==
 
 # URL should point to the fully qualified, publicly accessible URL. If using a
 # proxy the port in URL and PORT may be different.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     image: redis
     ports:
       - "127.0.0.1:6479:6379"
+    user: "redis:redis"
   postgres:
     image: postgres
     ports:
@@ -12,6 +13,7 @@ services:
       POSTGRES_USER: user
       POSTGRES_PASSWORD: pass
       POSTGRES_DB: outline
+    user: "postgres:postgres"
   s3:
     image: lphoward/fake-s3
     ports:

--- a/server/redis.ts
+++ b/server/redis.ts
@@ -1,6 +1,6 @@
 import Redis from "ioredis";
-import Logger from "./logging/logger";
 import { defaults } from "lodash";
+import Logger from "./logging/logger";
 
 const defaultOptions = {
   maxRetriesPerRequest: 20,
@@ -15,14 +15,14 @@ const defaultOptions = {
   tls:
     process.env.REDIS_URL && process.env.REDIS_URL.startsWith("rediss://")
       ? {
-        rejectUnauthorized: false,
-      }
+          rejectUnauthorized: false,
+        }
       : undefined,
 };
 
-function newRedisClient(url: String | undefined): Redis.Redis {
+function newRedisClient(url: string | undefined): Redis.Redis {
   if (!(url || "").startsWith("ioredis://")) {
-    return new Redis(process.env.REDIS_URL, defaultOptions)
+    return new Redis(process.env.REDIS_URL, defaultOptions);
   }
 
   const decodedString = Buffer.from(url!.slice(10), "base64").toString();

--- a/server/redis.ts
+++ b/server/redis.ts
@@ -51,11 +51,11 @@ export default class RedisAdapter extends Redis {
   private static _client: RedisAdapter;
   private static _subscriber: RedisAdapter;
 
-  public static get Client(): RedisAdapter {
+  public static get defaultClient(): RedisAdapter {
     return this._client || (this._client = new this(process.env.REDIS_URL));
   }
 
-  public static get Subscriber(): RedisAdapter {
+  public static get defaultSubscriber(): RedisAdapter {
     return (
       this._subscriber || (this._subscriber = new this(process.env.REDIS_URL))
     );

--- a/server/services/websockets.ts
+++ b/server/services/websockets.ts
@@ -49,8 +49,8 @@ export default function init(app: Koa, server: http.Server) {
 
   io.adapter(
     socketRedisAdapter({
-      pubClient: Redis.Client,
-      subClient: Redis.Subscriber,
+      pubClient: Redis.defaultClient,
+      subClient: Redis.defaultSubscriber,
     })
   );
 
@@ -92,7 +92,7 @@ export default function init(app: Koa, server: http.Server) {
 
         // store the mapping between socket id and user id in redis
         // so that it is accessible across multiple server nodes
-        await Redis.Client.hset(socket.id, "userId", user.id);
+        await Redis.defaultClient.hset(socket.id, "userId", user.id);
         return callback(null, true);
       } catch (err) {
         return callback(err, false);
@@ -173,7 +173,10 @@ export default function init(app: Koa, server: http.Server) {
                 const userIds = new Map();
 
                 for (const socketId of sockets) {
-                  const userId = await Redis.Client.hget(socketId, "userId");
+                  const userId = await Redis.defaultClient.hget(
+                    socketId,
+                    "userId"
+                  );
                   userIds.set(userId, userId);
                 }
 

--- a/server/services/websockets.ts
+++ b/server/services/websockets.ts
@@ -11,7 +11,7 @@ import { can } from "@server/policies";
 import { getUserForJWT } from "@server/utils/jwt";
 import { websocketQueue } from "../queues";
 import WebsocketsProcessor from "../queues/processors/WebsocketsProcessor";
-import { client, subscriber } from "../redis";
+import Redis from "../redis";
 
 export default function init(app: Koa, server: http.Server) {
   const path = "/realtime";
@@ -49,8 +49,8 @@ export default function init(app: Koa, server: http.Server) {
 
   io.adapter(
     socketRedisAdapter({
-      pubClient: client,
-      subClient: subscriber,
+      pubClient: Redis.Client,
+      subClient: Redis.Subscriber,
     })
   );
 
@@ -92,7 +92,7 @@ export default function init(app: Koa, server: http.Server) {
 
         // store the mapping between socket id and user id in redis
         // so that it is accessible across multiple server nodes
-        await client.hset(socket.id, "userId", user.id);
+        await Redis.Client.hset(socket.id, "userId", user.id);
         return callback(null, true);
       } catch (err) {
         return callback(err, false);
@@ -173,7 +173,7 @@ export default function init(app: Koa, server: http.Server) {
                 const userIds = new Map();
 
                 for (const socketId of sockets) {
-                  const userId = await client.hget(socketId, "userId");
+                  const userId = await Redis.Client.hget(socketId, "userId");
                   userIds.set(userId, userId);
                 }
 

--- a/server/utils/queue.ts
+++ b/server/utils/queue.ts
@@ -1,5 +1,4 @@
 import Queue from "bull";
-import Redis from "ioredis";
 import { snakeCase } from "lodash";
 import Metrics from "@server/logging/metrics";
 import { client, subscriber, newRedisClient } from "../redis";

--- a/server/utils/queue.ts
+++ b/server/utils/queue.ts
@@ -12,10 +12,10 @@ export function createQueue(
     createClient(type) {
       switch (type) {
         case "client":
-          return Redis.Client;
+          return Redis.defaultClient;
 
         case "subscriber":
-          return Redis.Subscriber;
+          return Redis.defaultSubscriber;
 
         default:
           return new Redis(process.env.REDIS_URL);

--- a/server/utils/queue.ts
+++ b/server/utils/queue.ts
@@ -1,7 +1,7 @@
 import Queue from "bull";
 import { snakeCase } from "lodash";
 import Metrics from "@server/logging/metrics";
-import { client, subscriber, newRedisClient } from "../redis";
+import Redis from "../redis";
 
 export function createQueue(
   name: string,
@@ -12,13 +12,13 @@ export function createQueue(
     createClient(type) {
       switch (type) {
         case "client":
-          return client;
+          return Redis.Client;
 
         case "subscriber":
-          return subscriber;
+          return Redis.Subscriber;
 
         default:
-          return newRedisClient(process.env.REDIS_URL);
+          return new Redis(process.env.REDIS_URL);
       }
     },
 

--- a/server/utils/queue.ts
+++ b/server/utils/queue.ts
@@ -2,7 +2,7 @@ import Queue from "bull";
 import Redis from "ioredis";
 import { snakeCase } from "lodash";
 import Metrics from "@server/logging/metrics";
-import { client, subscriber } from "../redis";
+import { client, subscriber, newRedisClient } from "../redis";
 
 export function createQueue(
   name: string,
@@ -19,7 +19,7 @@ export function createQueue(
           return subscriber;
 
         default:
-          return new Redis(process.env.REDIS_URL);
+          return newRedisClient(process.env.REDIS_URL);
       }
     },
 

--- a/server/utils/updates.ts
+++ b/server/utils/updates.ts
@@ -6,7 +6,7 @@ import Document from "@server/models/Document";
 import Team from "@server/models/Team";
 import User from "@server/models/User";
 import packageInfo from "../../package.json";
-import { client } from "../redis";
+import Redis from "../redis";
 
 const UPDATES_URL = "https://updates.getoutline.com";
 const UPDATES_KEY = "UPDATES_KEY";
@@ -40,7 +40,7 @@ export async function checkUpdates() {
       documentCount,
     },
   });
-  await client.del(UPDATES_KEY);
+  await Redis.Client.del(UPDATES_KEY);
 
   try {
     const response = await fetch(UPDATES_URL, {
@@ -54,7 +54,7 @@ export async function checkUpdates() {
     const data = await response.json();
 
     if (data.severity) {
-      await client.set(
+      await Redis.Client.set(
         UPDATES_KEY,
         JSON.stringify({
           severity: data.severity,

--- a/server/utils/updates.ts
+++ b/server/utils/updates.ts
@@ -40,7 +40,7 @@ export async function checkUpdates() {
       documentCount,
     },
   });
-  await Redis.Client.del(UPDATES_KEY);
+  await Redis.defaultClient.del(UPDATES_KEY);
 
   try {
     const response = await fetch(UPDATES_URL, {
@@ -54,7 +54,7 @@ export async function checkUpdates() {
     const data = await response.json();
 
     if (data.severity) {
-      await Redis.Client.set(
+      await Redis.defaultClient.set(
         UPDATES_KEY,
         JSON.stringify({
           severity: data.severity,


### PR DESCRIPTION
As mentioned in #2608 we need support for Redis Sentinel to increase fault tolerance. This PR makes the all `ioredis` client options available to administrators by setting `REDIS_URL` to `ioredis://<base64 encoded json>` instead of the usual `redis(s)://` URL (which will still work).

I first started to implement parsing of a custom `redis+sentinel://` URI scheme, which is not officially supported by redis, but used by some other redis client projects. Then I realized that I also need access to some other TLS related options. So I came up with the current solution, which basically gives us access to all redis related options and adds minimal complexity / maintenance burden to this project (as opposed to parsing a bunch of options to just hand them down to `ioredis`).

I realize that this approach is a little unusual, but I can't really see much downsides right now. That being said, I am open to other suggestions if this approach should not be acceptable.