### PR TITLE
Fix: Draft document are readable from collection member

### DIFF
--- a/server/policies/document.ts
+++ b/server/policies/document.ts
@@ -11,9 +11,19 @@ allow(User, "createDocument", Team, (user, team) => {
 });
 
 allow(User, ["read", "download"], Document, (user, document) => {
+  if (
+    !document.fromShare &&
+    !document.publishedAt &&
+    document.createdById !== user.id
+  ) {
+    return false;
+  }
+
   if (!document) {
     return false;
   }
+
+  if (!document.publishedAt && document.createdById !== user.id) return false;
 
   // existence of collection option is not required here to account for share tokens
   if (document.collection && cannot(user, "read", document.collection)) {
@@ -64,6 +74,7 @@ allow(User, "unstar", Document, (user, document) => {
 });
 
 allow(User, "share", Document, (user, document) => {
+  if (!document.publishedAt && document.createdById !== user.id) return false;
   if (!document) {
     return false;
   }
@@ -86,6 +97,7 @@ allow(User, "share", Document, (user, document) => {
 });
 
 allow(User, "update", Document, (user, document) => {
+  if (!document.publishedAt && document.createdById !== user.id) return false;
   if (!document) {
     return false;
   }
@@ -199,6 +211,7 @@ allow(User, ["pinToHome"], Document, (user, document) => {
 });
 
 allow(User, "delete", Document, (user, document) => {
+  if (!document.publishedAt && document.createdById !== user.id) return false;
   if (!document) {
     return false;
   }
@@ -215,11 +228,7 @@ allow(User, "delete", Document, (user, document) => {
   }
 
   // unpublished drafts can always be deleted
-  if (
-    !document.deletedAt &&
-    !document.publishedAt &&
-    user.teamId === document.teamId
-  ) {
+  if (!document.publishedAt && user.teamId === document.teamId) {
     return true;
   }
 

--- a/server/routes/api/documents.test.ts
+++ b/server/routes/api/documents.test.ts
@@ -1959,12 +1959,14 @@ describe("#documents.update", () => {
     const user = await buildUser();
     const collection = await buildCollection({
       teamId: user.teamId,
+      userId: user.id,
     });
     const template = await buildDocument({
       teamId: user.teamId,
       collectionId: collection.id,
       template: true,
       publishedAt: null,
+      userId: user.id,
     });
     const res = await server.post("/api/documents.update", {
       body: {

--- a/server/routes/api/documents.ts
+++ b/server/routes/api/documents.ts
@@ -459,6 +459,7 @@ async function loadDocument({
 
     // If the user has access to read the document, we can just update
     // the last access date and return the document without additional checks.
+    document.fromShare = true;
     const canReadDocument = user && can(user, "read", document);
 
     if (canReadDocument) {
@@ -567,12 +568,12 @@ router.post(
     const data =
       apiVersion === 2
         ? {
-            document: serializedDocument,
-            sharedTree:
-              share && share.includeChildDocuments
-                ? collection.getDocumentTree(share.documentId)
-                : undefined,
-          }
+          document: serializedDocument,
+          sharedTree:
+            share && share.includeChildDocuments
+              ? collection.getDocumentTree(share.documentId)
+              : undefined,
+        }
         : serializedDocument;
     ctx.body = {
       data,


### PR DESCRIPTION
## Description:

Currently, the draft documents are being readable by collection members through the URL. This should not happen. Made a resolution to successfully fix the same.