### PR TITLE
Add optional export notifications

### DIFF
--- a/app/scenes/CollectionExport.tsx
+++ b/app/scenes/CollectionExport.tsx
@@ -25,7 +25,9 @@ function CollectionExport({ collection, onSubmit }: Props) {
 
       setIsLoading(false);
       showToast(
-        t("Export started, you will receive an email when it’s complete.")
+        t(
+          "Export started. If you have notifications enabled, you will receive an email when it's complete."
+        )
       );
       onSubmit();
     },

--- a/app/scenes/Settings/Export.tsx
+++ b/app/scenes/Settings/Export.tsx
@@ -56,7 +56,7 @@ function Export() {
       <Heading>{t("Export")}</Heading>
       <Text type="secondary">
         <Trans
-          defaults="A full export might take some time, consider exporting a single document or collection. The exported data is a zip of your documents in Markdown format. You may leave this page once the export has started – we will email a link to <em>{{ userEmail }}</em> when it’s complete."
+          defaults="A full export might take some time, consider exporting a single document or collection. The exported data is a zip of your documents in Markdown format. You may leave this page once the export has started – if you have notifications enabled, we will email a link to <em>{{ userEmail }}</em> when it’s complete."
           values={{
             userEmail: user.email,
           }}

--- a/app/scenes/Settings/Notifications.tsx
+++ b/app/scenes/Settings/Notifications.tsx
@@ -52,6 +52,13 @@ function Notifications() {
       ),
     },
     {
+      event: "emails.export_completed",
+      title: t("Export completed"),
+      description: t(
+        "Receive a notification when an export you requested has been completed"
+      ),
+    },
+    {
       visible: isCloudHosted,
       event: "emails.onboarding",
       title: t("Getting started"),

--- a/server/emails/templates/ExportFailureEmail.tsx
+++ b/server/emails/templates/ExportFailureEmail.tsx
@@ -23,8 +23,8 @@ export default class ExportFailureEmail extends BaseEmail<Props> {
   protected async beforeSend({ userId, teamId }: Props) {
     const notificationSetting = await NotificationSetting.findOne({
       where: {
-        userId: userId,
-        teamId: teamId,
+        userId,
+        teamId,
         event: "emails.export_completed",
       },
     });

--- a/server/emails/templates/ExportFailureEmail.tsx
+++ b/server/emails/templates/ExportFailureEmail.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { NotificationSetting } from "@server/models";
 import BaseEmail from "./BaseEmail";
 import Body from "./components/Body";
 import Button from "./components/Button";
@@ -10,13 +11,27 @@ import Heading from "./components/Heading";
 
 type Props = {
   to: string;
+  userId: string;
   teamUrl: string;
+  teamId: string;
 };
 
 /**
  * Email sent to a user when their data export has failed for some reason.
  */
 export default class ExportFailureEmail extends BaseEmail<Props> {
+  protected async beforeSend({ userId, teamId }: Props) {
+    const notificationSetting = await NotificationSetting.findOne({
+      where: {
+        userId: userId,
+        teamId: teamId,
+        event: "emails.export_completed",
+      },
+    });
+
+    return notificationSetting !== null;
+  }
+
   protected subject() {
     return "Your requested export";
   }

--- a/server/emails/templates/ExportSuccessEmail.tsx
+++ b/server/emails/templates/ExportSuccessEmail.tsx
@@ -25,8 +25,8 @@ export default class ExportSuccessEmail extends BaseEmail<Props> {
   protected async beforeSend({ userId, teamId }: Props) {
     const notificationSetting = await NotificationSetting.findOne({
       where: {
-        userId: userId,
-        teamId: teamId,
+        userId,
+        teamId,
         event: "emails.export_completed",
       },
     });

--- a/server/emails/templates/ExportSuccessEmail.tsx
+++ b/server/emails/templates/ExportSuccessEmail.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { NotificationSetting } from "@server/models";
 import BaseEmail from "./BaseEmail";
 import Body from "./components/Body";
 import Button from "./components/Button";
@@ -10,8 +11,10 @@ import Heading from "./components/Heading";
 
 type Props = {
   to: string;
+  userId: string;
   id: string;
   teamUrl: string;
+  teamId: string;
 };
 
 /**
@@ -19,6 +22,18 @@ type Props = {
  * for download in the settings section.
  */
 export default class ExportSuccessEmail extends BaseEmail<Props> {
+  protected async beforeSend({ userId, teamId }: Props) {
+    const notificationSetting = await NotificationSetting.findOne({
+      where: {
+        userId: userId,
+        teamId: teamId,
+        event: "emails.export_completed",
+      },
+    });
+
+    return notificationSetting !== null;
+  }
+
   protected subject() {
     return "Your requested export";
   }

--- a/server/models/NotificationSetting.ts
+++ b/server/models/NotificationSetting.ts
@@ -41,6 +41,7 @@ class NotificationSetting extends Model {
       "emails.invite_accepted",
       "emails.onboarding",
       "emails.features",
+      "emails.export_completed",
     ],
   ])
   @Column(DataType.STRING)

--- a/server/models/User.ts
+++ b/server/models/User.ts
@@ -497,7 +497,8 @@ class User extends ParanoidModel {
   };
 
   // By default when a user signs up we subscribe them to email notifications
-  // when documents they created are edited by other team members and onboarding
+  // when documents they created are edited by other team members, onboarding
+  // and when an export they requested has been completed.
   @AfterCreate
   static subscribeToNotifications = async (
     model: User,
@@ -533,6 +534,14 @@ class User extends ParanoidModel {
           userId: model.id,
           teamId: model.teamId,
           event: "emails.invite_accepted",
+        },
+        transaction: options.transaction,
+      }),
+      NotificationSetting.findOrCreate({
+        where: {
+          userId: model.id,
+          teamId: model.teamId,
+          event: "emails.export_completed",
         },
         transaction: options.transaction,
       }),

--- a/server/models/User.ts
+++ b/server/models/User.ts
@@ -497,8 +497,9 @@ class User extends ParanoidModel {
   };
 
   // By default when a user signs up we subscribe them to email notifications
-  // when documents they created are edited by other team members, onboarding
-  // and when an export they requested has been completed.
+  // when documents they created are edited by other team members and onboarding.
+  // If the user is an admin, they will also be subscribed to export_completed
+  // notifications.
   @AfterCreate
   static subscribeToNotifications = async (
     model: User,
@@ -537,15 +538,18 @@ class User extends ParanoidModel {
         },
         transaction: options.transaction,
       }),
-      NotificationSetting.findOrCreate({
+    ]);
+
+    if (model.isAdmin) {
+      await NotificationSetting.findOrCreate({
         where: {
           userId: model.id,
           teamId: model.teamId,
           event: "emails.export_completed",
         },
         transaction: options.transaction,
-      }),
-    ]);
+      });
+    }
   };
 
   static getCounts = async function (teamId: string) {

--- a/server/queues/tasks/ExportMarkdownZipTask.ts
+++ b/server/queues/tasks/ExportMarkdownZipTask.ts
@@ -3,14 +3,7 @@ import { truncate } from "lodash";
 import ExportFailureEmail from "@server/emails/templates/ExportFailureEmail";
 import ExportSuccessEmail from "@server/emails/templates/ExportSuccessEmail";
 import Logger from "@server/logging/Logger";
-import {
-  Collection,
-  Event,
-  FileOperation,
-  Team,
-  User,
-  NotificationSetting,
-} from "@server/models";
+import { Collection, Event, FileOperation, Team, User } from "@server/models";
 import { FileOperationState } from "@server/models/FileOperation";
 import fileOperationPresenter from "@server/presenters/fileOperation";
 import { uploadToS3FromBuffer } from "@server/utils/s3";
@@ -36,16 +29,6 @@ export default class ExportMarkdownZipTask extends BaseTask<Props> {
       Team.findByPk(fileOperation.teamId, { rejectOnEmpty: true }),
       User.findByPk(fileOperation.userId, { rejectOnEmpty: true }),
     ]);
-
-    const notificationSetting = await NotificationSetting.findOne({
-      where: {
-        userId: fileOperation.userId,
-        teamId: fileOperation.teamId,
-        event: "emails.export_completed",
-      },
-    });
-
-    const sendEmail = notificationSetting !== null;
 
     const collectionIds = fileOperation.collectionId
       ? [fileOperation.collectionId]
@@ -87,24 +70,24 @@ export default class ExportMarkdownZipTask extends BaseTask<Props> {
         url,
       });
 
-      if (sendEmail) {
-        await ExportSuccessEmail.schedule({
-          to: user.email,
-          id: fileOperation.id,
-          teamUrl: team.url,
-        });
-      }
+      await ExportSuccessEmail.schedule({
+        to: user.email,
+        userId: user.id,
+        id: fileOperation.id,
+        teamUrl: team.url,
+        teamId: team.id,
+      });
     } catch (error) {
       await this.updateFileOperation(fileOperation, {
         state: FileOperationState.Error,
         error,
       });
-      if (sendEmail) {
-        await ExportFailureEmail.schedule({
-          to: user.email,
-          teamUrl: team.url,
-        });
-      }
+      await ExportFailureEmail.schedule({
+        to: user.email,
+        userId: user.id,
+        teamUrl: team.url,
+        teamId: team.id,
+      });
       throw error;
     }
   }

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -343,7 +343,7 @@
   "Sort": "Sort",
   "Saving": "Saving",
   "Save": "Save",
-  "Export started, you will receive an email when it’s complete.": "Export started, you will receive an email when it’s complete.",
+  "Export started. If you have notifications enabled, you will receive an email when it's complete.": "Export started. If you have notifications enabled, you will receive an email when it's complete.",
   "Exporting the collection <em>{{collectionName}}</em> may take a few seconds. Your documents will be a zip of folders with files in Markdown format. Please visit the Export section on settings to get the zip.": "Exporting the collection <em>{{collectionName}}</em> may take a few seconds. Your documents will be a zip of folders with files in Markdown format. Please visit the Export section on settings to get the zip.",
   "Exporting": "Exporting",
   "Export Collection": "Export Collection",

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -650,6 +650,8 @@
   "Receive a notification whenever a new collection is created": "Receive a notification whenever a new collection is created",
   "Invite accepted": "Invite accepted",
   "Receive a notification when someone you invited creates an account": "Receive a notification when someone you invited creates an account",
+  "Export completed": "Export completed",
+  "Receive a notification when an export you requested has been completed": "Receive a notification when an export you requested has been completed",
   "Getting started": "Getting started",
   "Tips on getting started with Outline’s features and functionality": "Tips on getting started with Outline’s features and functionality",
   "New features": "New features",

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -620,7 +620,7 @@
   "This is the screen that team members will first see when they sign in.": "This is the screen that team members will first see when they sign in.",
   "Export in progress…": "Export in progress…",
   "Export deleted": "Export deleted",
-  "A full export might take some time, consider exporting a single document or collection. The exported data is a zip of your documents in Markdown format. You may leave this page once the export has started – we will email a link to <em>{{ userEmail }}</em> when it’s complete.": "A full export might take some time, consider exporting a single document or collection. The exported data is a zip of your documents in Markdown format. You may leave this page once the export has started – we will email a link to <em>{{ userEmail }}</em> when it’s complete.",
+  "A full export might take some time, consider exporting a single document or collection. The exported data is a zip of your documents in Markdown format. You may leave this page once the export has started – if you have notifications enabled, we will email a link to <em>{{ userEmail }}</em> when it’s complete.": "A full export might take some time, consider exporting a single document or collection. The exported data is a zip of your documents in Markdown format. You may leave this page once the export has started – if you have notifications enabled, we will email a link to <em>{{ userEmail }}</em> when it’s complete.",
   "Export Requested": "Export Requested",
   "Requesting Export": "Requesting Export",
   "Export Data": "Export Data",


### PR DESCRIPTION
See: #3934

This adds a notification event called `emails.export_completed`. When a user is subscribed to this event, both success and failure emails can be sent when an export they requested is completed. Neither can be sent if the user is not subscribed to the event.

A toggle has been added to the notifications settings page for `emails.export_completed`. New users are automatically subscribed to this event when their accounts are created.

The secondary text on the export page in settings has been updated to reference how email notifications are optional, as has the toast shown when exporting a collection.

:)