### PR TITLE
Allow listening on a custom address

### DIFF
--- a/server/env.ts
+++ b/server/env.ts
@@ -155,6 +155,12 @@ export class Environment {
   public PORT = this.toOptionalNumber(process.env.PORT);
 
   /**
+   * The address that the server will listen on, defaults to localhost.
+   */
+  @IsOptional()
+  public LISTEN_ADDRESS = process.env.LISTEN_ADDRESS || "";
+
+  /**
    * Optional extra debugging. Comma separated
    */
   public DEBUG = process.env.DEBUG || "";

--- a/server/index.ts
+++ b/server/index.ts
@@ -68,6 +68,13 @@ async function start(id: number, disconnect: () => void) {
 
   // If a --port flag is passed then it takes priority over the env variable
   const normalizedPortFlag = getArg("port", "p");
+  const listenPort = Number(normalizedPortFlag || env.PORT || "3000");
+  if (Number.isNaN(listenPort)) {
+    throw new Error("Port is not a number");
+  }
+
+  const listenAddress = env.LISTEN_ADDRESS || "localhost";
+
   const app = new Koa();
   const server = stoppable(
     useHTTPS
@@ -113,13 +120,13 @@ async function start(id: number, disconnect: () => void) {
 
     Logger.info(
       "lifecycle",
-      `Listening on ${useHTTPS ? "https" : "http"}://localhost:${
+      `Listening on ${useHTTPS ? "https" : "http"}://${listenAddress}:${
         (address as AddressInfo).port
       }`
     );
   });
 
-  server.listen(normalizedPortFlag || env.PORT || "3000");
+  server.listen(listenPort, listenAddress);
   server.setTimeout(env.REQUEST_TIMEOUT);
 
   ShutdownHelper.add("server", ShutdownOrder.last, () => {


### PR DESCRIPTION
With the listen address hardcoded to `localhost`, it's not possible to run Outline behind an external load balancer.

A better way might be to have a single env var like `LISTEN=localhost:3000` and a corresponding flag like `-l`, but I didn't want to break backwards compatibility.