### PR TITLE
Expose Sequelize schema configuration through env variable

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -18,7 +18,7 @@ DATABASE_CONNECTION_POOL_MIN=
 DATABASE_CONNECTION_POOL_MAX=
 # Uncomment this to disable SSL for connecting to Postgres
 # PGSSLMODE=disable
-# Specify a specific schema to use if deviating from defaults.
+# Optionally specify a database schema if different from "public". 
 # DATABASE_SCHEMA=
 
 # For redis you can either specify an ioredis compatible url like this

--- a/.env.sample
+++ b/.env.sample
@@ -18,6 +18,8 @@ DATABASE_CONNECTION_POOL_MIN=
 DATABASE_CONNECTION_POOL_MAX=
 # Uncomment this to disable SSL for connecting to Postgres
 # PGSSLMODE=disable
+# Specify a specific schema to use if deviating from defaults.
+# DATABASE_SCHEMA=
 
 # For redis you can either specify an ioredis compatible url like this
 REDIS_URL=redis://localhost:6379

--- a/server/database/sequelize.ts
+++ b/server/database/sequelize.ts
@@ -3,6 +3,7 @@ import env from "@server/env";
 import Logger from "../logging/Logger";
 import * as models from "../models";
 
+const schema = env.DATABASE_SCHEMA;
 const isProduction = env.ENVIRONMENT === "production";
 const isSSLDisabled = env.PGSSLMODE === "disable";
 const poolMax = env.DATABASE_CONNECTION_POOL_MAX ?? 5;
@@ -13,6 +14,7 @@ const url =
   "postgres://localhost:5432/outline";
 
 export const sequelize = new Sequelize(url, {
+  schema,
   logging: (msg) => Logger.debug("database", msg),
   typeValidation: true,
   dialectOptions: {

--- a/server/env.ts
+++ b/server/env.ts
@@ -103,6 +103,12 @@ export class Environment {
   );
 
   /**
+   * Database schema name.
+   */
+  @IsOptional()
+  public DATABASE_SCHEMA = process.env.DATABASE_SCHEMA;
+ 
+  /**
    * Set to "disable" to disable SSL connection to the database. This option is
    * passed through to Postgres. See:
    *


### PR DESCRIPTION
This fixes https://github.com/outline/outline/issues/4863 by exposing the schema configuration value of Sequelize through a new DATABASE_SCHEMA environment variable. This way hosted installations of Outline can be directed to use custom schemas other than the default "public" schema if desired.

This is a follow up of #4864 as the earlier pull request included unintentional changes to code style.