### PR TITLE
Dark theme should have different strikethrough text background

### DIFF
--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -1279,7 +1279,7 @@ ins {
 }
 
 del {
-  background-color: ${props.theme.slateLight};
+  background-color: ${props.theme.delTextBackground};
   color: ${props.theme.slate};
   text-decoration: strikethrough;
 }

--- a/shared/styles/theme.ts
+++ b/shared/styles/theme.ts
@@ -145,6 +145,7 @@ export const light = {
   progressBarBackground: colors.slateLight,
   scrollbarBackground: colors.smoke,
   scrollbarThumb: darken(0.15, colors.smokeDark),
+  delTextBackground: colors.slateLight,
 };
 
 export const dark = {
@@ -207,6 +208,7 @@ export const dark = {
   progressBarBackground: colors.slate,
   scrollbarBackground: colors.black,
   scrollbarThumb: colors.lightBlack,
+  delTextBackground: colors.slateDark,
 };
 
 export const lightMobile = light;


### PR DESCRIPTION
Fixes #4200
Adds variable in themes "delTextBackground"
Changed del style to use this variable

I just used slateDark for darkmode as the text background.  It looks pretty good to me.  I realize it is a style choice though so feel free to reject or suggest alternative.