### PR TITLE
Return window origin instead of host

### DIFF
--- a/app/utils/routeHelpers.ts
+++ b/app/utils/routeHelpers.ts
@@ -136,7 +136,7 @@ export function sharedDocumentPath(shareId: string, docPath?: string) {
 }
 
 export function urlify(path: string): string {
-  return `${window.location.host}${path}`;
+  return `${window.location.origin}${path}`;
 }
 
 export const matchDocumentSlug =


### PR DESCRIPTION
This returns the window location's host AND protocol, instead of just host. In the only usage of this which I could find, it's for the "Copy link" feature in the comments menu.
This allows the same behaviour as all other share options, which return a fully valid URL.