### PR TITLE
fix: `DATABASE_URL` missing in env does not produce validation error

### DIFF
--- a/server/database/sequelize.ts
+++ b/server/database/sequelize.ts
@@ -7,27 +7,28 @@ const isProduction = env.ENVIRONMENT === "production";
 const isSSLDisabled = env.PGSSLMODE === "disable";
 const poolMax = env.DATABASE_CONNECTION_POOL_MAX ?? 5;
 const poolMin = env.DATABASE_CONNECTION_POOL_MIN ?? 0;
+const url =
+  env.DATABASE_URL ||
+  env.DATABASE_CONNECTION_POOL_URL ||
+  "postgres://localhost:5432/outline";
 
-export const sequelize = new Sequelize(
-  env.DATABASE_URL ?? env.DATABASE_CONNECTION_POOL_URL ?? "",
-  {
-    logging: (msg) => Logger.debug("database", msg),
-    typeValidation: true,
-    dialectOptions: {
-      ssl:
-        isProduction && !isSSLDisabled
-          ? {
-              // Ref.: https://github.com/brianc/node-postgres/issues/2009
-              rejectUnauthorized: false,
-            }
-          : false,
-    },
-    models: Object.values(models),
-    pool: {
-      max: poolMax,
-      min: poolMin,
-      acquire: 30000,
-      idle: 10000,
-    },
-  }
-);
+export const sequelize = new Sequelize(url, {
+  logging: (msg) => Logger.debug("database", msg),
+  typeValidation: true,
+  dialectOptions: {
+    ssl:
+      isProduction && !isSSLDisabled
+        ? {
+            // Ref.: https://github.com/brianc/node-postgres/issues/2009
+            rejectUnauthorized: false,
+          }
+        : false,
+  },
+  models: Object.values(models),
+  pool: {
+    max: poolMax,
+    min: poolMin,
+    acquire: 30000,
+    idle: 10000,
+  },
+});

--- a/server/database/sequelize.ts
+++ b/server/database/sequelize.ts
@@ -8,8 +8,8 @@ const isSSLDisabled = env.PGSSLMODE === "disable";
 const poolMax = env.DATABASE_CONNECTION_POOL_MAX ?? 5;
 const poolMin = env.DATABASE_CONNECTION_POOL_MIN ?? 0;
 const url =
-  env.DATABASE_URL ||
   env.DATABASE_CONNECTION_POOL_URL ||
+  env.DATABASE_URL ||
   "postgres://localhost:5432/outline";
 
 export const sequelize = new Sequelize(url, {

--- a/server/env.ts
+++ b/server/env.ts
@@ -37,6 +37,7 @@ export class Environment {
    * @returns A promise that resolves when the environment is validated.
    */
   public validate() {
+    console.log("validating…");
     return this.validationPromise;
   }
 
@@ -51,14 +52,14 @@ export class Environment {
    * set or your users will be unable to login.
    */
   @IsByteLength(32, 64)
-  public SECRET_KEY = `${process.env.SECRET_KEY}`;
+  public SECRET_KEY = process.env.SECRET_KEY ?? "";
 
   /**
    * The secret that should be passed to the cron utility endpoint to enable
    * triggering of scheduled tasks.
    */
   @IsNotEmpty()
-  public UTILS_SECRET = `${process.env.UTILS_SECRET}`;
+  public UTILS_SECRET = process.env.UTILS_SECRET ?? "";
 
   /**
    * The url of the database.
@@ -69,7 +70,7 @@ export class Environment {
     allow_underscores: true,
     protocols: ["postgres", "postgresql"],
   })
-  public DATABASE_URL = `${process.env.DATABASE_URL}`;
+  public DATABASE_URL = process.env.DATABASE_URL ?? "";
 
   /**
    * The url of the database pool.
@@ -125,7 +126,7 @@ export class Environment {
    */
   @IsNotEmpty()
   @IsUrl({ require_tld: false })
-  public URL = `${process.env.URL}`;
+  public URL = process.env.URL || "";
 
   /**
    * If using a Cloudfront/Cloudflare distribution or similar it can be set below.
@@ -157,7 +158,7 @@ export class Environment {
   /**
    * Optional extra debugging. Comma separated
    */
-  public DEBUG = `${process.env.DEBUG}`;
+  public DEBUG = process.env.DEBUG || "";
 
   /**
    * How many processes should be spawned. As a reasonable rule divide your

--- a/server/env.ts
+++ b/server/env.ts
@@ -37,7 +37,6 @@ export class Environment {
    * @returns A promise that resolves when the environment is validated.
    */
   public validate() {
-    console.log("validating…");
     return this.validationPromise;
   }
 


### PR DESCRIPTION
Missing `DATABASE_URL` in configuration was causing server to crash rather than produce a human readable error, see:
https://github.com/outline/outline/discussions/4408

This also fixes `DATABASE_CONNECTION_POOL_URL` never being evaluated as it sat behind the required `DATABASE_URL`.