### PR TITLE
fix: Dialog doesn't close after deleting a document with a parent

### DIFF
--- a/app/scenes/DocumentDelete.tsx
+++ b/app/scenes/DocumentDelete.tsx
@@ -44,12 +44,16 @@ function DocumentDelete({ document, onSubmit }: Props) {
 
             if (parent) {
               history.push(documentUrl(parent));
-              return;
+            }
+            else {
+              // if it is not available in the store then redirect to the collection
+              history.push(collectionUrl(collection?.url || "/"));
             }
           }
-
-          // otherwise, redirect to the collection home
-          history.push(collectionUrl(collection?.url || "/"));
+          else {
+            // If it has no parent then redirect to the collection home
+            history.push(collectionUrl(collection?.url || "/"));
+          }
         }
 
         onSubmit();

--- a/app/scenes/DocumentDelete.tsx
+++ b/app/scenes/DocumentDelete.tsx
@@ -44,16 +44,13 @@ function DocumentDelete({ document, onSubmit }: Props) {
 
             if (parent) {
               history.push(documentUrl(parent));
-            }
-            else {
-              // if it is not available in the store then redirect to the collection
-              history.push(collectionUrl(collection?.url || "/"));
+              onSubmit();
+              return;
             }
           }
-          else {
-            // If it has no parent then redirect to the collection home
-            history.push(collectionUrl(collection?.url || "/"));
-          }
+
+          // otherwise, redirect to the collection home
+          history.push(collectionUrl(collection?.url || "/"));
         }
 
         onSubmit();


### PR DESCRIPTION
fixes #4107

* Removes return inside the if statement that checks if the parent is available in the store to allow the rest of the code to be executed. 
* Else clause added to above if statement to redirect to collection if parent is not available in the store.
* Original redirect to collection wrapped in else in case there is no parent.

Sorry if there's a cleaner way to do this so that code isn't duplicated.