### PR TITLE
fix: infinite redirects when hosted subdomain is changed back and forth between two values

### DIFF
--- a/app/components/Authenticated.tsx
+++ b/app/components/Authenticated.tsx
@@ -2,9 +2,7 @@ import { observer } from "mobx-react";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Redirect } from "react-router-dom";
-import { parseDomain } from "@shared/utils/domains";
 import LoadingIndicator from "~/components/LoadingIndicator";
-import env from "~/env";
 import useStores from "~/hooks/useStores";
 import { changeLanguage } from "~/utils/language";
 
@@ -25,24 +23,8 @@ const Authenticated = ({ children }: Props) => {
 
   if (auth.authenticated) {
     const { user, team } = auth;
-    const { hostname } = window.location;
 
     if (!team || !user) {
-      return <LoadingIndicator />;
-    }
-
-    // If we're authenticated but viewing a domain that doesn't match the
-    // current team then kick the user to the teams correct domain.
-    if (team.domain) {
-      if (team.domain !== hostname) {
-        window.location.href = `${team.url}${window.location.pathname}`;
-        return <LoadingIndicator />;
-      }
-    } else if (
-      env.SUBDOMAINS_ENABLED &&
-      parseDomain(hostname).teamSubdomain !== (team.subdomain ?? "")
-    ) {
-      window.location.href = `${team.url}${window.location.pathname}`;
       return <LoadingIndicator />;
     }
 


### PR DESCRIPTION
moves the redirect logic to authstore next to the `postLoginRedirectPath` logic, after the initial call to `auth.info` returns with the latest user and team data.

fixes https://github.com/outline/outline/issues/3598