### PR TITLE
fix: Previously provisioned JWT's should be revoked on signout

### DIFF
--- a/app/stores/AuthStore.ts
+++ b/app/stores/AuthStore.ts
@@ -253,6 +253,12 @@ export default class AuthStore {
 
   @action
   logout = async (savePath = false) => {
+    if (!this.token) {
+      return;
+    }
+
+    client.post(`/auth.delete`);
+
     // remove user and team from localStorage
     Storage.set(AUTH_STORE, {
       user: null,

--- a/server/models/Event.ts
+++ b/server/models/Event.ts
@@ -1,4 +1,4 @@
-import { SaveOptions } from "sequelize";
+import type { SaveOptions } from "sequelize";
 import {
   ForeignKey,
   AfterSave,
@@ -159,6 +159,7 @@ class Event extends IdModel {
     "users.create",
     "users.update",
     "users.signin",
+    "users.signout",
     "users.promote",
     "users.demote",
     "users.invite",

--- a/server/routes/api/auth.test.ts
+++ b/server/routes/api/auth.test.ts
@@ -48,6 +48,30 @@ describe("#auth.info", () => {
   });
 });
 
+describe("#auth.delete", () => {
+  it("should make the access token unusable", async () => {
+    const user = await buildUser();
+    const res = await server.post("/api/auth.delete", {
+      body: {
+        token: user.getJwtToken(),
+      },
+    });
+    expect(res.status).toEqual(200);
+
+    const res2 = await server.post("/api/auth.info", {
+      body: {
+        token: user.getJwtToken(),
+      },
+    });
+    expect(res2.status).toEqual(401);
+  });
+
+  it("should require authentication", async () => {
+    const res = await server.post("/api/auth.delete");
+    expect(res.status).toEqual(401);
+  });
+});
+
 describe("#auth.config", () => {
   it("should return available SSO providers", async () => {
     env.DEPLOYMENT = "hosted";

--- a/server/types.ts
+++ b/server/types.ts
@@ -13,6 +13,7 @@ export type UserEvent =
   | {
   name: "users.create" // eslint-disable-line
         | "users.signin"
+        | "users.signout"
         | "users.update"
         | "users.suspend"
         | "users.activate"


### PR DESCRIPTION
This revokes all previously issued sessions on sign-out so even if the access token has been copied elsewhere it will no longer be usable. Also recording an event for sign-out, so that's a nice improvement too.

The small UX regression here is that logged in sessions on other browsers/computers will also get signed out, but this feels like a pragmatic trade-off for a rarely used action.