### PR TITLE
fix: Enter at beginning of collapsed heading

### DIFF
--- a/app/editor/components/Styles.ts
+++ b/app/editor/components/Styles.ts
@@ -405,6 +405,7 @@ const EditorStyles = styled.div<{
     &.collapsed {
       svg {
         transform: rotate(${(props) => (props.rtl ? "90deg" : "-90deg")});
+        pointer-events: none;
       }
       transition-delay: 0.1s;
       opacity: 1;


### PR DESCRIPTION
Should create a new heading of the same type above, currently the cursor disappears into the collapsed heading creating a new, hidden, paragraph.

closes #3753 