### PR TITLE
feat: Match incoming search requests using confirmed email as fallback

### DIFF
--- a/app/scenes/Settings/Slack.tsx
+++ b/app/scenes/Settings/Slack.tsx
@@ -92,7 +92,13 @@ function Slack() {
               </Button>
             ) : (
               <SlackButton
-                scopes={["commands", "links:read", "links:write"]}
+                scopes={[
+                  "commands",
+                  "links:read",
+                  "links:write",
+                  "users:read",
+                  "users:read.email",
+                ]}
                 redirectUri={`${env.URL}/auth/slack.commands`}
                 state={team.id}
                 icon={<SlackIcon color="currentColor" />}


### PR DESCRIPTION
Users often expect search in Slack to "just work" when they authenticate to Outline with Google. This provides just that as long as the email addresses match.