### PR TITLE
fix: string error with custom OIDC provider

### DIFF
--- a/server/commands/userProvisioner.ts
+++ b/server/commands/userProvisioner.ts
@@ -60,7 +60,7 @@ export default async function userProvisioner({
   const auth = authentication
     ? await UserAuthentication.findOne({
         where: {
-          providerId: authentication.providerId,
+          providerId: "" + authentication.providerId,
         },
         include: [
           {

--- a/server/models/decorators/Encrypted.ts
+++ b/server/models/decorators/Encrypted.ts
@@ -18,6 +18,9 @@ export default function Encrypted(target: any, propertyKey: string) {
  */
 export function getEncryptedColumn(target: any, propertyKey: string): string {
   try {
+    if (!target.getDataValue(propertyKey)) {
+      return "";
+    }
     return Reflect.getMetadata(key, target, propertyKey).get.call(target);
   } catch (err) {
     if (err.message.includes("Unexpected end of JSON input")) {


### PR DESCRIPTION
if OIDC provider gets user_id as integer Postgres failed query because providerId must be a string