### PR TITLE
feat: Add button to clear code blocks

### DIFF
--- a/app/hooks/useDictionary.ts
+++ b/app/hooks/useDictionary.ts
@@ -15,6 +15,7 @@ export default function useDictionary() {
       alignRight: t("Align right"),
       bulletList: t("Bulleted list"),
       checkboxList: t("Todo list"),
+      clear: t("Clear"),
       codeBlock: t("Code block"),
       codeCopied: t("Copied to clipboard"),
       codeInline: t("Code"),

--- a/shared/editor/nodes/CodeFence.ts
+++ b/shared/editor/nodes/CodeFence.ts
@@ -114,10 +114,15 @@ export default class CodeFence extends Node {
         },
       ],
       toDOM: (node) => {
-        const button = document.createElement("button");
-        button.innerText = this.options.dictionary.copy;
-        button.type = "button";
-        button.addEventListener("click", this.handleCopyToClipboard);
+        const copyButton = document.createElement("button");
+        copyButton.innerText = this.options.dictionary.copy;
+        copyButton.type = "button";
+        copyButton.addEventListener("click", this.handleCopyToClipboard);
+
+        const removeButton = document.createElement("button");
+        removeButton.innerText = this.options.dictionary.clear;
+        removeButton.type = "button";
+        removeButton.addEventListener("click", this.handleClearFormatting);
 
         const select = document.createElement("select");
         select.addEventListener("change", this.handleLanguageChange);
@@ -125,7 +130,8 @@ export default class CodeFence extends Node {
         const actions = document.createElement("div");
         actions.className = "code-actions";
         actions.appendChild(select);
-        actions.appendChild(button);
+        actions.appendChild(copyButton);
+        actions.appendChild(removeButton);
 
         this.languageOptions.forEach(([key, label]) => {
           const option = document.createElement("option");
@@ -227,6 +233,32 @@ export default class CodeFence extends Node {
       if (node) {
         copy(node.textContent);
         this.options.onShowToast(this.options.dictionary.codeCopied);
+      }
+    }
+  };
+
+  handleClearFormatting = (event: MouseEvent) => {
+    const element = event.currentTarget;
+    if (!(element instanceof HTMLButtonElement)) {
+      return;
+    }
+
+    const { view } = this.editor;
+    const { top, left } = element.getBoundingClientRect();
+    const { tr } = view.state;
+
+    const result = view.posAtCoords({ top, left });
+
+    if (result) {
+      const node = view.state.doc.nodeAt(result.pos);
+      if (node) {
+        const starting = view.state.doc.resolve(result.inside);
+        const transaction = tr.setBlockType(
+          starting.pos,
+          starting.pos + node.nodeSize,
+          view.state.schema.nodes.paragraph
+        );
+        view.dispatch(transaction);
       }
     }
   };

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -197,6 +197,7 @@
   "Align right": "Align right",
   "Bulleted list": "Bulleted list",
   "Todo list": "Task list",
+  "Clear": "Clear",
   "Code block": "Code block",
   "Copied to clipboard": "Copied to clipboard",
   "Code": "Code",


### PR DESCRIPTION
# Description

Issue #3471 describes the problem adequately. 

The gist is, unlike `inline_code` which you can clear by selecting the range and clicking `Code` option from the pop-up menu, code blocks like these

``` rust
#[derive(Debug, Clone, PartialEq)]
pub enum Role {
    Admin,
    User,
    Commander,
}
```
are quite difficult to edit once made.

One option would be to copy the content onto the clipboard via `Copy` button on the top left corner and paste the text content in a new paragraph (doesn't preserve formatting), delete the previous code block and create a new one with the contents on the clipboard. 

PR adds a `Clear` button that will change code block to paragraph (both block type nodes), thus preserving formatting and allowing users to quickly make edits.
![Screenshot](https://user-images.githubusercontent.com/58817502/179219939-8949b54f-fbef-4c0b-84a6-d4e6de06c143.png)


# Issue
Closes #3471