### PR TITLE
Disabling collaborative editing by default.

### DIFF
--- a/server/models/Team.ts
+++ b/server/models/Team.ts
@@ -98,7 +98,7 @@ class Team extends ParanoidModel {
   @Column
   memberCollectionCreate: boolean;
 
-  @Default(true)
+  @Default(false)
   @Column
   collaborativeEditing: boolean;
 


### PR DESCRIPTION
I made this small change since if you don't make it you can have many problems at the time you want to edit or create a document. Moreover to disable it the switch doesn't work as a result you would have to modify the database.