### PR TITLE
fix: Use previous language when creating code block from markdown shortcut

### DIFF
--- a/shared/editor/nodes/CodeFence.ts
+++ b/shared/editor/nodes/CodeFence.ts
@@ -308,7 +308,11 @@ export default class CodeFence extends Node {
   }
 
   inputRules({ type }: { type: NodeType }) {
-    return [textblockTypeInputRule(/^```$/, type)];
+    return [
+      textblockTypeInputRule(/^```$/, type, () => ({
+        language: localStorage?.getItem(PERSISTENCE_KEY) || DEFAULT_LANGUAGE,
+      })),
+    ];
   }
 
   toMarkdown(state: MarkdownSerializerState, node: ProsemirrorNode) {


### PR DESCRIPTION
closes #3825 