### PR TITLE
fix: Allow strikethrough of inline code (#5207

### DIFF
--- a/shared/editor/lib/ExtensionManager.ts
+++ b/shared/editor/lib/ExtensionManager.ts
@@ -41,7 +41,7 @@ export default class ExtensionManager {
   }
 
   get nodes() {
-    const nodes = this.extensions
+    return this.extensions
       .filter((extension) => extension.type === "node")
       .reduce(
         (nodes, node: Node) => ({
@@ -50,17 +50,6 @@ export default class ExtensionManager {
         }),
         {}
       );
-
-    for (const i in nodes) {
-      if (nodes[i].excludes) {
-        nodes[i].excludes = nodes[i].excludes
-          .split(" ")
-          .filter((m: string) => Object.keys(nodes).includes(m))
-          .join(" ");
-      }
-    }
-
-    return nodes;
   }
 
   get marks() {
@@ -76,6 +65,8 @@ export default class ExtensionManager {
 
     for (const i in marks) {
       if (marks[i].excludes) {
+        // We must filter marks from the excludes list that are not defined
+        // in the schema for the current editor.
         marks[i].excludes = marks[i].excludes
           .split(" ")
           .filter((m: string) => Object.keys(marks).includes(m))

--- a/shared/editor/lib/ExtensionManager.ts
+++ b/shared/editor/lib/ExtensionManager.ts
@@ -41,7 +41,7 @@ export default class ExtensionManager {
   }
 
   get nodes() {
-    return this.extensions
+    const nodes = this.extensions
       .filter((extension) => extension.type === "node")
       .reduce(
         (nodes, node: Node) => ({
@@ -50,6 +50,40 @@ export default class ExtensionManager {
         }),
         {}
       );
+
+    for (const i in nodes) {
+      if (nodes[i].excludes) {
+        nodes[i].excludes = nodes[i].excludes
+          .split(" ")
+          .filter((m: string) => Object.keys(nodes).includes(m))
+          .join(" ");
+      }
+    }
+
+    return nodes;
+  }
+
+  get marks() {
+    const marks = this.extensions
+      .filter((extension) => extension.type === "mark")
+      .reduce(
+        (marks, mark: Mark) => ({
+          ...marks,
+          [mark.name]: mark.schema,
+        }),
+        {}
+      );
+
+    for (const i in marks) {
+      if (marks[i].excludes) {
+        marks[i].excludes = marks[i].excludes
+          .split(" ")
+          .filter((m: string) => Object.keys(marks).includes(m))
+          .join(" ");
+      }
+    }
+
+    return marks;
   }
 
   serializer() {
@@ -102,18 +136,6 @@ export default class ExtensionManager {
       }, {});
 
     return new MarkdownParser(schema, makeRules({ rules, plugins }), tokens);
-  }
-
-  get marks() {
-    return this.extensions
-      .filter((extension) => extension.type === "mark")
-      .reduce(
-        (marks, { name, schema }: Mark) => ({
-          ...marks,
-          [name]: schema,
-        }),
-        {}
-      );
   }
 
   get plugins() {

--- a/shared/editor/marks/Code.ts
+++ b/shared/editor/marks/Code.ts
@@ -4,8 +4,10 @@ import {
   MarkType,
   Node as ProsemirrorNode,
   Mark as ProsemirrorMark,
+  Slice,
 } from "prosemirror-model";
 import { Plugin } from "prosemirror-state";
+import { EditorView } from "prosemirror-view";
 import moveLeft from "../commands/moveLeft";
 import moveRight from "../commands/moveRight";
 import markInputRule from "../lib/markInputRule";
@@ -40,7 +42,7 @@ export default class Code extends Mark {
 
   get schema(): MarkSpec {
     return {
-      excludes: "_",
+      excludes: "comment mention link placeholder highlight em strong",
       parseDOM: [{ tag: "code.inline", preserveWhitespace: true }],
       toDOM: () => ["code", { class: "inline", spellCheck: "false" }],
     };
@@ -66,7 +68,12 @@ export default class Code extends Mark {
         props: {
           // Typing a character inside of two backticks will wrap the character
           // in an inline code mark.
-          handleTextInput: (view, from: number, to: number, text: string) => {
+          handleTextInput: (
+            view: EditorView,
+            from: number,
+            to: number,
+            text: string
+          ) => {
             const { state } = view;
 
             // Prevent access out of document bounds
@@ -99,7 +106,7 @@ export default class Code extends Mark {
 
           // Pasting a character inside of two backticks will wrap the character
           // in an inline code mark.
-          handlePaste: (view, _event, slice) => {
+          handlePaste: (view: EditorView, _event: Event, slice: Slice) => {
             const { state } = view;
             const { from, to } = state.selection;
 


### PR DESCRIPTION
Previously inline code excluded all other marks.