### PR TITLE
chore: Remove over-usage of invariant

### DIFF
--- a/server/collaboration/PersistenceExtension.ts
+++ b/server/collaboration/PersistenceExtension.ts
@@ -3,7 +3,6 @@ import {
   onLoadDocumentPayload,
   Extension,
 } from "@hocuspocus/server";
-import invariant from "invariant";
 import * as Y from "yjs";
 import { sequelize } from "@server/database/sequelize";
 import Logger from "@server/logging/Logger";
@@ -30,11 +29,11 @@ export default class PersistenceExtension implements Extension {
       const document = await Document.scope("withState").findOne({
         transaction,
         lock: transaction.LOCK.UPDATE,
+        rejectOnEmpty: true,
         where: {
           id: documentId,
         },
       });
-      invariant(document, "Document not found");
 
       if (document.state) {
         const ydoc = new Y.Doc();

--- a/server/commands/documentCollaborativeUpdater.ts
+++ b/server/commands/documentCollaborativeUpdater.ts
@@ -1,5 +1,4 @@
 import { yDocToProsemirrorJSON } from "@getoutline/y-prosemirror";
-import invariant from "invariant";
 import { uniq } from "lodash";
 import { Node } from "prosemirror-model";
 import * as Y from "yjs";
@@ -25,9 +24,9 @@ export default async function documentCollaborativeUpdater({
           of: Document,
           level: transaction.LOCK.UPDATE,
         },
+        rejectOnEmpty: true,
         paranoid: false,
       });
-    invariant(document, "document not found");
 
     const state = Y.encodeStateAsUpdate(ydoc);
     const node = Node.fromJSON(schema, yDocToProsemirrorJSON(ydoc, "default"));

--- a/server/commands/documentCreator.ts
+++ b/server/commands/documentCreator.ts
@@ -1,4 +1,3 @@
-import invariant from "invariant";
 import { Transaction } from "sequelize";
 import { Document, Event, User } from "@server/models";
 
@@ -105,14 +104,12 @@ export default async function documentCreator({
   // reload to get all of the data needed to present (user, collection etc)
   // we need to specify publishedAt to bypass default scope that only returns
   // published documents
-  const doc = await Document.findOne({
+  return await Document.findOne({
     where: {
       id: document.id,
       publishedAt: document.publishedAt,
     },
+    rejectOnEmpty: true,
     transaction,
   });
-  invariant(doc, "Document must exist");
-
-  return doc;
 }

--- a/server/commands/documentLoader.ts
+++ b/server/commands/documentLoader.ts
@@ -149,8 +149,7 @@ export default async function loadDocument({
     }
 
     // It is possible to disable sharing at the team level so we must check
-    const team = await Team.findByPk(document.teamId);
-    invariant(team, "team not found");
+    const team = await Team.findByPk(document.teamId, { rejectOnEmpty: true });
 
     if (!team.sharing) {
       throw AuthorizationError();

--- a/server/commands/userInviter.ts
+++ b/server/commands/userInviter.ts
@@ -1,4 +1,3 @@
-import invariant from "invariant";
 import { uniqBy } from "lodash";
 import { Role } from "@shared/types";
 import InviteEmail from "@server/emails/templates/InviteEmail";
@@ -25,8 +24,7 @@ export default async function userInviter({
   sent: Invite[];
   users: User[];
 }> {
-  const team = await Team.findByPk(user.teamId);
-  invariant(team, "team not found");
+  const team = await Team.findByPk(user.teamId, { rejectOnEmpty: true });
 
   // filter out empties and obvious non-emails
   const compactedInvites = invites.filter(

--- a/server/queues/processors/RevisionsProcessor.ts
+++ b/server/queues/processors/RevisionsProcessor.ts
@@ -32,8 +32,8 @@ export default class RevisionsProcessor extends BaseProcessor {
 
         const user = await User.findByPk(event.actorId, {
           paranoid: false,
+          rejectOnEmpty: true,
         });
-        invariant(user, "User should exist");
         await revisionCreator({
           user,
           document,

--- a/server/queues/tasks/DeliverWebhookTask.ts
+++ b/server/queues/tasks/DeliverWebhookTask.ts
@@ -1,5 +1,4 @@
 import fetch from "fetch-with-proxy";
-import invariant from "invariant";
 import env from "@server/env";
 import Logger from "@server/logging/Logger";
 import {
@@ -73,8 +72,9 @@ type Props = {
 
 export default class DeliverWebhookTask extends BaseTask<Props> {
   public async perform({ subscriptionId, event }: Props) {
-    const subscription = await WebhookSubscription.findByPk(subscriptionId);
-    invariant(subscription, "Subscription not found");
+    const subscription = await WebhookSubscription.findByPk(subscriptionId, {
+      rejectOnEmpty: true,
+    });
 
     Logger.info(
       "task",

--- a/server/queues/tasks/ExportMarkdownZipTask.ts
+++ b/server/queues/tasks/ExportMarkdownZipTask.ts
@@ -1,5 +1,4 @@
 import fs from "fs";
-import invariant from "invariant";
 import { truncate } from "lodash";
 import ExportFailureEmail from "@server/emails/templates/ExportFailureEmail";
 import ExportSuccessEmail from "@server/emails/templates/ExportSuccessEmail";
@@ -22,15 +21,14 @@ export default class ExportMarkdownZipTask extends BaseTask<Props> {
    * @param props The props
    */
   public async perform({ fileOperationId }: Props) {
-    const fileOperation = await FileOperation.findByPk(fileOperationId);
-    invariant(fileOperation, "fileOperation not found");
+    const fileOperation = await FileOperation.findByPk(fileOperationId, {
+      rejectOnEmpty: true,
+    });
 
     const [team, user] = await Promise.all([
-      Team.findByPk(fileOperation.teamId),
-      User.findByPk(fileOperation.userId),
+      Team.findByPk(fileOperation.teamId, { rejectOnEmpty: true }),
+      User.findByPk(fileOperation.userId, { rejectOnEmpty: true }),
     ]);
-    invariant(team, "team operation not found");
-    invariant(user, "user operation not found");
 
     const collectionIds = fileOperation.collectionId
       ? [fileOperation.collectionId]

--- a/server/queues/tasks/ImportTask.ts
+++ b/server/queues/tasks/ImportTask.ts
@@ -1,4 +1,3 @@
-import invariant from "invariant";
 import { truncate } from "lodash";
 import attachmentCreator from "@server/commands/attachmentCreator";
 import documentCreator from "@server/commands/documentCreator";
@@ -79,8 +78,9 @@ export default abstract class ImportTask extends BaseTask<Props> {
    * @param props The props
    */
   public async perform({ fileOperationId }: Props) {
-    const fileOperation = await FileOperation.findByPk(fileOperationId);
-    invariant(fileOperation, "fileOperation not found");
+    const fileOperation = await FileOperation.findByPk(fileOperationId, {
+      rejectOnEmpty: true,
+    });
 
     try {
       Logger.info("task", `ImportTask fetching data for ${fileOperationId}`);
@@ -200,8 +200,8 @@ export default abstract class ImportTask extends BaseTask<Props> {
     return sequelize.transaction(async (transaction) => {
       const user = await User.findByPk(fileOperation.userId, {
         transaction,
+        rejectOnEmpty: true,
       });
-      invariant(user, "User not found");
 
       const ip = user.lastActiveIp || undefined;
 

--- a/server/routes/api/auth.ts
+++ b/server/routes/api/auth.ts
@@ -1,4 +1,3 @@
-import invariant from "invariant";
 import Router from "koa-router";
 import { find } from "lodash";
 import { parseDomain } from "@shared/utils/domains";
@@ -108,8 +107,9 @@ router.post("auth.config", async (ctx) => {
 
 router.post("auth.info", auth(), async (ctx) => {
   const { user } = ctx.state;
-  const team = await Team.scope("withDomains").findByPk(user.teamId);
-  invariant(team, "Team not found");
+  const team = await Team.scope("withDomains").findByPk(user.teamId, {
+    rejectOnEmpty: true,
+  });
 
   await ValidateSSOAccessTask.schedule({ userId: user.id });
 

--- a/server/routes/api/collections.ts
+++ b/server/routes/api/collections.ts
@@ -641,8 +641,7 @@ router.post("collections.update", auth(), async (ctx) => {
   // if the privacy level has changed. Otherwise skip this query for speed.
   if (privacyChanged || sharingChanged) {
     await collection.reload();
-    const team = await Team.findByPk(user.teamId);
-    invariant(team, "team not found");
+    const team = await Team.findByPk(user.teamId, { rejectOnEmpty: true });
 
     if (
       collection.permission === null &&

--- a/server/routes/api/documents.ts
+++ b/server/routes/api/documents.ts
@@ -26,7 +26,6 @@ import {
   Star,
   User,
   View,
-  Team,
 } from "@server/models";
 import { authorize, cannot } from "@server/policies";
 import {
@@ -626,7 +625,7 @@ router.post(
       }
 
       teamId = share.teamId;
-      const team = await Team.findByPk(teamId);
+      const team = await share.$get("team");
       invariant(team, "Share must belong to a team");
 
       response = await Document.searchForTeam(team, query, {

--- a/server/routes/api/fileOperations.ts
+++ b/server/routes/api/fileOperations.ts
@@ -1,4 +1,3 @@
-import invariant from "invariant";
 import Router from "koa-router";
 import { WhereOptions } from "sequelize/types";
 import fileOperationDeleter from "@server/commands/fileOperationDeleter";
@@ -18,8 +17,9 @@ router.post("fileOperations.info", auth(), async (ctx) => {
   assertUuid(id, "id is required");
   const { user } = ctx.state;
   const team = await Team.findByPk(user.teamId);
-  const fileOperation = await FileOperation.findByPk(id);
-  invariant(fileOperation, "File operation not found");
+  const fileOperation = await FileOperation.findByPk(id, {
+    rejectOnEmpty: true,
+  });
 
   authorize(user, fileOperation.type, team);
 

--- a/server/routes/api/groups.ts
+++ b/server/routes/api/groups.ts
@@ -1,4 +1,3 @@
-import invariant from "invariant";
 import Router from "koa-router";
 import { Op } from "sequelize";
 import { MAX_AVATAR_DISPLAY } from "@shared/constants";
@@ -80,8 +79,7 @@ router.post("groups.create", auth(), async (ctx) => {
   });
 
   // reload to get default scope
-  const group = await Group.findByPk(g.id);
-  invariant(group, "group not found");
+  const group = await Group.findByPk(g.id, { rejectOnEmpty: true });
 
   await Event.create({
     name: "groups.create",
@@ -231,12 +229,11 @@ router.post("groups.add_user", auth(), async (ctx) => {
         groupId: id,
         userId,
       },
+      rejectOnEmpty: true,
     });
-    invariant(membership, "membership not found");
 
     // reload to get default scope
-    group = await Group.findByPk(id);
-    invariant(group, "group not found");
+    group = await Group.findByPk(id, { rejectOnEmpty: true });
 
     await Event.create({
       name: "groups.add_user",
@@ -287,8 +284,7 @@ router.post("groups.remove_user", auth(), async (ctx) => {
   });
 
   // reload to get default scope
-  group = await Group.findByPk(id);
-  invariant(group, "group not found");
+  group = await Group.findByPk(id, { rejectOnEmpty: true });
 
   ctx.body = {
     data: {

--- a/server/routes/api/hooks.ts
+++ b/server/routes/api/hooks.ts
@@ -1,4 +1,3 @@
-import invariant from "invariant";
 import Router from "koa-router";
 import { escapeRegExp } from "lodash";
 import env from "@server/env";
@@ -103,8 +102,7 @@ router.post("hooks.interactive", async (ctx) => {
     throw InvalidRequestError("Invalid callback_id");
   }
 
-  const team = await Team.findByPk(document.teamId);
-  invariant(team, "team not found");
+  const team = await Team.findByPk(document.teamId, { rejectOnEmpty: true });
 
   // respond with a public message that will be posted in the original channel
   ctx.body = {

--- a/server/routes/api/pins.ts
+++ b/server/routes/api/pins.ts
@@ -1,4 +1,3 @@
-import invariant from "invariant";
 import Router from "koa-router";
 import { Sequelize, Op } from "sequelize";
 import pinCreator from "@server/commands/pinCreator";
@@ -106,8 +105,7 @@ router.post("pins.update", auth(), async (ctx) => {
   assertIndexCharacters(index);
 
   const { user } = ctx.state;
-  let pin = await Pin.findByPk(id);
-  invariant(pin, "pin not found");
+  let pin = await Pin.findByPk(id, { rejectOnEmpty: true });
 
   const document = await Document.findByPk(pin.documentId, {
     userId: user.id,
@@ -137,8 +135,7 @@ router.post("pins.delete", auth(), async (ctx) => {
   assertUuid(id, "id is required");
 
   const { user } = ctx.state;
-  const pin = await Pin.findByPk(id);
-  invariant(pin, "pin not found");
+  const pin = await Pin.findByPk(id, { rejectOnEmpty: true });
 
   const document = await Document.findByPk(pin.documentId, {
     userId: user.id,


### PR DESCRIPTION
We already have a typescript-safe alternative in `rejectOnEmpty`.