### PR TITLE
chore: Improvements to document move behavior

### DIFF
--- a/app/scenes/DocumentMove.tsx
+++ b/app/scenes/DocumentMove.tsx
@@ -63,13 +63,6 @@ function DocumentMove({ document, onRequestClose }: Props) {
     if (onlyShowCollections) {
       results = results.filter((result) => result.type === "collection");
     } else {
-      // Exclude root from search results if document is already at the root
-      if (!document.parentDocumentId) {
-        results = results.filter(
-          (result) => result.id !== document.collectionId
-        );
-      }
-
       // Exclude document if on the path to result, or the same result
       results = results.filter(
         (result) =>

--- a/server/commands/documentMover.test.ts
+++ b/server/commands/documentMover.test.ts
@@ -1,10 +1,6 @@
 import { sequelize } from "@server/database/sequelize";
 import Pin from "@server/models/Pin";
-import {
-  buildDocument,
-  buildCollection,
-  buildUser,
-} from "@server/test/factories";
+import { buildDocument, buildCollection } from "@server/test/factories";
 import { setupTestDatabase, seed } from "@server/test/support";
 import documentMover from "./documentMover";
 
@@ -25,28 +21,31 @@ describe("documentMover", () => {
     expect(response.documents.length).toEqual(1);
   });
 
-  it("should error when not in source collection documentStructure", async () => {
-    const user = await buildUser();
-    const collection = await buildCollection({
-      teamId: user.teamId,
-    });
-    const document = await buildDocument({
+  it("should succeed when not in source collection documentStructure", async () => {
+    const { document, user, collection } = await seed();
+    const newDocument = await buildDocument({
+      parentDocumentId: document.id,
       collectionId: collection.id,
+      teamId: collection.teamId,
+      userId: collection.createdById,
+      title: "Child document",
+      text: "content",
     });
-    await document.archive(user.id);
-
-    let error;
-    try {
-      await documentMover({
-        user,
-        document,
-        collectionId: collection.id,
-        ip,
-      });
-    } catch (err) {
-      error = err;
-    }
-    expect(error).toBeTruthy();
+    const response = await documentMover({
+      user,
+      document,
+      collectionId: collection.id,
+      parentDocumentId: undefined,
+      index: 0,
+      ip,
+    });
+    expect(response.collections[0].documentStructure![0].children[0].id).toBe(
+      newDocument.id
+    );
+    expect(response.collections.length).toEqual(1);
+    expect(response.documents.length).toEqual(1);
+    expect(response.documents[0].collection?.id).toEqual(collection.id);
+    expect(response.documents[0].updatedBy.id).toEqual(user.id);
   });
 
   it("should move with children", async () => {

--- a/server/commands/documentMover.ts
+++ b/server/commands/documentMover.ts
@@ -1,6 +1,5 @@
 import invariant from "invariant";
 import { Transaction } from "sequelize";
-import { ValidationError } from "@server/errors";
 import { traceFunction } from "@server/logging/tracing";
 import { User, Document, Collection, Pin, Event } from "@server/models";
 import pinDestroyer from "./pinDestroyer";
@@ -74,11 +73,11 @@ async function documentMover({
         save: collectionChanged,
       });
 
-      const documentJson = response?.[0];
+      let documentJson = response?.[0];
       const fromIndex = response?.[1] || 0;
 
       if (!documentJson) {
-        throw ValidationError("The document was not found in the collection");
+        documentJson = await document.toNavigationNode({ transaction });
       }
 
       // if we're reordering from within the same parent

--- a/server/models/Collection.test.ts
+++ b/server/models/Collection.test.ts
@@ -33,7 +33,10 @@ describe("getDocumentParents", () => {
     const document = await buildDocument();
     const collection = await buildCollection({
       documentStructure: [
-        { ...parent.toJSON(), children: [document.toJSON()] },
+        {
+          ...(await parent.toNavigationNode()),
+          children: [await document.toNavigationNode()],
+        },
       ],
     });
     const result = collection.getDocumentParents(document.id);
@@ -46,7 +49,10 @@ describe("getDocumentParents", () => {
     const document = await buildDocument();
     const collection = await buildCollection({
       documentStructure: [
-        { ...parent.toJSON(), children: [document.toJSON()] },
+        {
+          ...(await parent.toNavigationNode()),
+          children: [await document.toNavigationNode()],
+        },
       ],
     });
     const result = collection.getDocumentParents(parent.id);
@@ -66,9 +72,11 @@ describe("getDocumentTree", () => {
   test("should return document tree", async () => {
     const document = await buildDocument();
     const collection = await buildCollection({
-      documentStructure: [document.toJSON()],
+      documentStructure: [await document.toNavigationNode()],
     });
-    expect(collection.getDocumentTree(document.id)).toEqual(document.toJSON());
+    expect(collection.getDocumentTree(document.id)).toEqual(
+      await document.toNavigationNode()
+    );
   });
 
   test("should return nested documents in tree", async () => {
@@ -76,15 +84,20 @@ describe("getDocumentTree", () => {
     const document = await buildDocument();
     const collection = await buildCollection({
       documentStructure: [
-        { ...parent.toJSON(), children: [document.toJSON()] },
+        {
+          ...(await parent.toNavigationNode()),
+          children: [await document.toNavigationNode()],
+        },
       ],
     });
 
     expect(collection.getDocumentTree(parent.id)).toEqual({
-      ...parent.toJSON(),
-      children: [document.toJSON()],
+      ...(await parent.toNavigationNode()),
+      children: [await document.toNavigationNode()],
     });
-    expect(collection.getDocumentTree(document.id)).toEqual(document.toJSON());
+    expect(collection.getDocumentTree(document.id)).toEqual(
+      await document.toNavigationNode()
+    );
   });
 });
 

--- a/server/models/Collection.test.ts
+++ b/server/models/Collection.test.ts
@@ -105,10 +105,11 @@ describe("#addDocumentToStructure", () => {
   test("should add as last element without index", async () => {
     const { collection } = await seed();
     const id = uuidv4();
-    const newDocument = new Document({
+    const newDocument = await buildDocument({
       id,
       title: "New end node",
       parentDocumentId: null,
+      teamId: collection.teamId,
     });
     await collection.addDocumentToStructure(newDocument);
     expect(collection.documentStructure!.length).toBe(2);
@@ -118,10 +119,11 @@ describe("#addDocumentToStructure", () => {
   test("should add with an index", async () => {
     const { collection } = await seed();
     const id = uuidv4();
-    const newDocument = new Document({
+    const newDocument = await buildDocument({
       id,
       title: "New end node",
       parentDocumentId: null,
+      teamId: collection.teamId,
     });
     await collection.addDocumentToStructure(newDocument, 1);
     expect(collection.documentStructure!.length).toBe(2);
@@ -131,10 +133,11 @@ describe("#addDocumentToStructure", () => {
   test("should add as a child if with parent", async () => {
     const { collection, document } = await seed();
     const id = uuidv4();
-    const newDocument = new Document({
+    const newDocument = await buildDocument({
       id,
       title: "New end node",
       parentDocumentId: document.id,
+      teamId: collection.teamId,
     });
     await collection.addDocumentToStructure(newDocument, 1);
     expect(collection.documentStructure!.length).toBe(1);
@@ -145,16 +148,18 @@ describe("#addDocumentToStructure", () => {
 
   test("should add as a child if with parent with index", async () => {
     const { collection, document } = await seed();
-    const newDocument = new Document({
+    const newDocument = await buildDocument({
       id: uuidv4(),
       title: "node",
       parentDocumentId: document.id,
+      teamId: collection.teamId,
     });
     const id = uuidv4();
-    const secondDocument = new Document({
+    const secondDocument = await buildDocument({
       id,
       title: "New start node",
       parentDocumentId: document.id,
+      teamId: collection.teamId,
     });
     await collection.addDocumentToStructure(newDocument);
     await collection.addDocumentToStructure(secondDocument, 0);
@@ -167,10 +172,11 @@ describe("#addDocumentToStructure", () => {
     test("should append supplied json over document's own", async () => {
       const { collection } = await seed();
       const id = uuidv4();
-      const newDocument = new Document({
+      const newDocument = await buildDocument({
         id: uuidv4(),
         title: "New end node",
         parentDocumentId: null,
+        teamId: collection.teamId,
       });
       await collection.addDocumentToStructure(newDocument, undefined, {
         documentJson: {

--- a/server/routes/api/documents/documents.test.ts
+++ b/server/routes/api/documents/documents.test.ts
@@ -231,7 +231,7 @@ describe("#documents.info", () => {
       expect(body.data.document.id).toEqual(document.id);
       expect(body.data.document.createdBy).toEqual(undefined);
       expect(body.data.document.updatedBy).toEqual(undefined);
-      expect(body.data.sharedTree).toEqual(document.toJSON());
+      expect(body.data.sharedTree).toEqual(await document.toNavigationNode());
     });
     it("should not return sharedTree if child documents not shared", async () => {
       const { document, user } = await seed();
@@ -2622,7 +2622,7 @@ describe("#documents.update", () => {
             title: "Another doc",
             children: [],
           },
-          { ...document.toJSON(), children: [] },
+          { ...(await document.toNavigationNode()), children: [] },
         ],
       },
     ];


### PR DESCRIPTION
- Don't override the `toJSON` method, renamed to `toNavigationNode`
- Made more resilient so the method returns the correct result at any time
- Allow collection `documentStructure` to self-heal