### PR TITLE
feat: Add option to not include attachments in exported data

### DIFF
--- a/app/components/ExportDialog.tsx
+++ b/app/components/ExportDialog.tsx
@@ -21,6 +21,8 @@ function ExportDialog({ collection, onSubmit }: Props) {
   const [format, setFormat] = React.useState<FileOperationFormat>(
     FileOperationFormat.MarkdownZip
   );
+  const [includeAttachments, setIncludeAttachments] =
+    React.useState<boolean>(true);
   const user = useCurrentUser();
   const { showToast } = useToasts();
   const { collections } = useStores();
@@ -34,11 +36,18 @@ function ExportDialog({ collection, onSubmit }: Props) {
     []
   );
 
+  const handleIncludeAttachmentsChange = React.useCallback(
+    (ev: React.ChangeEvent<HTMLInputElement>) => {
+      setIncludeAttachments(ev.target.checked);
+    },
+    []
+  );
+
   const handleSubmit = async () => {
     if (collection) {
-      await collection.export(format);
+      await collection.export(format, includeAttachments);
     } else {
-      await collections.export(format);
+      await collections.export(format, includeAttachments);
     }
     onSubmit();
     showToast(t("Export started"), { type: "success" });
@@ -107,6 +116,23 @@ function ExportDialog({ collection, onSubmit }: Props) {
           </Option>
         ))}
       </Flex>
+      <hr />
+      <Option>
+        <input
+          type="checkbox"
+          name="includeAttachments"
+          checked={includeAttachments}
+          onChange={handleIncludeAttachmentsChange}
+        />
+        <div>
+          <Text size="small" weight="bold">
+            {t("Include attachments")}
+          </Text>
+          <Text size="small">
+            {t("Including uploaded images and files in the exported data")}.
+          </Text>{" "}
+        </div>
+      </Option>
     </ConfirmationDialog>
   );
 }

--- a/app/models/Collection.ts
+++ b/app/models/Collection.ts
@@ -266,9 +266,10 @@ export default class Collection extends ParanoidModel {
   @action
   unstar = async () => this.store.unstar(this);
 
-  export = (format: FileOperationFormat) =>
+  export = (format: FileOperationFormat, includeAttachments: boolean) =>
     client.post("/collections.export", {
       id: this.id,
       format,
+      includeAttachments,
     });
 }

--- a/app/stores/CollectionsStore.ts
+++ b/app/stores/CollectionsStore.ts
@@ -236,8 +236,9 @@ export default class CollectionsStore extends BaseStore<Collection> {
     this.rootStore.documents.fetchRecentlyViewed();
   };
 
-  export = (format: FileOperationFormat) =>
+  export = (format: FileOperationFormat, includeAttachments: boolean) =>
     client.post("/collections.export_all", {
       format,
+      includeAttachments,
     });
 }

--- a/server/commands/collectionExporter.ts
+++ b/server/commands/collectionExporter.ts
@@ -13,6 +13,7 @@ type Props = {
   team: Team;
   user: User;
   format?: FileOperationFormat;
+  includeAttachments?: boolean;
   ip: string;
   transaction: Transaction;
 };
@@ -22,6 +23,7 @@ async function collectionExporter({
   team,
   user,
   format = FileOperationFormat.MarkdownZip,
+  includeAttachments = true,
   ip,
   transaction,
 }: Props) {
@@ -36,6 +38,7 @@ async function collectionExporter({
       url: null,
       size: 0,
       collectionId,
+      includeAttachments,
       userId: user.id,
       teamId: user.teamId,
     },

--- a/server/migrations/20230621004649-add-include-attachments-file-operation.js
+++ b/server/migrations/20230621004649-add-include-attachments-file-operation.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.addColumn("file_operations", "includeAttachments", {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
+    });
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.removeColumn("file_operations", "includeAttachments");
+  }
+};

--- a/server/models/FileOperation.ts
+++ b/server/models/FileOperation.ts
@@ -58,6 +58,9 @@ class FileOperation extends IdModel {
   @Column(DataType.BIGINT)
   size: number;
 
+  @Column(DataType.BOOLEAN)
+  includeAttachments: boolean;
+
   /**
    * Mark the current file operation as expired and remove the file from storage.
    */

--- a/server/queues/tasks/ExportDocumentTreeTask.ts
+++ b/server/queues/tasks/ExportDocumentTreeTask.ts
@@ -25,12 +25,14 @@ export default abstract class ExportDocumentTreeTask extends ExportTask {
     pathInZip,
     documentId,
     format = FileOperationFormat.MarkdownZip,
+    includeAttachments,
     pathMap,
   }: {
     zip: JSZip;
     pathInZip: string;
     documentId: string;
     format: FileOperationFormat;
+    includeAttachments: boolean;
     pathMap: Map<string, string>;
   }) {
     Logger.debug("task", `Adding document to archive`, { documentId });
@@ -44,7 +46,9 @@ export default abstract class ExportDocumentTreeTask extends ExportTask {
         ? await DocumentHelper.toHTML(document, { centered: true })
         : await DocumentHelper.toMarkdown(document);
 
-    const attachmentIds = parseAttachmentIds(document.text);
+    const attachmentIds = includeAttachments
+      ? parseAttachmentIds(document.text)
+      : [];
     const attachments = attachmentIds.length
       ? await Attachment.findAll({
           where: {
@@ -117,13 +121,15 @@ export default abstract class ExportDocumentTreeTask extends ExportTask {
    * @param zip The JSZip instance to add files to
    * @param collections The collections to export
    * @param format The format to export in
+   * @param includeAttachments Whether to include attachments in the export
    *
    * @returns The path to the zip file in tmp.
    */
   protected async addCollectionsToArchive(
     zip: JSZip,
     collections: Collection[],
-    format: FileOperationFormat
+    format: FileOperationFormat,
+    includeAttachments = true
   ) {
     const pathMap = this.createPathMap(collections, format);
     Logger.debug(
@@ -139,6 +145,7 @@ export default abstract class ExportDocumentTreeTask extends ExportTask {
         zip,
         pathInZip,
         documentId,
+        includeAttachments,
         format,
         pathMap,
       });

--- a/server/queues/tasks/ExportHTMLZipTask.ts
+++ b/server/queues/tasks/ExportHTMLZipTask.ts
@@ -1,16 +1,17 @@
 import JSZip from "jszip";
 import { FileOperationFormat } from "@shared/types";
-import { Collection } from "@server/models";
+import { Collection, FileOperation } from "@server/models";
 import ExportDocumentTreeTask from "./ExportDocumentTreeTask";
 
 export default class ExportHTMLZipTask extends ExportDocumentTreeTask {
-  public async export(collections: Collection[]) {
+  public async export(collections: Collection[], fileOperation: FileOperation) {
     const zip = new JSZip();
 
     return await this.addCollectionsToArchive(
       zip,
       collections,
-      FileOperationFormat.HTMLZip
+      FileOperationFormat.HTMLZip,
+      fileOperation.includeAttachments
     );
   }
 }

--- a/server/queues/tasks/ExportMarkdownZipTask.ts
+++ b/server/queues/tasks/ExportMarkdownZipTask.ts
@@ -1,16 +1,17 @@
 import JSZip from "jszip";
 import { FileOperationFormat } from "@shared/types";
-import { Collection } from "@server/models";
+import { Collection, FileOperation } from "@server/models";
 import ExportDocumentTreeTask from "./ExportDocumentTreeTask";
 
 export default class ExportMarkdownZipTask extends ExportDocumentTreeTask {
-  public async export(collections: Collection[]) {
+  public async export(collections: Collection[], fileOperation: FileOperation) {
     const zip = new JSZip();
 
     return await this.addCollectionsToArchive(
       zip,
       collections,
-      FileOperationFormat.MarkdownZip
+      FileOperationFormat.MarkdownZip,
+      fileOperation.includeAttachments
     );
   }
 }

--- a/server/queues/tasks/ExportTask.ts
+++ b/server/queues/tasks/ExportTask.ts
@@ -41,7 +41,9 @@ export default abstract class ExportTask extends BaseTask<Props> {
     });
 
     try {
-      Logger.info("task", `ExportTask processing data for ${fileOperationId}`);
+      Logger.info("task", `ExportTask processing data for ${fileOperationId}`, {
+        includeAttachments: fileOperation.includeAttachments,
+      });
 
       await this.updateFileOperation(fileOperation, {
         state: FileOperationState.Creating,

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -181,6 +181,8 @@
   "Export": "Export",
   "Exporting the collection <em>{{collectionName}}</em> may take some time.": "Exporting the collection <em>{{collectionName}}</em> may take some time.",
   "You will receive an email when it's complete.": "You will receive an email when it's complete.",
+  "Include attachments": "Include attachments",
+  "Including uploaded images and files in the exported data": "Including uploaded images and files in the exported data",
   "{{ count }} member": "{{ count }} member",
   "{{ count }} member_plural": "{{ count }} members",
   "Group members": "Group members",


### PR DESCRIPTION
This is debugging for some failing exports, but seems useful enough – exports complete much faster when you don't need to include hundreds of mbs of files.