### PR TITLE
Feature: Sync groups from OIDC provider

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -96,6 +96,11 @@ OIDC_USERINFO_URI=
 # Supports any valid JSON path with the JWT payload
 OIDC_USERNAME_CLAIM=preferred_username
 
+# Specify a claim that contains an array of group names.
+# If set, these groups will be created an the user's group
+# membership will be updated on each login.
+OIDC_GROUPS_CLAIM=
+
 # Display name for OIDC authentication
 OIDC_DISPLAY_NAME=OpenID
 

--- a/server/commands/accountProvisioner.ts
+++ b/server/commands/accountProvisioner.ts
@@ -28,7 +28,7 @@ type Props = {
     subdomain: string;
     avatarUrl?: string | null;
   };
-  groups: string[] | undefined;
+  groups?: string[];
   authenticationProvider: {
     name: string;
     providerId: string;

--- a/server/commands/accountProvisioner.ts
+++ b/server/commands/accountProvisioner.ts
@@ -11,7 +11,7 @@ import { APM } from "@server/logging/tracing";
 import { Collection, Team, User } from "@server/models";
 import teamCreator from "./teamCreator";
 import userCreator from "./userCreator";
-import userGroupsUpdater from "./userGroupUpdater.js";
+import userGroupsUpdater from "./userGroupUpdater";
 
 type Props = {
   ip: string;

--- a/server/commands/accountProvisioner.ts
+++ b/server/commands/accountProvisioner.ts
@@ -11,6 +11,7 @@ import { APM } from "@server/logging/tracing";
 import { Collection, Team, User } from "@server/models";
 import teamCreator from "./teamCreator";
 import userCreator from "./userCreator";
+import userGroupsUpdater from "./userGroupUpdater.js";
 
 type Props = {
   ip: string;
@@ -27,6 +28,7 @@ type Props = {
     subdomain: string;
     avatarUrl?: string | null;
   };
+  groups: string[] | undefined;
   authenticationProvider: {
     name: string;
     providerId: string;
@@ -51,6 +53,7 @@ async function accountProvisioner({
   ip,
   user: userParams,
   team: teamParams,
+  groups: groupsParam,
   authenticationProvider: authenticationProviderParams,
   authentication: authenticationParams,
 }: Props): Promise<AccountProvisionerResult> {
@@ -117,6 +120,10 @@ async function accountProvisioner({
       if (provision) {
         await team.provisionFirstCollection(user.id);
       }
+    }
+
+    if (groupsParam) {
+      await userGroupsUpdater(user, groupsParam);
     }
 
     return {

--- a/server/commands/userGroupUpdater.ts
+++ b/server/commands/userGroupUpdater.ts
@@ -1,0 +1,53 @@
+import Group from "@server/models/Group";
+import GroupUser from "@server/models/GroupUser";
+import User from "@server/models/User";
+
+export default async function userGroupsUpdater(
+  user: User,
+  groupNames: string[]
+) {
+  const groups = [];
+  for (const groupName of groupNames) {
+    const group = await Group.findOne({
+      where: {
+        name: groupName,
+      },
+    });
+    if (group) {
+      groups.push(group);
+    } else {
+      const group = await Group.create({
+        name: groupName,
+        // TODO: Who should be the group's creator?
+        teamId: user.teamId,
+        createdById: user.id,
+      });
+      groups.push(group);
+    }
+  }
+  const groupIds = groups.map((group) => group.id);
+
+  const oldGroupUsers = await GroupUser.findAll({
+    where: {
+      userId: user.id,
+      createdById: user.id,
+    },
+  });
+
+  const oldGroupIds = oldGroupUsers.map((groupUser) => groupUser.groupId);
+
+  for (const groupUser of oldGroupUsers) {
+    if (groupIds.indexOf(groupUser.groupId) === -1) {
+      await groupUser.destroy();
+    }
+  }
+  for (const groupId of groupIds) {
+    if (oldGroupIds.indexOf(groupId) === -1) {
+      await GroupUser.create({
+        groupId,
+        userId: user.id,
+        createdById: user.id,
+      });
+    }
+  }
+}

--- a/server/commands/userGroupUpdater.ts
+++ b/server/commands/userGroupUpdater.ts
@@ -30,7 +30,6 @@ export default async function userGroupsUpdater(
   const oldGroupUsers = await GroupUser.findAll({
     where: {
       userId: user.id,
-      createdById: user.id,
     },
   });
 

--- a/server/env.ts
+++ b/server/env.ts
@@ -480,6 +480,15 @@ export class Environment {
     process.env.OIDC_USERNAME_CLAIM ?? "preferred_username";
 
   /**
+   * The OIDC profile field to use for groups claim. If set, this should
+   * contain an array of group names (as strings). The groups will be created
+   * if missing and the user's group memberships will be updated accordingly.
+   */
+  public OIDC_GROUPS_CLAIM = this.toOptionalString(
+    process.env.OIDC_GROUPS_CLAIM
+  );
+
+  /**
    * A space separated list of OIDC scopes to request. Defaults to "openid
    * profile email".
    */

--- a/server/routes/auth/providers/oidc.ts
+++ b/server/routes/auth/providers/oidc.ts
@@ -25,6 +25,7 @@ const providerName = "oidc";
 const OIDC_AUTH_URI = env.OIDC_AUTH_URI || "";
 const OIDC_TOKEN_URI = env.OIDC_TOKEN_URI || "";
 const OIDC_USERINFO_URI = env.OIDC_USERINFO_URI || "";
+const OIDC_GROUPS_CLAIM = env.OIDC_GROUPS_CLAIM;
 
 export const config = {
   name: env.OIDC_DISPLAY_NAME,
@@ -94,6 +95,16 @@ if (env.OIDC_CLIENT_ID && env.OIDC_CLIENT_SECRET) {
           // remove the TLD and form a subdomain from the remaining
           const subdomain = slugifyDomain(domain);
 
+          let groups: undefined | string[];
+          if (OIDC_GROUPS_CLAIM && profile[OIDC_GROUPS_CLAIM]) {
+            if (!Array.isArray(profile[OIDC_GROUPS_CLAIM])) {
+              throw AuthenticationError(
+                "The groups claim in the profile parameter that was returned must be an array."
+              );
+            }
+            groups = (profile[OIDC_GROUPS_CLAIM] as unknown) as string[];
+          }
+
           const result = await accountProvisioner({
             ip: ctx.ip,
             team: {
@@ -115,6 +126,7 @@ if (env.OIDC_CLIENT_ID && env.OIDC_CLIENT_SECRET) {
               name: providerName,
               providerId: domain,
             },
+            groups,
             authentication: {
               providerId: profile.sub,
               accessToken,


### PR DESCRIPTION
This PR implements an optional feature to sync groups from an OIDC provider. I'm using this with Keycloak, which supports a "groups" claim that contains an array of group names.

When setting the `OIDC_GROUPS_CLAIM` environment variable, then on each login, this claim will be interpreted as a list of group names. Missing groups will be created. The user's group membership will be updated (discarding old memberships).

This means that groups can be fully maintained upstream in an SSO/OpenID Connect provider, and changes will be reflected into Outline on each authentication request.

See [this discussion](https://github.com/outline/outline/discussions/3779) for details on how we want to use this.

This might not be finished and I only tested this with Keycloak, but wanted to share early and maybe get feedback.