### PR TITLE
Update redis port in sample env file

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -18,7 +18,7 @@ DATABASE_CONNECTION_POOL_MAX=
 # PGSSLMODE=disable
 
 # For redis you can either specify an ioredis compatible url like this
-REDIS_URL=redis://localhost:6479
+REDIS_URL=redis://localhost:6379
 # or alternatively, if you would like to provide addtional connection options,
 # use a base64 encoded JSON connection option object. Refer to the ioredis documentation
 # for a list of available options.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   redis:
     image: redis
     ports:
-      - "127.0.0.1:6479:6379"
+      - "127.0.0.1:6379:6379"
     user: "redis:redis"
   postgres:
     image: postgres


### PR DESCRIPTION
The wrong Redis port is specified in the sample file, in the [Documentation](https://app.getoutline.com/share/770a97da-13e5-401e-9f8a-37949c19f97e/doc/docker-7pfeLP5a8t) is an example docker-compose.yml using the correct port for Redis.
To avoid confusion I have updated it in the sample.env