### PR TITLE
fix: ToolbarMenu popup on inline code selection

### DIFF
--- a/app/editor/components/SelectionToolbar.tsx
+++ b/app/editor/components/SelectionToolbar.tsx
@@ -1,4 +1,5 @@
 import { some } from "lodash";
+import CodeIcon from "outline-icons/lib/components/CodeIcon";
 import { NodeSelection, TextSelection } from "prosemirror-state";
 import { CellSelection } from "prosemirror-tables";
 import { EditorView } from "prosemirror-view";
@@ -9,7 +10,6 @@ import filterExcessSeparators from "@shared/editor/lib/filterExcessSeparators";
 import getColumnIndex from "@shared/editor/queries/getColumnIndex";
 import getMarkRange from "@shared/editor/queries/getMarkRange";
 import getRowIndex from "@shared/editor/queries/getRowIndex";
-import isInCode from "@shared/editor/queries/isInCode";
 import isMarkActive from "@shared/editor/queries/isMarkActive";
 import isNodeActive from "@shared/editor/queries/isNodeActive";
 import { MenuItem } from "@shared/editor/types";
@@ -182,10 +182,14 @@ export default class SelectionToolbar extends React.Component<Props> {
     const { view } = rest;
     const { state } = view;
     const { selection }: { selection: any } = state;
+    const isCodeSelection = isNodeActive(state.schema.nodes.code_block)(state);
+    const isCodeInlineSelection = isMarkActive(state.schema.marks.code_inline)(
+      state
+    );
     const isDividerSelection = isNodeActive(state.schema.nodes.hr)(state);
 
     // toolbar is disabled in code blocks, no bold / italic etc
-    if (isInCode(state)) {
+    if (isCodeSelection) {
       return null;
     }
 
@@ -199,7 +203,17 @@ export default class SelectionToolbar extends React.Component<Props> {
     const isImageSelection = selection.node?.type?.name === "image";
 
     let items: MenuItem[] = [];
-    if (isTableSelection) {
+    if (isCodeInlineSelection) {
+      const { schema } = state;
+      items = [
+        {
+          name: "code_inline",
+          tooltip: dictionary.codeInline,
+          icon: CodeIcon,
+          active: isMarkActive(schema.marks.code_inline),
+        },
+      ];
+    } else if (isTableSelection) {
       items = getTableMenuItems(dictionary);
     } else if (colIndex !== undefined) {
       items = getTableColMenuItems(state, colIndex, rtl, dictionary);

--- a/app/editor/components/SelectionToolbar.tsx
+++ b/app/editor/components/SelectionToolbar.tsx
@@ -197,9 +197,6 @@ export default class SelectionToolbar extends React.Component<Props> {
     const link = isMarkActive(state.schema.marks.link)(state);
     const range = getMarkRange(selection.$from, state.schema.marks.link);
     const isImageSelection = selection.node?.type?.name === "image";
-    const isCodeInlineSelection = isMarkActive(state.schema.marks.code_inline)(
-      state
-    );
 
     let items: MenuItem[] = [];
     if (isTableSelection) {
@@ -230,12 +227,6 @@ export default class SelectionToolbar extends React.Component<Props> {
     items = filterExcessSeparators(items);
     if (!items.length) {
       return null;
-    }
-
-    // Only "code_inline" option should be visible if
-    // it's an inline code selection.
-    if (isCodeInlineSelection) {
-      items.map((item) => (item.visible = item.name === "code_inline"));
     }
 
     return (

--- a/app/editor/components/SelectionToolbar.tsx
+++ b/app/editor/components/SelectionToolbar.tsx
@@ -1,5 +1,4 @@
 import { some } from "lodash";
-import CodeIcon from "outline-icons/lib/components/CodeIcon";
 import { NodeSelection, TextSelection } from "prosemirror-state";
 import { CellSelection } from "prosemirror-tables";
 import { EditorView } from "prosemirror-view";
@@ -183,9 +182,6 @@ export default class SelectionToolbar extends React.Component<Props> {
     const { state } = view;
     const { selection }: { selection: any } = state;
     const isCodeSelection = isNodeActive(state.schema.nodes.code_block)(state);
-    const isCodeInlineSelection = isMarkActive(state.schema.marks.code_inline)(
-      state
-    );
     const isDividerSelection = isNodeActive(state.schema.nodes.hr)(state);
 
     // toolbar is disabled in code blocks, no bold / italic etc
@@ -201,19 +197,12 @@ export default class SelectionToolbar extends React.Component<Props> {
     const link = isMarkActive(state.schema.marks.link)(state);
     const range = getMarkRange(selection.$from, state.schema.marks.link);
     const isImageSelection = selection.node?.type?.name === "image";
+    const isCodeInlineSelection = isMarkActive(state.schema.marks.code_inline)(
+      state
+    );
 
     let items: MenuItem[] = [];
-    if (isCodeInlineSelection) {
-      const { schema } = state;
-      items = [
-        {
-          name: "code_inline",
-          tooltip: dictionary.codeInline,
-          icon: CodeIcon,
-          active: isMarkActive(schema.marks.code_inline),
-        },
-      ];
-    } else if (isTableSelection) {
+    if (isTableSelection) {
       items = getTableMenuItems(dictionary);
     } else if (colIndex !== undefined) {
       items = getTableColMenuItems(state, colIndex, rtl, dictionary);
@@ -241,6 +230,12 @@ export default class SelectionToolbar extends React.Component<Props> {
     items = filterExcessSeparators(items);
     if (!items.length) {
       return null;
+    }
+
+    // Only "code_inline" option should be visible if
+    // it's an inline code selection.
+    if (isCodeInlineSelection) {
+      items.map((item) => (item.visible = item.name === "code_inline"));
     }
 
     return (

--- a/app/editor/components/SelectionToolbar.tsx
+++ b/app/editor/components/SelectionToolbar.tsx
@@ -9,6 +9,7 @@ import filterExcessSeparators from "@shared/editor/lib/filterExcessSeparators";
 import getColumnIndex from "@shared/editor/queries/getColumnIndex";
 import getMarkRange from "@shared/editor/queries/getMarkRange";
 import getRowIndex from "@shared/editor/queries/getRowIndex";
+import isInCode from "@shared/editor/queries/isInCode";
 import isMarkActive from "@shared/editor/queries/isMarkActive";
 import isNodeActive from "@shared/editor/queries/isNodeActive";
 import { MenuItem } from "@shared/editor/types";
@@ -181,14 +182,10 @@ export default class SelectionToolbar extends React.Component<Props> {
     const { view } = rest;
     const { state } = view;
     const { selection }: { selection: any } = state;
-    const isCodeSelection = isNodeActive(state.schema.nodes.code_block)(state);
-    const isCodeInlineSelection = isMarkActive(state.schema.marks.code_inline)(
-      state
-    );
     const isDividerSelection = isNodeActive(state.schema.nodes.hr)(state);
 
     // toolbar is disabled in code blocks, no bold / italic etc
-    if (isCodeSelection || isCodeInlineSelection) {
+    if (isInCode(state)) {
       return null;
     }
 

--- a/app/editor/components/SelectionToolbar.tsx
+++ b/app/editor/components/SelectionToolbar.tsx
@@ -182,10 +182,13 @@ export default class SelectionToolbar extends React.Component<Props> {
     const { state } = view;
     const { selection }: { selection: any } = state;
     const isCodeSelection = isNodeActive(state.schema.nodes.code_block)(state);
+    const isCodeInlineSelection = isMarkActive(state.schema.marks.code_inline)(
+      state
+    );
     const isDividerSelection = isNodeActive(state.schema.nodes.hr)(state);
 
     // toolbar is disabled in code blocks, no bold / italic etc
-    if (isCodeSelection) {
+    if (isCodeSelection || isCodeInlineSelection) {
       return null;
     }
 

--- a/app/editor/menus/formatting.ts
+++ b/app/editor/menus/formatting.ts
@@ -14,6 +14,7 @@ import {
 } from "outline-icons";
 import { EditorState } from "prosemirror-state";
 import { isInTable } from "prosemirror-tables";
+import isInCode from "@shared/editor/queries/isInCode";
 import isInList from "@shared/editor/queries/isInList";
 import isMarkActive from "@shared/editor/queries/isMarkActive";
 import isNodeActive from "@shared/editor/queries/isNodeActive";
@@ -28,6 +29,7 @@ export default function formattingMenuItems(
   const { schema } = state;
   const isTable = isInTable(state);
   const isList = isInList(state);
+  const isCode = isInCode(state);
   const allowBlocks = !isTable && !isList;
 
   return [
@@ -47,19 +49,21 @@ export default function formattingMenuItems(
       tooltip: dictionary.strong,
       icon: BoldIcon,
       active: isMarkActive(schema.marks.strong),
+      visible: !isCode,
     },
     {
       name: "strikethrough",
       tooltip: dictionary.strikethrough,
       icon: StrikethroughIcon,
       active: isMarkActive(schema.marks.strikethrough),
+      visible: !isCode,
     },
     {
       name: "highlight",
       tooltip: dictionary.mark,
       icon: HighlightIcon,
       active: isMarkActive(schema.marks.highlight),
-      visible: !isTemplate,
+      visible: !isTemplate && !isCode,
     },
     {
       name: "code_inline",
@@ -69,7 +73,7 @@ export default function formattingMenuItems(
     },
     {
       name: "separator",
-      visible: allowBlocks,
+      visible: allowBlocks && !isCode,
     },
     {
       name: "heading",
@@ -77,7 +81,7 @@ export default function formattingMenuItems(
       icon: Heading1Icon,
       active: isNodeActive(schema.nodes.heading, { level: 1 }),
       attrs: { level: 1 },
-      visible: allowBlocks,
+      visible: allowBlocks && !isCode,
     },
     {
       name: "heading",
@@ -85,7 +89,7 @@ export default function formattingMenuItems(
       icon: Heading2Icon,
       active: isNodeActive(schema.nodes.heading, { level: 2 }),
       attrs: { level: 2 },
-      visible: allowBlocks,
+      visible: allowBlocks && !isCode,
     },
     {
       name: "blockquote",
@@ -93,11 +97,11 @@ export default function formattingMenuItems(
       icon: BlockQuoteIcon,
       active: isNodeActive(schema.nodes.blockquote),
       attrs: { level: 2 },
-      visible: allowBlocks,
+      visible: allowBlocks && !isCode,
     },
     {
       name: "separator",
-      visible: allowBlocks || isList,
+      visible: (allowBlocks || isList) && !isCode,
     },
     {
       name: "checkbox_list",
@@ -105,24 +109,25 @@ export default function formattingMenuItems(
       icon: TodoListIcon,
       keywords: "checklist checkbox task",
       active: isNodeActive(schema.nodes.checkbox_list),
-      visible: allowBlocks || isList,
+      visible: (allowBlocks || isList) && !isCode,
     },
     {
       name: "bullet_list",
       tooltip: dictionary.bulletList,
       icon: BulletedListIcon,
       active: isNodeActive(schema.nodes.bullet_list),
-      visible: allowBlocks || isList,
+      visible: (allowBlocks || isList) && !isCode,
     },
     {
       name: "ordered_list",
       tooltip: dictionary.orderedList,
       icon: OrderedListIcon,
       active: isNodeActive(schema.nodes.ordered_list),
-      visible: allowBlocks || isList,
+      visible: (allowBlocks || isList) && !isCode,
     },
     {
       name: "separator",
+      visible: !isCode,
     },
     {
       name: "link",
@@ -130,6 +135,7 @@ export default function formattingMenuItems(
       icon: LinkIcon,
       active: isMarkActive(schema.marks.link),
       attrs: { href: "" },
+      visible: !isCode,
     },
   ];
 }


### PR DESCRIPTION
# Description

This 

https://github.com/outline/outline/blob/e92d68a0a3328227daabea0d2db2db8f3efbb6d7/app/editor/components/SelectionToolbar.tsx#L184

combined with

https://github.com/outline/outline/blob/e92d68a0a3328227daabea0d2db2db8f3efbb6d7/app/editor/components/SelectionToolbar.tsx#L188-L190

takes care of code blocks like

```


```

PR adds check for `inline` code

| Before  | After |
| ------------- | ------------- |
|   ![Screenshot 2022-07-12 at 22-03-42 test - outline-dev-test](https://user-images.githubusercontent.com/58817502/178547014-d2ec8132-1e95-4d55-898a-503e76437c82.png)                |          ![Screenshot 2022-07-12 at 22-17-04 test - outline-dev-test](https://user-images.githubusercontent.com/58817502/178547198-51136b95-df31-4f1b-9646-b67793e9525f.png)       |

# Issue

Mentioned in  #3742