### PR TITLE
Fix: Image caption when Blank

### DIFF
--- a/shared/editor/nodes/Image.tsx
+++ b/shared/editor/nodes/Image.tsx
@@ -602,6 +602,6 @@ const ImageWrapper = styled.div`
   }
 
   &.ProseMirror-selectednode + ${Caption} {
-    display: block;
+    display: inherit;
   }
 `;


### PR DESCRIPTION
## Description:

Fixed image caption when the section is blank. It also solves the common UI issues such as The alt/caption takes up space even when it is not in use. There is an extra line added below the image. Trying to delete this line only results in the image being deleted.