### PR TITLE
remove `public` option from avatar & logo upload

### DIFF
--- a/app/scenes/Settings/components/ImageUpload.tsx
+++ b/app/scenes/Settings/components/ImageUpload.tsx
@@ -66,7 +66,7 @@ class ImageUpload extends React.Component<RootStore & Props> {
       });
       const attachment = await uploadFile(compressed, {
         name: this.file.name,
-        public: true,
+        // public: true,
       });
       this.props.onSuccess(attachment.url);
     } catch (err) {


### PR DESCRIPTION
Fix #2769.
Image upload from `Settings` area is public by default, remove this option from request body will allow the use of signed urls for avatar and logo when `AWS_S3_ACL = private`