### PR TITLE
chore: Add eslint rule for object shorthand

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,6 +25,7 @@
   "rules": {
     "eqeqeq": 2,
     "curly": 2,
+    "object-shorthand": "error",
     "no-mixed-operators": "off",
     "no-useless-escape": "off",
     "es/no-regexp-lookbehind-assertions": "error",

--- a/app/editor/index.tsx
+++ b/app/editor/index.tsx
@@ -430,7 +430,7 @@ export class Editor extends React.PureComponent<
       state: this.createState(this.props.value),
       editable: () => !this.props.readOnly,
       nodeViews: this.nodeViews,
-      dispatchTransaction: function (transaction) {
+      dispatchTransaction(transaction) {
         // callback is bound to have the view instance as its this binding
         const { state, transactions } = this.state.applyTransaction(
           transaction

--- a/app/scenes/GroupEdit.tsx
+++ b/app/scenes/GroupEdit.tsx
@@ -25,7 +25,7 @@ function GroupEdit({ group, onSubmit }: Props) {
 
       try {
         await group.save({
-          name: name,
+          name,
         });
         onSubmit();
       } catch (err) {

--- a/app/scenes/GroupNew.tsx
+++ b/app/scenes/GroupNew.tsx
@@ -29,7 +29,7 @@ function GroupNew({ onSubmit }: Props) {
 
     const group = new Group(
       {
-        name: name,
+        name,
       },
       groups
     );

--- a/app/stores/DocumentsStore.ts
+++ b/app/stores/DocumentsStore.ts
@@ -532,7 +532,7 @@ export default class DocumentsStore extends BaseStore<Document> {
         id: documentId,
         collectionId,
         parentDocumentId,
-        index: index,
+        index,
       });
       invariant(res?.data, "Data not available");
       res.data.documents.forEach(this.add);

--- a/app/utils/browser.ts
+++ b/app/utils/browser.ts
@@ -20,7 +20,7 @@ let supportsPassive = false;
 
 try {
   const opts = Object.defineProperty({}, "passive", {
-    get: function () {
+    get() {
       supportsPassive = true;
     },
   });

--- a/server/__mocks__/bull.ts
+++ b/server/__mocks__/bull.ts
@@ -35,7 +35,7 @@ export default class Queue {
 
   createJob = function (data: any) {
     return {
-      data: data,
+      data,
     };
   };
 }

--- a/server/commands/teamUpdater.ts
+++ b/server/commands/teamUpdater.ts
@@ -119,7 +119,7 @@ const teamUpdater = async ({ params, user, team, ip }: TeamUpdaterProps) => {
           actorId: user.id,
           teamId: user.teamId,
           data,
-          ip: ip,
+          ip,
         },
         {
           transaction,

--- a/server/models/Group.ts
+++ b/server/models/Group.ts
@@ -31,7 +31,7 @@ import NotContainsUrl from "./validators/NotContainsUrl";
   tableName: "groups",
   modelName: "group",
   validate: {
-    isUniqueNameInTeam: async function () {
+    async isUniqueNameInTeam() {
       const foundItem = await Group.findOne({
         where: {
           teamId: this.teamId,

--- a/server/presenters/webhook.ts
+++ b/server/presenters/webhook.ts
@@ -33,6 +33,6 @@ export default function present({
     webhookSubscriptionId: delivery.webhookSubscriptionId,
     createdAt: delivery.createdAt,
     event: event.name,
-    payload: payload,
+    payload,
   };
 }

--- a/server/routes/auth/providers/index.ts
+++ b/server/routes/auth/providers/index.ts
@@ -39,7 +39,7 @@ requireDirectory(__dirname).forEach(([module, id]) => {
       name: config.name,
       enabled: config.enabled,
       authUrl: signin(id),
-      router: router,
+      router,
     });
   }
 });

--- a/server/utils/turndown/breaks.ts
+++ b/server/utils/turndown/breaks.ts
@@ -8,7 +8,7 @@ import TurndownService from "turndown";
 export default function breaks(turndownService: TurndownService) {
   turndownService.addRule("breaks", {
     filter: ["br"],
-    replacement: function () {
+    replacement() {
       return "\n";
     },
   });

--- a/server/utils/turndown/confluence-code-block.ts
+++ b/server/utils/turndown/confluence-code-block.ts
@@ -10,7 +10,7 @@ const highlightRegExp = /brush: ([a-z0-9]+);/;
  */
 export default function confluenceCodeBlock(turndownService: TurndownService) {
   turndownService.addRule("fencedConfluenceHighlightedCodeBlock", {
-    filter: function (node) {
+    filter(node) {
       const firstChild = node.firstChild;
       return (
         node.nodeName === "DIV" &&
@@ -19,7 +19,7 @@ export default function confluenceCodeBlock(turndownService: TurndownService) {
         firstChild.className === "syntaxhighlighter-pre"
       );
     },
-    replacement: function (content, node) {
+    replacement(content, node) {
       const dataSyntaxhighlighterParams =
         // @ts-expect-error getAttribute exists
         node.firstChild?.getAttribute("data-syntaxhighlighter-params") ?? "";

--- a/server/utils/turndown/confluence-task-list.ts
+++ b/server/utils/turndown/confluence-task-list.ts
@@ -7,7 +7,7 @@ import TurndownService from "turndown";
  */
 export default function confluenceTaskList(turndownService: TurndownService) {
   turndownService.addRule("confluenceTaskList", {
-    filter: function (node) {
+    filter(node) {
       return (
         node.nodeName === "LI" &&
         node.parentNode?.nodeName === "UL" &&
@@ -15,7 +15,7 @@ export default function confluenceTaskList(turndownService: TurndownService) {
         node.parentNode?.className.includes("inline-task-list")
       );
     },
-    replacement: function (content, node) {
+    replacement(content, node) {
       return (
         // @ts-expect-error className exists
         (node.className === "checked" ? "- [x]" : "- [ ]") + ` ${content} \n`

--- a/server/utils/validators.ts
+++ b/server/utils/validators.ts
@@ -13,7 +13,7 @@ export function CannotUseWithout(
     registerDecorator({
       name: "cannotUseWithout",
       target: object.constructor,
-      propertyName: propertyName,
+      propertyName,
       constraints: [property],
       options: validationOptions,
       validator: {

--- a/shared/editor/nodes/Image.tsx
+++ b/shared/editor/nodes/Image.tsx
@@ -174,7 +174,7 @@ export default class Image extends Node {
               src: img?.getAttribute("src"),
               alt: img?.getAttribute("alt"),
               title: img?.getAttribute("title"),
-              layoutClass: layoutClass,
+              layoutClass,
             };
           },
         },

--- a/shared/editor/rules/notices.ts
+++ b/shared/editor/rules/notices.ts
@@ -6,7 +6,7 @@ export default function notice(md: MarkdownIt): void {
   return customFence(md, "notice", {
     marker: ":",
     validate: () => true,
-    render: function (tokens: Token[], idx: number) {
+    render(tokens: Token[], idx: number) {
       const { info } = tokens[idx];
 
       if (tokens[idx].nesting === 1) {


### PR DESCRIPTION
`yarn lint --fix` will now auto-correct.

ref: https://github.com/outline/outline/pull/3935#discussion_r943397751