### PR TITLE
fix: Call the OIDC logout endpoint when logging out.

### DIFF
--- a/app/components/Authenticated.tsx
+++ b/app/components/Authenticated.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Redirect } from "react-router-dom";
 import LoadingIndicator from "~/components/LoadingIndicator";
+import env from "~/env";
 import useStores from "~/hooks/useStores";
 import { changeLanguage } from "~/utils/language";
 
@@ -32,7 +33,16 @@ const Authenticated = ({ children }: Props) => {
   }
 
   auth.logout(true);
-  return <Redirect to="/" />;
+
+  if (auth.oidcRedirectLogout) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    window.location =
+      auth.oidcRedirectLogout + "&post_logout_redirect_uri=" + env.URL;
+    return null;
+  } else {
+    return <Redirect to="/" />;
+  }
 };
 
 export default observer(Authenticated);

--- a/app/stores/AuthStore.ts
+++ b/app/stores/AuthStore.ts
@@ -63,6 +63,9 @@ export default class AuthStore {
   token?: string | null;
 
   @observable
+  oidcRedirectLogout?: string | null;
+
+  @observable
   policies: Policy[] = [];
 
   @observable
@@ -325,7 +328,8 @@ export default class AuthStore {
     }
 
     // invalidate authentication token on server
-    client.post(`/auth.delete`);
+    const deleteResult = await client.post(`/auth.delete`);
+    this.oidcRedirectLogout = deleteResult.oidcEndSessionUri;
 
     // remove authentication token itself
     removeCookie("accessToken", {

--- a/plugins/oidc/server/auth/oidc.ts
+++ b/plugins/oidc/server/auth/oidc.ts
@@ -66,7 +66,7 @@ if (
         ctx: Context,
         accessToken: string,
         refreshToken: string,
-        params: { expires_in: number },
+        params: { expires_in: number; id_token: string },
         profile: Record<string, string>,
         done: (
           err: Error | null,
@@ -125,6 +125,7 @@ if (
               accessToken,
               refreshToken,
               expiresIn: params.expires_in,
+              oidcTokenId: params.id_token,
               scopes,
             },
           });

--- a/server/commands/accountProvisioner.ts
+++ b/server/commands/accountProvisioner.ts
@@ -57,6 +57,8 @@ type Props = {
     refreshToken?: string;
     /** A number of seconds that the given access token expires in */
     expiresIn?: number;
+    /** A token that may be used by the authentication provider */
+    oidcTokenId?: string;
   };
 };
 

--- a/server/env.ts
+++ b/server/env.ts
@@ -453,6 +453,7 @@ export class Environment {
   @CannotUseWithout("OIDC_TOKEN_URI")
   @CannotUseWithout("OIDC_USERINFO_URI")
   @CannotUseWithout("OIDC_DISPLAY_NAME")
+  @CannotUseWithout("OIDC_END_SESSION_URI")
   public OIDC_CLIENT_ID = this.toOptionalString(process.env.OIDC_CLIENT_ID);
 
   @IsOptional()
@@ -499,6 +500,18 @@ export class Environment {
   })
   public OIDC_USERINFO_URI = this.toOptionalString(
     process.env.OIDC_USERINFO_URI
+  );
+
+  /**
+   * The OIDC end session endpoint.
+   */
+  @IsOptional()
+  @IsUrl({
+    require_tld: false,
+    allow_underscores: true,
+  })
+  public OIDC_END_SESSION_URI = this.toOptionalString(
+    process.env.OIDC_END_SESSION_URI
   );
 
   /**

--- a/server/migrations/20230325030839-add-token-id-to-user-authentications.js
+++ b/server/migrations/20230325030839-add-token-id-to-user-authentications.js
@@ -1,0 +1,14 @@
+"use strict";
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn("user_authentications", "oidcTokenId", {
+      type: Sequelize.BLOB,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn("user_authentications", "oidcTokenId");
+  },
+};

--- a/server/models/UserAuthentication.ts
+++ b/server/models/UserAuthentication.ts
@@ -50,6 +50,9 @@ class UserAuthentication extends IdModel {
   @Column
   providerId: string;
 
+  @Column
+  oidcTokenId: string;
+
   @Column(DataType.DATE)
   expiresAt: Date;
 

--- a/server/routes/api/auth.ts
+++ b/server/routes/api/auth.ts
@@ -168,8 +168,13 @@ router.post("auth.delete", auth(), transaction(), async (ctx: APIContext) => {
     }
   );
 
+  const authentications = await user.$get("authentications");
+
   ctx.body = {
     success: true,
+    oidcEndSessionUri: authentications[0]?.oidcTokenId
+      ? `${env.OIDC_END_SESSION_URI}?id_token_hint=${authentications[0].oidcTokenId}`
+      : null,
   };
 });
 

--- a/server/utils/oauth.ts
+++ b/server/utils/oauth.ts
@@ -9,6 +9,7 @@ export default abstract class OAuthClient {
     authorize: "",
     token: "",
     userinfo: "",
+    endSession: "",
   };
 
   constructor(clientId: string, clientSecret: string) {

--- a/server/utils/oidc.ts
+++ b/server/utils/oidc.ts
@@ -6,5 +6,6 @@ export default class OIDCClient extends OAuthClient {
     authorize: env.OIDC_AUTH_URI || "",
     token: env.OIDC_TOKEN_URI || "",
     userinfo: env.OIDC_USERINFO_URI || "",
+    endSession: env.OIDC_END_SESSION_URI || "",
   };
 }


### PR DESCRIPTION
Draft for now.

This fix calls the OIDS logout endpoint to log the user out of the auth provider at the same time of the outline session.

Seeking for feedback. What I see missing:

- [ ] `${authentications[0].oidcTokenId` => not ideal. Can there be a case where a user has multiple authentication methods?
- [ ] Couple of tests 