### PR TITLE
Remove "millisecond" suffix from getSignedUrl() function

### DIFF
--- a/server/models/helpers/DocumentHelper.tsx
+++ b/server/models/helpers/DocumentHelper.tsx
@@ -298,7 +298,7 @@ export default class DocumentHelper {
    *
    * @param text The text either html or markdown which contains urls to be converted
    * @param teamId The team context
-   * @param expiresIn The time that signed urls should expire in (ms)
+   * @param expiresIn The time that signed urls should expire (in seconds)
    * @returns The replaced text
    */
   static async attachmentsToSignedUrls(

--- a/server/utils/s3.ts
+++ b/server/utils/s3.ts
@@ -158,12 +158,12 @@ export const deleteFromS3 = (key: string) =>
     })
     .promise();
 
-export const getSignedUrl = async (key: string, expiresInMs = 60) => {
+export const getSignedUrl = async (key: string, expiresIn = 60) => {
   const isDocker = AWS_S3_UPLOAD_BUCKET_URL.match(/http:\/\/s3:/);
   const params = {
     Bucket: AWS_S3_UPLOAD_BUCKET_NAME,
     Key: key,
-    Expires: expiresInMs,
+    Expires: expiresIn,
     ResponseContentDisposition: "attachment",
   };
 


### PR DESCRIPTION
The parameter actually expects seconds and not milliseconds, according to S3 documentation:

https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html

This was confusing me when debugging an issue with S3.