### PR TITLE
feat(build): update postgres port in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
   postgres:
     image: postgres
     ports:
-      - "127.0.0.1:5532:5432"
+      - "127.0.0.1:5432:5432"
     environment:
       POSTGRES_USER: user
       POSTGRES_PASSWORD: pass


### PR DESCRIPTION
Hello 👋 

I tried to setup Ouline for local development with `cp .env.sample .env` and `make up` as suggested [here](https://app.getoutline.com/s/770a97da-13e5-401e-9f8a-37949c19f97e/doc/local-development-5hEhFRXow7) and ran into this error:
```
Loaded configuration file "server/config/database.json".
Using environment "production".

ERROR: connect ECONNREFUSED 127.0.0.1:5432

error Command failed with exit code 1.
```

I believe this is due to exposing the wrong port in `docker-compose.yml`. 

I'm not sure if this is intended, a typo, or leftovers from #1271 - let me know what you think!