### PR TITLE
add word count feature

### DIFF
--- a/app/actions/definitions/documents.tsx
+++ b/app/actions/definitions/documents.tsx
@@ -18,6 +18,7 @@ import {
   CrossIcon,
   ArchiveIcon,
   ShuffleIcon,
+  NotepadIcon,
 } from "outline-icons";
 import * as React from "react";
 import { getEventFiles } from "@shared/utils/files";
@@ -25,6 +26,7 @@ import DocumentDelete from "~/scenes/DocumentDelete";
 import DocumentMove from "~/scenes/DocumentMove";
 import DocumentPermanentDelete from "~/scenes/DocumentPermanentDelete";
 import DocumentTemplatizeDialog from "~/components/DocumentTemplatizeDialog";
+import WordCountDialog from "~/components/WordCountDialog";
 import { createAction } from "~/actions";
 import { DocumentSection } from "~/actions/sections";
 import history from "~/utils/history";
@@ -571,6 +573,26 @@ export const permanentlyDeleteDocument = createAction({
   },
 });
 
+export const wordCount = createAction({
+  name: ({ t }) => t("Word count"),
+  section: DocumentSection,
+  icon: <NotepadIcon />,
+  visible: ({ activeDocumentId }) => !!activeDocumentId,
+  perform: ({ activeDocumentId, stores, t, event }) => {
+    if (!activeDocumentId) {
+      return;
+    }
+    event?.preventDefault();
+    event?.stopPropagation();
+
+    stores.dialogs.openModal({
+      title: t("Word count"),
+      isCentered: true,
+      content: <WordCountDialog documentId={activeDocumentId} />,
+    });
+  },
+});
+
 export const rootDocumentActions = [
   openDocument,
   archiveDocument,
@@ -590,4 +612,5 @@ export const rootDocumentActions = [
   printDocument,
   pinDocumentToCollection,
   pinDocumentToHome,
+  wordCount,
 ];

--- a/app/components/WordCountDialog.tsx
+++ b/app/components/WordCountDialog.tsx
@@ -1,0 +1,39 @@
+import invariant from "invariant";
+import { observer } from "mobx-react";
+import * as React from "react";
+import DocumentModel from "~/models/Document";
+import Flex from "~/components/Flex";
+import Text from "~/components/Text";
+import useStores from "~/hooks/useStores";
+
+type Props = {
+  documentId: string;
+};
+
+function WordCountDialog({ documentId }: Props) {
+  const { documents } = useStores();
+  const document = documents.get(documentId);
+  invariant(document, "Document must exist");
+
+  return (
+    <Flex>
+      <Text style={{ flexGrow: 1 }}>Words</Text>
+      <Text>{calculateWordCount(document)}</Text>
+    </Flex>
+  );
+}
+
+function calculateWordCount(document: DocumentModel): string {
+  const numTotalWords = countWords(document.text);
+
+  const selectedText = window.getSelection();
+  return selectedText?.toString().length
+    ? `${countWords(selectedText.toString())} of ${numTotalWords}`
+    : numTotalWords.toString();
+}
+
+function countWords(text: string): number {
+  return text.split(" ").length;
+}
+
+export default observer(WordCountDialog);

--- a/app/menus/DocumentMenu.tsx
+++ b/app/menus/DocumentMenu.tsx
@@ -38,6 +38,7 @@ import {
   unstarDocument,
   duplicateDocument,
   archiveDocument,
+  wordCount,
 } from "~/actions/definitions/documents";
 import useActionContext from "~/hooks/useActionContext";
 import useCurrentTeam from "~/hooks/useCurrentTeam";
@@ -256,6 +257,7 @@ function DocumentMenu({
             actionToMenuItem(unstarDocument, context),
             actionToMenuItem(subscribeDocument, context),
             actionToMenuItem(unsubscribeDocument, context),
+            actionToMenuItem(wordCount, context),
             {
               type: "separator",
             },

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -44,6 +44,7 @@
   "Delete {{ documentName }}": "Delete {{ documentName }}",
   "Permanently delete": "Permanently delete",
   "Permanently delete {{ documentName }}": "Permanently delete {{ documentName }}",
+  "Word count": "Word count",
   "Home": "Home",
   "Drafts": "Drafts",
   "Templates": "Templates",


### PR DESCRIPTION
### Summary

As discussed in https://github.com/outline/outline/discussions/3936, this adds an on-demand, minimal word count feature to Outline.

### Screenshots

* Location in `DocumentMenu`:

<img width="230" alt="image" src="https://user-images.githubusercontent.com/10440566/194784373-6b8b3040-d834-498c-9416-f9b9784f130a.png">

* Dialog without any words highlighted

<img width="533" alt="image" src="https://user-images.githubusercontent.com/10440566/194784423-9206cfcc-eefd-47b2-93cd-506a21515ffb.png">

* Dialog with words highlighted

<img width="533" alt="image" src="https://user-images.githubusercontent.com/10440566/194784437-79e9f798-5c59-4e14-b08d-5ca5ff4056a6.png">
