### PR TITLE
fix: Unable to delete user via API

### DIFF
--- a/app/menus/UserMenu.tsx
+++ b/app/menus/UserMenu.tsx
@@ -108,9 +108,7 @@ function UserMenu({ user }: Props) {
   const handleRevoke = React.useCallback(
     (ev: React.SyntheticEvent) => {
       ev.preventDefault();
-      users.delete(user, {
-        confirmation: true,
-      });
+      users.delete(user);
     },
     [users, user]
   );

--- a/app/stores/AuthStore.ts
+++ b/app/stores/AuthStore.ts
@@ -200,9 +200,7 @@ export default class AuthStore {
 
   @action
   deleteUser = async () => {
-    await client.post(`/users.delete`, {
-      confirmation: true,
-    });
+    await client.post(`/users.delete`);
     runInAction("AuthStore#updateUser", () => {
       this.user = null;
       this.team = null;

--- a/server/policies/user.ts
+++ b/server/policies/user.ts
@@ -28,7 +28,7 @@ allow(User, "update", User, (actor, user) => {
     return true;
   }
 
-  throw AdminRequiredError();
+  return false;
 });
 
 allow(User, "delete", User, (actor, user) => {
@@ -38,7 +38,7 @@ allow(User, "delete", User, (actor, user) => {
   if (user.id === actor.id) {
     return true;
   }
-  if (actor.isAdmin && !user.lastActiveAt) {
+  if (actor.isAdmin) {
     return true;
   }
 

--- a/server/routes/api/users.test.ts
+++ b/server/routes/api/users.test.ts
@@ -299,16 +299,6 @@ describe("#users.invite", () => {
 });
 
 describe("#users.delete", () => {
-  it("should not allow deleting without confirmation", async () => {
-    const user = await buildUser();
-    const res = await server.post("/api/users.delete", {
-      body: {
-        token: user.getJwtToken(),
-      },
-    });
-    expect(res.status).toEqual(400);
-  });
-
   it("should not allow deleting last admin if many users", async () => {
     const user = await buildAdmin();
     await buildUser({
@@ -318,13 +308,12 @@ describe("#users.delete", () => {
     const res = await server.post("/api/users.delete", {
       body: {
         token: user.getJwtToken(),
-        confirmation: true,
       },
     });
     expect(res.status).toEqual(400);
   });
 
-  it("should allow deleting user account with confirmation", async () => {
+  it("should allow deleting user account", async () => {
     const user = await buildUser();
     await buildUser({
       teamId: user.teamId,
@@ -332,30 +321,28 @@ describe("#users.delete", () => {
     const res = await server.post("/api/users.delete", {
       body: {
         token: user.getJwtToken(),
-        confirmation: true,
       },
     });
     expect(res.status).toEqual(200);
   });
 
-  it("should allow deleting pending user account with admin", async () => {
-    const user = await buildAdmin();
-    const pending = await buildUser({
-      teamId: user.teamId,
+  it("should allow deleting user account with admin", async () => {
+    const admin = await buildAdmin();
+    const user = await buildUser({
+      teamId: admin.teamId,
       lastActiveAt: null,
     });
     const res = await server.post("/api/users.delete", {
       body: {
-        token: user.getJwtToken(),
-        id: pending.id,
-        confirmation: true,
+        token: admin.getJwtToken(),
+        id: user.id,
       },
     });
     expect(res.status).toEqual(200);
   });
 
   it("should not allow deleting another user account", async () => {
-    const user = await buildAdmin();
+    const user = await buildUser();
     const user2 = await buildUser({
       teamId: user.teamId,
     });
@@ -363,7 +350,6 @@ describe("#users.delete", () => {
       body: {
         token: user.getJwtToken(),
         id: user2.id,
-        confirmation: true,
       },
     });
     expect(res.status).toEqual(403);

--- a/server/routes/api/users.ts
+++ b/server/routes/api/users.ts
@@ -355,8 +355,7 @@ router.post("users.resendInvite", auth(), async (ctx) => {
 });
 
 router.post("users.delete", auth(), async (ctx) => {
-  const { confirmation, id } = ctx.body;
-  assertPresent(confirmation, "confirmation is required");
+  const { id } = ctx.body;
   const actor = ctx.state.user;
   let user = actor;
 


### PR DESCRIPTION
Also removes requirement to pass 'confirmation' to users.delete. I think both of these checks were well-meaning, but ultimately not very useful.

closes #3604