### PR TITLE
Content is displayed wrongly when printing / Save as PDF

### DIFF
--- a/app/editor/components/Styles.ts
+++ b/app/editor/components/Styles.ts
@@ -1287,6 +1287,10 @@ const EditorStyles = styled.div<{
     .page-break {
       opacity: 0;
     }
+    
+    button.show-source-button {
+      display: none;
+    }
 
     em,
     blockquote {

--- a/app/editor/components/Styles.ts
+++ b/app/editor/components/Styles.ts
@@ -1275,6 +1275,7 @@ const EditorStyles = styled.div<{
     .placeholder:before,
     .block-menu-trigger,
     .heading-actions,
+    button.show-source-button,
     h1:not(.placeholder):before,
     h2:not(.placeholder):before,
     h3:not(.placeholder):before,
@@ -1286,10 +1287,6 @@ const EditorStyles = styled.div<{
 
     .page-break {
       opacity: 0;
-    }
-    
-    button.show-source-button {
-      display: none;
     }
 
     em,

--- a/app/styles/globals.ts
+++ b/app/styles/globals.ts
@@ -15,6 +15,8 @@ export default createGlobalStyle`
     min-height: 100vh;
     margin: 0;
     padding: 0;
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
   }
 
   body,


### PR DESCRIPTION
This first commit fixes problem number 6 in issue https://github.com/outline/outline/issues/4001, when printing a document.
The button "Show Source" in mermaid diagrams should be hidden, when printing a document.

The third commit fixes the problems number 1, 3, 4, 5, 7 in issue https://github.com/outline/outline/issues/4001, where backgrounds and task checkboxes are not visible when printing