### PR TITLE
Preview arbitrary urls within a document

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -181,3 +181,7 @@ RATE_LIMITER_ENABLED=true
 # Configure default throttling parameters for rate limiter
 RATE_LIMITER_REQUESTS=1000
 RATE_LIMITER_DURATION_WINDOW=60
+
+# Iframely API config
+IFRAMELY_URL=
+IFRAMELY_API_KEY=

--- a/app/components/HoverPreview/Components.tsx
+++ b/app/components/HoverPreview/Components.tsx
@@ -1,7 +1,6 @@
 import { transparentize } from "polished";
-import * as React from "react";
 import { Link } from "react-router-dom";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import { s } from "@shared/styles";
 import Text from "~/components/Text";
 
@@ -10,6 +9,12 @@ export const CARD_PADDING = 16;
 export const CARD_WIDTH = 375;
 
 export const THUMBNAIL_HEIGHT = 200;
+
+const NUMBER_OF_LINES = 10;
+
+const sharedVars = css`
+  --line-height: 1.6em;
+`;
 
 const StyledText = styled(Text)`
   margin-bottom: 0;
@@ -31,23 +36,20 @@ export const Title = styled.h2`
   color: ${s("text")};
 `;
 
-export const Info: React.FC = ({ children }: { children: string }) => (
-  <StyledText type="tertiary" size="xsmall">
-    {children}
-  </StyledText>
-);
+export const Info = styled(StyledText).attrs(() => ({
+  type: "tertiary",
+  size: "xsmall",
+}))``;
 
-export const Description: React.FC = styled(StyledText)`
+export const Description = styled(StyledText)`
+  ${sharedVars}
   margin-top: 0.5em;
-`;
-
-export const DescriptionContainer = styled.div`
-  margin-top: 0.5em;
+  line-height: var(--line-height);
+  max-height: calc(var(--line-height) * ${NUMBER_OF_LINES});
 `;
 
 export const CardContent = styled.div`
   overflow: hidden;
-  max-height: 20.5em;
   user-select: none;
 `;
 
@@ -78,6 +80,7 @@ export const Card = styled.div<{ fadeOut?: boolean; $borderRadius?: string }>`
   ${(props) =>
     props.fadeOut !== false
       ? `&:after {
+          ${sharedVars}
           content: "";
           display: block;
           position: absolute;
@@ -91,7 +94,7 @@ export const Card = styled.div<{ fadeOut?: boolean; $borderRadius?: string }>`
           bottom: 0;
           left: 0;
           right: 0;
-          height: 1.7em;
+          height: var(--line-height);
           border-bottom: 16px solid ${props.theme.menuBackground};
           border-bottom-left-radius: 4px;
           border-bottom-right-radius: 4px;

--- a/app/components/HoverPreview/Components.tsx
+++ b/app/components/HoverPreview/Components.tsx
@@ -21,13 +21,13 @@ const StyledText = styled(Text)`
 `;
 
 export const Preview = styled(Link)`
-  cursor: var(--pointer);
+  cursor: ${(props: any) =>
+    props.as === "div" ? "default" : "var(--pointer)"};
   border-radius: 4px;
   box-shadow: 0 30px 90px -20px rgba(0, 0, 0, 0.3),
     0 0 1px 1px rgba(0, 0, 0, 0.05);
   overflow: hidden;
   position: absolute;
-  ${(props) => (!props.to ? "pointer-events: none;" : "")}
 `;
 
 export const Title = styled.h2`

--- a/app/components/HoverPreview/Components.tsx
+++ b/app/components/HoverPreview/Components.tsx
@@ -1,7 +1,13 @@
+import * as React from "react";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 import { s } from "@shared/styles";
 import Text from "~/components/Text";
+
+const StyledText = styled(Text)`
+  margin-bottom: 0;
+  padding-top: 0.125em;
+`;
 
 export const Preview = styled(Link)`
   cursor: var(--pointer);
@@ -11,15 +17,16 @@ export const Preview = styled(Link)`
 
 export const Title = styled.h2`
   font-size: 1.25em;
-  margin: 2px 0 0 0;
+  margin: 0.125em 0 0 0;
   color: ${s("text")};
 `;
 
-export const Description = styled(Text)`
-  margin-bottom: 0;
-  padding-top: 2px;
-`;
+export const Info: React.FC = ({ children }) => (
+  <StyledText type="tertiary" size="xsmall">
+    {children}
+  </StyledText>
+);
 
-export const Summary = styled.div`
-  margin-top: 8px;
+export const DescriptionContainer = styled.div`
+  margin-top: 0.5em;
 `;

--- a/app/components/HoverPreview/Components.tsx
+++ b/app/components/HoverPreview/Components.tsx
@@ -27,6 +27,10 @@ export const Info: React.FC = ({ children }) => (
   </StyledText>
 );
 
+export const Description: React.FC = styled(StyledText)`
+  margin-top: 0.5em;
+`;
+
 export const DescriptionContainer = styled.div`
   margin-top: 0.5em;
 `;

--- a/app/components/HoverPreview/Components.tsx
+++ b/app/components/HoverPreview/Components.tsx
@@ -1,8 +1,15 @@
+import { transparentize } from "polished";
 import * as React from "react";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 import { s } from "@shared/styles";
 import Text from "~/components/Text";
+
+export const CARD_PADDING = 16;
+
+export const CARD_WIDTH = 375;
+
+export const THUMBNAIL_HEIGHT = 200;
 
 const StyledText = styled(Text)`
   margin-bottom: 0;
@@ -11,7 +18,11 @@ const StyledText = styled(Text)`
 
 export const Preview = styled(Link)`
   cursor: var(--pointer);
-  margin-bottom: 0;
+  border-radius: 4px;
+  box-shadow: 0 30px 90px -20px rgba(0, 0, 0, 0.3),
+    0 0 1px 1px rgba(0, 0, 0, 0.05);
+  overflow: hidden;
+  position: absolute;
   ${(props) => (!props.to ? "pointer-events: none;" : "")}
 `;
 
@@ -21,7 +32,7 @@ export const Title = styled.h2`
   color: ${s("text")};
 `;
 
-export const Info: React.FC = ({ children }) => (
+export const Info: React.FC = ({ children }: { children: string }) => (
   <StyledText type="tertiary" size="xsmall">
     {children}
   </StyledText>
@@ -33,4 +44,58 @@ export const Description: React.FC = styled(StyledText)`
 
 export const DescriptionContainer = styled.div`
   margin-top: 0.5em;
+`;
+
+export const CardContent = styled.div`
+  overflow: hidden;
+  max-height: 20.5em;
+  user-select: none;
+`;
+
+// &:after — gradient mask for overflow text
+export const Card = styled.div<{ fadeOut?: boolean; $borderRadius?: string }>`
+  backdrop-filter: blur(10px);
+  background: ${(props) => props.theme.menuBackground};
+  padding: ${CARD_PADDING}px;
+  width: ${CARD_WIDTH}px;
+  font-size: 0.9em;
+  position: relative;
+
+  .placeholder,
+  .heading-anchor {
+    display: none;
+  }
+
+  // fills the gap between the card and pointer to avoid a dead zone
+  &::before {
+    content: "";
+    position: absolute;
+    top: -10px;
+    left: 0;
+    right: 0;
+    height: 10px;
+  }
+
+  ${(props) =>
+    props.fadeOut !== false
+      ? `&:after {
+          content: "";
+          display: block;
+          position: absolute;
+          pointer-events: none;
+          background: linear-gradient(
+            90deg,
+            ${transparentize(1, props.theme.menuBackground)} 0%,
+            ${transparentize(1, props.theme.menuBackground)} 75%,
+            ${props.theme.menuBackground} 90%
+          );
+          bottom: 0;
+          left: 0;
+          right: 0;
+          height: 1.7em;
+          border-bottom: 16px solid ${props.theme.menuBackground};
+          border-bottom-left-radius: 4px;
+          border-bottom-right-radius: 4px;
+        }`
+      : ""}
 `;

--- a/app/components/HoverPreview/Components.tsx
+++ b/app/components/HoverPreview/Components.tsx
@@ -13,7 +13,6 @@ export const THUMBNAIL_HEIGHT = 200;
 
 const StyledText = styled(Text)`
   margin-bottom: 0;
-  padding-top: 0.125em;
 `;
 
 export const Preview = styled(Link)`
@@ -28,7 +27,7 @@ export const Preview = styled(Link)`
 
 export const Title = styled.h2`
   font-size: 1.25em;
-  margin: 0.125em 0 0 0;
+  margin: 0;
   color: ${s("text")};
 `;
 

--- a/app/components/HoverPreview/HoverPreview.tsx
+++ b/app/components/HoverPreview/HoverPreview.tsx
@@ -1,5 +1,4 @@
 import { m } from "framer-motion";
-import { transparentize } from "polished";
 import * as React from "react";
 import { Portal } from "react-portal";
 import styled from "styled-components";
@@ -12,14 +11,13 @@ import useOnClickOutside from "~/hooks/useOnClickOutside";
 import useRequest from "~/hooks/useRequest";
 import useStores from "~/hooks/useStores";
 import { client } from "~/utils/ApiClient";
+import { CARD_WIDTH, CARD_PADDING } from "./Components";
 import HoverPreviewDocument from "./HoverPreviewDocument";
 import HoverPreviewLink from "./HoverPreviewLink";
 import HoverPreviewMention from "./HoverPreviewMention";
 
 const DELAY_OPEN = 300;
 const DELAY_CLOSE = 600;
-const CARD_PADDING = 16;
-const CARD_MAX_WIDTH = 375;
 
 type Props = {
   /* The HTML element that is being hovered over */
@@ -123,10 +121,7 @@ function HoverPreviewInternal({ element, onClose }: Props) {
   const elemBounds = element.getBoundingClientRect();
   const cardBounds = cardRef.current?.getBoundingClientRect();
   const left = cardBounds
-    ? Math.min(
-        elemBounds.left,
-        window.innerWidth - CARD_PADDING - CARD_MAX_WIDTH
-      )
+    ? Math.min(elemBounds.left, window.innerWidth - CARD_PADDING - CARD_WIDTH)
     : elemBounds.left;
   const leftOffset = elemBounds.left - left;
 
@@ -151,33 +146,29 @@ function HoverPreviewInternal({ element, onClose }: Props) {
               initial={{ opacity: 0, y: -20, pointerEvents: "none" }}
               animate={{ opacity: 1, y: 0, pointerEvents: "auto" }}
             >
-              <Card fadeOut={data.type !== UnfurlType.Mention}>
-                <CardContent>
-                  {data.type === UnfurlType.Mention ? (
-                    <HoverPreviewMention
-                      url={data.thumbnailUrl}
-                      title={data.title}
-                      info={data.meta.info}
-                      color={data.meta.color}
-                    />
-                  ) : data.type === UnfurlType.Document ? (
-                    <HoverPreviewDocument
-                      id={data.meta.id}
-                      url={data.url}
-                      title={data.title}
-                      description={data.description}
-                      info={data.meta.info}
-                    />
-                  ) : (
-                    <HoverPreviewLink
-                      url={data.url}
-                      thumbnailUrl={data.thumbnailUrl}
-                      title={data.title}
-                      description={data.description}
-                    />
-                  )}
-                </CardContent>
-              </Card>
+              {data.type === UnfurlType.Mention ? (
+                <HoverPreviewMention
+                  url={data.thumbnailUrl}
+                  title={data.title}
+                  info={data.meta.info}
+                  color={data.meta.color}
+                />
+              ) : data.type === UnfurlType.Document ? (
+                <HoverPreviewDocument
+                  id={data.meta.id}
+                  url={data.url}
+                  title={data.title}
+                  description={data.description}
+                  info={data.meta.info}
+                />
+              ) : (
+                <HoverPreviewLink
+                  url={data.url}
+                  thumbnailUrl={data.thumbnailUrl}
+                  title={data.title}
+                  description={data.description}
+                />
+              )}
               <Pointer offset={leftOffset + elemBounds.width / 2} />
             </Animate>
           ) : null}
@@ -200,64 +191,6 @@ const Animate = styled(m.div)`
   @media print {
     display: none;
   }
-`;
-
-const CardContent = styled.div`
-  overflow: hidden;
-  max-height: 20.5em;
-  user-select: none;
-`;
-
-// &:after — gradient mask for overflow text
-const Card = styled.div<{ fadeOut?: boolean }>`
-  backdrop-filter: blur(10px);
-  background: ${(props) => props.theme.menuBackground};
-  border-radius: 4px;
-  box-shadow: 0 30px 90px -20px rgba(0, 0, 0, 0.3),
-    0 0 1px 1px rgba(0, 0, 0, 0.05);
-  padding: ${CARD_PADDING}px;
-  min-width: 350px;
-  max-width: ${CARD_MAX_WIDTH}px;
-  font-size: 0.9em;
-  position: relative;
-
-  .placeholder,
-  .heading-anchor {
-    display: none;
-  }
-
-  // fills the gap between the card and pointer to avoid a dead zone
-  &::before {
-    content: "";
-    position: absolute;
-    top: -10px;
-    left: 0;
-    right: 0;
-    height: 10px;
-  }
-
-  ${(props) =>
-    props.fadeOut !== false
-      ? `&:after {
-          content: "";
-          display: block;
-          position: absolute;
-          pointer-events: none;
-          background: linear-gradient(
-            90deg,
-            ${transparentize(1, props.theme.menuBackground)} 0%,
-            ${transparentize(1, props.theme.menuBackground)} 75%,
-            ${props.theme.menuBackground} 90%
-          );
-          bottom: 0;
-          left: 0;
-          right: 0;
-          height: 1.7em;
-          border-bottom: 16px solid ${props.theme.menuBackground};
-          border-bottom-left-radius: 4px;
-          border-bottom-right-radius: 4px;
-        }`
-      : ""}
 `;
 
 const Position = styled.div<{ fixed?: boolean; top?: number; left?: number }>`

--- a/app/components/HoverPreview/HoverPreview.tsx
+++ b/app/components/HoverPreview/HoverPreview.tsx
@@ -13,6 +13,7 @@ import useRequest from "~/hooks/useRequest";
 import useStores from "~/hooks/useStores";
 import { client } from "~/utils/ApiClient";
 import HoverPreviewDocument from "./HoverPreviewDocument";
+import HoverPreviewLink from "./HoverPreviewLink";
 import HoverPreviewMention from "./HoverPreviewMention";
 
 const DELAY_OPEN = 300;
@@ -167,7 +168,14 @@ function HoverPreviewInternal({ element, onClose }: Props) {
                       description={data.description}
                       info={data.meta.info}
                     />
-                  ) : null}
+                  ) : (
+                    <HoverPreviewLink
+                      url={data.url}
+                      thumbnailUrl={data.thumbnailUrl}
+                      title={data.title}
+                      description={data.description}
+                    />
+                  )}
                 </CardContent>
               </Card>
               <Pointer offset={leftOffset + elemBounds.width / 2} />
@@ -196,7 +204,7 @@ const Animate = styled(m.div)`
 
 const CardContent = styled.div`
   overflow: hidden;
-  max-height: 20em;
+  max-height: 20.5em;
   user-select: none;
 `;
 

--- a/app/components/HoverPreview/HoverPreview.tsx
+++ b/app/components/HoverPreview/HoverPreview.tsx
@@ -93,7 +93,7 @@ function HoverPreviewInternal({ element, onClose }: Props) {
   React.useEffect(() => {
     const card = cardRef.current;
 
-    if (data) {
+    if (data && !data.error) {
       startOpenTimer();
 
       if (card) {
@@ -134,7 +134,7 @@ function HoverPreviewInternal({ element, onClose }: Props) {
     return <LoadingIndicator />;
   }
 
-  if (!data) {
+  if (!data || data.error) {
     return null;
   }
 

--- a/app/components/HoverPreview/HoverPreview.tsx
+++ b/app/components/HoverPreview/HoverPreview.tsx
@@ -156,7 +156,7 @@ function HoverPreviewInternal({ element, onClose }: Props) {
                     <HoverPreviewMention
                       url={data.thumbnailUrl}
                       title={data.title}
-                      description={data.description}
+                      info={data.meta.info}
                       color={data.meta.color}
                     />
                   ) : data.type === UnfurlType.Document ? (
@@ -165,7 +165,7 @@ function HoverPreviewInternal({ element, onClose }: Props) {
                       url={data.url}
                       title={data.title}
                       description={data.description}
-                      summary={data.meta.summary}
+                      info={data.meta.info}
                     />
                   ) : null}
                 </CardContent>

--- a/app/components/HoverPreview/HoverPreview.tsx
+++ b/app/components/HoverPreview/HoverPreview.tsx
@@ -93,7 +93,7 @@ function HoverPreviewInternal({ element, onClose }: Props) {
   React.useEffect(() => {
     const card = cardRef.current;
 
-    if (data && !data.error) {
+    if (data) {
       startOpenTimer();
 
       if (card) {
@@ -134,7 +134,7 @@ function HoverPreviewInternal({ element, onClose }: Props) {
     return <LoadingIndicator />;
   }
 
-  if (!data || data.error) {
+  if (!data) {
     return null;
   }
 

--- a/app/components/HoverPreview/HoverPreviewDocument.tsx
+++ b/app/components/HoverPreview/HoverPreviewDocument.tsx
@@ -28,7 +28,7 @@ function HoverPreviewDocument({ id, url, title, info, description }: Props) {
     <Preview to={url}>
       <Card>
         <CardContent>
-          <Flex column>
+          <Flex column gap={2}>
             <Title>{title}</Title>
             <Info>{info}</Info>
             <DescriptionContainer>

--- a/app/components/HoverPreview/HoverPreviewDocument.tsx
+++ b/app/components/HoverPreview/HoverPreviewDocument.tsx
@@ -1,7 +1,14 @@
 import * as React from "react";
 import Editor from "~/components/Editor";
 import Flex from "~/components/Flex";
-import { Preview, Title, Info, DescriptionContainer } from "./Components";
+import {
+  Preview,
+  Title,
+  Info,
+  DescriptionContainer,
+  Card,
+  CardContent,
+} from "./Components";
 
 type Props = {
   /** Document id associated with the editor, if any */
@@ -19,20 +26,24 @@ type Props = {
 function HoverPreviewDocument({ id, url, title, info, description }: Props) {
   return (
     <Preview to={url}>
-      <Flex column>
-        <Title>{title}</Title>
-        <Info>{info}</Info>
-        <DescriptionContainer>
-          <React.Suspense fallback={<div />}>
-            <Editor
-              key={id}
-              defaultValue={description}
-              embedsDisabled
-              readOnly
-            />
-          </React.Suspense>
-        </DescriptionContainer>
-      </Flex>
+      <Card>
+        <CardContent>
+          <Flex column>
+            <Title>{title}</Title>
+            <Info>{info}</Info>
+            <DescriptionContainer>
+              <React.Suspense fallback={<div />}>
+                <Editor
+                  key={id}
+                  defaultValue={description}
+                  embedsDisabled
+                  readOnly
+                />
+              </React.Suspense>
+            </DescriptionContainer>
+          </Flex>
+        </CardContent>
+      </Card>
     </Preview>
   );
 }

--- a/app/components/HoverPreview/HoverPreviewDocument.tsx
+++ b/app/components/HoverPreview/HoverPreviewDocument.tsx
@@ -5,9 +5,9 @@ import {
   Preview,
   Title,
   Info,
-  DescriptionContainer,
   Card,
   CardContent,
+  Description,
 } from "./Components";
 
 type Props = {
@@ -31,7 +31,7 @@ function HoverPreviewDocument({ id, url, title, info, description }: Props) {
           <Flex column gap={2}>
             <Title>{title}</Title>
             <Info>{info}</Info>
-            <DescriptionContainer>
+            <Description as="div">
               <React.Suspense fallback={<div />}>
                 <Editor
                   key={id}
@@ -40,7 +40,7 @@ function HoverPreviewDocument({ id, url, title, info, description }: Props) {
                   readOnly
                 />
               </React.Suspense>
-            </DescriptionContainer>
+            </Description>
           </Flex>
         </CardContent>
       </Card>

--- a/app/components/HoverPreview/HoverPreviewDocument.tsx
+++ b/app/components/HoverPreview/HoverPreviewDocument.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import Editor from "~/components/Editor";
 import Flex from "~/components/Flex";
-import { Preview, Title, Description, Summary } from "./Components";
+import { Preview, Title, Info, DescriptionContainer } from "./Components";
 
 type Props = {
   /** Document id associated with the editor, if any */
@@ -10,25 +10,28 @@ type Props = {
   url: string;
   /** Title for the preview card */
   title: string;
-  /** Description about recent activity on document */
+  /** Info about last activity on the document */
+  info: string;
+  /** Text preview of document content */
   description: string;
-  /** Summary of document content */
-  summary: string;
 };
 
-function HoverPreviewDocument({ id, url, title, description, summary }: Props) {
+function HoverPreviewDocument({ id, url, title, info, description }: Props) {
   return (
     <Preview to={url}>
       <Flex column>
         <Title>{title}</Title>
-        <Description type="tertiary" size="xsmall">
-          {description}
-        </Description>
-        <Summary>
+        <Info>{info}</Info>
+        <DescriptionContainer>
           <React.Suspense fallback={<div />}>
-            <Editor key={id} defaultValue={summary} embedsDisabled readOnly />
+            <Editor
+              key={id}
+              defaultValue={description}
+              embedsDisabled
+              readOnly
+            />
           </React.Suspense>
-        </Summary>
+        </DescriptionContainer>
       </Flex>
     </Preview>
   );

--- a/app/components/HoverPreview/HoverPreviewLink.tsx
+++ b/app/components/HoverPreview/HoverPreviewLink.tsx
@@ -17,7 +17,7 @@ type Props = {
   url: string;
   /** Title for the preview card */
   title: string;
-  /** Url for thumbnail served by the link provider*/
+  /** Url for thumbnail served by the link provider */
   thumbnailUrl: string;
   /** Some description about the link provider */
   description: string;

--- a/app/components/HoverPreview/HoverPreviewLink.tsx
+++ b/app/components/HoverPreview/HoverPreviewLink.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import Img from "@shared/editor/components/Img";
+import Flex from "~/components/Flex";
+import { Preview, Title, Description } from "./Components";
+
+type Props = {
+  /** Link url */
+  url: string;
+  /** Title for the preview card */
+  title: string;
+  /** Url for thumbnail served by the link provider*/
+  thumbnailUrl: string;
+  /** Some description about the link provider */
+  description: string;
+};
+
+function HoverPreviewLink({ url, thumbnailUrl, title, description }: Props) {
+  return (
+    <Preview to={url}>
+      <Flex gap={12} column>
+        <Img src={thumbnailUrl} alt={""} />
+        <Flex column>
+          <Title>{title}</Title>
+          <Description>{description}</Description>
+        </Flex>
+      </Flex>
+    </Preview>
+  );
+}
+
+export default HoverPreviewLink;

--- a/app/components/HoverPreview/HoverPreviewLink.tsx
+++ b/app/components/HoverPreview/HoverPreviewLink.tsx
@@ -1,7 +1,16 @@
 import * as React from "react";
+import styled from "styled-components";
 import Img from "@shared/editor/components/Img";
 import Flex from "~/components/Flex";
-import { Preview, Title, Description } from "./Components";
+import {
+  Preview,
+  Title,
+  Description,
+  Card,
+  CardContent,
+  CARD_WIDTH,
+  THUMBNAIL_HEIGHT,
+} from "./Components";
 
 type Props = {
   /** Link url */
@@ -16,16 +25,26 @@ type Props = {
 
 function HoverPreviewLink({ url, thumbnailUrl, title, description }: Props) {
   return (
-    <Preview to={url}>
-      <Flex gap={12} column>
-        <Img src={thumbnailUrl} alt={""} />
-        <Flex column>
-          <Title>{title}</Title>
-          <Description>{description}</Description>
-        </Flex>
+    <Preview to={{ pathname: url }} target="_blank" rel="noopener noreferrer">
+      <Flex column>
+        {thumbnailUrl ? <Thumbnail src={thumbnailUrl} alt={""} /> : null}
+        <Card>
+          <CardContent>
+            <Flex column>
+              <Title>{title}</Title>
+              <Description>{description}</Description>
+            </Flex>
+          </CardContent>
+        </Card>
       </Flex>
     </Preview>
   );
 }
+
+const Thumbnail = styled(Img)`
+  object-fit: cover;
+  max-width: ${CARD_WIDTH}px;
+  height: ${THUMBNAIL_HEIGHT}px;
+`;
 
 export default HoverPreviewLink;

--- a/app/components/HoverPreview/HoverPreviewLink.tsx
+++ b/app/components/HoverPreview/HoverPreviewLink.tsx
@@ -25,7 +25,7 @@ type Props = {
 
 function HoverPreviewLink({ url, thumbnailUrl, title, description }: Props) {
   return (
-    <Preview to={{ pathname: url }} target="_blank" rel="noopener noreferrer">
+    <Preview as="a" href={url} target="_blank" rel="noopener noreferrer">
       <Flex column>
         {thumbnailUrl ? <Thumbnail src={thumbnailUrl} alt={""} /> : null}
         <Card>

--- a/app/components/HoverPreview/HoverPreviewMention.tsx
+++ b/app/components/HoverPreview/HoverPreviewMention.tsx
@@ -17,7 +17,7 @@ type Props = {
 
 function HoverPreviewMention({ url, title, info, color }: Props) {
   return (
-    <Preview to="">
+    <Preview as="div">
       <Card fadeOut={false}>
         <CardContent>
           <Flex gap={12}>

--- a/app/components/HoverPreview/HoverPreviewMention.tsx
+++ b/app/components/HoverPreview/HoverPreviewMention.tsx
@@ -2,20 +2,20 @@ import * as React from "react";
 import Avatar from "~/components/Avatar";
 import { AvatarSize } from "~/components/Avatar/Avatar";
 import Flex from "~/components/Flex";
-import { Preview, Title, Description } from "./Components";
+import { Preview, Title, Info } from "./Components";
 
 type Props = {
   /** Resource url, avatar url in case of user mention */
   url: string;
   /** Title for the preview card*/
   title: string;
-  /** Description about mentioned user's recent activity */
-  description: string;
+  /** Info about mentioned user's recent activity */
+  info: string;
   /** Used for avatar's background color in absence of avatar url */
   color: string;
 };
 
-function HoverPreviewMention({ url, title, description, color }: Props) {
+function HoverPreviewMention({ url, title, info, color }: Props) {
   return (
     <Preview to="">
       <Flex gap={12}>
@@ -29,9 +29,7 @@ function HoverPreviewMention({ url, title, description, color }: Props) {
         />
         <Flex column>
           <Title>{title}</Title>
-          <Description type="tertiary" size="xsmall">
-            {description}
-          </Description>
+          <Info>{info}</Info>
         </Flex>
       </Flex>
     </Preview>

--- a/app/components/HoverPreview/HoverPreviewMention.tsx
+++ b/app/components/HoverPreview/HoverPreviewMention.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import Avatar from "~/components/Avatar";
 import { AvatarSize } from "~/components/Avatar/Avatar";
 import Flex from "~/components/Flex";
-import { Preview, Title, Info } from "./Components";
+import { Preview, Title, Info, Card, CardContent } from "./Components";
 
 type Props = {
   /** Resource url, avatar url in case of user mention */
@@ -18,20 +18,24 @@ type Props = {
 function HoverPreviewMention({ url, title, info, color }: Props) {
   return (
     <Preview to="">
-      <Flex gap={12}>
-        <Avatar
-          model={{
-            avatarUrl: url,
-            initial: title ? title[0] : "?",
-            color,
-          }}
-          size={AvatarSize.XLarge}
-        />
-        <Flex column>
-          <Title>{title}</Title>
-          <Info>{info}</Info>
-        </Flex>
-      </Flex>
+      <Card fadeOut={false}>
+        <CardContent>
+          <Flex gap={12}>
+            <Avatar
+              model={{
+                avatarUrl: url,
+                initial: title ? title[0] : "?",
+                color,
+              }}
+              size={AvatarSize.XLarge}
+            />
+            <Flex column>
+              <Title>{title}</Title>
+              <Info>{info}</Info>
+            </Flex>
+          </Flex>
+        </CardContent>
+      </Card>
     </Preview>
   );
 }

--- a/app/components/HoverPreview/HoverPreviewMention.tsx
+++ b/app/components/HoverPreview/HoverPreviewMention.tsx
@@ -29,7 +29,7 @@ function HoverPreviewMention({ url, title, info, color }: Props) {
               }}
               size={AvatarSize.XLarge}
             />
-            <Flex column>
+            <Flex column gap={2} justify="center">
               <Title>{title}</Title>
               <Info>{info}</Info>
             </Flex>

--- a/plugins/iframely/plugin.json
+++ b/plugins/iframely/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "Iframely",
+  "description": "Integrate Iframely to enable unfurling of arbitrary urls",
+  "requiredEnvVars": ["IFRAMELY_URL", "IFRAMELY_API_KEY"]
+}

--- a/plugins/iframely/server/.babelrc
+++ b/plugins/iframely/server/.babelrc
@@ -1,0 +1,3 @@
+{ 
+  "extends": "../../../server/.babelrc"
+}

--- a/plugins/iframely/server/iframely.ts
+++ b/plugins/iframely/server/iframely.ts
@@ -26,9 +26,8 @@ class Iframely {
         response.cache_age
       );
     } catch (err) {
-      // just log it as a warning to not disrupt the flow,
-      // can skip caching and directly return response
-      Logger.warn("Could not cache Iframely response", err);
+      // just log it, can skip caching and directly return response
+      Logger.error("Could not cache Iframely response", err);
     }
   }
 
@@ -48,9 +47,8 @@ class Iframely {
         return JSON.parse(val);
       }
     } catch (err) {
-      // just log it as a warning to not disrupt the flow,
-      // response can still be obtained using the fetch call
-      Logger.warn("Could not fetch cached Iframely response", err);
+      // just log it, response can still be obtained using the fetch call
+      Logger.error("Could not fetch cached Iframely response", err);
     }
   }
 

--- a/plugins/iframely/server/iframely.ts
+++ b/plugins/iframely/server/iframely.ts
@@ -8,6 +8,7 @@ class Iframely {
   private static apiUrl = `${env.IFRAMELY_URL}/api`;
   private static apiKey = env.IFRAMELY_API_KEY;
   private static cacheKeyPrefix = "unfurl";
+  private static defaultCacheExpiry = 86400;
 
   private static cacheKey(url: string) {
     return `${this.cacheKeyPrefix}-${url}`;
@@ -23,7 +24,7 @@ class Iframely {
         this.cacheKey(url),
         JSON.stringify(response),
         "EX",
-        response.cache_age
+        response.cache_age || this.defaultCacheExpiry
       );
     } catch (err) {
       // just log it, can skip caching and directly return response

--- a/plugins/iframely/server/iframely.ts
+++ b/plugins/iframely/server/iframely.ts
@@ -1,0 +1,24 @@
+import fetch from "fetch-with-proxy";
+import env from "@server/env";
+import { InvalidRequestError } from "@server/errors";
+
+class Iframely {
+  private static apiUrl = `${env.IFRAMELY_URL}/api`;
+  private static apiKey = env.IFRAMELY_API_KEY;
+
+  public static async get(url: string, type = "oembed") {
+    try {
+      const res = await fetch(
+        `${this.apiUrl}/${type}?url=${encodeURIComponent(url)}&api_key=${
+          this.apiKey
+        }`
+      );
+      const data = await res.json();
+      return data;
+    } catch (err) {
+      throw InvalidRequestError(err);
+    }
+  }
+}
+
+export default Iframely;

--- a/plugins/iframely/server/iframely.ts
+++ b/plugins/iframely/server/iframely.ts
@@ -1,22 +1,54 @@
 import fetch from "fetch-with-proxy";
 import env from "@server/env";
-import { InvalidRequestError } from "@server/errors";
+import { InternalError } from "@server/errors";
+import Redis from "@server/redis";
 
 class Iframely {
   private static apiUrl = `${env.IFRAMELY_URL}/api`;
   private static apiKey = env.IFRAMELY_API_KEY;
+  private static cacheKeyPrefix = "unfurl";
 
-  public static async get(url: string, type = "oembed") {
-    try {
-      const res = await fetch(
-        `${this.apiUrl}/${type}?url=${encodeURIComponent(url)}&api_key=${
-          this.apiKey
-        }`
+  private static cacheKey(url: string) {
+    return `${this.cacheKeyPrefix}-${url}`;
+  }
+
+  private static async cache(url: string) {
+    const data = await this.fetch(url);
+
+    if (!data.error) {
+      await Redis.defaultClient.set(
+        this.cacheKey(url),
+        JSON.stringify(data),
+        "EX",
+        data.cache_age
       );
-      const data = await res.json();
-      return data;
+    }
+
+    return data;
+  }
+
+  private static async fetch(url: string, type = "oembed") {
+    const res = await fetch(
+      `${this.apiUrl}/${type}?url=${encodeURIComponent(url)}&api_key=${
+        this.apiKey
+      }`
+    );
+    return res.json();
+  }
+
+  private static async cached(url: string) {
+    const val = await Redis.defaultClient.get(this.cacheKey(url));
+    if (val) {
+      return JSON.parse(val);
+    }
+  }
+
+  public static async get(url: string) {
+    try {
+      const cached = await this.cached(url);
+      return cached ? cached : this.cache(url);
     } catch (err) {
-      throw InvalidRequestError(err);
+      throw InternalError(err);
     }
   }
 }

--- a/plugins/iframely/server/unfurl.ts
+++ b/plugins/iframely/server/unfurl.ts
@@ -1,0 +1,3 @@
+import Iframely from "./iframely";
+
+export const unfurl = async (url: string) => Iframely.get(url);

--- a/server/env.ts
+++ b/server/env.ts
@@ -617,7 +617,7 @@ export class Environment {
    */
   @IsOptional()
   @CannotUseWithout("IFRAMELY_URL")
-  public IFRAMELY_API_KEY = process.env.IFRAMELY_API_KEY ?? "";
+  public IFRAMELY_API_KEY = this.toOptionalString(process.env.IFRAMELY_API_KEY);
 
   /**
    * The product name

--- a/server/env.ts
+++ b/server/env.ts
@@ -602,6 +602,24 @@ export class Environment {
   );
 
   /**
+   * Iframely url
+   */
+  @IsOptional()
+  @IsUrl({
+    require_tld: false,
+    allow_underscores: true,
+    protocols: ["http", "https"],
+  })
+  public IFRAMELY_URL = process.env.IFRAMELY_URL ?? "https://iframe.ly";
+
+  /**
+   * Iframely API key
+   */
+  @IsOptional()
+  @CannotUseWithout("IFRAMELY_URL")
+  public IFRAMELY_API_KEY = this.toOptionalString(process.env.IFRAMELY_API_KEY);
+
+  /**
    * The product name
    */
   public APP_NAME = "Outline";

--- a/server/env.ts
+++ b/server/env.ts
@@ -617,7 +617,7 @@ export class Environment {
    */
   @IsOptional()
   @CannotUseWithout("IFRAMELY_URL")
-  public IFRAMELY_API_KEY = this.toOptionalString(process.env.IFRAMELY_API_KEY);
+  public IFRAMELY_API_KEY = process.env.IFRAMELY_API_KEY ?? "";
 
   /**
    * The product name

--- a/server/presenters/unfurls/document.ts
+++ b/server/presenters/unfurls/document.ts
@@ -10,10 +10,10 @@ function presentDocument(
     url: document.url,
     type: UnfurlType.Document,
     title: document.titleWithDefault,
-    description: presentLastActivityInfoFor(document, viewer),
+    description: document.getSummary(),
     meta: {
       id: document.id,
-      summary: document.getSummary(),
+      info: presentLastActivityInfoFor(document, viewer),
     },
   };
 }

--- a/server/presenters/unfurls/mention.ts
+++ b/server/presenters/unfurls/mention.ts
@@ -12,11 +12,11 @@ async function presentMention(
   return {
     type: UnfurlType.Mention,
     title: user.name,
-    description: `${lastOnlineInfo} • ${lastViewedInfo}`,
     thumbnailUrl: user.avatarUrl,
     meta: {
       id: user.id,
       color: user.color,
+      info: `${lastOnlineInfo} • ${lastViewedInfo}`,
     },
   };
 }

--- a/server/presenters/unfurls/unfurl.ts
+++ b/server/presenters/unfurls/unfurl.ts
@@ -1,0 +1,14 @@
+import { Unfurl } from "@shared/types";
+
+function presentUnfurl(data: any): Unfurl {
+  return {
+    url: data.url,
+    type: data.type,
+    title: data.title,
+    description: data.description,
+    thumbnailUrl: data.thumbnail_url,
+    meta: data.meta,
+  };
+}
+
+export default presentUnfurl;

--- a/server/presenters/unfurls/unfurl.ts
+++ b/server/presenters/unfurls/unfurl.ts
@@ -1,19 +1,14 @@
-import { IframelyErrorResponse, Unfurl } from "@shared/types";
+import { Unfurl } from "@shared/types";
 
-function presentUnfurl(data: any): Unfurl | IframelyErrorResponse {
-  return !data.error
-    ? {
-        url: data.url,
-        type: data.type,
-        title: data.title,
-        description: data.description,
-        thumbnailUrl: data.thumbnail_url,
-        meta: data.meta,
-      }
-    : {
-        status: data.status,
-        error: data.error,
-      };
+function presentUnfurl(data: any): Unfurl {
+  return {
+    url: data.url,
+    type: data.type,
+    title: data.title,
+    description: data.description,
+    thumbnailUrl: data.thumbnail_url,
+    meta: data.meta,
+  };
 }
 
 export default presentUnfurl;

--- a/server/presenters/unfurls/unfurl.ts
+++ b/server/presenters/unfurls/unfurl.ts
@@ -1,14 +1,19 @@
-import { Unfurl } from "@shared/types";
+import { IframelyErrorResponse, Unfurl } from "@shared/types";
 
-function presentUnfurl(data: any): Unfurl {
-  return {
-    url: data.url,
-    type: data.type,
-    title: data.title,
-    description: data.description,
-    thumbnailUrl: data.thumbnail_url,
-    meta: data.meta,
-  };
+function presentUnfurl(data: any): Unfurl | IframelyErrorResponse {
+  return !data.error
+    ? {
+        url: data.url,
+        type: data.type,
+        title: data.title,
+        description: data.description,
+        thumbnailUrl: data.thumbnail_url,
+        meta: data.meta,
+      }
+    : {
+        status: data.status,
+        error: data.error,
+      };
 }
 
 export default presentUnfurl;

--- a/server/routes/api/urls/urls.test.ts
+++ b/server/routes/api/urls/urls.test.ts
@@ -1,7 +1,7 @@
 import { User } from "@server/models";
 import { buildDocument, buildUser } from "@server/test/factories";
 import { getTestServer } from "@server/test/support";
-import { Iframely } from "@server/utils/unfurl";
+import resolvers from "@server/utils/unfurl";
 
 jest.mock("@server/utils/unfurl", () => ({
   Iframely: {
@@ -146,7 +146,7 @@ describe("#urls.unfurl", () => {
   });
 
   it("should succeed with status 200 ok for a valid external url", async () => {
-    (Iframely.unfurl as jest.Mock).mockResolvedValue(
+    (resolvers.Iframely.unfurl as jest.Mock).mockResolvedValue(
       Promise.resolve({
         url: "https://www.flickr.com",
         type: "rich",
@@ -167,7 +167,9 @@ describe("#urls.unfurl", () => {
 
     const body = await res.json();
 
-    expect(Iframely.unfurl).toHaveBeenCalledWith("https://www.flickr.com");
+    expect(resolvers.Iframely.unfurl).toHaveBeenCalledWith(
+      "https://www.flickr.com"
+    );
     expect(res.status).toEqual(200);
     expect(body.url).toEqual("https://www.flickr.com");
     expect(body.type).toEqual("rich");
@@ -181,7 +183,7 @@ describe("#urls.unfurl", () => {
   });
 
   it("should succeed with status 204 no content for a non-existing external url", async () => {
-    (Iframely.unfurl as jest.Mock).mockResolvedValue(
+    (resolvers.Iframely.unfurl as jest.Mock).mockResolvedValue(
       Promise.resolve({
         status: 404,
         error:
@@ -196,7 +198,9 @@ describe("#urls.unfurl", () => {
       },
     });
 
-    expect(Iframely.unfurl).toHaveBeenCalledWith("https://random.url");
+    expect(resolvers.Iframely.unfurl).toHaveBeenCalledWith(
+      "https://random.url"
+    );
     expect(res.status).toEqual(204);
   });
 });

--- a/server/routes/api/urls/urls.ts
+++ b/server/routes/api/urls/urls.ts
@@ -11,7 +11,7 @@ import { presentDocument, presentMention } from "@server/presenters/unfurls";
 import presentUnfurl from "@server/presenters/unfurls/unfurl";
 import { APIContext } from "@server/types";
 import { RateLimiterStrategy } from "@server/utils/RateLimiter";
-import { Iframely } from "@server/utils/unfurl";
+import resolvers from "@server/utils/unfurl";
 import * as T from "./schema";
 
 const router = new Router();
@@ -62,12 +62,14 @@ router.post(
       return;
     }
 
-    const data = await Iframely.unfurl(url);
-    if (data.error) {
-      ctx.response.status = 204;
-      return;
+    if (resolvers.Iframely) {
+      const data = await resolvers.Iframely.unfurl(url);
+      return data.error
+        ? (ctx.response.status = 204)
+        : (ctx.body = presentUnfurl(data));
     }
-    ctx.body = presentUnfurl(data);
+
+    ctx.response.status = 204;
   }
 );
 

--- a/server/routes/api/urls/urls.ts
+++ b/server/routes/api/urls/urls.ts
@@ -69,7 +69,7 @@ router.post(
         : (ctx.body = presentUnfurl(data));
     }
 
-    ctx.response.status = 204;
+    return (ctx.response.status = 204);
   }
 );
 

--- a/server/routes/api/urls/urls.ts
+++ b/server/routes/api/urls/urls.ts
@@ -51,7 +51,7 @@ router.post(
     const previewDocumentId = parseDocumentSlug(url);
     if (previewDocumentId) {
       const document = previewDocumentId
-        ? await Document.findByPk(previewDocumentId)
+        ? await Document.findByPk(previewDocumentId, { userId: actor.id })
         : undefined;
       if (!document) {
         throw NotFoundError("Document does not exist");

--- a/server/routes/api/urls/urls.ts
+++ b/server/routes/api/urls/urls.ts
@@ -63,6 +63,9 @@ router.post(
     }
 
     const data = await Iframely.unfurl(url);
+    if (data.error) {
+      ctx.response.status = data.status;
+    }
     ctx.body = presentUnfurl(data);
   }
 );

--- a/server/routes/api/urls/urls.ts
+++ b/server/routes/api/urls/urls.ts
@@ -8,6 +8,7 @@ import validate from "@server/middlewares/validate";
 import { Document, User } from "@server/models";
 import { authorize } from "@server/policies";
 import { presentDocument, presentMention } from "@server/presenters/unfurls";
+import presentUnfurl from "@server/presenters/unfurls/unfurl";
 import { APIContext } from "@server/types";
 import { RateLimiterStrategy } from "@server/utils/RateLimiter";
 import { Iframely } from "@server/utils/unfurl";
@@ -62,7 +63,7 @@ router.post(
     }
 
     const data = await Iframely.unfurl(url);
-    ctx.body = data;
+    ctx.body = presentUnfurl(data);
   }
 );
 

--- a/server/routes/api/urls/urls.ts
+++ b/server/routes/api/urls/urls.ts
@@ -64,7 +64,8 @@ router.post(
 
     const data = await Iframely.unfurl(url);
     if (data.error) {
-      ctx.response.status = data.status;
+      ctx.response.status = 204;
+      return;
     }
     ctx.body = presentUnfurl(data);
   }

--- a/server/types.ts
+++ b/server/types.ts
@@ -446,3 +446,7 @@ export type CollectionJSONExport = {
     [id: string]: AttachmentJSONExport;
   };
 };
+
+export type UnfurlResolver = {
+  unfurl: (url: string) => Promise<any>;
+};

--- a/server/utils/unfurl.ts
+++ b/server/utils/unfurl.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "fs";
 import path from "path";
 import glob from "glob";
 import { startCase } from "lodash";
@@ -5,20 +6,36 @@ import env from "@server/env";
 import Logger from "@server/logging/Logger";
 import { UnfurlResolver } from "@server/types";
 
-const resolvers: Record<string, UnfurlResolver> = {};
 const rootDir = env.ENVIRONMENT === "test" ? "" : "build";
 
-glob
-  .sync(path.join(rootDir, "plugins/*/server/unfurl.js"))
-  .forEach((filePath: string) => {
+const hasResolver = (plugin: string) => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const config = require(path.join(process.cwd(), plugin, "plugin.json"));
+
+  return (
+    existsSync(resolverPath(plugin)) &&
+    (config.requiredEnvVars ?? []).every((name: string) => !!env[name])
+  );
+};
+
+const resolverPath = (plugin: string) =>
+  path.join(plugin, "server", "unfurl.js");
+
+const plugins = glob.sync(path.join(rootDir, "plugins/*"));
+const resolvers: Record<string, UnfurlResolver> = plugins
+  .filter(hasResolver)
+  .map(resolverPath)
+  .reduce((resolvers, resolverPath) => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const resolver: UnfurlResolver = require(path.join(
       process.cwd(),
-      filePath
+      resolverPath
     ));
-    const name = startCase(filePath.split("/")[2]);
+    const name = startCase(resolverPath.split("/")[2]);
     resolvers[name] = resolver;
-    Logger.debug("utils", `Registered unfurl resolver ${filePath}`);
-  });
+    Logger.debug("utils", `Registered unfurl resolver ${resolverPath}`);
 
-export const Iframely = resolvers["Iframely"];
+    return resolvers;
+  }, {});
+
+export default resolvers;

--- a/server/utils/unfurl.ts
+++ b/server/utils/unfurl.ts
@@ -1,0 +1,24 @@
+import path from "path";
+import glob from "glob";
+import { startCase } from "lodash";
+import env from "@server/env";
+import Logger from "@server/logging/Logger";
+import { UnfurlResolver } from "@server/types";
+
+const resolvers: Record<string, UnfurlResolver> = {};
+const rootDir = env.ENVIRONMENT === "test" ? "" : "build";
+
+glob
+  .sync(path.join(rootDir, "plugins/*/server/unfurl.js"))
+  .forEach((filePath: string) => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const resolver: UnfurlResolver = require(path.join(
+      process.cwd(),
+      filePath
+    ));
+    const name = startCase(filePath.split("/")[2]);
+    resolvers[name] = resolver;
+    Logger.debug("utils", `Registered unfurl resolver ${filePath}`);
+  });
+
+export const Iframely = resolvers["Iframely"];

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -214,13 +214,15 @@ export enum UnfurlType {
   Document = "document",
 }
 
-export type Unfurl<T = unknown> = {
+export type OEmbedType = "photo" | "video" | "rich";
+
+export type Unfurl<T = OEmbedType> = {
   url?: string;
   type: T;
   title: string;
   description: string;
   thumbnailUrl?: string | null;
-  meta: Record<string, string>;
+  meta?: Record<string, string>;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -220,7 +220,7 @@ export type Unfurl<T = OEmbedType> = {
   url?: string;
   type: T;
   title: string;
-  description: string;
+  description?: string;
   thumbnailUrl?: string | null;
   meta?: Record<string, string>;
 };

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -225,5 +225,10 @@ export type Unfurl<T = OEmbedType> = {
   meta?: Record<string, string>;
 };
 
+export type IframelyErrorResponse = {
+  status: number;
+  error: string;
+};
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ProsemirrorData = Record<string, any>;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -225,10 +225,5 @@ export type Unfurl<T = OEmbedType> = {
   meta?: Record<string, string>;
 };
 
-export type IframelyErrorResponse = {
-  status: number;
-  error: string;
-};
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ProsemirrorData = Record<string, any>;


### PR DESCRIPTION
Enhances #5109 

- [x] Presenter named `presentUnfurl` or something similar
- [x] Iframely [error handling](https://iframely.com/docs/result-codes)
- [x] Integrate with FE
- [x] Tests

Further improvements:

- [x] Iframely API returns back [`cache_age`](https://oembed.com/) field which can be used to serve the cached response from our end rather than making calls to Iframely API
