### PR TITLE
Feat: add auth provider to users on sign in

### DIFF
--- a/server/commands/userCreator.test.ts
+++ b/server/commands/userCreator.test.ts
@@ -1,3 +1,4 @@
+import { v4 as uuidv4 } from "uuid";
 import { TeamDomain } from "@server/models";
 import { buildUser, buildTeam, buildInvite } from "@server/test/factories";
 import { flushdb, seed } from "@server/test/support";
@@ -35,6 +36,43 @@ describe("userCreator", () => {
     expect(user.email).toEqual(newEmail);
     expect(user.username).toEqual(newUsername);
     expect(isNewUser).toEqual(false);
+  });
+
+  it("should add authentication provider to existing user", async () => {
+    const team = await buildTeam({ inviteRequired: true });
+    const teamAuthProviders = await team.$get("authenticationProviders");
+    const authenticationProvider = teamAuthProviders[0];
+
+    const email = "mynam@email.com";
+    const existing = await buildUser({
+      email,
+      teamId: team.id,
+      lastActiveAt: null,
+      authentications: [],
+    });
+
+    const result = await userCreator({
+      name: existing.name,
+      email,
+      username: "new-username",
+      avatarUrl: existing.avatarUrl,
+      teamId: existing.teamId,
+      ip,
+      authentication: {
+        authenticationProviderId: authenticationProvider.id,
+        providerId: uuidv4(),
+        accessToken: "123",
+        scopes: ["read"],
+      },
+    });
+    const { user, authentication, isNewUser } = result;
+    expect(authentication.accessToken).toEqual("123");
+    expect(authentication.scopes.length).toEqual(1);
+    expect(authentication.scopes[0]).toEqual("read");
+
+    const authentications = await user.$get("authentications");
+    expect(authentications.length).toEqual(1);
+    expect(isNewUser).toEqual(true);
   });
 
   it("should create user with deleted user matching providerId", async () => {

--- a/server/commands/userCreator.ts
+++ b/server/commands/userCreator.ts
@@ -107,8 +107,7 @@ export default async function userCreator({
     // A `user` record might exist in the form of an invite.
     // In Outline an invite is a shell user record with no authentication method
     // that's never been active before.
-    const isInvite =
-      !existingUser.lastActiveAt && !existingUser.authentications.length;
+    const isInvite = existingUser.isInvited;
 
     const auth = await sequelize.transaction(async (transaction) => {
       if (isInvite) {
@@ -136,6 +135,8 @@ export default async function userCreator({
         {
           name,
           avatarUrl,
+          lastActiveAt: new Date(),
+          lastActiveIp: ip,
         },
         {
           transaction,

--- a/server/commands/userCreator.ts
+++ b/server/commands/userCreator.ts
@@ -97,9 +97,6 @@ export default async function userCreator({
       // however any existing invites will always be lowercased.
       email: email.toLowerCase(),
       teamId,
-      // lastActiveAt: {
-      //   [Op.is]: null,
-      // },
     },
   });
 

--- a/server/routes/api/team.test.ts
+++ b/server/routes/api/team.test.ts
@@ -39,7 +39,7 @@ describe("#team.update", () => {
     });
     const body = await res.json();
     expect(res.status).toEqual(200);
-    expect(body.data.allowedDomains).toEqual([
+    expect(body.data.allowedDomains.sort()).toEqual([
       "example-company.com",
       "example-company.org",
     ]);
@@ -47,7 +47,7 @@ describe("#team.update", () => {
     const teamDomains: TeamDomain[] = await TeamDomain.findAll({
       where: { teamId: team.id },
     });
-    expect(teamDomains.map((d) => d.name)).toEqual([
+    expect(teamDomains.map((d) => d.name).sort()).toEqual([
       "example-company.com",
       "example-company.org",
     ]);

--- a/server/test/factories.ts
+++ b/server/test/factories.ts
@@ -179,6 +179,7 @@ export async function buildInvite(overrides: Partial<User> = {}) {
     name: `User ${count}`,
     createdAt: new Date("2018-01-01T00:00:00.000Z"),
     invitedById: actor.id,
+    authentications: [],
     ...overrides,
     lastActiveAt: null,
   });


### PR DESCRIPTION
- when a user signs in via SSO, we look up existing user records on the same team by email and associate the SSO auth with that record if found
- this essentially treats all existing user records as if they were "invites"