### PR TITLE
Fix state cookie login flow for future timezones

### DIFF
--- a/server/utils/passport.ts
+++ b/server/utils/passport.ts
@@ -24,7 +24,7 @@ export class StateStore {
 
     ctx.cookies.set(this.key, state, {
       httpOnly: false,
-      expires: addMinutes(new Date(), 10),
+      maxAge: 1000 * 60 * 10, // 10 minutes in milliseconds
       domain: getCookieDomain(ctx.hostname),
     });
 


### PR DESCRIPTION
Use `maxAge` parameter instead of `expires` for relative expiry times when setting the `state` cookie in oauth login flow.

This fixes #3915