### PR TITLE
chore: Remove `DEPLOYMENT` and `SUBDOMAINS_ENABLED`

### DIFF
--- a/app/scenes/Settings/Details.tsx
+++ b/app/scenes/Settings/Details.tsx
@@ -18,7 +18,6 @@ import InputColor from "~/components/InputColor";
 import Scene from "~/components/Scene";
 import Switch from "~/components/Switch";
 import Text from "~/components/Text";
-import env from "~/env";
 import useCurrentTeam from "~/hooks/useCurrentTeam";
 import usePolicy from "~/hooks/usePolicy";
 import useStores from "~/hooks/useStores";
@@ -255,7 +254,7 @@ function Details() {
           <Heading as="h2">{t("Behavior")}</Heading>
 
           <SettingRow
-            visible={env.SUBDOMAINS_ENABLED && isCloudHosted}
+            visible={isCloudHosted}
             label={t("Subdomain")}
             name="subdomain"
             description={

--- a/app/stores/AuthStore.ts
+++ b/app/stores/AuthStore.ts
@@ -13,6 +13,7 @@ import env from "~/env";
 import { client } from "~/utils/ApiClient";
 import Desktop from "~/utils/Desktop";
 import Logger from "~/utils/Logger";
+import isCloudHosted from "~/utils/isCloudHosted";
 
 const AUTH_STORE = "AUTH_STORE";
 const NO_REDIRECT_PATHS = ["/", "/create", "/home", "/logout"];
@@ -212,7 +213,7 @@ export default class AuthStore {
             return;
           }
         } else if (
-          env.SUBDOMAINS_ENABLED &&
+          isCloudHosted &&
           parseDomain(hostname).teamSubdomain !== (team.subdomain ?? "")
         ) {
           window.location.href = `${team.url}${pathname}`;
@@ -372,7 +373,7 @@ export default class AuthStore {
       const sessions = JSON.parse(getCookie("sessions") || "{}");
       delete sessions[team.id];
       setCookie("sessions", JSON.stringify(sessions), {
-        domain: getCookieDomain(window.location.hostname),
+        domain: getCookieDomain(window.location.hostname, isCloudHosted),
       });
     }
 

--- a/app/utils/isCloudHosted.ts
+++ b/app/utils/isCloudHosted.ts
@@ -3,6 +3,10 @@ import env from "~/env";
 /**
  * True if the current installation is the cloud hosted version at getoutline.com
  */
-const isCloudHosted = env.DEPLOYMENT === "hosted";
+const isCloudHosted = [
+  "https://app.getoutline.com",
+  "https://app.outline.dev",
+  "https://app.outline.dev:3000",
+].includes(env.URL);
 
 export default isCloudHosted;

--- a/plugins/email/server/auth/email.test.ts
+++ b/plugins/email/server/auth/email.test.ts
@@ -72,8 +72,6 @@ describe("email", () => {
 
   it("should not send email when user is on another subdomain but respond with success", async () => {
     env.URL = sharedEnv.URL = "https://app.outline.dev";
-    env.SUBDOMAINS_ENABLED = sharedEnv.SUBDOMAINS_ENABLED = true;
-    env.DEPLOYMENT = "hosted";
 
     const user = await buildUser();
     const spy = jest.spyOn(WelcomeEmail.prototype, "schedule");
@@ -142,7 +140,6 @@ describe("email", () => {
     it("should default to current subdomain with SSO", async () => {
       const spy = jest.spyOn(SigninEmail.prototype, "schedule");
       env.URL = sharedEnv.URL = "https://app.outline.dev";
-      env.SUBDOMAINS_ENABLED = sharedEnv.SUBDOMAINS_ENABLED = true;
       const email = "sso-user@example.org";
       const team = await buildTeam({
         subdomain: "example",
@@ -172,7 +169,6 @@ describe("email", () => {
     it("should default to current subdomain with guest email", async () => {
       const spy = jest.spyOn(SigninEmail.prototype, "schedule");
       env.URL = sharedEnv.URL = "https://app.outline.dev";
-      env.SUBDOMAINS_ENABLED = sharedEnv.SUBDOMAINS_ENABLED = true;
       const email = "guest-user@example.org";
       const team = await buildTeam({
         subdomain: "example",

--- a/plugins/email/server/auth/email.test.ts
+++ b/plugins/email/server/auth/email.test.ts
@@ -1,17 +1,13 @@
-import sharedEnv from "@shared/env";
 import SigninEmail from "@server/emails/templates/SigninEmail";
 import WelcomeEmail from "@server/emails/templates/WelcomeEmail";
-import env from "@server/env";
 import { AuthenticationProvider } from "@server/models";
 import { buildUser, buildGuestUser, buildTeam } from "@server/test/factories";
-import { getTestServer } from "@server/test/support";
+import { getTestServer, setCloudHosted } from "@server/test/support";
 
 const server = getTestServer();
 
 describe("email", () => {
-  beforeEach(() => {
-    env.URL = sharedEnv.URL = "https://app.outline.dev";
-  });
+  beforeEach(setCloudHosted);
 
   it("should require email param", async () => {
     const res = await server.post("/auth/email", {
@@ -146,10 +142,10 @@ describe("email", () => {
     expect(spy).not.toHaveBeenCalled();
     spy.mockRestore();
   });
+
   describe("with multiple users matching email", () => {
     it("should default to current subdomain with SSO", async () => {
       const spy = jest.spyOn(SigninEmail.prototype, "schedule");
-      env.URL = sharedEnv.URL = "https://app.outline.dev";
       const email = "sso-user@example.org";
       const team = await buildTeam({
         subdomain: "example",
@@ -178,7 +174,6 @@ describe("email", () => {
 
     it("should default to current subdomain with guest email", async () => {
       const spy = jest.spyOn(SigninEmail.prototype, "schedule");
-      env.URL = sharedEnv.URL = "https://app.outline.dev";
       const email = "guest-user@example.org";
       const team = await buildTeam({
         subdomain: "example",

--- a/plugins/email/server/auth/email.ts
+++ b/plugins/email/server/auth/email.ts
@@ -25,13 +25,13 @@ router.post(
     const domain = parseDomain(ctx.request.hostname);
 
     let team: Team | null | undefined;
-    if (!env.isCloudHosted()) {
+    if (!env.isCloudHosted) {
       team = await Team.scope("withAuthenticationProviders").findOne();
     } else if (domain.custom) {
       team = await Team.scope("withAuthenticationProviders").findOne({
         where: { domain: domain.host },
       });
-    } else if (env.SUBDOMAINS_ENABLED && domain.teamSubdomain) {
+    } else if (domain.teamSubdomain) {
       team = await Team.scope("withAuthenticationProviders").findOne({
         where: { subdomain: domain.teamSubdomain },
       });

--- a/plugins/webhooks/server/tasks/DeliverWebhookTask.ts
+++ b/plugins/webhooks/server/tasks/DeliverWebhookTask.ts
@@ -599,7 +599,7 @@ export default class DeliverWebhookTask extends BaseTask<Props> {
       });
       status = response.ok ? "success" : "failed";
     } catch (err) {
-      if (err instanceof FetchError && env.DEPLOYMENT === "hosted") {
+      if (err instanceof FetchError && env.isCloudHosted) {
         Logger.warn(`Failed to send webhook: ${err.message}`, {
           event,
           deliveryId: delivery.id,

--- a/server/commands/accountProvisioner.test.ts
+++ b/server/commands/accountProvisioner.test.ts
@@ -1,10 +1,14 @@
 import WelcomeEmail from "@server/emails/templates/WelcomeEmail";
-import env from "@server/env";
 import { TeamDomain } from "@server/models";
 import Collection from "@server/models/Collection";
 import UserAuthentication from "@server/models/UserAuthentication";
 import { buildUser, buildTeam } from "@server/test/factories";
-import { setupTestDatabase, seed } from "@server/test/support";
+import {
+  setupTestDatabase,
+  seed,
+  setCloudHosted,
+  setSelfHosted,
+} from "@server/test/support";
 import accountProvisioner from "./accountProvisioner";
 
 setupTestDatabase();
@@ -13,9 +17,7 @@ describe("accountProvisioner", () => {
   const ip = "127.0.0.1";
 
   describe("hosted", () => {
-    beforeEach(() => {
-      env.URL = "https://app.outline.dev";
-    });
+    beforeEach(setCloudHosted);
 
     it("should create a new user and team", async () => {
       const spy = jest.spyOn(WelcomeEmail.prototype, "schedule");
@@ -325,9 +327,7 @@ describe("accountProvisioner", () => {
   });
 
   describe("self hosted", () => {
-    beforeEach(() => {
-      env.URL = "https://example.com";
-    });
+    beforeEach(setSelfHosted);
 
     it("should fail if existing team and domain not in allowed list", async () => {
       let error;

--- a/server/commands/accountProvisioner.test.ts
+++ b/server/commands/accountProvisioner.test.ts
@@ -14,7 +14,7 @@ describe("accountProvisioner", () => {
 
   describe("hosted", () => {
     beforeEach(() => {
-      env.DEPLOYMENT = "hosted";
+      env.URL = "https://app.outline.dev";
     });
 
     it("should create a new user and team", async () => {
@@ -326,7 +326,7 @@ describe("accountProvisioner", () => {
 
   describe("self hosted", () => {
     beforeEach(() => {
-      env.DEPLOYMENT = undefined;
+      env.URL = "https://example.com";
     });
 
     it("should fail if existing team and domain not in allowed list", async () => {

--- a/server/commands/teamProvisioner.test.ts
+++ b/server/commands/teamProvisioner.test.ts
@@ -1,7 +1,10 @@
-import env from "@server/env";
 import TeamDomain from "@server/models/TeamDomain";
 import { buildTeam, buildUser } from "@server/test/factories";
-import { setupTestDatabase } from "@server/test/support";
+import {
+  setCloudHosted,
+  setSelfHosted,
+  setupTestDatabase,
+} from "@server/test/support";
 import teamProvisioner from "./teamProvisioner";
 
 setupTestDatabase();
@@ -10,9 +13,7 @@ describe("teamProvisioner", () => {
   const ip = "127.0.0.1";
 
   describe("hosted", () => {
-    beforeEach(() => {
-      env.URL = "https://app.outline.dev";
-    });
+    beforeEach(setCloudHosted);
 
     it("should create team and authentication provider", async () => {
       const result = await teamProvisioner({
@@ -127,9 +128,7 @@ describe("teamProvisioner", () => {
   });
 
   describe("self hosted", () => {
-    beforeEach(() => {
-      env.URL = "https://example.com";
-    });
+    beforeEach(setSelfHosted);
 
     it("should allow creating first team", async () => {
       const { team, isNewTeam } = await teamProvisioner({

--- a/server/commands/teamProvisioner.test.ts
+++ b/server/commands/teamProvisioner.test.ts
@@ -11,7 +11,7 @@ describe("teamProvisioner", () => {
 
   describe("hosted", () => {
     beforeEach(() => {
-      env.DEPLOYMENT = "hosted";
+      env.URL = "https://app.outline.dev";
     });
 
     it("should create team and authentication provider", async () => {
@@ -128,7 +128,7 @@ describe("teamProvisioner", () => {
 
   describe("self hosted", () => {
     beforeEach(() => {
-      env.DEPLOYMENT = undefined;
+      env.URL = "https://example.com";
     });
 
     it("should allow creating first team", async () => {

--- a/server/commands/teamProvisioner.ts
+++ b/server/commands/teamProvisioner.ts
@@ -78,7 +78,7 @@ async function teamProvisioner({
     };
   } else if (teamId) {
     // The user is attempting to log into a team with an unfamiliar SSO provider
-    if (env.isCloudHosted()) {
+    if (env.isCloudHosted) {
       throw InvalidAuthenticationError();
     }
 

--- a/server/commands/teamUpdater.ts
+++ b/server/commands/teamUpdater.ts
@@ -34,7 +34,7 @@ const teamUpdater = async ({
     preferences,
   } = params;
 
-  if (subdomain !== undefined && env.SUBDOMAINS_ENABLED) {
+  if (subdomain !== undefined && env.isCloudHosted) {
     team.subdomain = subdomain === "" ? null : subdomain;
   }
 

--- a/server/emails/mailer.tsx
+++ b/server/emails/mailer.tsx
@@ -164,7 +164,7 @@ export class Mailer {
               },
             }
           : undefined,
-        attachments: env.isCloudHosted()
+        attachments: env.isCloudHosted
           ? undefined
           : [
               {

--- a/server/emails/templates/components/Header.tsx
+++ b/server/emails/templates/components/Header.tsx
@@ -14,7 +14,7 @@ export default () => (
           <img
             alt={env.APP_NAME}
             src={
-              env.isCloudHosted()
+              env.isCloudHosted
                 ? `${url}/email/header-logo.png`
                 : "cid:header-image"
             }

--- a/server/env.ts
+++ b/server/env.ts
@@ -11,7 +11,6 @@ import {
   IsUrl,
   IsOptional,
   IsByteLength,
-  Equals,
   IsNumber,
   IsIn,
   IsEmail,
@@ -207,13 +206,6 @@ export class Environment {
   public SSL_CERT = this.toOptionalString(process.env.SSL_CERT);
 
   /**
-   * Should always be left unset in a self-hosted environment.
-   */
-  @Equals("hosted")
-  @IsOptional()
-  public DEPLOYMENT = this.toOptionalString(process.env.DEPLOYMENT);
-
-  /**
    * The default interface language. See translate.getoutline.com for a list of
    * available language codes and their percentage translated.
    */
@@ -239,15 +231,6 @@ export class Environment {
    */
   @IsBoolean()
   public FORCE_HTTPS = this.toBoolean(process.env.FORCE_HTTPS ?? "true");
-
-  /**
-   * Whether to support multiple subdomains in a single instance.
-   */
-  @IsBoolean()
-  @Deprecated("The community edition of Outline does not support subdomains")
-  public SUBDOMAINS_ENABLED = this.toBoolean(
-    process.env.SUBDOMAINS_ENABLED ?? "false"
-  );
 
   /**
    * Should the installation send anonymized statistics to the maintainers.
@@ -666,8 +649,12 @@ export class Environment {
    * Returns true if the current installation is the cloud hosted version at
    * getoutline.com
    */
-  public isCloudHosted() {
-    return this.DEPLOYMENT === "hosted";
+  public get isCloudHosted() {
+    return [
+      "https://app.getoutline.com",
+      "https://app.outline.dev",
+      "https://app.outline.dev:3000",
+    ].includes(this.URL);
   }
 
   private toOptionalString(value: string | undefined) {

--- a/server/models/Team.ts
+++ b/server/models/Team.ts
@@ -70,9 +70,9 @@ class Team extends ParanoidModel {
   @Unique
   @Length({
     min: 2,
-    max: env.isCloudHosted() ? 32 : 255,
+    max: env.isCloudHosted ? 32 : 255,
     msg: `subdomain must be between 2 and ${
-      env.isCloudHosted() ? 32 : 255
+      env.isCloudHosted ? 32 : 255
     } characters`,
   })
   @Is({
@@ -169,7 +169,7 @@ class Team extends ParanoidModel {
       return `${url.protocol}//${this.domain}${url.port ? `:${url.port}` : ""}`;
     }
 
-    if (!this.subdomain || !env.SUBDOMAINS_ENABLED) {
+    if (!this.subdomain || !env.isCloudHosted) {
       return env.URL;
     }
 

--- a/server/models/TeamDomain.test.ts
+++ b/server/models/TeamDomain.test.ts
@@ -1,11 +1,12 @@
-import env from "@server/env";
 import { buildAdmin, buildTeam } from "@server/test/factories";
-import { setupTestDatabase } from "@server/test/support";
+import { setCloudHosted, setupTestDatabase } from "@server/test/support";
 import TeamDomain from "./TeamDomain";
 
 setupTestDatabase();
 
 describe("team domain model", () => {
+  beforeEach(setCloudHosted);
+
   describe("create", () => {
     it("should allow creation of domains", async () => {
       const team = await buildTeam();
@@ -37,7 +38,6 @@ describe("team domain model", () => {
     });
 
     it("should not allow creation of domains within restricted list", async () => {
-      env.URL = "https://app.outline.dev";
       const TeamDomain = await import("./TeamDomain");
       const team = await buildTeam();
       const user = await buildAdmin({ teamId: team.id });
@@ -57,7 +57,6 @@ describe("team domain model", () => {
     });
 
     it("should ignore casing and spaces when creating domains", async () => {
-      env.URL = "https://app.outline.dev";
       const TeamDomain = await import("./TeamDomain");
       const team = await buildTeam();
       const user = await buildAdmin({ teamId: team.id });

--- a/server/models/TeamDomain.test.ts
+++ b/server/models/TeamDomain.test.ts
@@ -37,7 +37,7 @@ describe("team domain model", () => {
     });
 
     it("should not allow creation of domains within restricted list", async () => {
-      env.DEPLOYMENT = "hosted";
+      env.URL = "https://app.outline.dev";
       const TeamDomain = await import("./TeamDomain");
       const team = await buildTeam();
       const user = await buildAdmin({ teamId: team.id });
@@ -57,7 +57,7 @@ describe("team domain model", () => {
     });
 
     it("should ignore casing and spaces when creating domains", async () => {
-      env.DEPLOYMENT = "hosted";
+      env.URL = "https://app.outline.dev";
       const TeamDomain = await import("./TeamDomain");
       const team = await buildTeam();
       const user = await buildAdmin({ teamId: team.id });

--- a/server/models/TeamDomain.ts
+++ b/server/models/TeamDomain.ts
@@ -23,7 +23,7 @@ import Length from "./validators/Length";
 @Fix
 class TeamDomain extends IdModel {
   @NotIn({
-    args: env.isCloudHosted() ? [emailProviders] : [],
+    args: env.isCloudHosted ? [emailProviders] : [],
     msg: "You chose a restricted domain, please try another.",
   })
   @NotEmpty

--- a/server/models/helpers/AuthenticationHelper.ts
+++ b/server/models/helpers/AuthenticationHelper.ts
@@ -74,7 +74,7 @@ export default class AuthenticationHelper {
    * @returns A list of authentication providers
    */
   public static providersForTeam(team?: Team) {
-    const isCloudHosted = env.isCloudHosted();
+    const isCloudHosted = env.isCloudHosted;
 
     return AuthenticationHelper.providers
       .sort((config) => (config.id === "email" ? 1 : -1))

--- a/server/policies/team.test.ts
+++ b/server/policies/team.test.ts
@@ -1,12 +1,15 @@
-import env from "@server/env";
 import { buildUser, buildTeam, buildAdmin } from "@server/test/factories";
-import { setupTestDatabase } from "@server/test/support";
+import {
+  setCloudHosted,
+  setSelfHosted,
+  setupTestDatabase,
+} from "@server/test/support";
 import { serialize } from "./index";
 
 setupTestDatabase();
 
 it("should allow reading only", async () => {
-  env.URL = "https://example.com";
+  setSelfHosted();
 
   const team = await buildTeam();
   const user = await buildUser({
@@ -23,7 +26,7 @@ it("should allow reading only", async () => {
 });
 
 it("should allow admins to manage", async () => {
-  env.URL = "https://example.com";
+  setSelfHosted();
 
   const team = await buildTeam();
   const admin = await buildAdmin({
@@ -40,7 +43,7 @@ it("should allow admins to manage", async () => {
 });
 
 it("should allow creation on hosted envs", async () => {
-  env.URL = "https://app.outline.dev";
+  setCloudHosted();
 
   const team = await buildTeam();
   const admin = await buildAdmin({

--- a/server/policies/team.test.ts
+++ b/server/policies/team.test.ts
@@ -6,6 +6,8 @@ import { serialize } from "./index";
 setupTestDatabase();
 
 it("should allow reading only", async () => {
+  env.URL = "https://example.com";
+
   const team = await buildTeam();
   const user = await buildUser({
     teamId: team.id,
@@ -21,6 +23,8 @@ it("should allow reading only", async () => {
 });
 
 it("should allow admins to manage", async () => {
+  env.URL = "https://example.com";
+
   const team = await buildTeam();
   const admin = await buildAdmin({
     teamId: team.id,
@@ -36,7 +40,7 @@ it("should allow admins to manage", async () => {
 });
 
 it("should allow creation on hosted envs", async () => {
-  env.DEPLOYMENT = "hosted";
+  env.URL = "https://app.outline.dev";
 
   const team = await buildTeam();
   const admin = await buildAdmin({

--- a/server/policies/team.ts
+++ b/server/policies/team.ts
@@ -13,7 +13,7 @@ allow(User, "share", Team, (user, team) => {
 });
 
 allow(User, "createTeam", Team, () => {
-  if (!env.isCloudHosted()) {
+  if (!env.isCloudHosted) {
     throw IncorrectEditionError("Functionality is only available on cloud");
   }
   return true;
@@ -27,7 +27,7 @@ allow(User, "update", Team, (user, team) => {
 });
 
 allow(User, ["delete", "audit"], Team, (user, team) => {
-  if (!env.isCloudHosted()) {
+  if (!env.isCloudHosted) {
     throw IncorrectEditionError("Functionality is only available on cloud");
   }
   if (!team || user.isViewer || user.teamId !== team.id) {

--- a/server/presenters/env.ts
+++ b/server/presenters/env.ts
@@ -16,14 +16,12 @@ export default function present(
     COLLABORATION_URL: (env.COLLABORATION_URL || env.URL)
       .replace(/\/$/, "")
       .replace(/^http/, "ws"),
-    DEPLOYMENT: env.DEPLOYMENT,
     ENVIRONMENT: env.ENVIRONMENT,
     SENTRY_DSN: env.SENTRY_DSN,
     SENTRY_TUNNEL: env.SENTRY_TUNNEL,
     SLACK_CLIENT_ID: env.SLACK_CLIENT_ID,
     SLACK_APP_ID: env.SLACK_APP_ID,
     MAXIMUM_IMPORT_SIZE: env.MAXIMUM_IMPORT_SIZE,
-    SUBDOMAINS_ENABLED: env.SUBDOMAINS_ENABLED,
     PDF_EXPORT_ENABLED: false,
     DEFAULT_LANGUAGE: env.DEFAULT_LANGUAGE,
     EMAIL_ENABLED: !!env.SMTP_HOST || env.ENVIRONMENT === "development",

--- a/server/routes/api/auth/auth.test.ts
+++ b/server/routes/api/auth/auth.test.ts
@@ -93,7 +93,7 @@ describe("#auth.delete", () => {
 
 describe("#auth.config", () => {
   it("should return available SSO providers", async () => {
-    env.DEPLOYMENT = "hosted";
+    env.URL = sharedEnv.URL = "https://app.outline.dev";
 
     const res = await server.post("/api/auth.config");
     const body = await res.json();
@@ -106,8 +106,6 @@ describe("#auth.config", () => {
 
   it("should return available providers for team subdomain", async () => {
     env.URL = sharedEnv.URL = "https://app.outline.dev";
-    env.SUBDOMAINS_ENABLED = sharedEnv.SUBDOMAINS_ENABLED = true;
-    env.DEPLOYMENT = "hosted";
 
     await buildTeam({
       guestSignin: false,
@@ -131,7 +129,7 @@ describe("#auth.config", () => {
   });
 
   it("should return available providers for team custom domain", async () => {
-    env.DEPLOYMENT = "hosted";
+    env.URL = sharedEnv.URL = "https://app.outline.dev";
 
     await buildTeam({
       guestSignin: false,
@@ -156,7 +154,6 @@ describe("#auth.config", () => {
 
   it("should return email provider for team when guest signin enabled", async () => {
     env.URL = sharedEnv.URL = "https://app.outline.dev";
-    env.DEPLOYMENT = "hosted";
 
     await buildTeam({
       guestSignin: true,
@@ -182,7 +179,6 @@ describe("#auth.config", () => {
 
   it("should not return provider when disabled", async () => {
     env.URL = sharedEnv.URL = "https://app.outline.dev";
-    env.DEPLOYMENT = "hosted";
 
     await buildTeam({
       guestSignin: false,
@@ -207,7 +203,8 @@ describe("#auth.config", () => {
 
   describe("self hosted", () => {
     it("should return all configured providers but respect email setting", async () => {
-      env.DEPLOYMENT = "";
+      env.URL = sharedEnv.URL = "https://example.com";
+
       await buildTeam({
         guestSignin: false,
         authenticationProviders: [
@@ -227,7 +224,8 @@ describe("#auth.config", () => {
     });
 
     it("should return email provider for team when guest signin enabled", async () => {
-      env.DEPLOYMENT = "";
+      env.URL = sharedEnv.URL = "https://example.com";
+
       await buildTeam({
         guestSignin: true,
         authenticationProviders: [

--- a/server/routes/api/auth/auth.test.ts
+++ b/server/routes/api/auth/auth.test.ts
@@ -1,7 +1,9 @@
-import sharedEnv from "@shared/env";
-import env from "@server/env";
 import { buildUser, buildTeam } from "@server/test/factories";
-import { getTestServer } from "@server/test/support";
+import {
+  getTestServer,
+  setCloudHosted,
+  setSelfHosted,
+} from "@server/test/support";
 
 const mockTeamInSessionId = "1e023d05-951c-41c6-9012-c9fa0402e1c3";
 
@@ -14,6 +16,8 @@ jest.mock("@server/utils/authentication", () => ({
 const server = getTestServer();
 
 describe("#auth.info", () => {
+  beforeEach(setCloudHosted);
+
   it("should return current authentication", async () => {
     const team = await buildTeam();
     const team2 = await buildTeam();
@@ -93,8 +97,6 @@ describe("#auth.delete", () => {
 
 describe("#auth.config", () => {
   it("should return available SSO providers", async () => {
-    env.URL = sharedEnv.URL = "https://app.outline.dev";
-
     const res = await server.post("/api/auth.config");
     const body = await res.json();
     expect(res.status).toEqual(200);
@@ -105,8 +107,6 @@ describe("#auth.config", () => {
   });
 
   it("should return available providers for team subdomain", async () => {
-    env.URL = sharedEnv.URL = "https://app.outline.dev";
-
     await buildTeam({
       guestSignin: false,
       subdomain: "example",
@@ -129,8 +129,6 @@ describe("#auth.config", () => {
   });
 
   it("should return available providers for team custom domain", async () => {
-    env.URL = sharedEnv.URL = "https://app.outline.dev";
-
     await buildTeam({
       guestSignin: false,
       domain: "docs.mycompany.com",
@@ -153,8 +151,6 @@ describe("#auth.config", () => {
   });
 
   it("should return email provider for team when guest signin enabled", async () => {
-    env.URL = sharedEnv.URL = "https://app.outline.dev";
-
     await buildTeam({
       guestSignin: true,
       subdomain: "example",
@@ -178,8 +174,6 @@ describe("#auth.config", () => {
   });
 
   it("should not return provider when disabled", async () => {
-    env.URL = sharedEnv.URL = "https://app.outline.dev";
-
     await buildTeam({
       guestSignin: false,
       subdomain: "example",
@@ -202,9 +196,9 @@ describe("#auth.config", () => {
   });
 
   describe("self hosted", () => {
-    it("should return all configured providers but respect email setting", async () => {
-      env.URL = sharedEnv.URL = "https://example.com";
+    beforeEach(setSelfHosted);
 
+    it("should return all configured providers but respect email setting", async () => {
       await buildTeam({
         guestSignin: false,
         authenticationProviders: [
@@ -224,8 +218,6 @@ describe("#auth.config", () => {
     });
 
     it("should return email provider for team when guest signin enabled", async () => {
-      env.URL = sharedEnv.URL = "https://example.com";
-
       await buildTeam({
         guestSignin: true,
         authenticationProviders: [

--- a/server/routes/api/auth/auth.ts
+++ b/server/routes/api/auth/auth.ts
@@ -26,7 +26,7 @@ router.post("auth.config", async (ctx: APIContext<T.AuthConfigReq>) => {
   // If self hosted AND there is only one team then that team becomes the
   // brand for the knowledge base and it's guest signin option is used for the
   // root login page.
-  if (!env.isCloudHosted()) {
+  if (!env.isCloudHosted) {
     const team = await Team.scope("withAuthenticationProviders").findOne();
 
     if (team) {
@@ -75,7 +75,7 @@ router.post("auth.config", async (ctx: APIContext<T.AuthConfigReq>) => {
 
   // If subdomain signin page then we return minimal team details to allow
   // for a custom screen showing only relevant signin options for that team.
-  else if (env.SUBDOMAINS_ENABLED && domain.teamSubdomain) {
+  else if (env.isCloudHosted && domain.teamSubdomain) {
     const team = await Team.scope("withAuthenticationProviders").findOne({
       where: {
         subdomain: domain.teamSubdomain,
@@ -179,7 +179,7 @@ router.post(
 
     ctx.cookies.set("accessToken", "", {
       expires: subMinutes(new Date(), 1),
-      domain: getCookieDomain(ctx.hostname),
+      domain: getCookieDomain(ctx.hostname, env.isCloudHosted),
     });
 
     ctx.body = {

--- a/server/routes/api/events/events.test.ts
+++ b/server/routes/api/events/events.test.ts
@@ -6,7 +6,7 @@ const server = getTestServer();
 
 describe("#events.list", () => {
   beforeEach(() => {
-    env.DEPLOYMENT = "hosted";
+    env.URL = "https://app.outline.dev";
   });
 
   it("should only return activity events", async () => {

--- a/server/routes/api/events/events.test.ts
+++ b/server/routes/api/events/events.test.ts
@@ -1,13 +1,10 @@
-import env from "@server/env";
 import { buildEvent, buildUser } from "@server/test/factories";
-import { seed, getTestServer } from "@server/test/support";
+import { seed, getTestServer, setCloudHosted } from "@server/test/support";
 
 const server = getTestServer();
 
 describe("#events.list", () => {
-  beforeEach(() => {
-    env.URL = "https://app.outline.dev";
-  });
+  beforeEach(setCloudHosted);
 
   it("should only return activity events", async () => {
     const { user, admin, document, collection } = await seed();

--- a/server/routes/api/teams/teams.test.ts
+++ b/server/routes/api/teams/teams.test.ts
@@ -1,13 +1,18 @@
-import env from "@server/env";
 import { TeamDomain } from "@server/models";
 import { buildAdmin, buildCollection, buildTeam } from "@server/test/factories";
-import { seed, getTestServer } from "@server/test/support";
+import {
+  seed,
+  getTestServer,
+  setCloudHosted,
+  setSelfHosted,
+} from "@server/test/support";
 
 const server = getTestServer();
 
 describe("teams.create", () => {
   it("creates a team", async () => {
-    env.URL = "https://app.outline.dev";
+    setCloudHosted();
+
     const team = await buildTeam();
     const user = await buildAdmin({ teamId: team.id });
     const res = await server.post("/api/teams.create", {
@@ -23,7 +28,8 @@ describe("teams.create", () => {
   });
 
   it("requires a cloud hosted deployment", async () => {
-    env.URL = "https://example.com";
+    setSelfHosted();
+
     const team = await buildTeam();
     const user = await buildAdmin({ teamId: team.id });
     const res = await server.post("/api/teams.create", {

--- a/server/routes/api/teams/teams.test.ts
+++ b/server/routes/api/teams/teams.test.ts
@@ -7,7 +7,7 @@ const server = getTestServer();
 
 describe("teams.create", () => {
   it("creates a team", async () => {
-    env.DEPLOYMENT = "hosted";
+    env.URL = "https://app.outline.dev";
     const team = await buildTeam();
     const user = await buildAdmin({ teamId: team.id });
     const res = await server.post("/api/teams.create", {
@@ -23,7 +23,7 @@ describe("teams.create", () => {
   });
 
   it("requires a cloud hosted deployment", async () => {
-    env.DEPLOYMENT = "";
+    env.URL = "https://example.com";
     const team = await buildTeam();
     const user = await buildAdmin({ teamId: team.id });
     const res = await server.post("/api/teams.create", {

--- a/server/test/env.ts
+++ b/server/test/env.ts
@@ -17,7 +17,6 @@ env.OIDC_TOKEN_URI = "http://localhost/token";
 env.OIDC_USERINFO_URI = "http://localhost/userinfo";
 
 env.RATE_LIMITER_ENABLED = false;
-env.DEPLOYMENT = undefined;
 
 if (process.env.DATABASE_URL_TEST) {
   env.DATABASE_URL = process.env.DATABASE_URL_TEST;

--- a/server/test/support.ts
+++ b/server/test/support.ts
@@ -1,6 +1,8 @@
 import TestServer from "fetch-test-server";
 import { v4 as uuidv4 } from "uuid";
+import sharedEnv from "@shared/env";
 import { CollectionPermission } from "@shared/types";
+import env from "@server/env";
 import { User, Document, Collection, Team } from "@server/models";
 import onerror from "@server/onerror";
 import webService from "@server/services/web";
@@ -136,4 +138,18 @@ export function setupTestDatabase() {
 
   afterAll(disconnect);
   beforeEach(flush);
+}
+
+/**
+ * Set the environment to be cloud hosted
+ */
+export function setCloudHosted() {
+  return (env.URL = sharedEnv.URL = "https://app.outline.dev");
+}
+
+/**
+ * Set the environment to be self hosted
+ */
+export function setSelfHosted() {
+  return (env.URL = sharedEnv.URL = "https://wiki.example.com");
 }

--- a/server/utils/authentication.ts
+++ b/server/utils/authentication.ts
@@ -71,7 +71,7 @@ export async function signIn(
     },
     ip: ctx.request.ip,
   });
-  const domain = getCookieDomain(ctx.request.hostname);
+  const domain = getCookieDomain(ctx.request.hostname, env.isCloudHosted);
   const expires = addMonths(new Date(), 3);
 
   // set a cookie for which service we last signed in with. This is
@@ -85,7 +85,7 @@ export async function signIn(
 
   // set a transfer cookie for the access token itself and redirect
   // to the teams subdomain if subdomains are enabled
-  if (env.SUBDOMAINS_ENABLED && team.subdomain) {
+  if (env.isCloudHosted && team.subdomain) {
     // get any existing sessions (teams signed in) and add this team
     const existing = getSessionsInCookie(ctx);
     const sessions = encodeURIComponent(

--- a/server/utils/azure.ts
+++ b/server/utils/azure.ts
@@ -22,7 +22,7 @@ export default class AzureClient extends OAuthClient {
     refreshToken?: string;
     expiresAt: Date;
   }> {
-    if (env.isCloudHosted()) {
+    if (env.isCloudHosted) {
       return super.rotateToken(accessToken, refreshToken);
     }
 

--- a/server/utils/fetch.ts
+++ b/server/utils/fetch.ts
@@ -19,10 +19,10 @@ export default function fetch(
 ): Promise<Response> {
   // In self-hosted, webhooks support proxying and are also allowed to connect
   // to internal services, so use fetchWithProxy without the filtering agent.
-  const fetch = env.isCloudHosted() ? nodeFetch : fetchWithProxy;
+  const fetch = env.isCloudHosted ? nodeFetch : fetchWithProxy;
 
   return fetch(url, {
     ...init,
-    agent: env.isCloudHosted() ? useAgent(url) : undefined,
+    agent: env.isCloudHosted ? useAgent(url) : undefined,
   });
 }

--- a/server/utils/passport.ts
+++ b/server/utils/passport.ts
@@ -28,7 +28,7 @@ export class StateStore {
 
     ctx.cookies.set(this.key, state, {
       expires: addMinutes(new Date(), 10),
-      domain: getCookieDomain(ctx.hostname),
+      domain: getCookieDomain(ctx.hostname, env.isCloudHosted),
     });
 
     callback(null, token);
@@ -54,7 +54,7 @@ export class StateStore {
     // Destroy the one-time pad token and ensure it matches
     ctx.cookies.set(this.key, "", {
       expires: subMinutes(new Date(), 1),
-      domain: getCookieDomain(ctx.hostname),
+      domain: getCookieDomain(ctx.hostname, env.isCloudHosted),
     });
 
     if (!token || token !== providedToken) {
@@ -100,11 +100,11 @@ export async function getTeamFromContext(ctx: Context) {
   const domain = parseDomain(host);
 
   let team;
-  if (!env.isCloudHosted()) {
+  if (!env.isCloudHosted) {
     team = await Team.findOne();
   } else if (domain.custom) {
     team = await Team.findOne({ where: { domain: domain.host } });
-  } else if (env.SUBDOMAINS_ENABLED && domain.teamSubdomain) {
+  } else if (domain.teamSubdomain) {
     team = await Team.findOne({
       where: { subdomain: domain.teamSubdomain },
     });

--- a/server/utils/robots.ts
+++ b/server/utils/robots.ts
@@ -1,7 +1,7 @@
 import env from "@server/env";
 
 export const robotsResponse = () => {
-  if (env.isCloudHosted()) {
+  if (env.isCloudHosted) {
     return `
 User-agent: *
 Allow: /

--- a/server/utils/startup.ts
+++ b/server/utils/startup.ts
@@ -10,7 +10,7 @@ export async function checkPendingMigrations() {
   try {
     const pending = await migrations.pending();
     if (!isEmpty(pending)) {
-      if (env.isCloudHosted()) {
+      if (env.isCloudHosted) {
         Logger.warn(chalk.red("Migrations are pending"));
         process.exit(1);
       } else {
@@ -34,7 +34,7 @@ export async function checkPendingMigrations() {
 }
 
 export async function checkDataMigrations() {
-  if (env.isCloudHosted()) {
+  if (env.isCloudHosted) {
     return;
   }
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -44,14 +44,12 @@ export type PublicEnv = {
   COLLABORATION_URL: string;
   AWS_S3_UPLOAD_BUCKET_URL: string;
   AWS_S3_ACCELERATE_URL: string;
-  DEPLOYMENT: string | undefined;
   ENVIRONMENT: string;
   SENTRY_DSN: string | undefined;
   SENTRY_TUNNEL: string | undefined;
   SLACK_CLIENT_ID: string | undefined;
   SLACK_APP_ID: string | undefined;
   MAXIMUM_IMPORT_SIZE: number;
-  SUBDOMAINS_ENABLED: boolean;
   EMAIL_ENABLED: boolean;
   PDF_EXPORT_ENABLED: boolean;
   DEFAULT_LANGUAGE: string;

--- a/shared/utils/domains.test.ts
+++ b/shared/utils/domains.test.ts
@@ -169,27 +169,27 @@ describe("#slugifyDomain", () => {
 describe("#getCookieDomain", () => {
   beforeEach(() => {
     env.URL = "https://example.com";
-    env.SUBDOMAINS_ENABLED = true;
   });
 
   it("returns the normalized app host when on the host domain", () => {
-    expect(getCookieDomain("subdomain.example.com")).toBe("example.com");
-    expect(getCookieDomain("www.example.com")).toBe("example.com");
-    expect(getCookieDomain("http://example.com:3000")).toBe("example.com");
-    expect(getCookieDomain("myteam.example.com/document/12345?q=query")).toBe(
+    expect(getCookieDomain("subdomain.example.com", true)).toBe("example.com");
+    expect(getCookieDomain("www.example.com", true)).toBe("example.com");
+    expect(getCookieDomain("http://example.com:3000", true)).toBe(
       "example.com"
     );
+    expect(
+      getCookieDomain("myteam.example.com/document/12345?q=query", true)
+    ).toBe("example.com");
   });
 
   it("returns the input if not on the host domain", () => {
-    expect(getCookieDomain("www.blogspot.com")).toBe("www.blogspot.com");
-    expect(getCookieDomain("anything else")).toBe("anything else");
+    expect(getCookieDomain("www.blogspot.com", true)).toBe("www.blogspot.com");
+    expect(getCookieDomain("anything else", true)).toBe("anything else");
   });
 
-  it("always returns the input when subdomains are not enabled", () => {
-    env.SUBDOMAINS_ENABLED = false;
-    expect(getCookieDomain("example.com")).toBe("example.com");
-    expect(getCookieDomain("www.blogspot.com")).toBe("www.blogspot.com");
-    expect(getCookieDomain("anything else")).toBe("anything else");
+  it("always returns the input when not cloud hosted", () => {
+    expect(getCookieDomain("example.com", false)).toBe("example.com");
+    expect(getCookieDomain("www.blogspot.com", false)).toBe("www.blogspot.com");
+    expect(getCookieDomain("anything else", false)).toBe("anything else");
   });
 });

--- a/shared/utils/domains.ts
+++ b/shared/utils/domains.ts
@@ -65,10 +65,10 @@ export function parseDomain(url: string): Domain {
   };
 }
 
-export function getCookieDomain(domain: string) {
+export function getCookieDomain(domain: string, isCloudHosted: boolean) {
   // always use the base URL for cookies when in hosted mode
   // and the domain is not custom
-  if (env.SUBDOMAINS_ENABLED) {
+  if (isCloudHosted) {
     const parsed = parseDomain(domain);
 
     if (!parsed.custom) {


### PR DESCRIPTION
Some long outstanding cleanup to not expose these variables which aren't useable in on-premise. `SUBDOMAINS_ENABLED` has been showing a deprecated message on startup for over 6mo.