### PR TITLE
Fix: clear localstore after logout

### DIFF
--- a/app/stores/AuthStore.ts
+++ b/app/stores/AuthStore.ts
@@ -204,6 +204,7 @@ export default class AuthStore {
     runInAction("AuthStore#updateUser", () => {
       this.user = null;
       this.team = null;
+      this.policies = [];
       this.token = null;
     });
   };
@@ -282,7 +283,6 @@ export default class AuthStore {
       setCookie("sessions", JSON.stringify(sessions), {
         domain: getCookieDomain(window.location.hostname),
       });
-      this.team = null;
     }
 
     // clear all credentials from cache (and local storage via autorun)

--- a/app/stores/AuthStore.ts
+++ b/app/stores/AuthStore.ts
@@ -259,14 +259,6 @@ export default class AuthStore {
 
     client.post(`/auth.delete`);
 
-    // remove user and team from localStorage
-    Storage.set(AUTH_STORE, {
-      user: null,
-      team: null,
-      policies: [],
-    });
-    this.token = null;
-
     // if this logout was forced from an authenticated route then
     // save the current path so we can go back there once signed in
     if (savePath) {
@@ -292,5 +284,11 @@ export default class AuthStore {
       });
       this.team = null;
     }
+
+    // clear all credentials from cache (and local storage via autorun)
+    this.user = null;
+    this.team = null;
+    this.policies = [];
+    this.token = null;
   };
 }


### PR DESCRIPTION
- fixes a bug that left user, team and policy information in localstorage after logout.
- the problem was that localstore was being cleared but the store itself was not, so `autorun` repopulated the values when `team` or `token` was modified