### PR TITLE
Feat: Added adjust for Editable title area

### DIFF
--- a/app/scenes/Document/components/EditableTitle.tsx
+++ b/app/scenes/Document/components/EditableTitle.tsx
@@ -13,6 +13,7 @@ import Document from "~/models/Document";
 import ContentEditable, { RefHandle } from "~/components/ContentEditable";
 import Star, { AnimatedStar } from "~/components/Star";
 import useEmojiWidth from "~/hooks/useEmojiWidth";
+import { AnimatedStar } from "~/components/Star";
 import { isModKey } from "~/utils/keyboard";
 
 type Props = {
@@ -38,17 +39,7 @@ const fontSize = "2.25em";
 
 const EditableTitle = React.forwardRef(
   (
-    {
-      value,
-      document,
-      readOnly,
-      onChange,
-      onSave,
-      onGoToNextInput,
-      onBlur,
-      starrable,
-      placeholder,
-    }: Props,
+    { value, document, readOnly, onChange, onSave, onGoToNextInput }: Props,
     ref: React.RefObject<RefHandle>
   ) => {
     const normalizedTitle =
@@ -161,7 +152,7 @@ type TitleProps = {
   $emojiWidth: number;
 };
 
-const Title = styled(ContentEditable)<TitleProps>`
+const Title = styled(ContentEditable) <TitleProps>`
   line-height: ${lineHeight};
   margin-top: 1em;
   margin-bottom: 0.5em;
@@ -172,6 +163,10 @@ const Title = styled(ContentEditable)<TitleProps>`
 
   > span {
     outline: none;
+    display: block;
+    padding-bottom: 10px;
+    margin-bottom: 5px;
+    border-bottom: 1px solid ${(props) => props.theme.smokeDark};
   }
 
   &::placeholder {


### PR DESCRIPTION
# Description:

It's difficult to click the tail of title, because the star button is so close to the title. I only star the very important documents, therefore I don't use the star button too much, but editing title is a frequently used function. To resolve this, moved the star button to the top area, near the New doc button. It's very useful to fix a button to a certain location just like Share and New doc, but now if we wanna star the document, we need to find the tail of the title, which takes some time because document lengths vary. This will also allow us to edit the title without accidentally pressing the star button.