### PR TITLE
feat: Allow moving draft documents

### DIFF
--- a/app/components/DocumentBreadcrumb.tsx
+++ b/app/components/DocumentBreadcrumb.tsx
@@ -77,8 +77,9 @@ const DocumentBreadcrumb: React.FC<Props> = ({
   }
 
   const path = React.useMemo(
-    () => collection?.pathToDocument?.(document.id).slice(0, -1) || [],
-    [collection, document]
+    () => collection?.pathToDocument(document.id).slice(0, -1) || [],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [collection, document, document.collectionId, document.parentDocumentId]
   );
 
   const items = React.useMemo(() => {

--- a/app/components/Sidebar/components/CollectionLink.tsx
+++ b/app/components/Sidebar/components/CollectionLink.tsx
@@ -27,7 +27,7 @@ import { useStarredContext } from "./StarredContext";
 type Props = {
   collection: Collection;
   expanded?: boolean;
-  onDisclosureClick: (ev: React.MouseEvent<HTMLButtonElement>) => void;
+  onDisclosureClick: (ev?: React.MouseEvent<HTMLButtonElement>) => void;
   activeDocument: Document | undefined;
   isDraggingAnyCollection?: boolean;
 };
@@ -62,7 +62,7 @@ const CollectionLink: React.FC<Props> = ({
   // Drop to re-parent document
   const [{ isOver, canDrop }, drop] = useDrop({
     accept: "document",
-    drop: (item: DragObject, monitor) => {
+    drop: async (item: DragObject, monitor) => {
       const { id, collectionId } = item;
       if (monitor.didDrop()) {
         return;
@@ -81,7 +81,8 @@ const CollectionLink: React.FC<Props> = ({
       if (
         prevCollection &&
         prevCollection.permission === null &&
-        prevCollection.permission !== collection.permission
+        prevCollection.permission !== collection.permission &&
+        !document?.isDraft
       ) {
         itemRef.current = item;
 
@@ -97,7 +98,11 @@ const CollectionLink: React.FC<Props> = ({
           ),
         });
       } else {
-        documents.move(id, collection.id);
+        await documents.move(id, collection.id);
+
+        if (!expanded) {
+          onDisclosureClick();
+        }
       }
     },
     canDrop: () => canUpdate,

--- a/app/components/Sidebar/components/DocumentLink.tsx
+++ b/app/components/Sidebar/components/DocumentLink.tsx
@@ -105,8 +105,7 @@ function InnerDocumentLink(
 
   const handleDisclosureClick = React.useCallback(
     (ev) => {
-      ev.preventDefault();
-      ev.stopPropagation();
+      ev?.preventDefault();
       setExpanded(!expanded);
     },
     [expanded]
@@ -150,14 +149,10 @@ function InnerDocumentLink(
     collect: (monitor) => ({
       isDragging: monitor.isDragging(),
     }),
-    canDrag: () => {
-      return (
-        !isDraft &&
-        (policies.abilities(node.id).move ||
-          policies.abilities(node.id).archive ||
-          policies.abilities(node.id).delete)
-      );
-    },
+    canDrag: () =>
+      policies.abilities(node.id).move ||
+      policies.abilities(node.id).archive ||
+      policies.abilities(node.id).delete,
   });
 
   const hoverExpanding = React.useRef<ReturnType<typeof setTimeout>>();
@@ -174,19 +169,18 @@ function InnerDocumentLink(
   // Drop to re-parent
   const [{ isOverReparent, canDropToReparent }, dropToReparent] = useDrop({
     accept: "document",
-    drop: (item: DragObject, monitor) => {
+    drop: async (item: DragObject, monitor) => {
       if (monitor.didDrop()) {
         return;
       }
       if (!collection) {
         return;
       }
-      documents.move(item.id, collection.id, node.id);
+      await documents.move(item.id, collection.id, node.id);
+      setExpanded(true);
     },
     canDrop: (_item, monitor) =>
-      !isDraft &&
-      !!pathToNode &&
-      !pathToNode.includes(monitor.getItem<DragObject>().id),
+      !!pathToNode && !pathToNode.includes(monitor.getItem<DragObject>().id),
     hover: (_item, monitor) => {
       // Enables expansion of document children when hovering over the document
       // for more than half a second.

--- a/app/components/Sidebar/components/DraggableCollectionLink.tsx
+++ b/app/components/Sidebar/components/DraggableCollectionLink.tsx
@@ -91,7 +91,7 @@ function DraggableCollectionLink({
   }, [collection.id, ui.activeCollectionId, locationStateStarred]);
 
   const handleDisclosureClick = React.useCallback((ev) => {
-    ev.preventDefault();
+    ev?.preventDefault();
     setExpanded((e) => !e);
   }, []);
 

--- a/app/models/Collection.ts
+++ b/app/models/Collection.ts
@@ -171,8 +171,11 @@ export default class Collection extends ParanoidModel {
   }
 
   pathToDocument(documentId: string) {
-    let path: NavigationNode[] | undefined;
+    let path: NavigationNode[] | undefined = [];
     const document = this.store.rootStore.documents.get(documentId);
+    if (!document) {
+      return path;
+    }
 
     const travelNodes = (
       nodes: NavigationNode[],
@@ -187,8 +190,8 @@ export default class Collection extends ParanoidModel {
         }
 
         if (
-          document?.parentDocumentId &&
-          node?.id === document?.parentDocumentId
+          document.parentDocumentId &&
+          node.id === document.parentDocumentId
         ) {
           path = [...newPath, document.asNavigationNode];
           return;
@@ -199,10 +202,10 @@ export default class Collection extends ParanoidModel {
     };
 
     if (this.documents) {
-      travelNodes(this.documents, []);
+      travelNodes(this.documents, path);
     }
 
-    return path || [];
+    return path;
   }
 
   @action

--- a/server/policies/document.test.ts
+++ b/server/policies/document.test.ts
@@ -128,7 +128,7 @@ describe("no collection", () => {
     expect(abilities.createChildDocument).toEqual(false);
     expect(abilities.delete).toEqual(true);
     expect(abilities.download).toEqual(true);
-    expect(abilities.move).toEqual(false);
+    expect(abilities.move).toEqual(true);
     expect(abilities.permanentDelete).toEqual(false);
     expect(abilities.pin).toEqual(false);
     expect(abilities.pinToHome).toEqual(false);

--- a/server/policies/document.ts
+++ b/server/policies/document.ts
@@ -174,9 +174,6 @@ allow(User, "move", Document, (user, document) => {
   if (document.deletedAt) {
     return false;
   }
-  if (!document.publishedAt) {
-    return false;
-  }
   invariant(
     document.collection,
     "collection is missing, did you forget to include in the query scope?"

--- a/server/policies/document.ts
+++ b/server/policies/document.ts
@@ -174,6 +174,9 @@ allow(User, "move", Document, (user, document) => {
   if (document.deletedAt) {
     return false;
   }
+  if (!document.publishedAt) {
+    return true;
+  }
   invariant(
     document.collection,
     "collection is missing, did you forget to include in the query scope?"

--- a/server/policies/document.ts
+++ b/server/policies/document.ts
@@ -174,14 +174,7 @@ allow(User, "move", Document, (user, document) => {
   if (document.deletedAt) {
     return false;
   }
-  if (!document.publishedAt) {
-    return true;
-  }
-  invariant(
-    document.collection,
-    "collection is missing, did you forget to include in the query scope?"
-  );
-  if (cannot(user, "update", document.collection)) {
+  if (document.collection && cannot(user, "update", document.collection)) {
     return false;
   }
   return user.teamId === document.teamId;


### PR DESCRIPTION
I don't really remember why we thought it was a good idea to prevent this, it's very useful to move a draft doc before you publish it.

This will use a new move modal once https://github.com/outline/outline/pull/4582 is complete, but for now the move UI remains unchanged.

closes #4644 