### PR TITLE
Expose Sequelize schema configuration through env variable

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -18,6 +18,8 @@ DATABASE_CONNECTION_POOL_MIN=
 DATABASE_CONNECTION_POOL_MAX=
 # Uncomment this to disable SSL for connecting to Postgres
 # PGSSLMODE=disable
+# Define a specific database schema if deviating from default.
+# DATABASE_SCHEMA=
 
 # For redis you can either specify an ioredis compatible url like this
 REDIS_URL=redis://localhost:6379

--- a/server/database/sequelize.ts
+++ b/server/database/sequelize.ts
@@ -1,27 +1,29 @@
-import { Sequelize } from "sequelize-typescript";
-import env from "@server/env";
-import Logger from "../logging/Logger";
-import * as models from "../models";
+import { Sequelize } from "sequelize-typescript"
+import env from "@server/env"
+import Logger from "../logging/Logger"
+import * as models from "../models"
 
-const isProduction = env.ENVIRONMENT === "production";
-const isSSLDisabled = env.PGSSLMODE === "disable";
-const poolMax = env.DATABASE_CONNECTION_POOL_MAX ?? 5;
-const poolMin = env.DATABASE_CONNECTION_POOL_MIN ?? 0;
+const schema = env.DATABASE_SCHEMA
+const isProduction = env.ENVIRONMENT === "production"
+const isSSLDisabled = env.PGSSLMODE === "disable"
+const poolMax = env.DATABASE_CONNECTION_POOL_MAX ?? 5
+const poolMin = env.DATABASE_CONNECTION_POOL_MIN ?? 0
 const url =
   env.DATABASE_CONNECTION_POOL_URL ||
   env.DATABASE_URL ||
-  "postgres://localhost:5432/outline";
+  "postgres://localhost:5432/outline"
 
 export const sequelize = new Sequelize(url, {
+  schema,
   logging: (msg) => Logger.debug("database", msg),
   typeValidation: true,
   dialectOptions: {
     ssl:
       isProduction && !isSSLDisabled
         ? {
-            // Ref.: https://github.com/brianc/node-postgres/issues/2009
-            rejectUnauthorized: false,
-          }
+          // Ref.: https://github.com/brianc/node-postgres/issues/2009
+          rejectUnauthorized: false,
+        }
         : false,
   },
   models: Object.values(models),
@@ -31,4 +33,4 @@ export const sequelize = new Sequelize(url, {
     acquire: 30000,
     idle: 10000,
   },
-});
+})

--- a/server/env.ts
+++ b/server/env.ts
@@ -3,7 +3,7 @@
 // Load the process environment variables
 require("dotenv").config({
   silent: true,
-});
+})
 
 import {
   validate,
@@ -18,17 +18,17 @@ import {
   IsBoolean,
   Contains,
   MaxLength,
-} from "class-validator";
-import { languages } from "@shared/i18n";
-import { CannotUseWithout } from "@server/utils/validators";
-import Deprecated from "./models/decorators/Deprecated";
-import { getArg } from "./utils/args";
+} from "class-validator"
+import { languages } from "@shared/i18n"
+import { CannotUseWithout } from "@server/utils/validators"
+import Deprecated from "./models/decorators/Deprecated"
+import { getArg } from "./utils/args"
 
 export class Environment {
-  private validationPromise;
+  private validationPromise
 
   constructor() {
-    this.validationPromise = validate(this);
+    this.validationPromise = validate(this)
   }
 
   /**
@@ -37,7 +37,7 @@ export class Environment {
    * @returns A promise that resolves when the environment is validated.
    */
   public validate() {
-    return this.validationPromise;
+    return this.validationPromise
   }
 
   /**
@@ -70,6 +70,12 @@ export class Environment {
     protocols: ["postgres", "postgresql"],
   })
   public DATABASE_URL = process.env.DATABASE_URL ?? "";
+
+  /**
+   * The database schema to be used.
+   */
+  @IsOptional()
+  public DATABASE_SCHEMA = process.env.DATABASE_SCHEMA;
 
   /**
    * The url of the database pool.
@@ -580,15 +586,15 @@ export class Environment {
    * getoutline.com
    */
   public isCloudHosted() {
-    return this.DEPLOYMENT === "hosted";
+    return this.DEPLOYMENT === "hosted"
   }
 
   private toOptionalString(value: string | undefined) {
-    return value ? value : undefined;
+    return value ? value : undefined
   }
 
   private toOptionalNumber(value: string | undefined) {
-    return value ? parseInt(value, 10) : undefined;
+    return value ? parseInt(value, 10) : undefined
   }
 
   /**
@@ -604,10 +610,10 @@ export class Environment {
    * @returns A boolean
    */
   private toBoolean(value: string) {
-    return value ? !!JSON.parse(value) : false;
+    return value ? !!JSON.parse(value) : false
   }
 }
 
-const env = new Environment();
+const env = new Environment()
 
-export default env;
+export default env


### PR DESCRIPTION
This fixes #4863 by exposing the `schema` configuration value of Sequelize through a new `DATABASE_SCHEMA` environment variable. This way hosted installations of Outline can be directed to use custom schemas other than the default "public" schema if desired.