### PR TITLE
fix: Azure single-tenant SSO tokens are unable to refresh

### DIFF
--- a/server/models/UserAuthentication.ts
+++ b/server/models/UserAuthentication.ts
@@ -93,6 +93,7 @@ class UserAuthentication extends IdModel {
   ): Promise<boolean> {
     // Check a maximum of once every 5 minutes
     if (this.lastValidatedAt > subMinutes(Date.now(), 5) && !force) {
+      Logger.debug("utils", "Skipping access token validation");
       return true;
     }
 
@@ -158,7 +159,10 @@ class UserAuthentication extends IdModel {
 
     const client = authenticationProvider.oauthClient;
     if (client) {
-      const response = await client.rotateToken(this.refreshToken);
+      const response = await client.rotateToken(
+        this.accessToken,
+        this.refreshToken
+      );
 
       // Not all OAuth providers return a new refreshToken so we need to guard
       // against setting to an empty value.

--- a/server/utils/azure.ts
+++ b/server/utils/azure.ts
@@ -1,4 +1,11 @@
+import JWT from "jsonwebtoken";
+import env from "@server/env";
 import OAuthClient from "./oauth";
+
+type AzurePayload = {
+  /* A GUID that represents the Azure AD tenant that the user is from */
+  tid: string;
+};
 
 export default class AzureClient extends OAuthClient {
   endpoints = {
@@ -6,4 +13,24 @@ export default class AzureClient extends OAuthClient {
     token: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
     userinfo: "https://graph.microsoft.com/v1.0/me",
   };
+
+  async rotateToken(
+    accessToken: string,
+    refreshToken: string
+  ): Promise<{
+    accessToken: string;
+    refreshToken?: string;
+    expiresAt: Date;
+  }> {
+    if (env.isCloudHosted()) {
+      return super.rotateToken(accessToken, refreshToken);
+    }
+
+    const payload = JWT.decode(accessToken) as AzurePayload;
+    return super.rotateToken(
+      accessToken,
+      refreshToken,
+      `https://login.microsoftonline.com/${payload.tid}/oauth2/v2.0/token`
+    );
+  }
 }

--- a/server/utils/oauth.ts
+++ b/server/utils/oauth.ts
@@ -1,4 +1,5 @@
 import fetch from "fetch-with-proxy";
+import Logger from "@server/logging/Logger";
 import { AuthenticationError, InvalidRequestError } from "../errors";
 
 export default abstract class OAuthClient {
@@ -41,18 +42,22 @@ export default abstract class OAuthClient {
     return data;
   };
 
-  rotateToken = async (
-    refreshToken: string
+  async rotateToken(
+    _accessToken: string,
+    refreshToken: string,
+    endpoint = this.endpoints.token
   ): Promise<{
     accessToken: string;
     refreshToken?: string;
     expiresAt: Date;
-  }> => {
+  }> {
     let data;
     let response;
 
     try {
-      response = await fetch(this.endpoints.token, {
+      Logger.debug("utils", "Rotating token", { endpoint });
+
+      response = await fetch(endpoint, {
         method: "POST",
         headers: {
           "Content-Type": "application/x-www-form-urlencoded",
@@ -79,5 +84,5 @@ export default abstract class OAuthClient {
       accessToken: data.access_token,
       expiresAt: new Date(Date.now() + data.expires_in * 1000),
     };
-  };
+  }
 }


### PR DESCRIPTION
Parses the correct tenant ID from the access token and constructs the tenant-specific endpoint for refreshing auth in single-tenant apps.

closes #5532 