### PR TITLE
Improve validation on `api/users` endpoints

### DIFF
--- a/app/components/UserDialogs.tsx
+++ b/app/components/UserDialogs.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
+import { UserRole } from "@shared/types";
 import User from "~/models/User";
 import ConfirmationDialog from "~/components/ConfirmationDialog";
 import Input from "~/components/Input";
@@ -15,7 +16,7 @@ export function UserChangeToViewerDialog({ user, onSubmit }: Props) {
   const { users } = useStores();
 
   const handleSubmit = async () => {
-    await users.demote(user, "viewer");
+    await users.demote(user, UserRole.Viewer);
     onSubmit();
   };
 
@@ -41,7 +42,7 @@ export function UserChangeToMemberDialog({ user, onSubmit }: Props) {
   const { users } = useStores();
 
   const handleSubmit = async () => {
-    await users.demote(user, "member");
+    await users.demote(user, UserRole.Member);
     onSubmit();
   };
 

--- a/app/models/User.ts
+++ b/app/models/User.ts
@@ -7,8 +7,9 @@ import {
   NotificationEventType,
   UserPreference,
   UserPreferences,
+  UserRole,
 } from "@shared/types";
-import type { Role, NotificationSettings } from "@shared/types";
+import type { NotificationSettings } from "@shared/types";
 import { client } from "~/utils/ApiClient";
 import ParanoidModel from "./ParanoidModel";
 import Field from "./decorators/Field";
@@ -74,13 +75,13 @@ class User extends ParanoidModel {
   }
 
   @computed
-  get role(): Role {
+  get role(): UserRole {
     if (this.isAdmin) {
-      return "admin";
+      return UserRole.Admin;
     } else if (this.isViewer) {
-      return "viewer";
+      return UserRole.Viewer;
     } else {
-      return "member";
+      return UserRole.Member;
     }
   }
 

--- a/app/scenes/Invite.tsx
+++ b/app/scenes/Invite.tsx
@@ -5,7 +5,7 @@ import { useTranslation, Trans } from "react-i18next";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 import { s } from "@shared/styles";
-import { Role } from "@shared/types";
+import { UserRole } from "@shared/types";
 import { UserValidation } from "@shared/validations";
 import Button from "~/components/Button";
 import CopyToClipboard from "~/components/CopyToClipboard";
@@ -28,7 +28,7 @@ type Props = {
 type InviteRequest = {
   email: string;
   name: string;
-  role: Role;
+  role: UserRole;
 };
 
 function Invite({ onSubmit }: Props) {
@@ -38,17 +38,17 @@ function Invite({ onSubmit }: Props) {
     {
       email: "",
       name: "",
-      role: "member",
+      role: UserRole.Member,
     },
     {
       email: "",
       name: "",
-      role: "member",
+      role: UserRole.Member,
     },
     {
       email: "",
       name: "",
-      role: "member",
+      role: UserRole.Member,
     },
   ]);
   const { users } = useStores();
@@ -65,7 +65,7 @@ function Invite({ onSubmit }: Props) {
       setIsSaving(true);
 
       try {
-        const data = await users.invite(invites);
+        const data = await users.invite(invites.filter((i) => i.email));
         onSubmit();
 
         if (data.sent.length > 0) {
@@ -113,7 +113,7 @@ function Invite({ onSubmit }: Props) {
       newInvites.push({
         email: "",
         name: "",
-        role: "member",
+        role: UserRole.Member,
       });
       return newInvites;
     });
@@ -138,13 +138,16 @@ function Invite({ onSubmit }: Props) {
     });
   }, [showToast, t]);
 
-  const handleRoleChange = React.useCallback((role: Role, index: number) => {
-    setInvites((prevInvites) => {
-      const newInvites = [...prevInvites];
-      newInvites[index]["role"] = role;
-      return newInvites;
-    });
-  }, []);
+  const handleRoleChange = React.useCallback(
+    (role: UserRole, index: number) => {
+      setInvites((prevInvites) => {
+        const newInvites = [...prevInvites];
+        newInvites[index]["role"] = role;
+        return newInvites;
+      });
+    },
+    []
+  );
 
   return (
     <form onSubmit={handleSubmit}>
@@ -224,7 +227,7 @@ function Invite({ onSubmit }: Props) {
             flex
           />
           <InputSelectRole
-            onChange={(role: Role) => handleRoleChange(role, index)}
+            onChange={(role: UserRole) => handleRoleChange(role, index)}
             value={invite.role}
             labelHidden={index !== 0}
             short

--- a/app/scenes/Settings/Members.tsx
+++ b/app/scenes/Settings/Members.tsx
@@ -39,8 +39,8 @@ function Members() {
   const [totalPages, setTotalPages] = React.useState(0);
   const [userIds, setUserIds] = React.useState<string[]>([]);
   const can = usePolicy(team);
-  const query = params.get("query") || "";
-  const filter = params.get("filter") || "";
+  const query = params.get("query") || undefined;
+  const filter = params.get("filter") || undefined;
   const sort = params.get("sort") || "name";
   const direction = (params.get("direction") || "asc").toUpperCase() as
     | "ASC"
@@ -176,11 +176,14 @@ function Members() {
       <Flex gap={8}>
         <InputSearch
           short
-          value={query}
+          value={query ?? ""}
           placeholder={`${t("Filter")}…`}
           onChange={handleSearch}
         />
-        <LargeUserStatusFilter activeKey={filter} onSelect={handleFilter} />
+        <LargeUserStatusFilter
+          activeKey={filter ?? ""}
+          onSelect={handleFilter}
+        />
       </Flex>
       <PeopleTable
         data={data}

--- a/app/stores/UsersStore.ts
+++ b/app/stores/UsersStore.ts
@@ -2,7 +2,7 @@ import invariant from "invariant";
 import filter from "lodash/filter";
 import orderBy from "lodash/orderBy";
 import { observable, computed, action, runInAction } from "mobx";
-import { Role } from "@shared/types";
+import { UserRole } from "@shared/types";
 import User from "~/models/User";
 import { client } from "~/utils/ApiClient";
 import BaseStore from "./BaseStore";
@@ -82,15 +82,15 @@ export default class UsersStore extends BaseStore<User> {
   @action
   promote = async (user: User) => {
     try {
-      this.updateCounts("admin", user.role);
+      this.updateCounts(UserRole.Admin, user.role);
       await this.actionOnUser("promote", user);
     } catch {
-      this.updateCounts(user.role, "admin");
+      this.updateCounts(user.role, UserRole.Admin);
     }
   };
 
   @action
-  demote = async (user: User, to: Role) => {
+  demote = async (user: User, to: UserRole) => {
     try {
       this.updateCounts(to, user.role);
       await this.actionOnUser("demote", user, to);
@@ -128,7 +128,7 @@ export default class UsersStore extends BaseStore<User> {
     invites: {
       email: string;
       name: string;
-      role: Role;
+      role: UserRole;
     }[]
   ) => {
     const res = await client.post(`/users.invite`, {
@@ -206,29 +206,29 @@ export default class UsersStore extends BaseStore<User> {
   }
 
   @action
-  updateCounts = (to: Role, from: Role) => {
-    if (to === "admin") {
+  updateCounts = (to: UserRole, from: UserRole) => {
+    if (to === UserRole.Admin) {
       this.counts.admins += 1;
 
-      if (from === "viewer") {
+      if (from === UserRole.Viewer) {
         this.counts.viewers -= 1;
       }
     }
 
-    if (to === "viewer") {
+    if (to === UserRole.Viewer) {
       this.counts.viewers += 1;
 
-      if (from === "admin") {
+      if (from === UserRole.Admin) {
         this.counts.admins -= 1;
       }
     }
 
-    if (to === "member") {
-      if (from === "viewer") {
+    if (to === UserRole.Member) {
+      if (from === UserRole.Viewer) {
         this.counts.viewers -= 1;
       }
 
-      if (from === "admin") {
+      if (from === UserRole.Admin) {
         this.counts.admins -= 1;
       }
     }
@@ -296,7 +296,7 @@ export default class UsersStore extends BaseStore<User> {
     return queriedUsers(users, query);
   };
 
-  actionOnUser = async (action: string, user: User, to?: Role) => {
+  actionOnUser = async (action: string, user: User, to?: UserRole) => {
     const res = await client.post(`/users.${action}`, {
       id: user.id,
       to,

--- a/server/commands/userDemoter.test.ts
+++ b/server/commands/userDemoter.test.ts
@@ -1,6 +1,5 @@
-import { CollectionPermission } from "@shared/types";
+import { CollectionPermission, UserRole } from "@shared/types";
 import { CollectionUser } from "@server/models";
-import { UserRole } from "@server/models/User";
 import { buildUser, buildAdmin, buildCollection } from "@server/test/factories";
 import { setupTestDatabase } from "@server/test/support";
 import userDemoter from "./userDemoter";

--- a/server/commands/userDemoter.ts
+++ b/server/commands/userDemoter.ts
@@ -1,6 +1,6 @@
+import { UserRole } from "@shared/types";
 import { ValidationError } from "@server/errors";
 import { Event, User } from "@server/models";
-import type { UserRole } from "@server/models/User";
 import CleanupDemotedUserTask from "@server/queues/tasks/CleanupDemotedUserTask";
 import { sequelize } from "@server/storage/database";
 

--- a/server/commands/userInviter.test.ts
+++ b/server/commands/userInviter.test.ts
@@ -1,3 +1,4 @@
+import { UserRole } from "@shared/types";
 import { buildUser } from "@server/test/factories";
 import { setupTestDatabase } from "@server/test/support";
 import userInviter from "./userInviter";
@@ -12,7 +13,7 @@ describe("userInviter", () => {
     const response = await userInviter({
       invites: [
         {
-          role: "member",
+          role: UserRole.Member,
           email: "test@example.com",
           name: "Test",
         },
@@ -28,7 +29,7 @@ describe("userInviter", () => {
     const response = await userInviter({
       invites: [
         {
-          role: "member",
+          role: UserRole.Member,
           email: " ",
           name: "Test",
         },
@@ -44,7 +45,7 @@ describe("userInviter", () => {
     const response = await userInviter({
       invites: [
         {
-          role: "member",
+          role: UserRole.Member,
           email: "notanemail",
           name: "Test",
         },
@@ -60,12 +61,12 @@ describe("userInviter", () => {
     const response = await userInviter({
       invites: [
         {
-          role: "member",
+          role: UserRole.Member,
           email: "the@same.com",
           name: "Test",
         },
         {
-          role: "member",
+          role: UserRole.Member,
           email: "the@SAME.COM",
           name: "Test",
         },
@@ -81,7 +82,7 @@ describe("userInviter", () => {
     const response = await userInviter({
       invites: [
         {
-          role: "member",
+          role: UserRole.Member,
           email: user.email!,
           name: user.name,
         },

--- a/server/commands/userInviter.ts
+++ b/server/commands/userInviter.ts
@@ -1,5 +1,5 @@
 import uniqBy from "lodash/uniqBy";
-import { Role } from "@shared/types";
+import { UserRole } from "@shared/types";
 import InviteEmail from "@server/emails/templates/InviteEmail";
 import env from "@server/env";
 import Logger from "@server/logging/Logger";
@@ -9,7 +9,7 @@ import { UserFlag } from "@server/models/User";
 export type Invite = {
   name: string;
   email: string;
-  role: Role;
+  role: UserRole;
 };
 
 export default async function userInviter({
@@ -59,8 +59,8 @@ export default async function userInviter({
       name: invite.name,
       email: invite.email,
       service: null,
-      isAdmin: invite.role === "admin",
-      isViewer: invite.role === "viewer",
+      isAdmin: invite.role === UserRole.Admin,
+      isViewer: invite.role === UserRole.Viewer,
       invitedById: user.id,
       flags: {
         [UserFlag.InviteSent]: 1,

--- a/server/models/User.ts
+++ b/server/models/User.ts
@@ -31,6 +31,7 @@ import {
   UserPreferences,
   NotificationEventType,
   NotificationEventDefaults,
+  UserRole,
 } from "@shared/types";
 import { stringToColor } from "@shared/utils/color";
 import env from "@server/env";
@@ -63,11 +64,6 @@ export enum UserFlag {
   Desktop = "desktop",
   DesktopWeb = "desktopWeb",
   MobileWeb = "mobileWeb",
-}
-
-export enum UserRole {
-  Member = "member",
-  Viewer = "viewer",
 }
 
 @Scopes(() => ({
@@ -532,7 +528,7 @@ class User extends ParanoidModel {
     });
 
     if (res.count >= 1) {
-      if (to === "member") {
+      if (to === UserRole.Member) {
         await this.update(
           {
             isAdmin: false,
@@ -540,7 +536,7 @@ class User extends ParanoidModel {
           },
           options
         );
-      } else if (to === "viewer") {
+      } else if (to === UserRole.Viewer) {
         await this.update(
           {
             isAdmin: false,

--- a/server/routes/api/teams/schema.ts
+++ b/server/routes/api/teams/schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { UserRole } from "@server/models/User";
+import { UserRole } from "@shared/types";
 import BaseSchema from "@server/routes/api/BaseSchema";
 
 export const TeamsUpdateSchema = BaseSchema.extend({
@@ -21,10 +21,7 @@ export const TeamsUpdateSchema = BaseSchema.extend({
     /** The default landing collection for the team */
     defaultCollectionId: z.string().uuid().nullish(),
     /** The default user role */
-    defaultUserRole: z
-      .string()
-      .refine((val) => Object.values(UserRole).includes(val as UserRole))
-      .optional(),
+    defaultUserRole: z.nativeEnum(UserRole).optional(),
     /** Whether new users must be invited to join the team */
     inviteRequired: z.boolean().optional(),
     /** Domains allowed to sign-in with SSO */

--- a/server/routes/api/users/schema.ts
+++ b/server/routes/api/users/schema.ts
@@ -1,6 +1,47 @@
 import { z } from "zod";
-import { NotificationEventType, UserPreference } from "@shared/types";
+import { NotificationEventType, UserPreference, UserRole } from "@shared/types";
+import User from "@server/models/User";
 import BaseSchema from "../BaseSchema";
+
+const BaseIdSchema = z.object({
+  id: z.string().uuid(),
+});
+
+export const UsersListSchema = z.object({
+  body: z.object({
+    /** Groups sorting direction */
+    direction: z
+      .string()
+      .optional()
+      .transform((val) => (val !== "ASC" ? "DESC" : val)),
+
+    /** Groups sorting column */
+    sort: z
+      .string()
+      .refine((val) => Object.keys(User.getAttributes()).includes(val), {
+        message: "Invalid sort parameter",
+      })
+      .default("createdAt"),
+
+    ids: z.array(z.string().uuid()).optional(),
+
+    query: z.string().optional(),
+
+    filter: z
+      .enum([
+        "invited",
+        "viewers",
+        "admins",
+        "members",
+        "active",
+        "all",
+        "suspended",
+      ])
+      .optional(),
+  }),
+});
+
+export type UsersListReq = z.infer<typeof UsersListSchema>;
 
 export const UsersNotificationsSubscribeSchema = z.object({
   body: z.object({
@@ -42,3 +83,58 @@ export const UsersDeleteSchema = BaseSchema.extend({
 });
 
 export type UsersDeleteSchemaReq = z.infer<typeof UsersDeleteSchema>;
+
+export const UsersInfoSchema = BaseSchema.extend({
+  body: z.object({
+    id: z.string().uuid().optional(),
+  }),
+});
+
+export type UsersInfoReq = z.infer<typeof UsersInfoSchema>;
+
+export const UsersActivateSchema = BaseSchema.extend({
+  body: BaseIdSchema,
+});
+
+export type UsersActivateReq = z.infer<typeof UsersActivateSchema>;
+
+export const UsersPromoteSchema = BaseSchema.extend({
+  body: BaseIdSchema,
+});
+
+export type UsersPromoteReq = z.infer<typeof UsersPromoteSchema>;
+
+export const UsersDemoteSchema = BaseSchema.extend({
+  body: z.object({
+    id: z.string().uuid(),
+    to: z.nativeEnum(UserRole).default(UserRole.Member),
+  }),
+});
+
+export type UsersDemoteReq = z.infer<typeof UsersDemoteSchema>;
+
+export const UsersSuspendSchema = BaseSchema.extend({
+  body: BaseIdSchema,
+});
+
+export type UsersSuspendReq = z.infer<typeof UsersSuspendSchema>;
+
+export const UsersResendInviteSchema = BaseSchema.extend({
+  body: BaseIdSchema,
+});
+
+export type UsersResendInviteReq = z.infer<typeof UsersResendInviteSchema>;
+
+export const UsersInviteSchema = z.object({
+  body: z.object({
+    invites: z.array(
+      z.object({
+        email: z.string().email(),
+        name: z.string(),
+        role: z.nativeEnum(UserRole),
+      })
+    ),
+  }),
+});
+
+export type UsersInviteReq = z.infer<typeof UsersInviteSchema>;

--- a/server/routes/api/users/users.test.ts
+++ b/server/routes/api/users/users.test.ts
@@ -307,27 +307,6 @@ describe("#users.invite", () => {
     expect(body.data.users[0].isAdmin).toBeFalsy();
   });
 
-  it("should invite user as a member if role is any arbitary value", async () => {
-    const admin = await buildAdmin();
-    const res = await server.post("/api/users.invite", {
-      body: {
-        token: admin.getJwtToken(),
-        invites: [
-          {
-            email: "test@example.com",
-            name: "Test",
-            role: "arbitary",
-          },
-        ],
-      },
-    });
-    const body = await res.json();
-    expect(res.status).toEqual(200);
-    expect(body.data.sent.length).toEqual(1);
-    expect(body.data.users[0].isViewer).toBeFalsy();
-    expect(body.data.users[0].isAdmin).toBeFalsy();
-  });
-
   it("should require authentication", async () => {
     const res = await server.post("/api/users.invite");
     expect(res.status).toEqual(401);

--- a/server/routes/api/users/users.ts
+++ b/server/routes/api/users/users.ts
@@ -35,13 +35,7 @@ router.post(
   pagination(),
   validate(T.UsersListSchema),
   async (ctx: APIContext<T.UsersListReq>) => {
-    const {
-      sort = "createdAt",
-      direction,
-      query,
-      filter,
-      ids,
-    } = ctx.input.body;
+    const { sort, direction, query, filter, ids } = ctx.input.body;
 
     const actor = ctx.state.auth.user;
     let where: WhereOptions<User> = {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1,4 +1,8 @@
-export type Role = "admin" | "viewer" | "member";
+export enum UserRole {
+  Admin = "admin",
+  Member = "member",
+  Viewer = "viewer",
+}
 
 export type DateFilter = "day" | "week" | "month" | "year";
 


### PR DESCRIPTION
Had some server errors related to incorrect payloads users were posting through the API that made me realize the switch to zod validation hadn't happened on all these endpoints.

Took the opportunity to centralize the `UserRole` type in an enum

Related #4284