### PR TITLE
fix: Cursor disappearing behind emoji

### DIFF
--- a/app/editor/components/Styles.ts
+++ b/app/editor/components/Styles.ts
@@ -325,6 +325,20 @@ const EditorStyles = styled.div<{
     }
   }
 
+  /* Prosmirror adds a 'br' tag with class 'ProseMirror-trailingBreak'
+   * to inlined content if they are a leaf node.
+   * It makes sure empty paragraphs take up space and
+   * solves some edge case cursor positioning issues
+   * at the end of a block that in a break or non-editable node.
+   * In this case that works adversarially because of
+   * the way span elements take up space.
+   * This fixes this problem by essentially
+   * 'emulating' a 'span' with a 'div' element.
+   */
+  .emoji {
+    display: inline-block;
+  }
+
   .with-emoji {
     margin-${(props) => (props.rtl ? "right" : "left")}: -1em;
   }

--- a/app/editor/components/Styles.ts
+++ b/app/editor/components/Styles.ts
@@ -325,20 +325,6 @@ const EditorStyles = styled.div<{
     }
   }
 
-  /* Prosmirror adds a 'br' tag with class 'ProseMirror-trailingBreak'
-   * to inlined content if they are a leaf node.
-   * It makes sure empty paragraphs take up space and
-   * solves some edge case cursor positioning issues
-   * at the end of a block, especially in a break or non-editable node.
-   * In this case that works adversarially because of
-   * the way span elements take up space.
-   * This fixes the problem by essentially
-   * 'emulating' a 'span' with a 'div' element.
-   */
-  .emoji {
-    display: inline-block;
-  }
-
   .with-emoji {
     margin-${(props) => (props.rtl ? "right" : "left")}: -1em;
   }

--- a/app/editor/components/Styles.ts
+++ b/app/editor/components/Styles.ts
@@ -329,10 +329,10 @@ const EditorStyles = styled.div<{
    * to inlined content if they are a leaf node.
    * It makes sure empty paragraphs take up space and
    * solves some edge case cursor positioning issues
-   * at the end of a block that in a break or non-editable node.
+   * at the end of a block, especially in a break or non-editable node.
    * In this case that works adversarially because of
    * the way span elements take up space.
-   * This fixes this problem by essentially
+   * This fixes the problem by essentially
    * 'emulating' a 'span' with a 'div' element.
    */
   .emoji {

--- a/shared/editor/nodes/Emoji.tsx
+++ b/shared/editor/nodes/Emoji.tsx
@@ -22,7 +22,7 @@ export default class Emoji extends Node {
     return {
       attrs: {
         style: {
-          default: "",
+          default: "display: inline-block",
         },
         "data-name": {
           default: undefined,
@@ -35,10 +35,11 @@ export default class Emoji extends Node {
       selectable: false,
       parseDOM: [
         {
-          tag: "span.emoji",
+          tag: "div.emoji",
           preserveWhitespace: "full",
           getAttrs: (dom: HTMLDivElement) => ({
             "data-name": dom.dataset.name,
+            style: "display: inline-block",
           }),
         },
       ],
@@ -48,16 +49,17 @@ export default class Emoji extends Node {
             nameToEmoji[node.attrs["data-name"]]
           );
           return [
-            "span",
+            "div",
             {
               class: `emoji ${node.attrs["data-name"]}`,
               "data-name": node.attrs["data-name"],
+              style: "display: inline-block",
             },
             text,
           ];
         }
         const text = document.createTextNode(`:${node.attrs["data-name"]}:`);
-        return ["span", { class: "emoji" }, text];
+        return ["div", { class: "emoji" }, text];
       },
       toPlainText: (node) => nameToEmoji[node.attrs["data-name"]],
     };

--- a/shared/editor/nodes/Emoji.tsx
+++ b/shared/editor/nodes/Emoji.tsx
@@ -35,9 +35,9 @@ export default class Emoji extends Node {
       selectable: false,
       parseDOM: [
         {
-          tag: "div.emoji",
+          tag: "strong.emoji",
           preserveWhitespace: "full",
-          getAttrs: (dom: HTMLDivElement) => ({
+          getAttrs: (dom: HTMLStrongElement) => ({
             "data-name": dom.dataset.name,
           }),
         },
@@ -48,7 +48,7 @@ export default class Emoji extends Node {
             nameToEmoji[node.attrs["data-name"]]
           );
           return [
-            "div",
+            "strong",
             {
               class: `emoji ${node.attrs["data-name"]}`,
               "data-name": node.attrs["data-name"],
@@ -57,7 +57,7 @@ export default class Emoji extends Node {
           ];
         }
         const text = document.createTextNode(`:${node.attrs["data-name"]}:`);
-        return ["div", { class: "emoji" }, text];
+        return ["strong", { class: "emoji" }, text];
       },
       toPlainText: (node) => nameToEmoji[node.attrs["data-name"]],
     };

--- a/shared/editor/nodes/Emoji.tsx
+++ b/shared/editor/nodes/Emoji.tsx
@@ -37,7 +37,7 @@ export default class Emoji extends Node {
         {
           tag: "strong.emoji",
           preserveWhitespace: "full",
-          getAttrs: (dom: HTMLStrongElement) => ({
+          getAttrs: (dom: HTMLElement) => ({
             "data-name": dom.dataset.name,
           }),
         },

--- a/shared/editor/nodes/Emoji.tsx
+++ b/shared/editor/nodes/Emoji.tsx
@@ -22,7 +22,7 @@ export default class Emoji extends Node {
     return {
       attrs: {
         style: {
-          default: "display: inline-block",
+          default: "",
         },
         "data-name": {
           default: undefined,
@@ -39,7 +39,6 @@ export default class Emoji extends Node {
           preserveWhitespace: "full",
           getAttrs: (dom: HTMLDivElement) => ({
             "data-name": dom.dataset.name,
-            style: "display: inline-block",
           }),
         },
       ],
@@ -53,7 +52,6 @@ export default class Emoji extends Node {
             {
               class: `emoji ${node.attrs["data-name"]}`,
               "data-name": node.attrs["data-name"],
-              style: "display: inline-block",
             },
             text,
           ];


### PR DESCRIPTION
# Description

This took _surprisingly long_ to debug, had to go down a very deep and convoluted rabbit hole but finally figured it out!

---

Here's a clip describing the issue (Two parts, bug then solution)

https://user-images.githubusercontent.com/58817502/179033019-18e27163-47a7-4238-967d-3a3da6f312a9.mp4

---

Finding this disappeared cursor becomes a guessing game if there are more than a few emojis in the document. Only way to fix it was clicking around a lot until you see it pop up somewhere.

---

Here are some reference that should explain why that happens.

ProseMirror issue 
- 1241
- 1069
- 472

[Source](https://github.com/ProseMirror/prosemirror-view/blob/089aa9bd8f261d8181782bc5f8c46c5dc5e11a5f/src/viewdesc.js#L1271)
[Solution hint](https://github.com/Patternslib/pat-tiptap/pull/8/files)
[About setting default](https://discuss.prosemirror.net/t/what-is-the-best-way-just-add-some-css-class-attribute-to-specific-node/2148/4)

# Issue
Closes #3603

Issue mentions Firefox but I was able to replicate it on Edge and Chromium.