### PR TITLE
feat: dynamically load code blocks language

### DIFF
--- a/shared/editor/nodes/CodeFence.ts
+++ b/shared/editor/nodes/CodeFence.ts
@@ -15,42 +15,6 @@ import {
   Plugin,
   PluginKey,
 } from "prosemirror-state";
-import refractor from "refractor/core";
-import bash from "refractor/lang/bash";
-import clike from "refractor/lang/clike";
-import csharp from "refractor/lang/csharp";
-import css from "refractor/lang/css";
-import elixir from "refractor/lang/elixir";
-import erlang from "refractor/lang/erlang";
-import go from "refractor/lang/go";
-import graphql from "refractor/lang/graphql";
-import groovy from "refractor/lang/groovy";
-import haskell from "refractor/lang/haskell";
-import ini from "refractor/lang/ini";
-import java from "refractor/lang/java";
-import javascript from "refractor/lang/javascript";
-import json from "refractor/lang/json";
-import kotlin from "refractor/lang/kotlin";
-import lisp from "refractor/lang/lisp";
-import lua from "refractor/lang/lua";
-import markup from "refractor/lang/markup";
-import objectivec from "refractor/lang/objectivec";
-import ocaml from "refractor/lang/ocaml";
-import perl from "refractor/lang/perl";
-import php from "refractor/lang/php";
-import powershell from "refractor/lang/powershell";
-import python from "refractor/lang/python";
-import ruby from "refractor/lang/ruby";
-import rust from "refractor/lang/rust";
-import scala from "refractor/lang/scala";
-import solidity from "refractor/lang/solidity";
-import sql from "refractor/lang/sql";
-import swift from "refractor/lang/swift";
-import toml from "refractor/lang/toml";
-import typescript from "refractor/lang/typescript";
-import visualbasic from "refractor/lang/visual-basic";
-import yaml from "refractor/lang/yaml";
-import zig from "refractor/lang/zig";
 
 import { UserPreferences } from "@shared/types";
 import { Dictionary } from "~/hooks/useDictionary";
@@ -65,44 +29,6 @@ import Node from "./Node";
 
 const PERSISTENCE_KEY = "rme-code-language";
 const DEFAULT_LANGUAGE = "javascript";
-
-[
-  bash,
-  css,
-  clike,
-  csharp,
-  elixir,
-  erlang,
-  go,
-  graphql,
-  groovy,
-  haskell,
-  ini,
-  java,
-  javascript,
-  json,
-  kotlin,
-  lisp,
-  lua,
-  markup,
-  objectivec,
-  ocaml,
-  perl,
-  php,
-  python,
-  powershell,
-  ruby,
-  rust,
-  scala,
-  sql,
-  solidity,
-  swift,
-  toml,
-  typescript,
-  visualbasic,
-  yaml,
-  zig,
-].forEach(refractor.register);
 
 export default class CodeFence extends Node {
   constructor(options: {

--- a/shared/editor/plugins/Prism.ts
+++ b/shared/editor/plugins/Prism.ts
@@ -45,6 +45,9 @@ export const LANGUAGES = {
   zig: "Zig",
 };
 
+// Languages that are not supported by refractor or are specially handled
+const EXCLUDED_LANGUAGES = ["mermaidjs"];
+
 type ParsedNode = {
   text: string;
   classes: string[];
@@ -89,7 +92,8 @@ function getDecorations({
   blocks.forEach(async (block) => {
     let startPos = block.pos + 1;
     const language = block.node.attrs.language;
-    if (!language || language === "none") {
+    const isExcluded = EXCLUDED_LANGUAGES.includes(language);
+    if (!language || language === "none" || isExcluded) {
       return;
     }
 

--- a/shared/editor/plugins/Prism.ts
+++ b/shared/editor/plugins/Prism.ts
@@ -32,6 +32,7 @@ export const LANGUAGES = {
   php: "PHP",
   powershell: "Powershell",
   python: "Python",
+  rego: "Rego",
   ruby: "Ruby",
   rust: "Rust",
   scala: "Scala",

--- a/shared/editor/plugins/Prism.ts
+++ b/shared/editor/plugins/Prism.ts
@@ -94,7 +94,7 @@ function getDecorations({
     let startPos = block.pos + 1;
     const language = block.node.attrs.language;
     const isExcluded = EXCLUDED_LANGUAGES.includes(language);
-    if (!language || language === "none" || isExcluded) {
+    if (!language || isExcluded) {
       return;
     }
 

--- a/shared/editor/plugins/Prism.ts
+++ b/shared/editor/plugins/Prism.ts
@@ -47,7 +47,7 @@ export const LANGUAGES = {
 };
 
 // Languages that are not supported by refractor or are specially handled
-const EXCLUDED_LANGUAGES = ["mermaidjs"];
+const EXCLUDED_LANGUAGES = ["mermaidjs", "none"];
 
 type ParsedNode = {
   text: string;

--- a/shared/editor/plugins/Prism.ts
+++ b/shared/editor/plugins/Prism.ts
@@ -40,7 +40,7 @@ export const LANGUAGES = {
   swift: "Swift",
   toml: "TOML",
   typescript: "TypeScript",
-  visualbasic: "Visual Basic",
+  "visual-basic": "Visual Basic",
   yaml: "YAML",
   zig: "Zig",
 };

--- a/shared/editor/plugins/Prism.ts
+++ b/shared/editor/plugins/Prism.ts
@@ -86,11 +86,22 @@ function getDecorations({
     });
   }
 
-  blocks.forEach((block) => {
+  blocks.forEach(async (block) => {
     let startPos = block.pos + 1;
     const language = block.node.attrs.language;
-    if (!language || language === "none" || !refractor.registered(language)) {
+    if (!language || language === "none") {
       return;
+    }
+
+    if (!refractor.registered(language)) {
+      try {
+        // Dynamically load and register the language module
+        const mod = await import(`refractor/lang/${language}`);
+        refractor.register(mod.default);
+      } catch (e) {
+        console.error(`Failed loading '${language}' language module: ${e}`);
+        return;
+      }
     }
 
     const lineDecorations = [];


### PR DESCRIPTION
# Description

Add support for languages in code blocks to be loaded dynamically. This opens the door to more easily support additional languages without affecting page loading that don't use those languages.

As a follow-up to this PR it'd be interesting to generate the list of languages dynamically (on build, maybe?) to keep it in sync with supported languages from Refractor/Prism.js. For now, I've added a language to the list: [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/).

# Implementation

- Removed the auto-register logic in CodeFence
- Used [Webpack's Dynamic Imports feature](https://webpack.js.org/guides/code-splitting/#dynamic-imports) in the Prism.js plugin. On each block, if a language isn't already registered it is imported and registered. This effectively loads only the languages for the code blocks already present or added in a document.
- Toggling a code block selected language causes a new chunk to be fetched with that language's definition, if not previously fetched and registered (this behavior can be observed by looking at the network tab).

# Issues

This implementation, as of now, has a couple of issues:

- Adding a code block, adding some content and then toggling the selected language to one that hasn't been loaded/registered already doesn't re-render the code block (i.e. syntax highlighting isn't rendered). If we type something in the same code block afterwards the syntax  is correctly highlighted.
- Adding a code block, selecting the language we want first, and typing some code causes the cursor to move to the start of the line.

_See [this screencast](https://www.loom.com/share/444e7f546ff1441fb6a8842157f399ef) for a demo of the issues._

# Related Issues/Discussions

- #4764 
- fixes #4769
- closes #4770 