### PR TITLE
feat(editor): Ability to select line in codeblocks

### DIFF
--- a/shared/editor/nodes/CodeFence.ts
+++ b/shared/editor/nodes/CodeFence.ts
@@ -12,6 +12,8 @@ import {
   Selection,
   TextSelection,
   Transaction,
+  Plugin,
+  PluginKey,
 } from "prosemirror-state";
 import refractor from "refractor/core";
 import bash from "refractor/lang/bash";
@@ -283,7 +285,23 @@ export default class CodeFence extends Node {
   };
 
   get plugins() {
-    return [Prism({ name: this.name }), Mermaid({ name: this.name })];
+    return [
+      Prism({ name: this.name }),
+      Mermaid({ name: this.name }),
+      new Plugin({
+        key: new PluginKey("triple-click"),
+        props: {
+          handleDOMEvents: {
+            mousedown(view, event) {
+              const {
+                selection: { $from, $to },
+              } = view.state;
+              return $from.sameParent($to) && event.detail === 3;
+            },
+          },
+        },
+      }),
+    ];
   }
 
   inputRules({ type }: { type: NodeType }) {

--- a/shared/editor/nodes/CodeFence.ts
+++ b/shared/editor/nodes/CodeFence.ts
@@ -296,6 +296,9 @@ export default class CodeFence extends Node {
               const {
                 selection: { $from, $to },
               } = view.state;
+              if (!isInCode(view.state)) {
+                return false;
+              }
               return $from.sameParent($to) && event.detail === 3;
             },
           },


### PR DESCRIPTION
# Description

PR adds ability to select single line by triple clicking in code blocks. Previously a single click will place cursor, two will select a word and three will select entire block. 4th click will then deselect everything and place cursor.

Now single click will display cursor inside the block, double will highlight a word.

4 consecutive clicks will select the entire block.

## Note

These clicks should be roughly even, 3 quick ones and 1 slow will select a line and deselect it at final click.

# Issue 
Closes  #3304