### PR TITLE
fix: `svg+xml` image type ext not assigned properly

### DIFF
--- a/shared/editor/nodes/Image.tsx
+++ b/shared/editor/nodes/Image.tsx
@@ -119,7 +119,7 @@ const downloadImageNode = async (node: ProsemirrorNode) => {
   const image = await fetch(node.attrs.src);
   const imageBlob = await image.blob();
   const imageURL = URL.createObjectURL(imageBlob);
-  const extension = imageBlob.type.split("/")[1];
+  const extension = imageBlob.type.split("/")[1].split("+")[0];
   const potentialName = node.attrs.alt || "image";
 
   // create a temporary link node and click it with our image data

--- a/shared/editor/nodes/Image.tsx
+++ b/shared/editor/nodes/Image.tsx
@@ -119,7 +119,7 @@ const downloadImageNode = async (node: ProsemirrorNode) => {
   const image = await fetch(node.attrs.src);
   const imageBlob = await image.blob();
   const imageURL = URL.createObjectURL(imageBlob);
-  const extension = imageBlob.type.split("/")[1].split("+")[0];
+  const extension = imageBlob.type.split(/\/|\+/g)[1];
   const potentialName = node.attrs.alt || "image";
 
   // create a temporary link node and click it with our image data


### PR DESCRIPTION
# Description

`svg+xml` image type wasn't being set properly because

https://github.com/outline/outline/blob/e92d68a0a3328227daabea0d2db2db8f3efbb6d7/shared/editor/nodes/Image.tsx#L122

which uses 

https://github.com/outline/outline/blob/e92d68a0a3328227daabea0d2db2db8f3efbb6d7/shared/utils/files.ts#L26

particularly 

https://github.com/outline/outline/blob/e92d68a0a3328227daabea0d2db2db8f3efbb6d7/shared/utils/files.ts#L36

would apply like 

``` js
"image/svg+xml".split('/')[1]

"svg+xml"
```

PR does this

``` js
"image/svg+xml".split('/')[1].split('+')[0]
"svg"
"image/jpeg".split('/')[1].split('+')[0]
"jpeg"
```

Download link is set here

https://github.com/outline/outline/blob/e92d68a0a3328227daabea0d2db2db8f3efbb6d7/shared/editor/nodes/Image.tsx#L128

# Issue

Closes #3768