### PR TITLE
#3665: Save button should not be shown when adding and removing a domain row

### DIFF
--- a/app/scenes/Settings/Security.tsx
+++ b/app/scenes/Settings/Security.tsx
@@ -47,11 +47,6 @@ function Security() {
 
   const [existingDomainsTouched, setExistingDomainsTouched] = useState(false);
 
-  const showSaveDomainsButton = React.useCallback(() => {
-    const validDomains = allowedDomains.filter((value) => value !== "");
-    return existingDomainsTouched || validDomains.length > lastKnownDomainCount;
-  }, [existingDomainsTouched, allowedDomains, lastKnownDomainCount]);
-
   const authenticationMethods = team.signinMethods;
 
   const showSuccessMessage = React.useMemo(
@@ -176,6 +171,8 @@ function Security() {
       setExistingDomainsTouched(true);
     }
   };
+
+  const excludeEmpty = (value: unknown) => value !== "";
 
   return (
     <Scene title={t("Security")} icon={<PadlockIcon color="currentColor" />}>
@@ -333,7 +330,9 @@ function Security() {
             <span />
           )}
 
-          {showSaveDomainsButton() && (
+          {(existingDomainsTouched ||
+            allowedDomains.filter(excludeEmpty).length > // New domains were added
+              lastKnownDomainCount) && (
             <Fade>
               <Button
                 type="button"

--- a/app/stores/AuthStore.ts
+++ b/app/stores/AuthStore.ts
@@ -236,6 +236,7 @@ export default class AuthStore {
     collaborativeEditing?: boolean;
     defaultCollectionId?: string | null;
     subdomain?: string | null | undefined;
+    allowedDomains?: string[] | null | undefined;
   }) => {
     this.isSaving = true;
 


### PR DESCRIPTION
Note: This is my first commit into this repo; I have used prettier to ensure the styling matches, but could not find any unit tests to add/modify. Please let me know if I have missed something; I have thoroughly manually tested these changes.

Please also let me know if this commit overreaches its goal or goes against some underlying design goals that I was not aware of!

---
This change consists of two commits.

The first one fixes an existing bug: The change handlers for the toggles on the Security page were submitting all data on toggle, including the "allowed domains" config which had its own save button. As a result, if a user added some domains (without saving), then changed a toggle value, their domains would be updated. Similarly, the "save" button also submitted all toggle states, even though it directly relates to the "domains" field.
The change made here modifies this behaviour so that the "save" button only affects the "domains" field, and toggles no longer implicitly submit the field. Since the `team.update` endpoint takes partial data, this was very simple to achieve by moving the `allowedDomains` property into a separate state and making the changes a separate update.

The second commit fixes #3665: The save button should not be visible when adding and removing an empty domain.
The way it is implemented is that there is slightly more logic to compute whether to show the button. The logic is that we show the button if either:
a) one or more new non-empty domains have been added, or
b) an existing domain was modified, even if the modification was then undone.

The reasoning for b) is as follows:
If a user adds a new domain row, makes changes, then removes the domain row, it is clear to the user that no changes have been made, and therefore the "save" button should not be visible.
However, as soon as the user makes any changes to an existing domain, they want to feel confident that they can hit save and ensure that whatever change they made is persisted; even if the change is identical to the current state, because they may not be able to recall accurately what the current state was. In those situations a user gets more confidence out of being able to hit save, than they would from being told by the system "you haven't made any changes".