### PR TITLE
perf: reduce memory usage upon running server tests

### DIFF
--- a/.jestconfig.json
+++ b/.jestconfig.json
@@ -15,7 +15,8 @@
         "<rootDir>/server/test/setup.ts"
       ],
       "testEnvironment": "node",
-      "runner": "@getoutline/jest-runner-serial"
+      "runner": "@getoutline/jest-runner-serial",
+      "detectLeaks": true
     },
     {
       "displayName": "app",

--- a/.jestconfig.json
+++ b/.jestconfig.json
@@ -57,6 +57,9 @@
       "setupFiles": [
         "<rootDir>/__mocks__/console.js"
       ],
+      "setupFilesAfterEnv": [
+        "<rootDir>/shared/test/setup.ts"
+      ],
       "testEnvironment": "node"
     },
     {

--- a/server/commands/accountProvisioner.test.ts
+++ b/server/commands/accountProvisioner.test.ts
@@ -4,12 +4,14 @@ import { TeamDomain } from "@server/models";
 import Collection from "@server/models/Collection";
 import UserAuthentication from "@server/models/UserAuthentication";
 import { buildUser, buildTeam } from "@server/test/factories";
-import { flushdb, seed } from "@server/test/support";
+import { getTestDatabase, seed } from "@server/test/support";
 import accountProvisioner from "./accountProvisioner";
 
-beforeEach(() => {
-  return flushdb();
-});
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
 
 describe("accountProvisioner", () => {
   const ip = "127.0.0.1";

--- a/server/commands/documentImporter.test.ts
+++ b/server/commands/documentImporter.test.ts
@@ -2,11 +2,16 @@ import path from "path";
 import fs from "fs-extra";
 import Attachment from "@server/models/Attachment";
 import { buildUser } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import documentImporter from "./documentImporter";
 
 jest.mock("../utils/s3");
-beforeEach(() => flushdb());
+
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
 
 describe("documentImporter", () => {
   const ip = "127.0.0.1";

--- a/server/commands/documentMover.test.ts
+++ b/server/commands/documentMover.test.ts
@@ -5,10 +5,14 @@ import {
   buildCollection,
   buildUser,
 } from "@server/test/factories";
-import { flushdb, seed } from "@server/test/support";
+import { getTestDatabase, seed } from "@server/test/support";
 import documentMover from "./documentMover";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
 
 describe("documentMover", () => {
   const ip = "127.0.0.1";

--- a/server/commands/documentPermanentDeleter.test.ts
+++ b/server/commands/documentPermanentDeleter.test.ts
@@ -1,10 +1,14 @@
 import { subDays } from "date-fns";
 import { Attachment, Document } from "@server/models";
 import { buildAttachment, buildDocument } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import documentPermanentDeleter from "./documentPermanentDeleter";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
 
 describe("documentPermanentDeleter", () => {
   it("should destroy documents", async () => {

--- a/server/commands/documentUpdater.test.ts
+++ b/server/commands/documentUpdater.test.ts
@@ -1,10 +1,14 @@
 import { sequelize } from "@server/database/sequelize";
 import { Event } from "@server/models";
 import { buildDocument, buildUser } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import documentUpdater from "./documentUpdater";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
 
 describe("documentUpdater", () => {
   const ip = "127.0.0.1";

--- a/server/commands/fileOperationDeleter.test.ts
+++ b/server/commands/fileOperationDeleter.test.ts
@@ -1,9 +1,13 @@
 import { FileOperation } from "@server/models";
 import { buildAdmin, buildFileOperation } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import fileOperationDeleter from "./fileOperationDeleter";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
 
 describe("fileOperationDeleter", () => {
   const ip = "127.0.0.1";

--- a/server/commands/pinCreator.test.ts
+++ b/server/commands/pinCreator.test.ts
@@ -1,9 +1,14 @@
 import { Event } from "@server/models";
 import { buildDocument, buildUser } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import pinCreator from "./pinCreator";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
+
 describe("pinCreator", () => {
   const ip = "127.0.0.1";
 

--- a/server/commands/pinDestroyer.test.ts
+++ b/server/commands/pinDestroyer.test.ts
@@ -1,9 +1,14 @@
 import { Pin, Event } from "@server/models";
 import { buildDocument, buildUser } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import pinDestroyer from "./pinDestroyer";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
+
 describe("pinCreator", () => {
   const ip = "127.0.0.1";
 

--- a/server/commands/revisionCreator.test.ts
+++ b/server/commands/revisionCreator.test.ts
@@ -1,9 +1,13 @@
 import { Event } from "@server/models";
 import { buildDocument, buildUser } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import revisionCreator from "./revisionCreator";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
 
 describe("revisionCreator", () => {
   const ip = "127.0.0.1";

--- a/server/commands/starCreator.test.ts
+++ b/server/commands/starCreator.test.ts
@@ -1,10 +1,15 @@
 import { sequelize } from "@server/database/sequelize";
 import { Star, Event } from "@server/models";
 import { buildDocument, buildUser } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import starCreator from "./starCreator";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
+
 describe("starCreator", () => {
   const ip = "127.0.0.1";
 

--- a/server/commands/starDestroyer.test.ts
+++ b/server/commands/starDestroyer.test.ts
@@ -1,9 +1,13 @@
 import { Star, Event } from "@server/models";
 import { buildDocument, buildUser } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import starDestroyer from "./starDestroyer";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
 
 describe("starDestroyer", () => {
   const ip = "127.0.0.1";

--- a/server/commands/starUpdater.test.ts
+++ b/server/commands/starUpdater.test.ts
@@ -1,9 +1,13 @@
 import { Star, Event } from "@server/models";
 import { buildDocument, buildUser } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import starUpdater from "./starUpdater";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
 
 describe("starUpdater", () => {
   const ip = "127.0.0.1";

--- a/server/commands/teamPermanentDeleter.test.ts
+++ b/server/commands/teamPermanentDeleter.test.ts
@@ -6,10 +6,14 @@ import {
   buildTeam,
   buildDocument,
 } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import teamPermanentDeleter from "./teamPermanentDeleter";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
 
 describe("teamPermanentDeleter", () => {
   it("should destroy related data", async () => {

--- a/server/commands/teamProvisioner.test.ts
+++ b/server/commands/teamProvisioner.test.ts
@@ -1,10 +1,14 @@
 import env from "@server/env";
 import TeamDomain from "@server/models/TeamDomain";
 import { buildTeam, buildUser } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import teamProvisioner from "./teamProvisioner";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
 
 describe("teamProvisioner", () => {
   const ip = "127.0.0.1";

--- a/server/commands/userDestroyer.test.ts
+++ b/server/commands/userDestroyer.test.ts
@@ -1,8 +1,12 @@
 import { buildUser, buildAdmin } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import userDestroyer from "./userDestroyer";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
 
 describe("userDestroyer", () => {
   const ip = "127.0.0.1";

--- a/server/commands/userInviter.test.ts
+++ b/server/commands/userInviter.test.ts
@@ -1,8 +1,12 @@
 import { buildUser } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import userInviter from "./userInviter";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
 
 describe("userInviter", () => {
   const ip = "127.0.0.1";

--- a/server/commands/userProvisioner.test.ts
+++ b/server/commands/userProvisioner.test.ts
@@ -1,10 +1,14 @@
 import { v4 as uuidv4 } from "uuid";
 import { TeamDomain } from "@server/models";
 import { buildUser, buildTeam, buildInvite } from "@server/test/factories";
-import { flushdb, seed } from "@server/test/support";
+import { getTestDatabase, seed } from "@server/test/support";
 import userProvisioner from "./userProvisioner";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
 
 describe("userProvisioner", () => {
   const ip = "127.0.0.1";

--- a/server/commands/userSuspender.test.ts
+++ b/server/commands/userSuspender.test.ts
@@ -1,9 +1,13 @@
 import GroupUser from "@server/models/GroupUser";
 import { buildGroup, buildAdmin, buildUser } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import userSuspender from "./userSuspender";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
 
 describe("userSuspender", () => {
   const ip = "127.0.0.1";

--- a/server/middlewares/authentication.test.ts
+++ b/server/middlewares/authentication.test.ts
@@ -1,10 +1,14 @@
 import randomstring from "randomstring";
 import ApiKey from "@server/models/ApiKey";
 import { buildUser, buildTeam } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import auth from "./authentication";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
 
 describe("Authentication middleware", () => {
   describe("with JWT", () => {

--- a/server/models/Collection.test.ts
+++ b/server/models/Collection.test.ts
@@ -7,13 +7,19 @@ import {
   buildTeam,
   buildDocument,
 } from "@server/test/factories";
-import { flushdb, seed } from "@server/test/support";
+import { getTestDatabase, seed } from "@server/test/support";
 import slugify from "@server/utils/slugify";
 import Collection from "./Collection";
 import Document from "./Document";
 
-beforeEach(() => flushdb());
-beforeEach(jest.resetAllMocks);
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(async () => {
+  await db.flush();
+  jest.resetAllMocks();
+});
 
 describe("#url", () => {
   test("should return correct url for the collection", () => {

--- a/server/models/Document.test.ts
+++ b/server/models/Document.test.ts
@@ -6,11 +6,17 @@ import {
   buildUser,
   buildShare,
 } from "@server/test/factories";
-import { flushdb, seed } from "@server/test/support";
+import { getTestDatabase, seed } from "@server/test/support";
 import slugify from "@server/utils/slugify";
 
-beforeEach(() => flushdb());
-beforeEach(jest.resetAllMocks);
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(async () => {
+  await db.flush();
+  jest.resetAllMocks();
+});
 
 describe("#getSummary", () => {
   test("should strip markdown", async () => {

--- a/server/models/Group.test.ts
+++ b/server/models/Group.test.ts
@@ -1,10 +1,16 @@
 import { buildUser, buildGroup, buildCollection } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import CollectionGroup from "./CollectionGroup";
 import GroupUser from "./GroupUser";
 
-beforeEach(() => flushdb());
-beforeEach(jest.resetAllMocks);
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(async () => {
+  await db.flush();
+  jest.resetAllMocks();
+});
 
 describe("afterDestroy hook", () => {
   test("should destroy associated group and collection join relations", async () => {

--- a/server/models/Revision.test.ts
+++ b/server/models/Revision.test.ts
@@ -1,9 +1,15 @@
 import { buildDocument } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import Revision from "./Revision";
 
-beforeEach(() => flushdb());
-beforeEach(jest.resetAllMocks);
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(() => {
+  db.flush();
+  jest.resetAllMocks();
+});
 
 describe("#findLatest", () => {
   test("should return latest revision", async () => {

--- a/server/models/Revision.test.ts
+++ b/server/models/Revision.test.ts
@@ -6,8 +6,8 @@ const db = getTestDatabase();
 
 afterAll(db.disconnect);
 
-beforeEach(() => {
-  db.flush();
+beforeEach(async () => {
+  await db.flush();
   jest.resetAllMocks();
 });
 

--- a/server/models/Team.test.ts
+++ b/server/models/Team.test.ts
@@ -1,7 +1,14 @@
 import { buildTeam, buildCollection } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(() => {
+  db.flush();
+  jest.resetAllMocks();
+});
 
 describe("collectionIds", () => {
   it("should return non-private collection ids", async () => {

--- a/server/models/Team.test.ts
+++ b/server/models/Team.test.ts
@@ -5,8 +5,8 @@ const db = getTestDatabase();
 
 afterAll(db.disconnect);
 
-beforeEach(() => {
-  db.flush();
+beforeEach(async () => {
+  await db.flush();
   jest.resetAllMocks();
 });
 

--- a/server/models/TeamDomain.test.ts
+++ b/server/models/TeamDomain.test.ts
@@ -6,8 +6,8 @@ const db = getTestDatabase();
 
 afterAll(db.disconnect);
 
-beforeEach(() => {
-  db.flush();
+beforeEach(async () => {
+  await db.flush();
   jest.resetAllMocks();
 });
 

--- a/server/models/TeamDomain.test.ts
+++ b/server/models/TeamDomain.test.ts
@@ -1,8 +1,15 @@
 import { buildAdmin, buildTeam } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import TeamDomain from "./TeamDomain";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(() => {
+  db.flush();
+  jest.resetAllMocks();
+});
 
 describe("team domain model", () => {
   describe("create", () => {

--- a/server/models/User.test.ts
+++ b/server/models/User.test.ts
@@ -1,15 +1,20 @@
 import { buildUser, buildTeam, buildCollection } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import CollectionUser from "./CollectionUser";
 import UserAuthentication from "./UserAuthentication";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
 beforeAll(() => {
   jest.useFakeTimers().setSystemTime(new Date("2018-01-02T00:00:00.000Z"));
 });
+
 afterAll(() => {
   jest.useRealTimers();
+  db.disconnect();
 });
+
+beforeEach(db.flush);
 
 describe("user model", () => {
   describe("destroy", () => {

--- a/server/policies/collection.test.ts
+++ b/server/policies/collection.test.ts
@@ -1,9 +1,13 @@
 import { CollectionUser, Collection } from "@server/models";
 import { buildUser, buildTeam, buildCollection } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import { serialize } from "./index";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
 
 describe("read_write permission", () => {
   it("should allow read write permissions for team member", async () => {

--- a/server/policies/document.test.ts
+++ b/server/policies/document.test.ts
@@ -4,10 +4,14 @@ import {
   buildDocument,
   buildCollection,
 } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import { serialize } from "./index";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
 
 describe("read_write collection", () => {
   it("should allow read write permissions for team member", async () => {

--- a/server/policies/index.test.ts
+++ b/server/policies/index.test.ts
@@ -1,8 +1,12 @@
 import { buildUser, buildTeam } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import { serialize } from "./index";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
 
 it("should serialize policy", async () => {
   const user = await buildUser();

--- a/server/policies/team.test.ts
+++ b/server/policies/team.test.ts
@@ -1,8 +1,13 @@
 import { buildUser, buildTeam, buildAdmin } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import { serialize } from "./index";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
+
 it("should allow reading only", async () => {
   const team = await buildTeam();
   const user = await buildUser({

--- a/server/queues/processors/BacklinksProcessor.test.ts
+++ b/server/queues/processors/BacklinksProcessor.test.ts
@@ -1,12 +1,18 @@
 import { Backlink } from "@server/models";
 import { buildDocument } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import BacklinksProcessor from "./BacklinksProcessor";
 
 const ip = "127.0.0.1";
 
-beforeEach(() => flushdb());
-beforeEach(jest.resetAllMocks);
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(async () => {
+  await db.flush();
+  jest.resetAllMocks();
+});
 
 describe("documents.publish", () => {
   test("should create new backlink records", async () => {
@@ -161,7 +167,7 @@ describe("documents.update", () => {
       ip,
     });
     document.text = `First link is gone
-    
+
 [this is a another link](${yetAnotherDocument.url})`;
     await document.save();
 

--- a/server/queues/processors/NotificationsProcessor.test.ts
+++ b/server/queues/processors/NotificationsProcessor.test.ts
@@ -5,14 +5,20 @@ import {
   buildCollection,
   buildUser,
 } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import NotificationsProcessor from "./NotificationsProcessor";
 
 jest.mock("@server/emails/templates/DocumentNotificationEmail");
 const ip = "127.0.0.1";
 
-beforeEach(() => flushdb());
-beforeEach(jest.resetAllMocks);
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(async () => {
+  await db.flush();
+  jest.resetAllMocks();
+});
 
 describe("documents.publish", () => {
   test("should not send a notification to author", async () => {

--- a/server/queues/processors/RevisionsProcessor.test.ts
+++ b/server/queues/processors/RevisionsProcessor.test.ts
@@ -1,12 +1,18 @@
 import { Revision } from "@server/models";
 import { buildDocument } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import RevisionsProcessor from "./RevisionsProcessor";
 
 const ip = "127.0.0.1";
 
-beforeEach(() => flushdb());
-beforeEach(jest.resetAllMocks);
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(async () => {
+  await db.flush();
+  jest.resetAllMocks();
+});
 
 describe("documents.update.debounced", () => {
   test("should create a revision", async () => {

--- a/server/queues/processors/WebhookProcessor.test.ts
+++ b/server/queues/processors/WebhookProcessor.test.ts
@@ -1,17 +1,20 @@
 import { buildUser, buildWebhookSubscription } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import { UserEvent } from "@server/types";
 import DeliverWebhookTask from "../tasks/DeliverWebhookTask";
 import WebhookProcessor from "./WebhookProcessor";
 
 jest.mock("@server/queues/tasks/DeliverWebhookTask");
+const ip = "127.0.0.1";
 
-beforeEach(() => flushdb());
-beforeEach(() => {
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(async () => {
+  await db.flush();
   jest.resetAllMocks();
 });
-
-const ip = "127.0.0.1";
 
 describe("WebhookProcessor", () => {
   test("it schedules a delivery for the event", async () => {

--- a/server/queues/tasks/CleanupDeletedDocumentsTask.test.ts
+++ b/server/queues/tasks/CleanupDeletedDocumentsTask.test.ts
@@ -1,10 +1,14 @@
 import { subDays } from "date-fns";
 import { Document } from "@server/models";
 import { buildDocument } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import CleanupDeletedDocumentsTask from "./CleanupDeletedDocumentsTask";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
 
 describe("CleanupDeletedDocumentsTask", () => {
   it("should not destroy documents not deleted", async () => {

--- a/server/queues/tasks/CleanupDemotedUserTask.test.ts
+++ b/server/queues/tasks/CleanupDemotedUserTask.test.ts
@@ -6,10 +6,14 @@ import {
   buildWebhookSubscription,
   buildViewer,
 } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import CleanupDemotedUserTask from "./CleanupDemotedUserTask";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
 
 describe("CleanupDemotedUserTask", () => {
   it("should delete api keys for suspended user", async () => {

--- a/server/queues/tasks/CleanupExpiredFileOperationsTask.test.ts
+++ b/server/queues/tasks/CleanupExpiredFileOperationsTask.test.ts
@@ -5,10 +5,14 @@ import {
   FileOperationType,
 } from "@server/models/FileOperation";
 import { buildFileOperation } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import CleanupExpiredFileOperationsTask from "./CleanupExpiredFileOperationsTask";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
 
 describe("CleanupExpiredFileOperationsTask", () => {
   it("should expire exports older than 15 days ago", async () => {

--- a/server/queues/tasks/CleanupWebhookDeliveriesTask.test.ts
+++ b/server/queues/tasks/CleanupWebhookDeliveriesTask.test.ts
@@ -1,10 +1,14 @@
 import { subDays } from "date-fns";
 import { WebhookDelivery } from "@server/models";
 import { buildWebhookDelivery } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import CleanupWebhookDeliveriesTask from "./CleanupWebhookDeliveriesTask";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
 
 const deliveryExists = async (delivery: WebhookDelivery) => {
   const results = await WebhookDelivery.findOne({ where: { id: delivery.id } });

--- a/server/queues/tasks/DeliverWebhookTask.test.ts
+++ b/server/queues/tasks/DeliverWebhookTask.test.ts
@@ -6,12 +6,16 @@ import {
   buildWebhookDelivery,
   buildWebhookSubscription,
 } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import { UserEvent } from "@server/types";
 import DeliverWebhookTask from "./DeliverWebhookTask";
 
-beforeEach(() => flushdb());
-beforeEach(() => {
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(async () => {
+  await db.flush();
   jest.resetAllMocks();
   fetchMock.resetMocks();
   fetchMock.doMock();

--- a/server/queues/tasks/ImportMarkdownZipTask.test.ts
+++ b/server/queues/tasks/ImportMarkdownZipTask.test.ts
@@ -2,10 +2,14 @@ import fs from "fs";
 import path from "path";
 import { FileOperation } from "@server/models";
 import { buildFileOperation } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import ImportMarkdownZipTask from "./ImportMarkdownZipTask";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
 
 describe("ImportMarkdownZipTask", () => {
   it("should import the documents, attachments", async () => {

--- a/server/queues/tasks/ImportNotionTask.test.ts
+++ b/server/queues/tasks/ImportNotionTask.test.ts
@@ -2,10 +2,14 @@ import fs from "fs";
 import path from "path";
 import { FileOperation } from "@server/models";
 import { buildFileOperation } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import ImportNotionTask from "./ImportNotionTask";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
 
 describe("ImportNotionTask", () => {
   it("should import successfully from a Markdown export", async () => {

--- a/server/queues/tasks/InviteReminderTask.test.ts
+++ b/server/queues/tasks/InviteReminderTask.test.ts
@@ -1,10 +1,14 @@
 import { subDays } from "date-fns";
 import InviteReminderEmail from "@server/emails/templates/InviteReminderEmail";
 import { buildInvite } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import InviteReminderTask from "./InviteReminderTask";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
 
 describe("InviteReminderTask", () => {
   it("should not destroy documents not deleted", async () => {

--- a/server/routes/api/attachments.test.ts
+++ b/server/routes/api/attachments.test.ts
@@ -6,13 +6,16 @@ import {
   buildAttachment,
   buildDocument,
 } from "@server/test/factories";
-import { flushdb, getTestServer } from "@server/test/support";
-
-const server = getTestServer();
+import { getTestDatabase, getTestServer } from "@server/test/support";
 
 jest.mock("@server/utils/s3");
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+const server = getTestServer();
+
+afterAll(server.disconnect);
+
+beforeEach(db.flush);
 
 describe("#attachments.create", () => {
   it("should require authentication", async () => {

--- a/server/routes/api/auth.test.ts
+++ b/server/routes/api/auth.test.ts
@@ -1,10 +1,14 @@
 import sharedEnv from "@shared/env";
 import env from "@server/env";
 import { buildUser, buildTeam } from "@server/test/factories";
-import { flushdb, getTestServer } from "@server/test/support";
+import { getTestDatabase, getTestServer } from "@server/test/support";
 
+const db = getTestDatabase();
 const server = getTestServer();
-beforeEach(() => flushdb());
+
+afterAll(server.disconnect);
+
+beforeEach(db.flush);
 
 describe("#auth.info", () => {
   it("should return current authentication", async () => {

--- a/server/routes/api/authenticationProviders.test.ts
+++ b/server/routes/api/authenticationProviders.test.ts
@@ -1,10 +1,13 @@
 import { v4 as uuidv4 } from "uuid";
 import { buildUser, buildAdmin, buildTeam } from "@server/test/factories";
-import { flushdb, getTestServer } from "@server/test/support";
+import { getTestDatabase, getTestServer } from "@server/test/support";
 
+const db = getTestDatabase();
 const server = getTestServer();
 
-beforeEach(() => flushdb());
+afterAll(server.disconnect);
+
+beforeEach(db.flush);
 
 describe("#authenticationProviders.info", () => {
   it("should return auth provider", async () => {

--- a/server/routes/api/collections.test.ts
+++ b/server/routes/api/collections.test.ts
@@ -7,10 +7,14 @@ import {
   buildCollection,
   buildDocument,
 } from "@server/test/factories";
-import { flushdb, seed, getTestServer } from "@server/test/support";
+import { seed, getTestDatabase, getTestServer } from "@server/test/support";
 
+const db = getTestDatabase();
 const server = getTestServer();
-beforeEach(() => flushdb());
+
+afterAll(server.disconnect);
+
+beforeEach(db.flush);
 
 describe("#collections.list", () => {
   it("should require authentication", async () => {

--- a/server/routes/api/cron.test.ts
+++ b/server/routes/api/cron.test.ts
@@ -1,8 +1,11 @@
-import { flushdb, getTestServer } from "@server/test/support";
+import { getTestDatabase, getTestServer } from "@server/test/support";
 
+const db = getTestDatabase();
 const server = getTestServer();
 
-beforeEach(() => flushdb());
+afterAll(server.disconnect);
+
+beforeEach(db.flush);
 
 describe("#cron.daily", () => {
   it("should require authentication", async () => {

--- a/server/routes/api/documents.test.ts
+++ b/server/routes/api/documents.test.ts
@@ -15,9 +15,15 @@ import {
   buildDocument,
   buildViewer,
 } from "@server/test/factories";
-import { flushdb, seed, getTestServer } from "@server/test/support";
+import {
+  flushdb,
+  seed,
+  getTestServer,
+  disconnectdb,
+} from "@server/test/support";
 
 const server = getTestServer();
+afterAll(() => disconnectdb().then(() => server.close()));
 beforeEach(() => flushdb());
 
 describe("#documents.info", () => {

--- a/server/routes/api/documents.test.ts
+++ b/server/routes/api/documents.test.ts
@@ -15,16 +15,14 @@ import {
   buildDocument,
   buildViewer,
 } from "@server/test/factories";
-import {
-  flushdb,
-  seed,
-  getTestServer,
-  disconnectdb,
-} from "@server/test/support";
+import { seed, getTestDatabase, getTestServer } from "@server/test/support";
 
+const db = getTestDatabase();
 const server = getTestServer();
-afterAll(() => disconnectdb().then(() => server.close()));
-beforeEach(() => flushdb());
+
+afterAll(server.disconnect);
+
+beforeEach(db.flush);
 
 describe("#documents.info", () => {
   it("should return published document", async () => {

--- a/server/routes/api/events.test.ts
+++ b/server/routes/api/events.test.ts
@@ -1,8 +1,12 @@
 import { buildEvent, buildUser } from "@server/test/factories";
-import { flushdb, seed, getTestServer } from "@server/test/support";
+import { seed, getTestDatabase, getTestServer } from "@server/test/support";
 
+const db = getTestDatabase();
 const server = getTestServer();
-beforeEach(() => flushdb());
+
+afterAll(server.disconnect);
+
+beforeEach(db.flush);
 
 describe("#events.list", () => {
   it("should only return activity events", async () => {

--- a/server/routes/api/fileOperations.test.ts
+++ b/server/routes/api/fileOperations.test.ts
@@ -10,13 +10,17 @@ import {
   buildTeam,
   buildUser,
 } from "@server/test/factories";
-import { flushdb, getTestServer } from "@server/test/support";
 
+import { getTestDatabase, getTestServer } from "@server/test/support";
+
+const db = getTestDatabase();
 const server = getTestServer();
 
 jest.mock("@server/utils/s3");
 
-beforeEach(() => flushdb());
+afterAll(server.disconnect);
+
+beforeEach(db.flush);
 
 describe("#fileOperations.info", () => {
   it("should return fileOperation", async () => {

--- a/server/routes/api/groups.test.ts
+++ b/server/routes/api/groups.test.ts
@@ -1,9 +1,13 @@
 import { Event } from "@server/models";
 import { buildUser, buildAdmin, buildGroup } from "@server/test/factories";
-import { flushdb, getTestServer } from "@server/test/support";
+import { getTestDatabase, getTestServer } from "@server/test/support";
 
+const db = getTestDatabase();
 const server = getTestServer();
-beforeEach(() => flushdb());
+
+afterAll(server.disconnect);
+
+beforeEach(db.flush);
 
 describe("#groups.create", () => {
   it("should create a group", async () => {

--- a/server/routes/api/hooks.test.ts
+++ b/server/routes/api/hooks.test.ts
@@ -1,15 +1,19 @@
 import env from "@server/env";
 import { IntegrationAuthentication, SearchQuery } from "@server/models";
 import { buildDocument, buildIntegration } from "@server/test/factories";
-import { flushdb, seed, getTestServer } from "@server/test/support";
+import { seed, getTestDatabase, getTestServer } from "@server/test/support";
 import * as Slack from "@server/utils/slack";
-
-const server = getTestServer();
-beforeEach(() => flushdb());
 
 jest.mock("../../utils/slack", () => ({
   post: jest.fn(),
 }));
+
+const db = getTestDatabase();
+const server = getTestServer();
+
+afterAll(server.disconnect);
+
+beforeEach(db.flush);
 
 describe("#hooks.unfurl", () => {
   it("should return documents", async () => {

--- a/server/routes/api/index.test.ts
+++ b/server/routes/api/index.test.ts
@@ -1,8 +1,11 @@
-import { flushdb, getTestServer } from "@server/test/support";
+import { getTestDatabase, getTestServer } from "@server/test/support";
 
+const db = getTestDatabase();
 const server = getTestServer();
 
-beforeEach(() => flushdb());
+afterAll(server.disconnect);
+
+beforeEach(db.flush);
 
 describe("POST unknown endpoint", () => {
   it("should be not found", async () => {

--- a/server/routes/api/index.test.ts
+++ b/server/routes/api/index.test.ts
@@ -1,11 +1,8 @@
-import { getTestDatabase, getTestServer } from "@server/test/support";
+import { getTestServer } from "@server/test/support";
 
-const db = getTestDatabase();
 const server = getTestServer();
 
 afterAll(server.disconnect);
-
-beforeEach(db.flush);
 
 describe("POST unknown endpoint", () => {
   it("should be not found", async () => {

--- a/server/routes/api/integrations.test.ts
+++ b/server/routes/api/integrations.test.ts
@@ -4,11 +4,15 @@ import {
   buildUser,
   buildIntegration,
 } from "@server/test/factories";
-import { flushdb, getTestServer } from "@server/test/support";
 
+import { getTestDatabase, getTestServer } from "@server/test/support";
+
+const db = getTestDatabase();
 const server = getTestServer();
 
-beforeEach(() => flushdb());
+afterAll(server.disconnect);
+
+beforeEach(db.flush);
 
 describe("#integrations.update", () => {
   it("should allow updating integration events", async () => {

--- a/server/routes/api/middlewares/pagination.test.ts
+++ b/server/routes/api/middlewares/pagination.test.ts
@@ -1,7 +1,11 @@
-import { flushdb, seed, getTestServer } from "@server/test/support";
+import { seed, getTestDatabase, getTestServer } from "@server/test/support";
 
+const db = getTestDatabase();
 const server = getTestServer();
-beforeEach(() => flushdb());
+
+afterAll(server.disconnect);
+
+beforeEach(db.flush);
 
 describe("#pagination", () => {
   it("should allow offset and limit", async () => {

--- a/server/routes/api/revisions.test.ts
+++ b/server/routes/api/revisions.test.ts
@@ -1,9 +1,13 @@
 import { Revision } from "@server/models";
 import { buildDocument, buildUser } from "@server/test/factories";
-import { flushdb, seed, getTestServer } from "@server/test/support";
+import { seed, getTestDatabase, getTestServer } from "@server/test/support";
 
+const db = getTestDatabase();
 const server = getTestServer();
-beforeEach(() => flushdb());
+
+afterAll(server.disconnect);
+
+beforeEach(db.flush);
 
 describe("#revisions.info", () => {
   it("should return a document revision", async () => {

--- a/server/routes/api/shares.test.ts
+++ b/server/routes/api/shares.test.ts
@@ -6,10 +6,15 @@ import {
   buildAdmin,
   buildCollection,
 } from "@server/test/factories";
-import { flushdb, seed, getTestServer } from "@server/test/support";
 
+import { seed, getTestDatabase, getTestServer } from "@server/test/support";
+
+const db = getTestDatabase();
 const server = getTestServer();
-beforeEach(() => flushdb());
+
+afterAll(server.disconnect);
+
+beforeEach(db.flush);
 
 describe("#shares.list", () => {
   it("should only return shares created by user", async () => {

--- a/server/routes/api/stars.test.ts
+++ b/server/routes/api/stars.test.ts
@@ -1,8 +1,12 @@
 import { buildUser, buildStar, buildDocument } from "@server/test/factories";
-import { flushdb, getTestServer } from "@server/test/support";
+import { getTestDatabase, getTestServer } from "@server/test/support";
 
+const db = getTestDatabase();
 const server = getTestServer();
-beforeEach(() => flushdb());
+
+afterAll(server.disconnect);
+
+beforeEach(db.flush);
 
 describe("#stars.create", () => {
   it("should create a star", async () => {

--- a/server/routes/api/team.test.ts
+++ b/server/routes/api/team.test.ts
@@ -1,9 +1,13 @@
 import { TeamDomain } from "@server/models";
 import { buildAdmin, buildCollection, buildTeam } from "@server/test/factories";
-import { flushdb, seed, getTestServer } from "@server/test/support";
+import { seed, getTestDatabase, getTestServer } from "@server/test/support";
 
+const db = getTestDatabase();
 const server = getTestServer();
-beforeEach(() => flushdb());
+
+afterAll(server.disconnect);
+
+beforeEach(db.flush);
 
 describe("#team.update", () => {
   it("should update team details", async () => {

--- a/server/routes/api/users.test.ts
+++ b/server/routes/api/users.test.ts
@@ -1,19 +1,18 @@
-import TestServer from "fetch-test-server";
-import webService from "@server/services/web";
 import { buildTeam, buildAdmin, buildUser } from "@server/test/factories";
-import { flushdb, seed } from "@server/test/support";
+import { seed, getTestDatabase, getTestServer } from "@server/test/support";
 
-const app = webService();
-const server = new TestServer(app.callback());
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+const server = getTestServer();
 
 beforeAll(() => {
   jest.useFakeTimers().setSystemTime(new Date("2018-01-02T00:00:00.000Z"));
 });
 afterAll(() => {
   jest.useRealTimers();
-  return server.close();
+  server.disconnect();
 });
+
+beforeEach(db.flush);
 
 describe("#users.list", () => {
   it("should allow filtering by user name", async () => {

--- a/server/routes/api/views.test.ts
+++ b/server/routes/api/views.test.ts
@@ -1,9 +1,13 @@
 import { View, CollectionUser } from "@server/models";
 import { buildUser } from "@server/test/factories";
-import { flushdb, seed, getTestServer } from "@server/test/support";
+import { seed, getTestDatabase, getTestServer } from "@server/test/support";
 
+const db = getTestDatabase();
 const server = getTestServer();
-beforeEach(() => flushdb());
+
+afterAll(server.disconnect);
+
+beforeEach(db.flush);
 
 describe("#views.list", () => {
   it("should return views for a document", async () => {

--- a/server/routes/auth/index.test.ts
+++ b/server/routes/auth/index.test.ts
@@ -1,9 +1,12 @@
 import { buildUser, buildCollection } from "@server/test/factories";
-import { flushdb, getTestServer } from "@server/test/support";
+import { getTestDatabase, getTestServer } from "@server/test/support";
 
+const db = getTestDatabase();
 const server = getTestServer();
 
-beforeEach(() => flushdb());
+afterAll(server.disconnect);
+
+beforeEach(db.flush);
 
 describe("auth/redirect", () => {
   it("should redirect to home", async () => {

--- a/server/routes/auth/providers/email.test.ts
+++ b/server/routes/auth/providers/email.test.ts
@@ -3,11 +3,14 @@ import SigninEmail from "@server/emails/templates/SigninEmail";
 import WelcomeEmail from "@server/emails/templates/WelcomeEmail";
 import env from "@server/env";
 import { buildUser, buildGuestUser, buildTeam } from "@server/test/factories";
-import { flushdb, getTestServer } from "@server/test/support";
+import { getTestDatabase, getTestServer } from "@server/test/support";
 
+const db = getTestDatabase();
 const server = getTestServer();
 
-beforeEach(() => flushdb());
+afterAll(server.disconnect);
+
+beforeEach(db.flush);
 
 describe("email", () => {
   it("should require email param", async () => {

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -1,8 +1,12 @@
 import { buildShare, buildDocument } from "@server/test/factories";
-import { flushdb, getTestServer } from "@server/test/support";
+import { getTestDatabase, getTestServer } from "@server/test/support";
 
+const db = getTestDatabase();
 const server = getTestServer();
-beforeEach(() => flushdb());
+
+afterAll(server.disconnect);
+
+beforeEach(db.flush);
 
 describe("/share/:id", () => {
   it("should return standard title in html when loading unpublished share", async () => {

--- a/server/scripts/20210716000000-backfill-revisions.test.ts
+++ b/server/scripts/20210716000000-backfill-revisions.test.ts
@@ -1,9 +1,13 @@
 import { Revision, Event } from "@server/models";
 import { buildDocument } from "@server/test/factories";
-import { flushdb } from "@server/test/support";
+import { getTestDatabase } from "@server/test/support";
 import script from "./20210716000000-backfill-revisions";
 
-beforeEach(() => flushdb());
+const db = getTestDatabase();
+
+afterAll(db.disconnect);
+
+beforeEach(db.flush);
 
 describe("#work", () => {
   it("should create events for revisions", async () => {

--- a/server/test/setup.ts
+++ b/server/test/setup.ts
@@ -18,7 +18,6 @@ if (process.env.DATABASE_URL_TEST) {
 require("@server/database/sequelize");
 
 jest.mock("bull");
-jest.mock("i18next-http-backend");
 
 // This is needed for the relative manual mock to be picked up
 jest.mock("../queues");

--- a/server/test/setup.ts
+++ b/server/test/setup.ts
@@ -18,6 +18,7 @@ if (process.env.DATABASE_URL_TEST) {
 require("@server/database/sequelize");
 
 jest.mock("bull");
+jest.mock("i18next-http-backend");
 
 // This is needed for the relative manual mock to be picked up
 jest.mock("../queues");

--- a/server/test/support.ts
+++ b/server/test/support.ts
@@ -1,28 +1,27 @@
 import TestServer from "fetch-test-server";
 import { v4 as uuidv4 } from "uuid";
-import { sequelize } from "@server/database/sequelize";
+import { sequelize as db } from "@server/database/sequelize";
 import { User, Document, Collection, Team } from "@server/models";
 import webService from "@server/services/web";
 
-const sql = sequelize.getQueryInterface();
-const tables = Object.keys(sequelize.models).map((model) => {
-  const n = sequelize.models[model].getTableName();
-  return (sql.queryGenerator as any).quoteTable(
-    typeof n === "string" ? n : n.tableName
-  );
-});
-const flushQuery = `TRUNCATE ${tables.join(", ")} CASCADE`;
-
 export function flushdb() {
-  return sequelize.query(flushQuery);
+  const sql = db.getQueryInterface();
+  const tables = Object.keys(db.models).map((model) => {
+    const n = db.models[model].getTableName();
+    return (sql.queryGenerator as any).quoteTable(
+      typeof n === "string" ? n : n.tableName
+    );
+  });
+  const flushQuery = `TRUNCATE ${tables.join(", ")} CASCADE`;
+  return db.query(flushQuery);
 }
 
 export function disconnectdb() {
-  return sequelize.close();
+  return db.close();
 }
 
 export const seed = async () => {
-  return sequelize.transaction(async (transaction) => {
+  return db.transaction(async (transaction) => {
     const team = await Team.create(
       {
         name: "Team",
@@ -116,14 +115,35 @@ export const seed = async () => {
   });
 };
 
-let testServer: typeof TestServer | undefined;
-
 export function getTestServer() {
-  if (testServer) {
-    return testServer;
-  }
-
   const app = webService();
-  testServer = new TestServer(app.callback());
-  return testServer;
+  const server = new TestServer(app.callback());
+
+  server.disconnect = async () => {
+    await db.close();
+    server.close();
+  };
+
+  return server;
+}
+
+export function getTestDatabase() {
+  const flush = async () => {
+    const sql = db.getQueryInterface();
+    const tables = Object.keys(db.models).map((model) => {
+      const n = db.models[model].getTableName();
+      return (sql.queryGenerator as any).quoteTable(
+        typeof n === "string" ? n : n.tableName
+      );
+    });
+    const flushQuery = `TRUNCATE ${tables.join(", ")} CASCADE`;
+
+    await db.query(flushQuery);
+  };
+
+  const disconnect = async () => {
+    await db.close();
+  };
+
+  return { flush, disconnect };
 }

--- a/server/test/support.ts
+++ b/server/test/support.ts
@@ -4,22 +4,6 @@ import { sequelize as db } from "@server/database/sequelize";
 import { User, Document, Collection, Team } from "@server/models";
 import webService from "@server/services/web";
 
-export function flushdb() {
-  const sql = db.getQueryInterface();
-  const tables = Object.keys(db.models).map((model) => {
-    const n = db.models[model].getTableName();
-    return (sql.queryGenerator as any).quoteTable(
-      typeof n === "string" ? n : n.tableName
-    );
-  });
-  const flushQuery = `TRUNCATE ${tables.join(", ")} CASCADE`;
-  return db.query(flushQuery);
-}
-
-export function disconnectdb() {
-  return db.close();
-}
-
 export const seed = async () => {
   return db.transaction(async (transaction) => {
     const team = await Team.create(

--- a/server/test/support.ts
+++ b/server/test/support.ts
@@ -17,6 +17,10 @@ export function flushdb() {
   return sequelize.query(flushQuery);
 }
 
+export function disconnectdb() {
+  return sequelize.close();
+}
+
 export const seed = async () => {
   return sequelize.transaction(async (transaction) => {
     const team = await Team.create(

--- a/shared/editor/embeds/Abstract.test.ts
+++ b/shared/editor/embeds/Abstract.test.ts
@@ -1,8 +1,8 @@
-import Abstract from "./Abstract";
+import { URL_REGEX } from "./Abstract";
 
 describe("Abstract", () => {
-  const match = Abstract.ENABLED[0];
-  const match2 = Abstract.ENABLED[1];
+  const match = URL_REGEX[0];
+  const match2 = URL_REGEX[1];
 
   test("to be enabled on share subdomain link", () => {
     expect(

--- a/shared/editor/embeds/Abstract.test.ts
+++ b/shared/editor/embeds/Abstract.test.ts
@@ -1,8 +1,8 @@
-import { URL_REGEX } from "./Abstract";
+import Abstract from "./Abstract";
 
 describe("Abstract", () => {
-  const match = URL_REGEX[0];
-  const match2 = URL_REGEX[1];
+  const match = Abstract.ENABLED[0];
+  const match2 = Abstract.ENABLED[1];
 
   test("to be enabled on share subdomain link", () => {
     expect(

--- a/shared/editor/embeds/Abstract.tsx
+++ b/shared/editor/embeds/Abstract.tsx
@@ -2,11 +2,13 @@ import * as React from "react";
 import Frame from "../components/Frame";
 import { EmbedProps as Props } from ".";
 
+export const URL_REGEX = [
+  new RegExp("https?://share\\.(?:go)?abstract\\.com/(.*)$"),
+  new RegExp("https?://app\\.(?:go)?abstract\\.com/(?:share|embed)/(.*)$"),
+];
+
 export default class Abstract extends React.Component<Props> {
-  static ENABLED = [
-    new RegExp("https?://share\\.(?:go)?abstract\\.com/(.*)$"),
-    new RegExp("https?://app\\.(?:go)?abstract\\.com/(?:share|embed)/(.*)$"),
-  ];
+  static ENABLED = URL_REGEX;
 
   render() {
     const { matches } = this.props.attrs;

--- a/shared/editor/embeds/Abstract.tsx
+++ b/shared/editor/embeds/Abstract.tsx
@@ -2,13 +2,11 @@ import * as React from "react";
 import Frame from "../components/Frame";
 import { EmbedProps as Props } from ".";
 
-export const URL_REGEX = [
-  new RegExp("https?://share\\.(?:go)?abstract\\.com/(.*)$"),
-  new RegExp("https?://app\\.(?:go)?abstract\\.com/(?:share|embed)/(.*)$"),
-];
-
 export default class Abstract extends React.Component<Props> {
-  static ENABLED = URL_REGEX;
+  static ENABLED = [
+    new RegExp("https?://share\\.(?:go)?abstract\\.com/(.*)$"),
+    new RegExp("https?://app\\.(?:go)?abstract\\.com/(?:share|embed)/(.*)$"),
+  ];
 
   render() {
     const { matches } = this.props.attrs;

--- a/shared/test/setup.ts
+++ b/shared/test/setup.ts
@@ -1,0 +1,3 @@
+jest.mock("i18next-http-backend");
+
+export {};


### PR DESCRIPTION
Closes #3939 

This attempts to plug the memory leaks that occur upon running `yarn test:server`. I almost completely relied upon the [`--detect-leaks`](https://github.com/facebook/jest/issues/7874#issuecomment-1057890147) flag to spot and fix them. This flag gives room for the GC to sweep by [awaiting for a few ticks in between](https://github.com/facebook/jest/blob/3f3aa80254f2b2f365825c6ac5b5f0a2217631a5/packages/jest-leak-detector/src/index.ts#L53-L58).

Following are the results collected after making changes across the board:

**`node@16.16`**
```
$ node -v
v16.16.0

$ npx jest-heap-graph "yarn test:server --logHeapUsage --detect-leaks"

Test Suites: 120 passed, 120 total
Tests:       890 passed, 890 total
Snapshots:   86 passed, 86 total
Time:        335.578 s
Ran all test suites.
Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?

--- n: 120 ---
    1719.00 ┤                                                    ╭───────╮
    1568.60 ┤                                               ╭────╯       │
    1418.20 ┤                                          ╭────╯            │
    1267.80 ┤                                     ╭────╯                 │
    1117.40 ┤                                 ╭───╯                      │                       ╭────
     967.00 ┤                             ╭───╯                          │                  ╭────╯
     816.60 ┤                         ╭───╯                              │             ╭────╯
     666.20 ┤                     ╭───╯                                  │         ╭───╯
     515.80 ┤                 ╭───╯                                      │    ╭────╯
     365.40 ┼───╮╭─╮╭─────────╯                                          ╰────╯
     215.00 ┤   ╰╯ ╰╯
```

**`node@16.10`**
```
$ node -v
v16.10.0

$ npx jest-heap-graph "yarn test:server --logHeapUsage --detect-leaks"

Test Suites: 120 passed, 120 total
Tests:       890 passed, 890 total
Snapshots:   86 passed, 86 total
Time:        291.507 s
Ran all test suites.
Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?

--- n: 120 ---
     235.00 ┤                                      ╭╮
     228.40 ┤                                      ││╭╮                    ╭╮  ╭─╮
     221.80 ┤                                      ││││                  ╭─╯│╭─╯ │  ╭─╮
     215.20 ┤                        ╭╮            ││││             ╭╮╭──╯  ╰╯   ╰╮ │ │           ╭──╮
     208.60 ┤           ╭─╮          ││╭╮          │╰╯╰╮           ╭╯││           │ │ │╭─╮  ╭╮ ╭╮╭╯  │
     202.00 ┤           │ │╭╮        ││││   ╭╮   ╭─╯   │           │ ││           ╰╮│ ╰╯ ╰──╯╰─╯╰╯   │
     195.40 ┤           │ ╰╯╰╮ ╭╮╭─╮ ││││   │╰───╯     │    ╭╮     │ ││            ││                │
     188.80 ┤        ╭╮ │    │╭╯││ ╰╮│││╰─╮ │          ╰╮  ╭╯╰─────╯ ╰╯            ╰╯                ╰
     182.20 ┼────────╯╰─╯    ││ ╰╯  ││╰╯  │╭╯           ╰──╯
     175.60 ┤                ││     ╰╯    ││
     169.00 ┤                ╰╯           ╰╯
```

**`node@14.19`**
```
$ node -v
v14.19.3

$ npx jest-heap-graph "yarn test:server --logHeapUsage --detect-leaks"

Test Suites: 120 passed, 120 total
Tests:       890 passed, 890 total
Snapshots:   86 passed, 86 total
Time:        262.933 s
Ran all test suites.
Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?

--- n: 120 ---
     228.00 ┤                                                                                        ╭
     222.30 ┤                                                                        ╭╮   ╭──────────╯
     216.60 ┤                                                                ╭╮ ╭────╯╰───╯
     210.90 ┤                      ╭─╮╭╮╭╮╭╮ ╭─╮                     ╭╮ ╭────╯╰─╯
     205.20 ┤       ╭╮      ╭──────╯ ╰╯╰╯╰╯╰─╯ │             ╭╮╭─────╯╰─╯
     199.50 ┤       ││      │                  │╭─╮╭─────────╯╰╯
     193.80 ┤       ││      │                  ╰╯ ╰╯
     188.10 ┤      ╭╯│      │
     182.40 ┤╭╮╭╮╭╮│ ╰╮ ╭─╮ │
     176.70 ┼╯╰╯╰╯╰╯  ╰─╯ ╰╮│
     171.00 ┤              ╰╯

```