### PR TITLE
fix errors with custom OIDC provider

### DIFF
--- a/server/commands/userProvisioner.ts
+++ b/server/commands/userProvisioner.ts
@@ -60,7 +60,7 @@ export default async function userProvisioner({
   const auth = authentication
     ? await UserAuthentication.findOne({
         where: {
-          providerId: authentication.providerId,
+          providerId: "" + authentication.providerId,
         },
         include: [
           {

--- a/server/models/UserAuthentication.ts
+++ b/server/models/UserAuthentication.ts
@@ -1,5 +1,6 @@
 import { addMinutes, subMinutes } from "date-fns";
 import invariant from "invariant";
+import { isObject } from "lodash";
 import { SaveOptions } from "sequelize";
 import {
   BeforeCreate,
@@ -145,6 +146,7 @@ class UserAuthentication extends IdModel {
     if (
       this.expiresAt > addMinutes(Date.now(), 5) ||
       !this.refreshToken ||
+      isObject(this.refreshToken) ||
       // Some providers send no expiry depending on setup, in this case we can't
       // refresh and assume the session is valid until logged out.
       !this.expiresAt


### PR DESCRIPTION
There are 2 errors fixed in pull request:
1. if OIDC provider gets user_id as integer Postgres failed query because providerId must be a string
2. if there isn't refreshToken function getEncryptedColumn returns empty object and expression "!this.refreshToken" returns false