### PR TITLE
feat: Allow Document to be fetched without Slug

### DIFF
--- a/server/models/Collection.test.ts
+++ b/server/models/Collection.test.ts
@@ -372,6 +372,13 @@ describe("#findByPk", () => {
     expect(response!.id).toBe(collection.id);
   });
 
+  test("should return collection when urlId is present, but missing slug", async () => {
+    const collection = await buildCollection();
+    const id = collection.urlId;
+    const response = await Collection.findByPk(id);
+    expect(response!.id).toBe(collection.id);
+  });
+
   test("should return undefined when incorrect uuid type", async () => {
     const collection = await buildCollection();
     const response = await Collection.findByPk(collection.id + "-incorrect");

--- a/server/models/Document.test.ts
+++ b/server/models/Document.test.ts
@@ -532,6 +532,13 @@ describe("#findByPk", () => {
     const response = await Document.findByPk(id);
     expect(response?.id).toBe(document.id);
   });
+
+  test("should return document when urlId is given without the slug prefix", async () => {
+    const { document } = await seed();
+    const id = document.urlId;
+    const response = await Document.findByPk(id);
+    expect(response?.id).toBe(document.id);
+  });
 });
 
 describe("tasks", () => {

--- a/server/models/Document.ts
+++ b/server/models/Document.ts
@@ -36,7 +36,7 @@ import { DateFilter } from "@shared/types";
 import getTasks from "@shared/utils/getTasks";
 import parseTitle from "@shared/utils/parseTitle";
 import unescape from "@shared/utils/unescape";
-import { SLUG_URL_REGEX } from "@shared/utils/urlHelpers";
+import { SLUG_URL_REGEX, URL_ID_REGEX } from "@shared/utils/urlHelpers";
 import slugify from "@server/utils/slugify";
 import Backlink from "./Backlink";
 import Collection from "./Collection";
@@ -426,11 +426,21 @@ class Document extends ParanoidModel {
       });
     }
 
-    const match = id.match(SLUG_URL_REGEX);
-    if (match) {
+    const urlMatch = id.match(SLUG_URL_REGEX);
+    if (urlMatch) {
       return scope.findOne({
         where: {
-          urlId: match[1],
+          urlId: urlMatch[1],
+        },
+        ...options,
+      });
+    }
+
+    const idMatch = id.match(URL_ID_REGEX);
+    if (idMatch) {
+      return scope.findOne({
+        where: {
+          urlId: idMatch[1],
         },
         ...options,
       });

--- a/server/models/Document.ts
+++ b/server/models/Document.ts
@@ -426,11 +426,11 @@ class Document extends ParanoidModel {
       });
     }
 
-    const urlMatch = id.match(SLUG_URL_REGEX);
-    if (urlMatch) {
+    const match = id.match(SLUG_URL_REGEX);
+    if (match) {
       return scope.findOne({
         where: {
-          urlId: urlMatch[1],
+          urlId: match[1],
         },
         ...options,
       });

--- a/server/models/Document.ts
+++ b/server/models/Document.ts
@@ -36,7 +36,7 @@ import { DateFilter } from "@shared/types";
 import getTasks from "@shared/utils/getTasks";
 import parseTitle from "@shared/utils/parseTitle";
 import unescape from "@shared/utils/unescape";
-import { SLUG_URL_REGEX, URL_ID_REGEX } from "@shared/utils/urlHelpers";
+import { SLUG_URL_REGEX } from "@shared/utils/urlHelpers";
 import slugify from "@server/utils/slugify";
 import Backlink from "./Backlink";
 import Collection from "./Collection";
@@ -431,16 +431,6 @@ class Document extends ParanoidModel {
       return scope.findOne({
         where: {
           urlId: urlMatch[1],
-        },
-        ...options,
-      });
-    }
-
-    const idMatch = id.match(URL_ID_REGEX);
-    if (idMatch) {
-      return scope.findOne({
-        where: {
-          urlId: idMatch[1],
         },
         ...options,
       });

--- a/shared/utils/urlHelpers.ts
+++ b/shared/utils/urlHelpers.ts
@@ -51,6 +51,4 @@ export function signin(service = "slack"): string {
   return `${process.env.URL}/auth/${service}`;
 }
 
-export const URL_ID_REGEX = /^([a-zA-Z0-9]{10,15})$/;
-
-export const SLUG_URL_REGEX = /^[0-9a-zA-Z-_~]*-([a-zA-Z0-9]{10,15})$/;
+export const SLUG_URL_REGEX = /^(?:[0-9a-zA-Z-_~]*-)?([a-zA-Z0-9]{10,15})$/;

--- a/shared/utils/urlHelpers.ts
+++ b/shared/utils/urlHelpers.ts
@@ -51,4 +51,6 @@ export function signin(service = "slack"): string {
   return `${process.env.URL}/auth/${service}`;
 }
 
+export const URL_ID_REGEX = /^([a-zA-Z0-9]{10,15})$/;
+
 export const SLUG_URL_REGEX = /^[0-9a-zA-Z-_~]*-([a-zA-Z0-9]{10,15})$/;


### PR DESCRIPTION
Fixes #3423

This PR refactors the `Document.findByPk` method to not require the
`slug` portion of the urlID.

Before this function accepted two different 'formats' for the ID.

 - The `uuid` ID of the Document
 - The full `urlID` which looked something like
   `some-document-1234567890`

However the `some-document` slug portion of this identifier wasn't
actually used when looking for a document.

We now allow searching by JUST the postfix of the `urlID`, in the above
example that is `1234567890`.
We do this via a new Regex pattern to match on that just looks for the
right looking id alone, without the prefix.

This codepath looks the same as when we find it by the full `urlID`
besides the different regex that we match on.

The issue #3423 mentions that this should apply to all the API
endpoints. I believe that this `findByPk` method is all that should be
needed for that change. But if this is incorrect, OR you would like more
test coverage on the API endpoints as a more 'end to end test' please
let me know!