### PR TITLE
Additional policy regarding comments on a document

### DIFF
--- a/server/policies/document.test.ts
+++ b/server/policies/document.test.ts
@@ -34,6 +34,7 @@ describe("read_write collection", () => {
     expect(abilities.delete).toEqual(true);
     expect(abilities.share).toEqual(true);
     expect(abilities.move).toEqual(true);
+    expect(abilities.comment).toEqual(true);
   });
 
   it("should allow read permissions for viewer", async () => {
@@ -61,6 +62,7 @@ describe("read_write collection", () => {
     expect(abilities.move).toEqual(false);
     expect(abilities.subscribe).toEqual(true);
     expect(abilities.unsubscribe).toEqual(true);
+    expect(abilities.comment).toEqual(true);
   });
 });
 
@@ -89,6 +91,7 @@ describe("read collection", () => {
     expect(abilities.move).toEqual(false);
     expect(abilities.subscribe).toEqual(true);
     expect(abilities.unsubscribe).toEqual(true);
+    expect(abilities.comment).toEqual(true);
   });
 });
 
@@ -117,6 +120,7 @@ describe("private collection", () => {
     expect(abilities.move).toEqual(false);
     expect(abilities.subscribe).toEqual(false);
     expect(abilities.unsubscribe).toEqual(false);
+    expect(abilities.comment).toEqual(false);
   });
 });
 
@@ -149,5 +153,6 @@ describe("no collection", () => {
     expect(abilities.unstar).toEqual(true);
     expect(abilities.unsubscribe).toEqual(false);
     expect(abilities.update).toEqual(true);
+    expect(abilities.comment).toEqual(true);
   });
 });

--- a/server/policies/document.ts
+++ b/server/policies/document.ts
@@ -10,20 +10,7 @@ allow(User, "createDocument", Team, (user, team) => {
   return true;
 });
 
-allow(User, "read", Document, (user, document) => {
-  if (!document) {
-    return false;
-  }
-
-  // existence of collection option is not required here to account for share tokens
-  if (document.collection && cannot(user, "read", document.collection)) {
-    return false;
-  }
-
-  return user.teamId === document.teamId;
-});
-
-allow(User, "comment", Document, (user, document) => {
+allow(User, ["read", "comment"], Document, (user, document) => {
   if (!document) {
     return false;
   }

--- a/server/policies/document.ts
+++ b/server/policies/document.ts
@@ -23,6 +23,19 @@ allow(User, "read", Document, (user, document) => {
   return user.teamId === document.teamId;
 });
 
+allow(User, "comment", Document, (user, document) => {
+  if (!document) {
+    return false;
+  }
+
+  // existence of collection option is not required here to account for share tokens
+  if (document.collection && cannot(user, "read", document.collection)) {
+    return false;
+  }
+
+  return user.teamId === document.teamId;
+});
+
 allow(User, "download", Document, (user, document) => {
   if (!document) {
     return false;

--- a/server/routes/api/comments/comments.ts
+++ b/server/routes/api/comments/comments.ts
@@ -29,7 +29,7 @@ router.post(
       userId: user.id,
       transaction,
     });
-    authorize(user, "read", document);
+    authorize(user, "comment", document);
 
     const comment = await commentCreator({
       id,


### PR DESCRIPTION
Closes #5065 

Although for now it's just an alias of the `read` permission but can be later modified to support tighter constraints enforced by admins specifically for _commenting_ - allow/disallow a `group` of users, allow/disallow commenting altogether on a document etc.