### PR TITLE
fix: Users should not be redirected to disabled authentication providers (#5055

### DIFF
--- a/.jestconfig.json
+++ b/.jestconfig.json
@@ -3,7 +3,7 @@
   "projects": [
     {
       "displayName": "server",
-      "roots": ["<rootDir>/server"],
+      "roots": ["<rootDir>/server", "<rootDir>/plugins"],
       "moduleNameMapper": {
         "^@server/(.*)$": "<rootDir>/server/$1",
         "^@shared/(.*)$": "<rootDir>/shared/$1"

--- a/plugins/email/server/auth/email.ts
+++ b/plugins/email/server/auth/email.ts
@@ -1,5 +1,4 @@
 import Router from "koa-router";
-import { find } from "lodash";
 import { Client } from "@shared/types";
 import { parseDomain } from "@shared/utils/domains";
 import InviteAcceptedEmail from "@server/emails/templates/InviteAcceptedEmail";
@@ -59,18 +58,15 @@ router.post(
     // If the user matches an email address associated with an SSO
     // provider then just forward them directly to that sign-in page
     if (user.authentications.length) {
-      const authProvider = find(team.authenticationProviders, {
-        id: user.authentications[0].authenticationProviderId,
-      });
-      if (authProvider?.enabled) {
-        ctx.body = {
-          redirect: `${team.url}/auth/${authProvider?.name}`,
-        };
-        return;
-      }
+      const authenticationProvider =
+        user.authentications[0].authenticationProvider;
+      ctx.body = {
+        redirect: `${team.url}/auth/${authenticationProvider?.name}`,
+      };
+      return;
     }
 
-    // send email to users registered address with a short-lived token
+    // send email to users email address with a short-lived token
     await SigninEmail.schedule({
       to: user.email,
       token: user.getEmailSigninToken(),

--- a/plugins/slack/server/api/hooks.test.ts
+++ b/plugins/slack/server/api/hooks.test.ts
@@ -5,7 +5,7 @@ import { buildDocument, buildIntegration } from "@server/test/factories";
 import { seed, getTestServer } from "@server/test/support";
 import * as Slack from "../slack";
 
-jest.mock("@server/utils/slack", () => ({
+jest.mock("../slack", () => ({
   post: jest.fn(),
 }));
 

--- a/plugins/webhooks/server/processors/WebhookProcessor.test.ts
+++ b/plugins/webhooks/server/processors/WebhookProcessor.test.ts
@@ -4,7 +4,7 @@ import { UserEvent } from "@server/types";
 import DeliverWebhookTask from "../tasks/DeliverWebhookTask";
 import WebhookProcessor from "./WebhookProcessor";
 
-jest.mock("@server/queues/tasks/DeliverWebhookTask");
+jest.mock("../tasks/DeliverWebhookTask");
 const ip = "127.0.0.1";
 
 setupTestDatabase();

--- a/server/models/User.ts
+++ b/server/models/User.ts
@@ -36,6 +36,7 @@ import parseAttachmentIds from "@server/utils/parseAttachmentIds";
 import { ValidationError } from "../errors";
 import ApiKey from "./ApiKey";
 import Attachment from "./Attachment";
+import AuthenticationProvider from "./AuthenticationProvider";
 import Collection from "./Collection";
 import CollectionUser from "./CollectionUser";
 import NotificationSetting from "./NotificationSetting";
@@ -71,8 +72,18 @@ export enum UserRole {
   withAuthentications: {
     include: [
       {
+        separate: true,
         model: UserAuthentication,
         as: "authentications",
+        include: [
+          {
+            model: AuthenticationProvider,
+            as: "authenticationProvider",
+            where: {
+              enabled: true,
+            },
+          },
+        ],
       },
     ],
   },

--- a/server/routes/api/index.ts
+++ b/server/routes/api/index.ts
@@ -53,8 +53,9 @@ api.use(apiWrapper());
 api.use(editor());
 
 // register package API routes before others to allow for overrides
+const rootDir = env.ENVIRONMENT === "test" ? "" : "build";
 glob
-  .sync("build/plugins/*/server/api/!(*.test).js")
+  .sync(path.join(rootDir, "plugins/*/server/api/!(*.test).[jt]s"))
   .forEach((filePath: string) => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const pkg: Router = require(path.join(process.cwd(), filePath)).default;

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -505,7 +505,7 @@
   "Anyone with the link can view this document": "Anyone with the link can view this document",
   "The shared link was last accessed {{ timeAgo }}.": "The shared link was last accessed {{ timeAgo }}.",
   "Share this document": "Share this document",
-  "This document is shared because the parent<1>{documentTitle}</1>is publicly shared.": "This document is shared because the parent<1>{documentTitle}</1>is publicly shared.",
+  "This document is shared because the parent <2>{documentTitle}</2> is publicly shared.": "This document is shared because the parent <2>{documentTitle}</2> is publicly shared.",
   "Share nested documents": "Share nested documents",
   "Nested documents are publicly available": "Nested documents are publicly available",
   "Nested documents are not shared": "Nested documents are not shared",


### PR DESCRIPTION
Re-enabled tests in plugin directory (Needs a little more work yet)

closes #5049 