### PR TITLE
add warning on collaborative editing feature

### DIFF
--- a/app/scenes/Settings/Features.tsx
+++ b/app/scenes/Settings/Features.tsx
@@ -48,7 +48,9 @@ function Features() {
         label={t("Collaborative editing")}
         description={t(
           "When enabled multiple people can edit documents at the same time with shared presence and live cursors."
-        )}
+          ) + " " + t(
+          "WARNING: CANNOT BE DISABLED ONCE ENABLED."
+          )}
       >
         <Switch
           id="collaborativeEditing"


### PR DESCRIPTION
Per: https://github.com/outline/outline/issues/3388#issuecomment-1127248086

Hopefully this won't break the translation just combining the translated strings. Do I need to also manually add the second string to the translation API or is that auto-generated somehow? 