### PR TITLE
feat: Custom Length decorator for UTF-8 chars len 

### DIFF
--- a/server/models/Document.ts
+++ b/server/models/Document.ts
@@ -17,7 +17,6 @@ import {
   BelongsTo,
   Column,
   Default,
-  Length,
   PrimaryKey,
   Table,
   BeforeValidate,
@@ -51,6 +50,7 @@ import User from "./User";
 import View from "./View";
 import ParanoidModel from "./base/ParanoidModel";
 import Fix from "./decorators/Fix";
+import { Length } from "./decorators/Length";
 
 export type SearchResponse = {
   results: {

--- a/server/models/decorators/Length.ts
+++ b/server/models/decorators/Length.ts
@@ -1,0 +1,19 @@
+import { size } from "lodash";
+import { addAttributeOptions } from "sequelize-typescript";
+
+/**
+ * A decorator that calculates size of the string based on lodash's size function.
+ * particularly useful for strings with unicode characters of variable lengths.
+ */
+export function Length({ msg, min, max }: { msg?: string; min: number; max: number }): Function {
+    return (target: any, propertyName: string) =>
+        addAttributeOptions(target, propertyName, {
+            validate: {
+                validLength(value: string) {
+                    if (size(value) > max || size(value) < min) {
+                        throw new Error(msg);
+                    }
+                }
+            },
+        });
+}

--- a/server/models/decorators/Length.ts
+++ b/server/models/decorators/Length.ts
@@ -5,15 +5,23 @@ import { addAttributeOptions } from "sequelize-typescript";
  * A decorator that calculates size of the string based on lodash's size function.
  * particularly useful for strings with unicode characters of variable lengths.
  */
-export function Length({ msg, min, max }: { msg?: string; min: number; max: number }): Function {
-    return (target: any, propertyName: string) =>
-        addAttributeOptions(target, propertyName, {
-            validate: {
-                validLength(value: string) {
-                    if (size(value) > max || size(value) < min) {
-                        throw new Error(msg);
-                    }
-                }
-            },
-        });
+export function Length({
+  msg,
+  min,
+  max,
+}: {
+  msg?: string;
+  min: number;
+  max: number;
+}): (target: any, propertyName: string) => void {
+  return (target: any, propertyName: string) =>
+    addAttributeOptions(target, propertyName, {
+      validate: {
+        validLength(value: string) {
+          if (size(value) > max || size(value) < min) {
+            throw new Error(msg);
+          }
+        },
+      },
+    });
 }

--- a/server/routes/api/documents.test.ts
+++ b/server/routes/api/documents.test.ts
@@ -1883,6 +1883,25 @@ describe("#documents.create", () => {
     expect(res.status).toEqual(400);
   });
 
+  // The length of UTF-8 "🛡" is 2 according to "🛡".length in node,
+  // so the length of the title totals to be 101.
+  // This test should not pass but does because length of the character
+  // calculated by lodash's size function is _.size('🛡') == 1.
+  // So the sentence's length comes out to be exactly 100.
+  it("should count variable length unicode character using lodash's size function", async () => {
+    const { user, collection } = await seed();
+    const res = await server.post("/api/documents.create", {
+      body: {
+        token: user.getJwtToken(),
+        collectionId: collection.id,
+        title:
+          "This text would be exactly 100 chars long if the following unicode character was counted as 1 char 🛡",
+        text: " ",
+      },
+    });
+    expect(res.status).toEqual(200);
+  });
+
   it("should create as a child and add to collection if published", async () => {
     const { user, document, collection } = await seed();
     const res = await server.post("/api/documents.create", {


### PR DESCRIPTION
## Description
Fixes error when importing document through `ImportTask` with a title longer than 100 chars.

Uses same strategy as in

https://github.com/outline/outline/blob/68dd76cfa37cc4559ffc323937456b8afb652889/server/commands/documentImporter.ts#L224

## Issue
Closes #3705