### PR TITLE
Revert "Upgrade maximum allowed Node version to 18"

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "url": "https://github.com/sponsors/outline"
   },
   "engines": {
-    "node": ">= 14 <=18"
+    "node": ">= 14 <=16"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Reverts outline/outline#4844

Sorry, this broke Heroku deploy due to Webpack dep – need to wait until Vite is merged.

```
Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:133:10)
```