### PR TITLE
chore: Use `httpOnly` authentication cookie

### DIFF
--- a/app/components/Authenticated.tsx
+++ b/app/components/Authenticated.tsx
@@ -1,7 +1,6 @@
 import { observer } from "mobx-react";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import { Redirect } from "react-router-dom";
 import LoadingIndicator from "~/components/LoadingIndicator";
 import useStores from "~/hooks/useStores";
 import { changeLanguage } from "~/utils/language";
@@ -21,18 +20,11 @@ const Authenticated = ({ children }: Props) => {
     void changeLanguage(language, i18n);
   }, [i18n, language]);
 
-  if (auth.authenticated) {
-    const { user, team } = auth;
-
-    if (!team || !user) {
-      return <LoadingIndicator />;
-    }
-
+  if (auth.user && auth.team) {
     return children;
   }
 
-  void auth.logout(true);
-  return <Redirect to="/" />;
+  return <LoadingIndicator />;
 };
 
 export default observer(Authenticated);

--- a/app/components/Authenticated.tsx
+++ b/app/components/Authenticated.tsx
@@ -20,7 +20,7 @@ const Authenticated = ({ children }: Props) => {
     void changeLanguage(language, i18n);
   }, [i18n, language]);
 
-  if (auth.user && auth.team) {
+  if (auth.authenticated) {
     return children;
   }
 

--- a/app/components/WebsocketProvider.tsx
+++ b/app/components/WebsocketProvider.tsx
@@ -70,6 +70,7 @@ class WebsocketProvider extends React.Component<Props> {
       transports: ["websocket"],
       reconnectionDelay: 1000,
       reconnectionDelayMax: 30000,
+      withCredentials: true,
     });
     invariant(this.socket, "Socket should be defined");
 
@@ -89,18 +90,6 @@ class WebsocketProvider extends React.Component<Props> {
       fileOperations,
       notifications,
     } = this.props;
-    if (!auth.token) {
-      return;
-    }
-
-    this.socket.on("connect", () => {
-      // immediately send current users token to the websocket backend where it
-      // is verified, if all goes well an 'authenticated' message will be
-      // received in response
-      this.socket?.emit("authentication", {
-        token: auth.token,
-      });
-    });
 
     // on reconnection, reset the transports option, as the Websocket
     // connection may have failed (caused by proxy, firewall, browser, ...)

--- a/app/hooks/useCurrentToken.ts
+++ b/app/hooks/useCurrentToken.ts
@@ -1,8 +1,0 @@
-import invariant from "invariant";
-import useStores from "./useStores";
-
-export default function useCurrentToken() {
-  const { auth } = useStores();
-  invariant(auth.token, "token is required");
-  return auth.token;
-}

--- a/app/scenes/Document/components/MultiplayerEditor.tsx
+++ b/app/scenes/Document/components/MultiplayerEditor.tsx
@@ -52,6 +52,7 @@ function MultiplayerEditor({ onSynced, ...props }: Props, ref: any) {
   const [isRemoteSynced, setRemoteSynced] = React.useState(false);
   const [ydoc] = React.useState(() => new Y.Doc());
   const { showToast } = useToasts();
+  const token = auth.collaborationToken;
   const isIdle = useIdle();
   const isVisible = usePageVisibility();
   const isMounted = useIsMounted();
@@ -68,7 +69,7 @@ function MultiplayerEditor({ onSynced, ...props }: Props, ref: any) {
       url: `${env.COLLABORATION_URL}/collaboration`,
       name,
       document: ydoc,
-      token: auth.collaborationToken,
+      token,
     });
 
     const syncScrollPosition = throttle(() => {
@@ -187,6 +188,7 @@ function MultiplayerEditor({ onSynced, ...props }: Props, ref: any) {
     ui,
     presence,
     ydoc,
+    token,
     currentUser.id,
     isMounted,
   ]);

--- a/app/scenes/Document/components/MultiplayerEditor.tsx
+++ b/app/scenes/Document/components/MultiplayerEditor.tsx
@@ -44,7 +44,7 @@ function MultiplayerEditor({ onSynced, ...props }: Props, ref: any) {
   const history = useHistory();
   const { t } = useTranslation();
   const currentUser = useCurrentUser();
-  const { presence, ui } = useStores();
+  const { presence, auth, ui } = useStores();
   const [showCursorNames, setShowCursorNames] = React.useState(false);
   const [remoteProvider, setRemoteProvider] =
     React.useState<HocuspocusProvider | null>(null);
@@ -68,7 +68,7 @@ function MultiplayerEditor({ onSynced, ...props }: Props, ref: any) {
       url: `${env.COLLABORATION_URL}/collaboration`,
       name,
       document: ydoc,
-      token: "not-used",
+      token: auth.collaborationToken,
     });
 
     const syncScrollPosition = throttle(() => {

--- a/app/scenes/Document/components/MultiplayerEditor.tsx
+++ b/app/scenes/Document/components/MultiplayerEditor.tsx
@@ -8,7 +8,6 @@ import * as Y from "yjs";
 import MultiplayerExtension from "@shared/editor/extensions/Multiplayer";
 import Editor, { Props as EditorProps } from "~/components/Editor";
 import env from "~/env";
-import useCurrentToken from "~/hooks/useCurrentToken";
 import useCurrentUser from "~/hooks/useCurrentUser";
 import useIdle from "~/hooks/useIdle";
 import useIsMounted from "~/hooks/useIsMounted";
@@ -46,7 +45,6 @@ function MultiplayerEditor({ onSynced, ...props }: Props, ref: any) {
   const { t } = useTranslation();
   const currentUser = useCurrentUser();
   const { presence, ui } = useStores();
-  const token = useCurrentToken();
   const [showCursorNames, setShowCursorNames] = React.useState(false);
   const [remoteProvider, setRemoteProvider] =
     React.useState<HocuspocusProvider | null>(null);
@@ -70,7 +68,7 @@ function MultiplayerEditor({ onSynced, ...props }: Props, ref: any) {
       url: `${env.COLLABORATION_URL}/collaboration`,
       name,
       document: ydoc,
-      token,
+      token: "not-used",
     });
 
     const syncScrollPosition = throttle(() => {
@@ -188,7 +186,6 @@ function MultiplayerEditor({ onSynced, ...props }: Props, ref: any) {
     documentId,
     ui,
     presence,
-    token,
     ydoc,
     currentUser.id,
     isMounted,

--- a/app/stores/AuthStore.ts
+++ b/app/stores/AuthStore.ts
@@ -20,6 +20,7 @@ const NO_REDIRECT_PATHS = ["/", "/create", "/home", "/logout"];
 type PersistedData = {
   user?: User;
   team?: Team;
+  collaborationToken?: string;
   availableTeams?: {
     id: string;
     name: string;
@@ -50,6 +51,9 @@ export default class AuthStore {
 
   @observable
   team?: Team | null;
+
+  @observable
+  collaborationToken?: string;
 
   @observable
   availableTeams?: {
@@ -121,12 +125,10 @@ export default class AuthStore {
   rehydrate(data: PersistedData) {
     this.user = data.user ? new User(data.user, this) : undefined;
     this.team = data.team ? new Team(data.team, this) : undefined;
+    this.collaborationToken = data.collaborationToken;
     this.lastSignedIn = getCookie("lastSignedIn");
     this.addPolicies(data.policies);
-
-    if (this.user) {
-      setTimeout(() => this.fetch(), 0);
-    }
+    void this.fetch();
   }
 
   addPolicies(policies?: Policy[]) {
@@ -147,6 +149,7 @@ export default class AuthStore {
     return {
       user: this.user,
       team: this.team,
+      collaborationToken: this.collaborationToken,
       availableTeams: this.availableTeams,
       policies: this.policies,
     };
@@ -172,6 +175,7 @@ export default class AuthStore {
         this.user = new User(user, this);
         this.team = new Team(team, this);
         this.availableTeams = res.data.availableTeams;
+        this.collaborationToken = res.data.collaborationToken;
 
         if (env.SENTRY_DSN) {
           Sentry.configureScope(function (scope) {

--- a/app/stores/AuthStore.ts
+++ b/app/stores/AuthStore.ts
@@ -233,6 +233,7 @@ export default class AuthStore {
     runInAction("AuthStore#updateUser", () => {
       this.user = null;
       this.team = null;
+      this.collaborationToken = null;
       this.availableTeams = this.availableTeams?.filter(
         (team) => team.id !== this.team?.id
       );

--- a/app/stores/AuthStore.ts
+++ b/app/stores/AuthStore.ts
@@ -142,7 +142,7 @@ export default class AuthStore {
 
   @computed
   get authenticated(): boolean {
-    return !!this.user;
+    return !!this.user && !!this.team;
   }
 
   @computed

--- a/app/utils/ApiClient.ts
+++ b/app/utils/ApiClient.ts
@@ -1,10 +1,8 @@
 import retry from "fetch-retry";
-import invariant from "invariant";
 import { trim } from "lodash";
 import queryString from "query-string";
 import EDITOR_VERSION from "@shared/editor/version";
 import stores from "~/stores";
-import isCloudHosted from "~/utils/isCloudHosted";
 import Logger from "./Logger";
 import download from "./download";
 import {
@@ -95,14 +93,8 @@ class ApiClient {
     }
 
     const headers = new Headers(headerOptions);
-
-    if (stores.auth.authenticated) {
-      invariant(stores.auth.token, "JWT token not set properly");
-      headers.set("Authorization", `Bearer ${stores.auth.token}`);
-    }
-
-    let response;
     const timeStart = window.performance.now();
+    let response;
 
     try {
       response = await fetchWithRetry(urlToFetch, {
@@ -110,15 +102,7 @@ class ApiClient {
         body,
         headers,
         redirect: "follow",
-        // For the hosted deployment we omit cookies on API requests as they are
-        // not needed for authentication this offers a performance increase.
-        // For self-hosted we include them to support a wide variety of
-        // authenticated proxies, e.g. Pomerium, Cloudflare Access etc.
-        credentials: options.credentials
-          ? options.credentials
-          : isCloudHosted
-          ? "omit"
-          : "same-origin",
+        credentials: "same-origin",
         cache: "no-cache",
       });
     } catch (err) {

--- a/app/utils/ApiClient.ts
+++ b/app/utils/ApiClient.ts
@@ -131,7 +131,8 @@ class ApiClient {
 
     // Handle 401, log out user
     if (response.status === 401) {
-      await stores.auth.logout();
+      const tokenIsExpired = true;
+      await stores.auth.logout(false, tokenIsExpired);
       return;
     }
 

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "class-validator": "^0.14.0",
     "command-score": "^0.1.2",
     "compressorjs": "^1.2.1",
+    "cookie": "^0.5.0",
     "copy-to-clipboard": "^3.3.3",
     "core-js": "^3.30.2",
     "crypto-js": "^4.1.1",

--- a/server/collaboration/AuthenticationExtension.ts
+++ b/server/collaboration/AuthenticationExtension.ts
@@ -19,7 +19,7 @@ export default class AuthenticationExtension implements Extension {
       throw AuthenticationError("Authentication required");
     }
 
-    const user = await getUserForJWT(token);
+    const user = await getUserForJWT(token, ["session", "collaboration"]);
 
     if (user.isSuspended) {
       throw AuthenticationError("Account suspended");

--- a/server/models/User.ts
+++ b/server/models/User.ts
@@ -1,5 +1,5 @@
 import crypto from "crypto";
-import { addMinutes, subMinutes } from "date-fns";
+import { addMinutes, addWeeks, subMinutes } from "date-fns";
 import JWT from "jsonwebtoken";
 import { Context } from "koa";
 import { Transaction, QueryTypes, SaveOptions, Op } from "sequelize";
@@ -449,6 +449,22 @@ class User extends ParanoidModel {
         id: this.id,
         expiresAt: expiresAt ? expiresAt.toISOString() : undefined,
         type: "session",
+      },
+      this.jwtSecret
+    );
+
+  /**
+   * Returns a session token that is used to make collaboration requests and is
+   * stored in the client memory.
+   *
+   * @returns The session token
+   */
+  getCollaborationToken = () =>
+    JWT.sign(
+      {
+        id: this.id,
+        expiresAt: addWeeks(new Date(), 1).toISOString(),
+        type: "collaboration",
       },
       this.jwtSecret
     );

--- a/server/models/User.ts
+++ b/server/models/User.ts
@@ -1,5 +1,5 @@
 import crypto from "crypto";
-import { addMinutes, addWeeks, subMinutes } from "date-fns";
+import { addHours, addMinutes, subMinutes } from "date-fns";
 import JWT from "jsonwebtoken";
 import { Context } from "koa";
 import { Transaction, QueryTypes, SaveOptions, Op } from "sequelize";
@@ -463,7 +463,7 @@ class User extends ParanoidModel {
     JWT.sign(
       {
         id: this.id,
-        expiresAt: addWeeks(new Date(), 1).toISOString(),
+        expiresAt: addHours(new Date(), 24).toISOString(),
         type: "collaboration",
       },
       this.jwtSecret

--- a/server/routes/api/auth/auth.ts
+++ b/server/routes/api/auth/auth.ts
@@ -1,8 +1,8 @@
-import { subHours } from "date-fns";
+import { subHours, subMinutes } from "date-fns";
 import Router from "koa-router";
 import { uniqBy } from "lodash";
 import { TeamPreference } from "@shared/types";
-import { parseDomain } from "@shared/utils/domains";
+import { getCookieDomain, parseDomain } from "@shared/utils/domains";
 import env from "@server/env";
 import auth from "@server/middlewares/authentication";
 import { transaction } from "@server/middlewares/transaction";
@@ -175,6 +175,11 @@ router.post(
         transaction,
       }
     );
+
+    ctx.cookies.set("accessToken", "", {
+      expires: subMinutes(new Date(), 1),
+      domain: getCookieDomain(ctx.hostname),
+    });
 
     ctx.body = {
       success: true,

--- a/server/routes/api/auth/auth.ts
+++ b/server/routes/api/auth/auth.ts
@@ -139,6 +139,7 @@ router.post("auth.info", auth(), async (ctx: APIContext<T.AuthInfoReq>) => {
         includeDetails: true,
       }),
       team: presentTeam(team),
+      collaborationToken: user.getCollaborationToken(),
       availableTeams: uniqBy([...signedInTeams, ...availableTeams], "id").map(
         (team) =>
           presentAvailableTeam(

--- a/server/routes/auth/index.ts
+++ b/server/routes/auth/index.ts
@@ -32,7 +32,6 @@ router.get("/redirect", auth(), async (ctx: APIContext) => {
   await user.updateActiveAt(ctx, true);
 
   ctx.cookies.set("accessToken", jwtToken, {
-    httpOnly: false,
     sameSite: "lax",
     expires: addMonths(new Date(), 3),
   });

--- a/server/utils/authentication.ts
+++ b/server/utils/authentication.ts
@@ -118,7 +118,7 @@ export async function signIn(
       );
     }
   } else {
-    ctx.cookies.set("accessToken", user.getJwtToken(), {
+    ctx.cookies.set("accessToken", user.getJwtToken(expires), {
       sameSite: "lax",
       expires,
     });

--- a/server/utils/authentication.ts
+++ b/server/utils/authentication.ts
@@ -120,7 +120,6 @@ export async function signIn(
   } else {
     ctx.cookies.set("accessToken", user.getJwtToken(), {
       sameSite: "lax",
-      httpOnly: false,
       expires,
     });
 

--- a/server/utils/jwt.ts
+++ b/server/utils/jwt.ts
@@ -20,10 +20,13 @@ function getJWTPayload(token: string) {
   }
 }
 
-export async function getUserForJWT(token: string): Promise<User> {
+export async function getUserForJWT(
+  token: string,
+  allowedTypes = ["session", "transfer"]
+): Promise<User> {
   const payload = getJWTPayload(token);
 
-  if (payload.type === "email-signin") {
+  if (!allowedTypes.includes(payload.type)) {
     throw AuthenticationError("Invalid token");
   }
 

--- a/server/utils/passport.ts
+++ b/server/utils/passport.ts
@@ -27,7 +27,6 @@ export class StateStore {
     const state = buildState(host, token, client);
 
     ctx.cookies.set(this.key, state, {
-      httpOnly: false,
       expires: addMinutes(new Date(), 10),
       domain: getCookieDomain(ctx.hostname),
     });
@@ -54,7 +53,6 @@ export class StateStore {
 
     // Destroy the one-time pad token and ensure it matches
     ctx.cookies.set(this.key, "", {
-      httpOnly: false,
       expires: subMinutes(new Date(), 1),
       domain: getCookieDomain(ctx.hostname),
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4949,6 +4949,11 @@ cookie@^0.4.1, cookie@~0.4.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
   integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
 
+cookie@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
+  integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
+
 cookiejar@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.4.tgz#ee669c1fea2cf42dc31585469d193fef0d65771b"


### PR DESCRIPTION
Currently our `authToken` cookie is not http only which allows javascript access to the value – this was done so that the token could be read and passed to websockets through websocket messages however it leaves the app vulnerable to XSS vulnerabilities. 

This PR moves the auth for the main websocket to use the cookie directly, and the collaboration socket to use a new short-lived `collaborationToken` which will be sent in the `auth.info` payload and retained in memory only.