### PR TITLE
Reference email image by cid for self hosted instances

### DIFF
--- a/server/emails/mailer.tsx
+++ b/server/emails/mailer.tsx
@@ -5,6 +5,7 @@ import Logger from "@server/logging/Logger";
 import { APM } from "@server/logging/tracing";
 import { baseStyles } from "./templates/components/EmailLayout";
 
+const isCloudHosted = env.DEPLOYMENT === "hosted";
 const useTestEmailService =
   env.ENVIRONMENT === "development" && !env.SMTP_USERNAME;
 
@@ -77,6 +78,15 @@ export class Mailer {
         subject: data.subject,
         html,
         text: data.text,
+        attachments: isCloudHosted
+          ? undefined
+          : [
+              {
+                filename: "header-logo.png",
+                path: process.cwd() + "/public/email/header-logo.png",
+                cid: "header-image",
+              },
+            ],
       });
 
       if (useTestEmailService) {

--- a/server/emails/templates/components/Header.tsx
+++ b/server/emails/templates/components/Header.tsx
@@ -4,6 +4,7 @@ import env from "@server/env";
 import EmptySpace from "./EmptySpace";
 
 const url = env.CDN_URL ?? env.URL;
+const isCloudHosted = env.DEPLOYMENT === "hosted";
 
 export default () => {
   return (
@@ -14,7 +15,11 @@ export default () => {
             <EmptySpace height={40} />
             <img
               alt="Outline"
-              src={`${url}/email/header-logo.png`}
+              src={
+                isCloudHosted
+                  ? `${url}/email/header-logo.png`
+                  : "cid:header-image"
+              }
               height="48"
               width="48"
             />


### PR DESCRIPTION
Removes requirement for images to be publicly accessible to work in email body.

closes #3870