### PR TITLE
if OIDC provider gets user_id as integer Postgres failed query 

### DIFF
--- a/server/commands/userProvisioner.ts
+++ b/server/commands/userProvisioner.ts
@@ -60,7 +60,7 @@ export default async function userProvisioner({
   const auth = authentication
     ? await UserAuthentication.findOne({
         where: {
-          providerId: authentication.providerId,
+          providerId: "" + authentication.providerId,
         },
         include: [
           {


### PR DESCRIPTION
Sorry for that, but previous pull request had wrong commit (((
 
if OIDC provider gets user_id as integer Postgres failed query because providerId must be a string