### PR TITLE
chore: convert Avatar component to functional component (#4204)

### DIFF
--- a/app/components/Avatar/Avatar.tsx
+++ b/app/components/Avatar/Avatar.tsx
@@ -1,4 +1,3 @@
-import { observable } from "mobx";
 import { observer } from "mobx-react";
 import * as React from "react";
 import styled from "styled-components";
@@ -16,34 +15,30 @@ type Props = {
   className?: string;
 };
 
-@observer
-class Avatar extends React.Component<Props> {
-  @observable
-  error: boolean;
+function Avatar(props: Props) {
+  const { src, icon, showBorder, ...rest } = props;
 
-  static defaultProps = {
-    size: 24,
+  const [error, setError] = React.useState(false);
+  const handleError = () => {
+    setError(true);
   };
 
-  handleError = () => {
-    this.error = true;
-  };
-
-  render() {
-    const { src, icon, showBorder, ...rest } = this.props;
-    return (
-      <AvatarWrapper>
-        <CircleImg
-          onError={this.handleError}
-          src={this.error ? placeholder : src}
-          $showBorder={showBorder}
-          {...rest}
-        />
-        {icon && <IconWrapper>{icon}</IconWrapper>}
-      </AvatarWrapper>
-    );
-  }
+  return (
+    <AvatarWrapper>
+      <CircleImg
+        onError={handleError}
+        src={error ? placeholder : src}
+        $showBorder={showBorder}
+        {...rest}
+      />
+      {icon && <IconWrapper>{icon}</IconWrapper>}
+    </AvatarWrapper>
+  );
 }
+
+Avatar.defaultProps = {
+  size: 24,
+};
 
 const AvatarWrapper = styled.div`
   position: relative;
@@ -72,4 +67,4 @@ const CircleImg = styled.img<{ size: number; $showBorder?: boolean }>`
   flex-shrink: 0;
 `;
 
-export default Avatar;
+export default observer(Avatar);

--- a/app/components/Avatar/Avatar.tsx
+++ b/app/components/Avatar/Avatar.tsx
@@ -1,4 +1,3 @@
-import { observer } from "mobx-react";
 import * as React from "react";
 import styled from "styled-components";
 import User from "~/models/User";
@@ -65,4 +64,4 @@ const CircleImg = styled.img<{ size: number; $showBorder?: boolean }>`
   flex-shrink: 0;
 `;
 
-export default observer(Avatar);
+export default Avatar;

--- a/app/components/Avatar/Avatar.tsx
+++ b/app/components/Avatar/Avatar.tsx
@@ -2,6 +2,7 @@ import { observer } from "mobx-react";
 import * as React from "react";
 import styled from "styled-components";
 import User from "~/models/User";
+import useBoolean from "~/hooks/useBoolean";
 import placeholder from "./placeholder.png";
 
 type Props = {
@@ -18,10 +19,7 @@ type Props = {
 function Avatar(props: Props) {
   const { src, icon, showBorder, ...rest } = props;
 
-  const [error, setError] = React.useState(false);
-  const handleError = () => {
-    setError(true);
-  };
+  const [error, handleError] = useBoolean(false);
 
   return (
     <AvatarWrapper>


### PR DESCRIPTION
Converts Avatar component to function component as per #4204 

Brief summary:
1. Removed `@observable` in favour of `React.useState` - not sure if that's the correct migration strategy. 
2. Removed `@observer` in favour of wrapping `Avatar` with `observer`