### PR TITLE
feat: scope login attempts to specific subdomains if available - do not switch subdomains

### DIFF
--- a/app/scenes/Login/Notices.tsx
+++ b/app/scenes/Login/Notices.tsx
@@ -57,6 +57,15 @@ export default function Notices() {
             Please try again.
           </NoticeAlert>
         ))}
+      {notice === "invalid-authentication" &&
+        (description ? (
+          <NoticeAlert>{description}</NoticeAlert>
+        ) : (
+          <NoticeAlert>
+            Authentication failed – you do not have permission to access this
+            team.
+          </NoticeAlert>
+        ))}
       {notice === "expired-token" && (
         <NoticeAlert>
           Sorry, it looks like that sign-in link is no longer valid, please try

--- a/server/commands/accountProvisioner.ts
+++ b/server/commands/accountProvisioner.ts
@@ -3,6 +3,7 @@ import { UniqueConstraintError } from "sequelize";
 import WelcomeEmail from "@server/emails/templates/WelcomeEmail";
 import {
   AuthenticationError,
+  InvalidAuthenticationError,
   EmailAuthenticationRequiredError,
   AuthenticationProviderDisabledError,
 } from "@server/errors";
@@ -62,7 +63,7 @@ async function accountProvisioner({
       ip,
     });
   } catch (err) {
-    throw AuthenticationError(err.message);
+    throw InvalidAuthenticationError(err.message);
   }
 
   invariant(result, "Team creator result must exist");

--- a/server/commands/accountProvisioner.ts
+++ b/server/commands/accountProvisioner.ts
@@ -20,6 +20,7 @@ type Props = {
     username?: string;
   };
   team: {
+    id?: string;
     name: string;
     domain?: string;
     subdomain: string;
@@ -56,10 +57,7 @@ async function accountProvisioner({
 
   try {
     result = await teamCreator({
-      name: teamParams.name,
-      domain: teamParams.domain,
-      subdomain: teamParams.subdomain,
-      avatarUrl: teamParams.avatarUrl,
+      ...teamParams,
       authenticationProvider: authenticationProviderParams,
       ip,
     });

--- a/server/commands/teamCreator.ts
+++ b/server/commands/teamCreator.ts
@@ -1,6 +1,10 @@
 import { sequelize } from "@server/database/sequelize";
 import env from "@server/env";
-import { DomainNotAllowedError, MaximumTeamsError } from "@server/errors";
+import {
+  InvalidAuthenticationError,
+  DomainNotAllowedError,
+  MaximumTeamsError,
+} from "@server/errors";
 import Logger from "@server/logging/Logger";
 import { APM } from "@server/logging/tracing";
 import { Team, AuthenticationProvider, Event } from "@server/models";
@@ -55,6 +59,11 @@ async function teamCreator({
       team: authP.team,
       isNewTeam: false,
     };
+  }
+  // A team id was provided but no auth provider was found matching those credentials
+  // The user is attempting to log into a team with an incorrect SSO - fail the login
+  else if (id) {
+    throw InvalidAuthenticationError("incorrect authentication credentials");
   }
 
   // This team has never been seen before, if self hosted the logic is different

--- a/server/commands/teamCreator.ts
+++ b/server/commands/teamCreator.ts
@@ -13,6 +13,7 @@ type TeamCreatorResult = {
 };
 
 type Props = {
+  id?: string;
   name: string;
   domain?: string;
   subdomain: string;
@@ -25,6 +26,7 @@ type Props = {
 };
 
 async function teamCreator({
+  id,
   name,
   domain,
   subdomain,
@@ -33,7 +35,9 @@ async function teamCreator({
   ip,
 }: Props): Promise<TeamCreatorResult> {
   let authP = await AuthenticationProvider.findOne({
-    where: authenticationProvider,
+    where: id
+      ? { ...authenticationProvider, teamId: id }
+      : authenticationProvider,
     include: [
       {
         model: Team,

--- a/server/commands/userCreator.ts
+++ b/server/commands/userCreator.ts
@@ -40,7 +40,6 @@ export default async function userCreator({
 }: Props): Promise<UserCreatorResult> {
   const { authenticationProviderId, providerId, ...rest } = authentication;
 
-  // TODO: this needs otr be scoped to the righ tteam!!!!
   const auth = await UserAuthentication.findOne({
     where: {
       providerId,
@@ -49,6 +48,8 @@ export default async function userCreator({
       {
         model: User,
         as: "user",
+        where: { teamId },
+        required: true,
       },
     ],
   });

--- a/server/commands/userCreator.ts
+++ b/server/commands/userCreator.ts
@@ -40,6 +40,7 @@ export default async function userCreator({
 }: Props): Promise<UserCreatorResult> {
   const { authenticationProviderId, providerId, ...rest } = authentication;
 
+  // TODO: this needs otr be scoped to the righ tteam!!!!
   const auth = await UserAuthentication.findOne({
     where: {
       providerId,

--- a/server/errors.ts
+++ b/server/errors.ts
@@ -1,5 +1,4 @@
 import httpErrors from "http-errors";
-import env from "./env";
 
 export function AuthenticationError(
   message = "Authentication required",
@@ -122,7 +121,7 @@ export function MaximumTeamsError(
 
 export function EmailAuthenticationRequiredError(
   message = "User must authenticate with email",
-  redirectUrl = env.URL
+  redirectUrl = "/"
 ) {
   return httpErrors(400, message, {
     redirectUrl,
@@ -174,7 +173,7 @@ export function OIDCMalformedUserInfoError(
 
 export function AuthenticationProviderDisabledError(
   message = "Authentication method has been disabled by an admin",
-  redirectUrl = env.URL
+  redirectUrl = "/"
 ) {
   return httpErrors(400, message, {
     redirectUrl,

--- a/server/errors.ts
+++ b/server/errors.ts
@@ -2,12 +2,22 @@ import httpErrors from "http-errors";
 import env from "./env";
 
 export function AuthenticationError(
-  message = "Invalid authentication",
-  redirectUrl = env.URL
+  message = "Authentication required",
+  redirectUrl = "/"
 ) {
   return httpErrors(401, message, {
     redirectUrl,
     id: "authentication_required",
+  });
+}
+
+export function InvalidAuthenticationError(
+  message = "Invalid authentication",
+  redirectUrl = "/"
+) {
+  return httpErrors(401, message, {
+    redirectUrl,
+    id: "invalid_authentication",
   });
 }
 

--- a/server/routes/auth/providers/azure.ts
+++ b/server/routes/auth/providers/azure.ts
@@ -1,7 +1,7 @@
 import passport from "@outlinewiki/koa-passport";
 import { Strategy as AzureStrategy } from "@outlinewiki/passport-azure-ad-oauth2";
-import type { Request } from "express";
 import jwt from "jsonwebtoken";
+import type { Context } from "koa";
 import Router from "koa-router";
 import { Profile } from "passport";
 import accountProvisioner, {
@@ -40,7 +40,7 @@ if (env.AZURE_CLIENT_ID && env.AZURE_CLIENT_SECRET) {
       scope: scopes,
     },
     async function (
-      req: Request,
+      req: Context,
       accessToken: string,
       refreshToken: string,
       params: { expires_in: number; id_token: string },

--- a/server/routes/auth/providers/azure.ts
+++ b/server/routes/auth/providers/azure.ts
@@ -1,7 +1,7 @@
 import passport from "@outlinewiki/koa-passport";
 import { Strategy as AzureStrategy } from "@outlinewiki/passport-azure-ad-oauth2";
+import type { Request } from "express";
 import jwt from "jsonwebtoken";
-import { Request } from "koa";
 import Router from "koa-router";
 import { Profile } from "passport";
 import accountProvisioner, {
@@ -11,7 +11,11 @@ import env from "@server/env";
 import { MicrosoftGraphError } from "@server/errors";
 import passportMiddleware from "@server/middlewares/passport";
 import { User } from "@server/models";
-import { StateStore, request } from "@server/utils/passport";
+import {
+  StateStore,
+  request,
+  getTeamFromRequest,
+} from "@server/utils/passport";
 
 const router = new Router();
 const providerName = "azure";
@@ -88,12 +92,15 @@ if (env.AZURE_CLIENT_ID && env.AZURE_CLIENT_SECRET) {
           );
         }
 
+        const team = await getTeamFromRequest(req);
+
         const domain = email.split("@")[1];
         const subdomain = domain.split(".")[0];
         const teamName = organization.displayName;
         const result = await accountProvisioner({
           ip: req.ip,
           team: {
+            id: team?.id,
             name: teamName,
             domain,
             subdomain,

--- a/server/routes/auth/providers/azure.ts
+++ b/server/routes/auth/providers/azure.ts
@@ -14,7 +14,7 @@ import { User } from "@server/models";
 import {
   StateStore,
   request,
-  getTeamFromRequest,
+  getTeamFromContext,
 } from "@server/utils/passport";
 
 const router = new Router();
@@ -40,7 +40,7 @@ if (env.AZURE_CLIENT_ID && env.AZURE_CLIENT_SECRET) {
       scope: scopes,
     },
     async function (
-      req: Context,
+      ctx: Context,
       accessToken: string,
       refreshToken: string,
       params: { expires_in: number; id_token: string },
@@ -92,13 +92,13 @@ if (env.AZURE_CLIENT_ID && env.AZURE_CLIENT_SECRET) {
           );
         }
 
-        const team = await getTeamFromRequest(req);
+        const team = await getTeamFromContext(ctx);
 
         const domain = email.split("@")[1];
         const subdomain = domain.split(".")[0];
         const teamName = organization.displayName;
         const result = await accountProvisioner({
-          ip: req.ip,
+          ip: ctx.ip,
           team: {
             id: team?.id,
             name: teamName,

--- a/server/routes/auth/providers/google.ts
+++ b/server/routes/auth/providers/google.ts
@@ -69,8 +69,6 @@ if (env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET) {
           const domain = profile._json.hd;
           const team = await getTeamFromRequest(req);
 
-          console.log("TEAM------------------>>", { team });
-
           // Existence of domain means this is a Google Workspaces account
           // so we'll attempt to provision an account (team and user)
           if (domain) {

--- a/server/routes/auth/providers/google.ts
+++ b/server/routes/auth/providers/google.ts
@@ -16,7 +16,7 @@ import {
 } from "@server/errors";
 import passportMiddleware from "@server/middlewares/passport";
 import { User } from "@server/models";
-import { StateStore, getTeamFromRequest } from "@server/utils/passport";
+import { StateStore, getTeamFromContext } from "@server/utils/passport";
 
 const router = new Router();
 const providerName = "google";
@@ -51,7 +51,7 @@ if (env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET) {
         scope: scopes,
       },
       async function (
-        req: Context,
+        ctx: Context,
         accessToken: string,
         refreshToken: string,
         params: { expires_in: number },
@@ -67,7 +67,7 @@ if (env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET) {
 
           // "domain" is the Google Workspaces domain
           const domain = profile._json.hd;
-          const team = await getTeamFromRequest(req);
+          const team = await getTeamFromContext(ctx);
 
           // Existence of domain means this is a Google Workspaces account
           // so we'll attempt to provision an account (team and user)
@@ -86,7 +86,7 @@ if (env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET) {
             // that team in particular; otherwise, we will do a best effort at finding their account
             // or provisioning a new one (within AccountProvisioner)
             result = await accountProvisioner({
-              ip: req.ip,
+              ip: ctx.ip,
               team: {
                 id: team?.id,
                 name: teamName,

--- a/server/routes/auth/providers/oidc.ts
+++ b/server/routes/auth/providers/oidc.ts
@@ -1,5 +1,5 @@
 import passport from "@outlinewiki/koa-passport";
-import { Request } from "koa";
+import type { Request } from "express";
 import Router from "koa-router";
 import { get } from "lodash";
 import { Strategy } from "passport-oauth2";
@@ -13,7 +13,11 @@ import {
 } from "@server/errors";
 import passportMiddleware from "@server/middlewares/passport";
 import { User } from "@server/models";
-import { StateStore, request } from "@server/utils/passport";
+import {
+  StateStore,
+  request,
+  getTeamFromRequest,
+} from "@server/utils/passport";
 
 const router = new Router();
 const providerName = "oidc";
@@ -77,6 +81,7 @@ if (env.OIDC_CLIENT_ID && env.OIDC_CLIENT_SECRET) {
               `An email field was not returned in the profile parameter, but is required.`
             );
           }
+          const team = await getTeamFromRequest(req);
 
           const parts = profile.email.toLowerCase().split("@");
           const domain = parts.length && parts[1];
@@ -91,6 +96,7 @@ if (env.OIDC_CLIENT_ID && env.OIDC_CLIENT_SECRET) {
           const result = await accountProvisioner({
             ip: req.ip,
             team: {
+              id: team?.id,
               // https://github.com/outline/outline/pull/2388#discussion_r681120223
               name: "Wiki",
               domain,

--- a/server/routes/auth/providers/oidc.ts
+++ b/server/routes/auth/providers/oidc.ts
@@ -85,7 +85,9 @@ if (env.OIDC_CLIENT_ID && env.OIDC_CLIENT_SECRET) {
             throw OIDCMalformedUserInfoError();
           }
 
-          const subdomain = domain.split(".")[0];
+          // remove the TLD and form a subdomain from the remaining
+          const subdomain = domain.split(".").slice(0, -1).join("-");
+
           const result = await accountProvisioner({
             ip: req.ip,
             team: {

--- a/server/routes/auth/providers/oidc.ts
+++ b/server/routes/auth/providers/oidc.ts
@@ -17,7 +17,7 @@ import { User } from "@server/models";
 import {
   StateStore,
   request,
-  getTeamFromRequest,
+  getTeamFromContext,
 } from "@server/utils/passport";
 
 const router = new Router();
@@ -65,7 +65,7 @@ if (env.OIDC_CLIENT_ID && env.OIDC_CLIENT_SECRET) {
       // Any claim supplied in response to the userinfo request will be
       // available on the `profile` parameter
       async function (
-        req: Context,
+        ctx: Context,
         accessToken: string,
         refreshToken: string,
         params: { expires_in: number },
@@ -82,7 +82,7 @@ if (env.OIDC_CLIENT_ID && env.OIDC_CLIENT_SECRET) {
               `An email field was not returned in the profile parameter, but is required.`
             );
           }
-          const team = await getTeamFromRequest(req);
+          const team = await getTeamFromContext(ctx);
 
           const parts = profile.email.toLowerCase().split("@");
           const domain = parts.length && parts[1];
@@ -95,7 +95,7 @@ if (env.OIDC_CLIENT_ID && env.OIDC_CLIENT_SECRET) {
           const subdomain = slugifyDomain(domain);
 
           const result = await accountProvisioner({
-            ip: req.ip,
+            ip: ctx.ip,
             team: {
               id: team?.id,
               // https://github.com/outline/outline/pull/2388#discussion_r681120223

--- a/server/routes/auth/providers/oidc.ts
+++ b/server/routes/auth/providers/oidc.ts
@@ -1,8 +1,9 @@
 import passport from "@outlinewiki/koa-passport";
-import type { Request } from "express";
+import type { Context } from "koa";
 import Router from "koa-router";
 import { get } from "lodash";
 import { Strategy } from "passport-oauth2";
+import { slugifyDomain } from "@shared/utils/domains";
 import accountProvisioner, {
   AccountProvisionerResult,
 } from "@server/commands/accountProvisioner";
@@ -64,7 +65,7 @@ if (env.OIDC_CLIENT_ID && env.OIDC_CLIENT_SECRET) {
       // Any claim supplied in response to the userinfo request will be
       // available on the `profile` parameter
       async function (
-        req: Request,
+        req: Context,
         accessToken: string,
         refreshToken: string,
         params: { expires_in: number },
@@ -91,7 +92,7 @@ if (env.OIDC_CLIENT_ID && env.OIDC_CLIENT_SECRET) {
           }
 
           // remove the TLD and form a subdomain from the remaining
-          const subdomain = domain.split(".").slice(0, -1).join("-");
+          const subdomain = slugifyDomain(domain);
 
           const result = await accountProvisioner({
             ip: req.ip,

--- a/server/routes/auth/providers/slack.ts
+++ b/server/routes/auth/providers/slack.ts
@@ -1,5 +1,5 @@
 import passport from "@outlinewiki/koa-passport";
-import { Request } from "koa";
+import type { Request } from "express";
 import Router from "koa-router";
 import { Profile } from "passport";
 import { Strategy as SlackStrategy } from "passport-slack-oauth2";
@@ -16,7 +16,7 @@ import {
   Team,
   User,
 } from "@server/models";
-import { StateStore } from "@server/utils/passport";
+import { getTeamFromRequest, StateStore } from "@server/utils/passport";
 import * as Slack from "@server/utils/slack";
 import { assertPresent, assertUuid } from "@server/validation";
 
@@ -75,9 +75,11 @@ if (env.SLACK_CLIENT_ID && env.SLACK_CLIENT_SECRET) {
       ) => void
     ) {
       try {
+        const team = await getTeamFromRequest(req);
         const result = await accountProvisioner({
           ip: req.ip,
           team: {
+            id: team?.id,
             name: profile.team.name,
             subdomain: profile.team.domain,
             avatarUrl: profile.team.image_230,

--- a/server/routes/auth/providers/slack.ts
+++ b/server/routes/auth/providers/slack.ts
@@ -1,5 +1,5 @@
 import passport from "@outlinewiki/koa-passport";
-import type { Request } from "express";
+import type { Context } from "koa";
 import Router from "koa-router";
 import { Profile } from "passport";
 import { Strategy as SlackStrategy } from "passport-slack-oauth2";
@@ -63,7 +63,7 @@ if (env.SLACK_CLIENT_ID && env.SLACK_CLIENT_SECRET) {
       scope: scopes,
     },
     async function (
-      req: Request,
+      req: Context,
       accessToken: string,
       refreshToken: string,
       params: { expires_in: number },

--- a/server/routes/auth/providers/slack.ts
+++ b/server/routes/auth/providers/slack.ts
@@ -16,7 +16,7 @@ import {
   Team,
   User,
 } from "@server/models";
-import { getTeamFromRequest, StateStore } from "@server/utils/passport";
+import { getTeamFromContext, StateStore } from "@server/utils/passport";
 import * as Slack from "@server/utils/slack";
 import { assertPresent, assertUuid } from "@server/validation";
 
@@ -63,7 +63,7 @@ if (env.SLACK_CLIENT_ID && env.SLACK_CLIENT_SECRET) {
       scope: scopes,
     },
     async function (
-      req: Context,
+      ctx: Context,
       accessToken: string,
       refreshToken: string,
       params: { expires_in: number },
@@ -75,9 +75,9 @@ if (env.SLACK_CLIENT_ID && env.SLACK_CLIENT_SECRET) {
       ) => void
     ) {
       try {
-        const team = await getTeamFromRequest(req);
+        const team = await getTeamFromContext(ctx);
         const result = await accountProvisioner({
-          ip: req.ip,
+          ip: ctx.ip,
           team: {
             id: team?.id,
             name: profile.team.name,

--- a/server/utils/passport.ts
+++ b/server/utils/passport.ts
@@ -1,7 +1,7 @@
 import crypto from "crypto";
 import { addMinutes, subMinutes } from "date-fns";
-import type { Request } from "express";
 import fetch from "fetch-with-proxy";
+import type { Context } from "koa";
 import {
   StateStoreStoreCallback,
   StateStoreVerifyCallback,
@@ -14,7 +14,7 @@ import { AuthRedirectError, OAuthStateMismatchError } from "../errors";
 export class StateStore {
   key = "state";
 
-  store = (req: Request, callback: StateStoreStoreCallback) => {
+  store = (req: Context, callback: StateStoreStoreCallback) => {
     // token is a short lived one-time pad to prevent replay attacks
     // appDomain is the domain the user originated from when attempting auth
     // we expect it to be a team subdomain, custom domain, or apex domain
@@ -32,7 +32,7 @@ export class StateStore {
   };
 
   verify = (
-    req: Request,
+    req: Context,
     providedToken: string,
     callback: StateStoreVerifyCallback
   ) => {
@@ -101,7 +101,7 @@ export function parseState(state: string) {
   return { host, token };
 }
 
-export async function getTeamFromRequest(req: Request) {
+export async function getTeamFromRequest(req: Context) {
   // "domain" is the domain the user came from when attempting auth
   // we use it to infer the team they intend on signing into
   const state = req.cookies.get("state");

--- a/shared/utils/domains.test.ts
+++ b/shared/utils/domains.test.ts
@@ -1,5 +1,5 @@
 import env from "@shared/env";
-import { parseDomain, getCookieDomain } from "./domains";
+import { parseDomain, getCookieDomain, slugifyDomain } from "./domains";
 
 // test suite is based on subset of parse-domain module we want to support
 // https://github.com/peerigon/parse-domain/blob/master/test/parseDomain.test.js
@@ -155,6 +155,14 @@ describe("#parseDomain", () => {
       host: "myteam.localhost",
       custom: false,
     });
+  });
+});
+
+describe("#slugifyDomain", () => {
+  it("strips the last . delineated segment from strings", () => {
+    expect(slugifyDomain("foo.co")).toBe("foo");
+    expect(slugifyDomain("foo.co.uk")).toBe("foo-co");
+    expect(slugifyDomain("www.foo.co.uk")).toBe("www-foo-co");
   });
 });
 

--- a/shared/utils/domains.ts
+++ b/shared/utils/domains.ts
@@ -7,6 +7,16 @@ type Domain = {
   custom: boolean;
 };
 
+/**
+ * Removes the the top level domain from the argument and slugifies it
+ *
+ * @param domain Domain string to slugify
+ * @returns String with only non top-level domains
+ */
+export function slugifyDomain(domain: string) {
+  return domain.split(".").slice(0, -1).join("-");
+}
+
 // strips protocol and whitespace from input
 // then strips the path and query string
 function normalizeUrl(url: string) {


### PR DESCRIPTION
Functionality
- if a user tries to authenticate from a specific custom domain or team subdomain, the scope of the auth attempt will be limited to that team only.
- even if they have an existing account with their SSO on a different team, we will not consider accounts outside of the team referenced by the url
- if a user authenticates from the apex domain, or if subdomains are not enabled, then it will fall back to the best-effort path, and behave as before

Basic QA test cases
1. **Attempt to auth into a subdomain with an SSO account that exists on a different subdomain. It should fail. Previously, it would have redirected to the other subdomain**
2. Attempt to auth into a subdomain with an SSO account from apex. It should find a team if it exists.
3. Attempt to auth into a subdomain with an SSO that exists on that team. It should succeed.