### PR TITLE
fix: remove strikethrough text background

### DIFF
--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -1283,8 +1283,12 @@ del {
   text-decoration: strikethrough;
 }
 
-del img {
-  opacity: .5;
+del[data-operation-index] {
+  background-color: ${props.theme.slateLight};
+  
+  img {
+    opacity: .5;
+  }
 }
 
 @media print {

--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -1279,7 +1279,6 @@ ins {
 }
 
 del {
-  background-color: ${props.theme.slateLight};
   color: ${props.theme.slate};
   text-decoration: strikethrough;
 }


### PR DESCRIPTION
Removes background-color from del selector, which is only used for strikethrough text.

Fixes #4200