### PR TITLE
Fix github action for stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,8 +24,6 @@ jobs:
           operations-per-run: 60
           stale-issue-label: stale
           stale-pr-label: stale
-          exempt-issue-labels:
-            - security
-            - pinned
+          exempt-issue-labels: "security,pinned"
       - name: Print outputs
         run: echo ${{ join(steps.stale.outputs.*, ',') }}


### PR DESCRIPTION
the github action "Close Stale PRs" fails with error "`The workflow is not valid. .github/workflows/stale.yml (Line: 28, Col: 13): A sequence was not expected`"