### PR TITLE
Add `SENTRY_TUNNEL` option

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -21,7 +21,7 @@ DATABASE_CONNECTION_POOL_MAX=
 
 # For redis you can either specify an ioredis compatible url like this
 REDIS_URL=redis://localhost:6379
-# or alternatively, if you would like to provide addtional connection options,
+# or alternatively, if you would like to provide additional connection options,
 # use a base64 encoded JSON connection option object. Refer to the ioredis documentation
 # for a list of available options.
 # Example: Use Redis Sentinel for high availability
@@ -38,7 +38,7 @@ PORT=3000
 COLLABORATION_URL=
 
 # To support uploading of images for avatars and document attachments an
-# s3-compatible storage must be provided. AWS S3 is recommended for redundency
+# s3-compatible storage must be provided. AWS S3 is recommended for redundancy
 # however if you want to keep all file storage local an alternative such as
 # minio (https://github.com/minio/minio) can be used.
 
@@ -131,7 +131,7 @@ ENABLE_UPDATES=true
 # available memory by 512 for a rough estimate
 WEB_CONCURRENCY=1
 
-# Override the maxium size of document imports, could be required if you have
+# Override the maximum size of document imports, could be required if you have
 # especially large Word documents with embedded imagery
 MAXIMUM_IMPORT_SIZE=5120000
 
@@ -150,8 +150,11 @@ SLACK_MESSAGE_ACTIONS=true
 # Optionally enable google analytics to track pageviews in the knowledge base
 GOOGLE_ANALYTICS_ID=
 
-# Optionally enable Sentry (sentry.io) to track errors and performance
+# Optionally enable Sentry (sentry.io) to track errors and performance,
+# and optionally add a sentry tunnel for bypassing ad blockers in the UI:
+# https://docs.sentry.io/platforms/javascript/troubleshooting/#using-the-tunnel-option)
 SENTRY_DSN=
+SENTRY_TUNNEL=
 
 # To support sending outgoing transactional emails such as "document updated" or
 # "you've been invited" you'll need to provide authentication for an SMTP server

--- a/.env.sample
+++ b/.env.sample
@@ -151,7 +151,7 @@ SLACK_MESSAGE_ACTIONS=true
 GOOGLE_ANALYTICS_ID=
 
 # Optionally enable Sentry (sentry.io) to track errors and performance,
-# and optionally add a sentry tunnel for bypassing ad blockers in the UI:
+# and optionally add a Sentry proxy tunnel for bypassing ad blockers in the UI:
 # https://docs.sentry.io/platforms/javascript/troubleshooting/#using-the-tunnel-option)
 SENTRY_DSN=
 SENTRY_TUNNEL=

--- a/app.json
+++ b/app.json
@@ -195,6 +195,10 @@
       "description": "An API key for Sentry if you wish to collect error reporting (optional)",
       "required": false
     },
+    "SENTRY_TUNNEL": {
+      "description": "A sentry tunnel URL for bypassing ad blockers in the UI (optional)",
+      "required": false
+    },
     "TEAM_LOGO": {
       "description": "A logo that will be displayed on the signed out home page",
       "required": false

--- a/app/utils/sentry.ts
+++ b/app/utils/sentry.ts
@@ -8,6 +8,7 @@ export function initSentry(history: History) {
     dsn: env.SENTRY_DSN,
     environment: env.ENVIRONMENT,
     release: env.RELEASE,
+    tunnel: env.SENTRY_TUNNEL,
     integrations: [
       new Integrations.BrowserTracing({
         routingInstrumentation: Sentry.reactRouterV5Instrumentation(history),

--- a/server/env.ts
+++ b/server/env.ts
@@ -323,6 +323,13 @@ export class Environment {
   public SENTRY_DSN = this.toOptionalString(process.env.SENTRY_DSN);
 
   /**
+   * Sentry tunnel URL for bypassing ad blockers
+   */
+  @IsUrl()
+  @IsOptional()
+  public SENTRY_TUNNEL = this.toOptionalString(process.env.SENTRY_TUNNEL);
+
+  /**
    * A release SHA or other identifier for Sentry.
    */
   public RELEASE = this.toOptionalString(process.env.RELEASE);

--- a/server/presenters/env.ts
+++ b/server/presenters/env.ts
@@ -15,6 +15,7 @@ export default function present(env: Environment): PublicEnv {
     DEPLOYMENT: env.DEPLOYMENT,
     ENVIRONMENT: env.ENVIRONMENT,
     SENTRY_DSN: env.SENTRY_DSN,
+    SENTRY_TUNNEL: env.SENTRY_TUNNEL,
     TEAM_LOGO: env.TEAM_LOGO,
     SLACK_CLIENT_ID: env.SLACK_CLIENT_ID,
     SLACK_APP_ID: env.SLACK_APP_ID,

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -11,6 +11,7 @@ export type PublicEnv = {
   DEPLOYMENT: string | undefined;
   ENVIRONMENT: string;
   SENTRY_DSN: string | undefined;
+  SENTRY_TUNNEL: string | undefined;
   TEAM_LOGO: string | undefined;
   SLACK_CLIENT_ID: string | undefined;
   SLACK_APP_ID: string | undefined;


### PR DESCRIPTION
This adds a `SENTRY_TUNNEL` config option to bypass adblockers when sending reports to sentry (a sentry tunnel basically acts as a proxy). This also fixes some spelling mistakes in the sample environment file