### PR TITLE
fix: Don't show /share/ link in popover when team sharing disabled

### DIFF
--- a/app/scenes/Document/components/ShareButton.tsx
+++ b/app/scenes/Document/components/ShareButton.tsx
@@ -7,6 +7,7 @@ import Document from "~/models/Document";
 import Button from "~/components/Button";
 import Popover from "~/components/Popover";
 import Tooltip from "~/components/Tooltip";
+import useCurrentTeam from "~/hooks/useCurrentTeam";
 import useStores from "~/hooks/useStores";
 import SharePopover from "./SharePopover";
 
@@ -17,10 +18,12 @@ type Props = {
 function ShareButton({ document }: Props) {
   const { t } = useTranslation();
   const { shares } = useStores();
+  const team = useCurrentTeam();
   const share = shares.getByDocumentId(document.id);
   const sharedParent = shares.getByDocumentParents(document.id);
   const isPubliclyShared =
-    share?.published || (sharedParent?.published && !document.isDraft);
+    team.sharing &&
+    (share?.published || (sharedParent?.published && !document.isDraft));
 
   const popover = usePopoverState({
     gutter: 0,


### PR DESCRIPTION
fix: Docs appear to be publicly shared when sharing previously enabled

closes #3708