### PR TITLE
fix: Visual Basic syntax higlighting (#4769)

### DIFF
--- a/shared/editor/plugins/Prism.ts
+++ b/shared/editor/plugins/Prism.ts
@@ -40,7 +40,7 @@ export const LANGUAGES = {
   swift: "Swift",
   toml: "TOML",
   typescript: "TypeScript",
-  visualbasic: "Visual Basic",
+  vb: "Visual Basic",
   yaml: "YAML",
   zig: "Zig",
 };


### PR DESCRIPTION
Aliases "vb" or "vba" need to be used for Prism, rather than "visualbasic".