### PR TITLE
fix: Impossible to type more than one dollar symbol in a paragraph without triggering LaTeX

### DIFF
--- a/shared/editor/nodes/Math.ts
+++ b/shared/editor/nodes/Math.ts
@@ -2,7 +2,6 @@ import {
   mathBackspaceCmd,
   insertMathCmd,
   makeInlineMathInputRule,
-  REGEX_INLINE_MATH_DOLLARS,
   mathSchemaSpec,
 } from "@benrbray/prosemirror-math";
 import { PluginSimple } from "markdown-it";
@@ -21,7 +20,7 @@ import {
 import { EditorState, Plugin } from "prosemirror-state";
 import { MarkdownSerializerState } from "../lib/markdown/serializer";
 import MathPlugin from "../plugins/Math";
-import mathRule from "../rules/math";
+import mathRule, { REGEX_INLINE_MATH_DOLLARS } from "../rules/math";
 import { Dispatch } from "../types";
 import Node from "./Node";
 
@@ -71,9 +70,9 @@ export default class Math extends Node {
   }
 
   toMarkdown(state: MarkdownSerializerState, node: ProsemirrorNode) {
-    state.write("$");
+    state.write("$$");
     state.text(node.textContent, false);
-    state.write("$");
+    state.write("$$");
   }
 
   parseMarkdown() {

--- a/shared/editor/nodes/MathBlock.ts
+++ b/shared/editor/nodes/MathBlock.ts
@@ -1,13 +1,12 @@
 import {
   makeBlockMathInputRule,
-  REGEX_BLOCK_MATH_DOLLARS,
   mathSchemaSpec,
 } from "@benrbray/prosemirror-math";
 import { PluginSimple } from "markdown-it";
 import { NodeSpec, NodeType, Node as ProsemirrorNode } from "prosemirror-model";
 import { EditorState } from "prosemirror-state";
 import { MarkdownSerializerState } from "../lib/markdown/serializer";
-import mathRule from "../rules/math";
+import mathRule, { REGEX_BLOCK_MATH_DOLLARS } from "../rules/math";
 import { Dispatch } from "../types";
 import Node from "./Node";
 
@@ -36,10 +35,10 @@ export default class MathBlock extends Node {
   }
 
   toMarkdown(state: MarkdownSerializerState, node: ProsemirrorNode) {
-    state.write("$$\n");
+    state.write("$$$\n");
     state.text(node.textContent, false);
     state.ensureNewLine();
-    state.write("$$");
+    state.write("$$$");
     state.closeBlock(node);
   }
 

--- a/shared/editor/rules/math.ts
+++ b/shared/editor/rules/math.ts
@@ -2,6 +2,10 @@ import MarkdownIt from "markdown-it";
 import StateBlock from "markdown-it/lib/rules_block/state_block";
 import StateInline from "markdown-it/lib/rules_inline/state_inline";
 
+export const REGEX_INLINE_MATH_DOLLARS = /\$\$(.+)\$\$/;
+
+export const REGEX_BLOCK_MATH_DOLLARS = /\$\$\$\s+$/;
+
 // test if potential opening or closing delimiter
 // assumes that there is a "$" at state.src[pos]
 function isValidDelimiter(state: StateInline, pos: number) {


### PR DESCRIPTION
This change will unfortunately regress any shared links with Math blocks in them until they are re-saved, I don't see a way around that for now.

closes #4778