### PR TITLE
feat: Add pending migrations check during startup

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -20,7 +20,11 @@ import { requestErrorHandler } from "./logging/sentry";
 import services from "./services";
 import { getArg } from "./utils/args";
 import { getSSLOptions } from "./utils/ssl";
-import { checkEnv, checkMigrations } from "./utils/startup";
+import {
+  checkEnv,
+  checkMigrations,
+  checkPendingMigrations,
+} from "./utils/startup";
 import { checkUpdates } from "./utils/updates";
 
 // If a services flag is passed it takes priority over the environment variable
@@ -53,6 +57,7 @@ if (serviceNames.includes("collaboration")) {
 // This function will only be called once in the original process
 async function master() {
   await checkEnv();
+  checkPendingMigrations();
   await checkMigrations();
 
   if (env.TELEMETRY && env.ENVIRONMENT === "production") {

--- a/server/utils/startup.ts
+++ b/server/utils/startup.ts
@@ -1,8 +1,34 @@
+import { execSync } from "child_process";
 import chalk from "chalk";
 import env from "@server/env";
 import Logger from "@server/logging/Logger";
 import AuthenticationProvider from "@server/models/AuthenticationProvider";
 import Team from "@server/models/Team";
+
+export function checkPendingMigrations() {
+  const commandResult = execSync("yarn sequelize db:migrate:status");
+  const commandResultArray = Buffer.from(commandResult)
+    .toString("utf-8")
+    .split("\n");
+
+  const pendingMigrations = commandResultArray.filter((line) =>
+    line.startsWith("down")
+  );
+
+  if (pendingMigrations.length) {
+    Logger.warn("You have pending migrations");
+    Logger.warn(
+      pendingMigrations
+        .map((line, i) => `${i + 1}. ${line.replace("down ", "")}`)
+        .join("\n")
+    );
+    Logger.warn(
+      "Please run `yarn sequelize db:migrate` to run all pending migrations"
+    );
+
+    process.exit(1);
+  }
+}
 
 export async function checkMigrations() {
   if (env.DEPLOYMENT === "hosted") {

--- a/server/utils/startup.ts
+++ b/server/utils/startup.ts
@@ -23,7 +23,7 @@ export function checkPendingMigrations() {
         .join("\n")
     );
     Logger.warn(
-      "Please run `yarn sequelize db:migrate` to run all pending migrations"
+      "Please run `yarn db:migrate` or `yarn db:migrate --env production-ssl-disabled` to run all pending migrations"
     );
 
     process.exit(1);


### PR DESCRIPTION
# Description

PR prevents server startup if migrations are outstanding.

## Example

``` shell
[api] info: [email] SMTP_USERNAME not provided, generating test account...
[api] Running Outline in development mode. To run Outline in production [omit]
[api] You have pending migrations
[api] 1. 20220702132722-add-webhooks-deleted-at.js
[api] Please run `yarn sequelize db:migrate` to run all pending migrations
[api] node build/server/index.js --services=collaboration,websockets, [omit]
```

### Applying fix suggested

``` shell
❯ yarn sequelize db:migrate

Sequelize CLI [Node: 16.15.1, CLI: 6.4.1, ORM: 6.20.1]

Loaded configuration file "server/config/database.json".
Using environment "development".
== 20220702132722-add-webhooks-deleted-at: migrating =======
== 20220702132722-add-webhooks-deleted-at: migrated (0.012s)

Done in 0.49s
```

### Successful rerun

``` shell
[api] info: [email] SMTP_USERNAME not provided, generating test account...
[api] info: [lifecycle] Starting collaboration service
[api] info: [lifecycle] Starting websockets service
[api] info: [lifecycle] Starting admin service
[api] info: [lifecycle] Starting web service
[api] info: [lifecycle] Starting worker service
```

### Considerations

`checkPendingMigrations` uses synchronous API unlike its neighbors in `utils/startup.ts`.

This isn't exactly a programmatic approach but since we are using

https://github.com/outline/outline/blob/c6fdffba774086a4a10d9483c4e79abf81b17ed9/Makefile#L4

to run migrations, I think using a programmatic way to detect pending migrations
might diverge similar interfaces, potentially increasing friction. This also avoids
adding additional dependencies.

We could consider side-grading both to programmatic approach in the future.

## Issue

Closes #3704