### PR TITLE
feat: Add tracking pixel to notifications for mark-as-read functionality

### DIFF
--- a/server/models/Notification.ts
+++ b/server/models/Notification.ts
@@ -196,6 +196,16 @@ class Notification extends Model {
     hash.update(`${this.id}-${env.SECRET_KEY}`);
     return hash.digest("hex");
   }
+
+  /**
+   * Returns a URL that can be used to mark this notification as read
+   * without being logged in.
+   *
+   * @returns A URL
+   */
+  public get pixelUrl() {
+    return `${env.URL}/api/notifications.pixel?token=${this.pixelToken}&id=${this.id}`;
+  }
 }
 
 export default Notification;


### PR DESCRIPTION
Adds a tracking pixel to outgoing email notifications allowing them to be remotely marked as read. This means in the app you won't have to manually clear notifications that you've already seen in your email client.