### PR TITLE
Init app language with DEFAULT_LANGUAGE

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -25,7 +25,7 @@ import Logger from "./utils/Logger";
 import history from "./utils/history";
 import { initSentry } from "./utils/sentry";
 
-initI18n();
+initI18n(env.DEFAULT_LANGUAGE);
 const element = window.document.getElementById("root");
 
 history.listen(() => {


### PR DESCRIPTION
Currently, the app is intialized with en_US as default language and ignores the env variable for DEFAULT_LANGUAGE.

This pull request fixes that.