### PR TITLE
fix: show a distinct error message when a user tries to create an account using a personal gmail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build
 node_modules/*
 .env
 .log
+.vscode/*
 npm-debug.log
 stats.json
 .DS_Store

--- a/app/scenes/Login/Notices.tsx
+++ b/app/scenes/Login/Notices.tsx
@@ -18,6 +18,13 @@ export default function Notices() {
           invite email.
         </NoticeAlert>
       )}
+      {notice === "gmail-account-creation" && (
+        <NoticeAlert>
+          Sorry, accounts cannot be created using a personal Gmail address.
+          <hr />
+          Please use a Google Workspaces account instead.
+        </NoticeAlert>
+      )}
       {notice === "maximum-teams" && (
         <NoticeAlert>
           The team you authenticated with is not authorized on this

--- a/app/scenes/Login/Notices.tsx
+++ b/app/scenes/Login/Notices.tsx
@@ -20,7 +20,7 @@ export default function Notices() {
       )}
       {notice === "gmail-account-creation" && (
         <NoticeAlert>
-          Sorry, accounts cannot be created using a personal Gmail address.
+          Sorry, a new account cannot be created with a personal Gmail address.
           <hr />
           Please use a Google Workspaces account instead.
         </NoticeAlert>

--- a/server/errors.ts
+++ b/server/errors.ts
@@ -136,6 +136,14 @@ export function TeamDomainRequiredError(
   });
 }
 
+export function GmailAccountCreationError(
+  message = "Cannot create account using personal gmail address"
+) {
+  return httpErrors(400, message, {
+    id: "gmail_account_creation",
+  });
+}
+
 export function AuthRedirectError(
   message = "Redirect to the correct domain after authentication",
   redirectUrl: string

--- a/server/routes/auth/providers/google.ts
+++ b/server/routes/auth/providers/google.ts
@@ -9,7 +9,11 @@ import accountProvisioner, {
   AccountProvisionerResult,
 } from "@server/commands/accountProvisioner";
 import env from "@server/env";
-import { InviteRequiredError, TeamDomainRequiredError } from "@server/errors";
+import {
+  GmailAccountCreationError,
+  InviteRequiredError,
+  TeamDomainRequiredError,
+} from "@server/errors";
 import passportMiddleware from "@server/middlewares/passport";
 import { Team, User } from "@server/models";
 import { StateStore, parseState } from "@server/utils/passport";
@@ -99,7 +103,16 @@ if (env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET) {
             });
           } else {
             // No domain means it's a personal Gmail account
-            // We only allow sign-in to existing invites here
+            // We only allow sign-in to existing user accounts
+
+            const isExistingUser = await User.count({
+              where: { email: profile.email.toLowerCase() },
+            });
+
+            if (!isExistingUser) {
+              throw GmailAccountCreationError();
+            }
+
             let team;
             if (appDomain.custom) {
               team = await Team.findOne({ where: { domain: appDomain.host } });


### PR DESCRIPTION
As discussed in the [slack thread](https://getoutline.slack.com/archives/DKTBDD5EU/p1656075504147239)

New messaging
<img width="806" alt="image" src="https://user-images.githubusercontent.com/427579/176781005-5d8e25cc-7ba0-4077-a6b3-589eae8db0e2.png">

