### PR TITLE
Enter in table cell adds a row after the current one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ fakes3/*
 *.pem
 *.key
 *.cert
+docker-compose.yml
+yarn-error.log

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,3 @@ fakes3/*
 *.pem
 *.key
 *.cert
-docker-compose.yml
-yarn-error.log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,12 @@ services:
   redis:
     image: redis
     ports:
-      - "0.0.0.0:6379:6379"
+      - "127.0.0.1:6379:6379"
     user: "redis:redis"
   postgres:
     image: postgres
     ports:
-      - "0.0.0.0:5432:5432"
+      - "127.0.0.1:5432:5432"
     environment:
       POSTGRES_USER: user
       POSTGRES_PASSWORD: pass

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,12 @@ services:
   redis:
     image: redis
     ports:
-      - "127.0.0.1:6379:6379"
+      - "0.0.0.0:6379:6379"
     user: "redis:redis"
   postgres:
     image: postgres
     ports:
-      - "127.0.0.1:5532:5432"
+      - "0.0.0.0:5432:5432"
     environment:
       POSTGRES_USER: user
       POSTGRES_PASSWORD: pass

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
   postgres:
     image: postgres
     ports:
-      - "127.0.0.1:5432:5432"
+      - "127.0.0.1:5532:5432"
     environment:
       POSTGRES_USER: user
       POSTGRES_PASSWORD: pass

--- a/shared/editor/nodes/Table.ts
+++ b/shared/editor/nodes/Table.ts
@@ -128,9 +128,17 @@ export default class Table extends Node {
         const index = getRowIndexFromText(
           (state.selection as unknown) as CellSelection
         );
+
         if (index === 0) {
+          const cells = getCellsInColumn(0)(state.selection);
+          if (!cells) {
+            return false;
+          }
+
           const tr = addRowAt(index + 2, true)(state.tr);
-          dispatch(moveRow(index + 2, index + 1)(tr));
+          dispatch(
+            setTextSelection(cells[1].pos)(moveRow(index + 2, index + 1)(tr))
+          );
         } else {
           dispatch(addRowAt(index + 1, true)(state.tr));
         }

--- a/shared/editor/nodes/Table.ts
+++ b/shared/editor/nodes/Table.ts
@@ -19,6 +19,7 @@ import {
   createTable,
   getCellsInColumn,
   moveRow,
+  setTextSelection,
 } from "prosemirror-utils";
 import { Decoration, DecorationSet } from "prosemirror-view";
 import { MarkdownSerializerState } from "../lib/markdown/serializer";

--- a/shared/editor/nodes/Table.ts
+++ b/shared/editor/nodes/Table.ts
@@ -12,6 +12,7 @@ import {
   toggleHeaderCell,
   toggleHeaderColumn,
   toggleHeaderRow,
+  CellSelection,
 } from "prosemirror-tables";
 import {
   addRowAt,
@@ -21,6 +22,7 @@ import {
 } from "prosemirror-utils";
 import { Decoration, DecorationSet } from "prosemirror-view";
 import { MarkdownSerializerState } from "../lib/markdown/serializer";
+import getRowIndex from "../queries/getRowIndex";
 import tablesRule from "../rules/tables";
 import { Dispatch } from "../types";
 import Node from "./Node";
@@ -123,12 +125,15 @@ export default class Table extends Node {
         if (!isInTable(state)) {
           return false;
         }
-
-        // TODO: Adding row at the end for now, can we find the current cell
-        // row index and add the row below that?
-        const cells = getCellsInColumn(0)(state.selection) || [];
-
-        dispatch(addRowAt(cells.length, true)(state.tr));
+        const index = Number(
+          getRowIndex((state.selection as unknown) as CellSelection)
+        );
+        if (index === 0) {
+          const tr = addRowAt(index + 2, true)(state.tr);
+          dispatch(moveRow(index + 2, index + 1)(tr));
+        } else {
+          dispatch(addRowAt(index + 1, true)(state.tr));
+        }
         return true;
       },
     };

--- a/shared/editor/nodes/Table.ts
+++ b/shared/editor/nodes/Table.ts
@@ -22,7 +22,7 @@ import {
 } from "prosemirror-utils";
 import { Decoration, DecorationSet } from "prosemirror-view";
 import { MarkdownSerializerState } from "../lib/markdown/serializer";
-import getRowIndex from "../queries/getRowIndex";
+import { getRowIndexFromText } from "../queries/getRowIndex";
 import tablesRule from "../rules/tables";
 import { Dispatch } from "../types";
 import Node from "./Node";
@@ -125,7 +125,7 @@ export default class Table extends Node {
         if (!isInTable(state)) {
           return false;
         }
-        const index = getRowIndex(
+        const index = getRowIndexFromText(
           (state.selection as unknown) as CellSelection
         );
         if (index === 0) {

--- a/shared/editor/nodes/Table.ts
+++ b/shared/editor/nodes/Table.ts
@@ -125,8 +125,8 @@ export default class Table extends Node {
         if (!isInTable(state)) {
           return false;
         }
-        const index = Number(
-          getRowIndex((state.selection as unknown) as CellSelection)
+        const index = getRowIndex(
+          (state.selection as unknown) as CellSelection
         );
         if (index === 0) {
           const tr = addRowAt(index + 2, true)(state.tr);

--- a/shared/editor/queries/getRowIndex.ts
+++ b/shared/editor/queries/getRowIndex.ts
@@ -8,9 +8,8 @@ export default function getRowIndex(selection: CellSelection) {
   } else {
     const fromStr = selection.$from.toString();
     if (fromStr.includes("table")) {
-      return fromStr.substring(
-        fromStr.indexOf("tr_") + 3,
-        fromStr.indexOf("/td_")
+      return Number(
+        fromStr.substring(fromStr.indexOf("tr_") + 3, fromStr.indexOf("/td_"))
       );
     } else {
       return undefined;

--- a/shared/editor/queries/getRowIndex.ts
+++ b/shared/editor/queries/getRowIndex.ts
@@ -2,10 +2,18 @@ import { CellSelection } from "prosemirror-tables";
 
 export default function getRowIndex(selection: CellSelection) {
   const isRowSelection = selection.isRowSelection && selection.isRowSelection();
-  if (!isRowSelection) {
-    return undefined;
+  if (isRowSelection) {
+    const path = (selection.$from as any).path;
+    return path[path.length - 8];
+  } else {
+    const fromStr = selection.$from.toString();
+    if (fromStr.includes("table")) {
+      return fromStr.substring(
+        fromStr.indexOf("tr_") + 3,
+        fromStr.indexOf("/td_")
+      );
+    } else {
+      return undefined;
+    }
   }
-
-  const path = (selection.$from as any).path;
-  return path[path.length - 8];
 }

--- a/shared/editor/queries/getRowIndex.ts
+++ b/shared/editor/queries/getRowIndex.ts
@@ -2,17 +2,20 @@ import { CellSelection } from "prosemirror-tables";
 
 export default function getRowIndex(selection: CellSelection) {
   const isRowSelection = selection.isRowSelection && selection.isRowSelection();
+  if (!isRowSelection) {
+    return undefined;
+  }
+
+  const path = (selection.$from as any).path;
+  return path[path.length - 8];
+}
+
+export function getRowIndexFromText(selection: CellSelection) {
+  const isRowSelection = selection.isRowSelection && selection.isRowSelection();
+  const path = (selection.$from as any).path;
   if (isRowSelection) {
-    const path = (selection.$from as any).path;
     return path[path.length - 8];
   } else {
-    const fromStr = selection.$from.toString();
-    if (fromStr.includes("table")) {
-      return Number(
-        fromStr.substring(fromStr.indexOf("tr_") + 3, fromStr.indexOf("/td_"))
-      );
-    } else {
-      return undefined;
-    }
+    return path[path.length - 11];
   }
 }


### PR DESCRIPTION
Solves issue #4129 

I changed getRowIndex to return the row index whenever the user writes in a table cell. It still returns undefined if not in a table. Also, on Enter key pressed, we get the index from the modified getRowIndex and use it to add new row below the current one.