### PR TITLE
Add document unsubscribe link in email footer

### DIFF
--- a/app/hooks/useQueryNotices.ts
+++ b/app/hooks/useQueryNotices.ts
@@ -1,0 +1,31 @@
+import * as React from "react";
+import { useTranslation } from "react-i18next";
+import { QueryNotices } from "@shared/types";
+import useQuery from "./useQuery";
+import useToasts from "./useToasts";
+
+/**
+ * Display a toast message based on a notice in the query string. This is usually
+ * used when redirecting from an external source to the client, such as OAuth,
+ * or emails.
+ */
+export default function useQueryNotices() {
+  const query = useQuery();
+  const { t } = useTranslation();
+  const { showToast } = useToasts();
+  const notice = query.get("notice") as QueryNotices;
+
+  React.useEffect(() => {
+    switch (notice) {
+      case QueryNotices.UnsubscribeDocument: {
+        showToast(
+          t("Unsubscribed from document", {
+            type: "success",
+          })
+        );
+        break;
+      }
+      default:
+    }
+  }, [t, showToast, notice]);
+}

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -4,6 +4,7 @@ import DesktopRedirect from "~/scenes/DesktopRedirect";
 import DelayedMount from "~/components/DelayedMount";
 import FullscreenLoading from "~/components/FullscreenLoading";
 import Route from "~/components/ProfiledRoute";
+import useQueryNotices from "~/hooks/useQueryNotices";
 import lazyWithRetry from "~/utils/lazyWithRetry";
 import { matchDocumentSlug as slug } from "~/utils/routeHelpers";
 
@@ -14,6 +15,8 @@ const Login = lazyWithRetry(() => import("~/scenes/Login"));
 const Logout = lazyWithRetry(() => import("~/scenes/Logout"));
 
 export default function Routes() {
+  useQueryNotices();
+
   return (
     <React.Suspense
       fallback={

--- a/server/emails/templates/BaseEmail.tsx
+++ b/server/emails/templates/BaseEmail.tsx
@@ -14,7 +14,7 @@ export interface EmailProps {
 
 export default abstract class BaseEmail<
   T extends EmailProps,
-  S extends Record<string, any>
+  S extends Record<string, any> | void = void
 > {
   private props: T;
   private metadata?: NotificationMetadata;
@@ -106,7 +106,7 @@ export default abstract class BaseEmail<
         ),
         text: this.renderAsText(data),
         headCSS: this.headCSS?.(data),
-        unsubscribeUrl: data.unsubscribeUrl,
+        unsubscribeUrl: this.unsubscribeUrl?.(data),
       });
       Metrics.increment("email.sent", {
         templateName,
@@ -166,6 +166,14 @@ export default abstract class BaseEmail<
    * @returns A JSX element
    */
   protected abstract render(props: S & T): JSX.Element;
+
+  /**
+   * Returns the unsubscribe URL for the email.
+   *
+   * @param props Props in email constructor
+   * @returns The unsubscribe URL as a string
+   */
+  protected unsubscribeUrl?(props: T): string;
 
   /**
    * Allows injecting additional CSS into the head of the email.

--- a/server/emails/templates/ConfirmTeamDeleteEmail.tsx
+++ b/server/emails/templates/ConfirmTeamDeleteEmail.tsx
@@ -16,10 +16,7 @@ type Props = EmailProps & {
 /**
  * Email sent to a user when they request to delete their workspace.
  */
-export default class ConfirmTeamDeleteEmail extends BaseEmail<
-  Props,
-  Record<string, any>
-> {
+export default class ConfirmTeamDeleteEmail extends BaseEmail<Props> {
   protected subject() {
     return `Your workspace deletion request`;
   }

--- a/server/emails/templates/ConfirmUserDeleteEmail.tsx
+++ b/server/emails/templates/ConfirmUserDeleteEmail.tsx
@@ -16,10 +16,7 @@ type Props = EmailProps & {
 /**
  * Email sent to a user when they request to delete their account.
  */
-export default class ConfirmUserDeleteEmail extends BaseEmail<
-  Props,
-  Record<string, any>
-> {
+export default class ConfirmUserDeleteEmail extends BaseEmail<Props> {
   protected subject() {
     return `Your account deletion request`;
   }

--- a/server/emails/templates/DocumentMentionedEmail.tsx
+++ b/server/emails/templates/DocumentMentionedEmail.tsx
@@ -57,12 +57,13 @@ Open Document: ${teamUrl}${document.url}
 `;
   }
 
-  protected render({ document, actorName, teamUrl }: Props) {
+  protected render(props: Props) {
+    const { document, actorName, teamUrl } = props;
     const documentLink = `${teamUrl}${document.url}?ref=notification-email`;
 
     return (
       <EmailTemplate
-        previewText={this.preview({ actorName } as Props)}
+        previewText={this.preview(props)}
         goToAction={{ url: documentLink, name: "View Document" }}
       >
         <Header />

--- a/server/emails/templates/DocumentPublishedOrUpdatedEmail.tsx
+++ b/server/emails/templates/DocumentPublishedOrUpdatedEmail.tsx
@@ -6,13 +6,14 @@ import env from "@server/env";
 import { Document, Collection, Revision } from "@server/models";
 import DocumentHelper from "@server/models/helpers/DocumentHelper";
 import NotificationSettingsHelper from "@server/models/helpers/NotificationSettingsHelper";
+import SubscriptionHelper from "@server/models/helpers/SubscriptionHelper";
 import BaseEmail, { EmailProps } from "./BaseEmail";
 import Body from "./components/Body";
 import Button from "./components/Button";
 import Diff from "./components/Diff";
 import EmailTemplate from "./components/EmailLayout";
 import EmptySpace from "./components/EmptySpace";
-import Footer from "./components/Footer";
+import Footer, { Link } from "./components/Footer";
 import Header from "./components/Header";
 import Heading from "./components/Heading";
 
@@ -175,7 +176,16 @@ Open Document: ${teamUrl}${document.url}
           </p>
         </Body>
 
-        <Footer unsubscribeUrl={unsubscribeUrl} />
+        <Footer unsubscribeUrl={unsubscribeUrl}>
+          <Link
+            href={SubscriptionHelper.unsubscribeUrl(
+              props.userId,
+              props.documentId
+            )}
+          >
+            Unsubscribe from this doc
+          </Link>
+        </Footer>
       </EmailTemplate>
     );
   }

--- a/server/emails/templates/ExportFailureEmail.tsx
+++ b/server/emails/templates/ExportFailureEmail.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { NotificationEventType } from "@shared/types";
-import { User } from "@server/models";
 import NotificationSettingsHelper from "@server/models/helpers/NotificationSettingsHelper";
 import BaseEmail, { EmailProps } from "./BaseEmail";
 import Body from "./components/Body";
@@ -11,30 +10,36 @@ import Footer from "./components/Footer";
 import Header from "./components/Header";
 import Heading from "./components/Heading";
 
-type Props = EmailProps & {
+type InputProps = EmailProps & {
   userId: string;
   teamUrl: string;
   teamId: string;
 };
 
-type BeforeSendProps = {
+type BeforeSend = {
   unsubscribeUrl: string;
 };
+
+type Props = InputProps & BeforeSend;
 
 /**
  * Email sent to a user when their data export has failed for some reason.
  */
 export default class ExportFailureEmail extends BaseEmail<
-  Props,
-  BeforeSendProps
+  InputProps,
+  BeforeSend
 > {
-  protected async beforeSend({ userId }: Props) {
+  protected async beforeSend(props: InputProps) {
     return {
-      unsubscribeUrl: NotificationSettingsHelper.unsubscribeUrl(
-        await User.findByPk(userId, { rejectOnEmpty: true }),
-        NotificationEventType.ExportCompleted
-      ),
+      unsubscribeUrl: this.unsubscribeUrl(props),
     };
+  }
+
+  protected unsubscribeUrl({ userId }: InputProps) {
+    return NotificationSettingsHelper.unsubscribeUrl(
+      userId,
+      NotificationEventType.ExportCompleted
+    );
   }
 
   protected subject() {
@@ -54,7 +59,7 @@ section to try again – if the problem persists please contact support.
 `;
   }
 
-  protected render({ teamUrl, unsubscribeUrl }: Props & BeforeSendProps) {
+  protected render({ teamUrl, unsubscribeUrl }: Props) {
     const exportLink = `${teamUrl}/settings/export`;
 
     return (

--- a/server/emails/templates/InviteReminderEmail.tsx
+++ b/server/emails/templates/InviteReminderEmail.tsx
@@ -21,10 +21,7 @@ type Props = EmailProps & {
  * Email sent to an external user when an admin sends them an invite and they
  * haven't signed in after a few days.
  */
-export default class InviteReminderEmail extends BaseEmail<
-  Props,
-  Record<string, any>
-> {
+export default class InviteReminderEmail extends BaseEmail<Props> {
   protected subject({ actorName, teamName }: Props) {
     return `Reminder: ${actorName} invited you to join ${teamName}’s knowledge base`;
   }

--- a/server/emails/templates/WebhookDisabledEmail.tsx
+++ b/server/emails/templates/WebhookDisabledEmail.tsx
@@ -17,10 +17,7 @@ type Props = EmailProps & {
  * Email sent to the creator of a webhook when the webhook has become disabled
  * due to repeated failure.
  */
-export default class WebhookDisabledEmail extends BaseEmail<
-  Props,
-  Record<string, any>
-> {
+export default class WebhookDisabledEmail extends BaseEmail<Props> {
   protected subject() {
     return `Warning: Webhook disabled`;
   }
@@ -38,10 +35,12 @@ Webhook settings: ${teamUrl}/settings/webhooks
 `;
   }
 
-  protected render({ webhookName, teamUrl }: Props) {
+  protected render(props: Props) {
+    const { webhookName, teamUrl } = props;
     const webhookSettingsLink = `${teamUrl}/settings/webhooks`;
+
     return (
-      <EmailTemplate previewText={this.preview({ webhookName } as Props)}>
+      <EmailTemplate previewText={this.preview(props)}>
         <Header />
 
         <Body>

--- a/server/emails/templates/WelcomeEmail.tsx
+++ b/server/emails/templates/WelcomeEmail.tsx
@@ -17,10 +17,7 @@ type Props = EmailProps & {
  * Email sent to a user when their account has just been created, or they signed
  * in for the first time from an invite.
  */
-export default class WelcomeEmail extends BaseEmail<
-  Props,
-  Record<string, any>
-> {
+export default class WelcomeEmail extends BaseEmail<Props> {
   protected subject() {
     return `Welcome to ${env.APP_NAME}`;
   }

--- a/server/emails/templates/components/Footer.tsx
+++ b/server/emails/templates/components/Footer.tsx
@@ -6,39 +6,54 @@ import env from "@server/env";
 
 type Props = {
   unsubscribeUrl?: string;
+  children?: React.ReactNode;
 };
 
-export default ({ unsubscribeUrl }: Props) => {
-  const footerStyle = {
-    padding: "20px 0",
-    borderTop: `1px solid ${theme.smokeDark}`,
-    color: theme.slate,
-    fontSize: "14px",
-  };
-  const unsubStyle = {
-    padding: "0",
-    color: theme.slate,
-    fontSize: "14px",
-  };
+export const Link = ({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+}) => {
   const linkStyle = {
     color: theme.slate,
     fontWeight: 500,
     textDecoration: "none",
     marginRight: "10px",
   };
+
+  return (
+    <a href={href} style={linkStyle}>
+      {children}
+    </a>
+  );
+};
+
+export default ({ unsubscribeUrl, children }: Props) => {
+  const footerStyle = {
+    padding: "20px 0",
+    borderTop: `1px solid ${theme.smokeDark}`,
+    color: theme.slate,
+    fontSize: "14px",
+  };
+  const footerLinkStyle = {
+    padding: "0",
+    color: theme.slate,
+    fontSize: "14px",
+  };
   const externalLinkStyle = {
     color: theme.slate,
     textDecoration: "none",
     margin: "0 10px",
   };
+
   return (
     <Table width="100%">
       <TBody>
         <TR>
           <TD style={footerStyle}>
-            <a href={env.URL} style={linkStyle}>
-              {env.APP_NAME}
-            </a>
+            <Link href={env.URL}>{env.APP_NAME}</Link>
             <a href={twitterUrl()} style={externalLinkStyle}>
               Twitter
             </a>
@@ -46,11 +61,14 @@ export default ({ unsubscribeUrl }: Props) => {
         </TR>
         {unsubscribeUrl && (
           <TR>
-            <TD style={unsubStyle}>
-              <a href={unsubscribeUrl} style={linkStyle}>
-                Unsubscribe from these emails
-              </a>
+            <TD style={footerLinkStyle}>
+              <Link href={unsubscribeUrl}>Unsubscribe from these emails</Link>
             </TD>
+          </TR>
+        )}
+        {children && (
+          <TR>
+            <TD style={footerLinkStyle}>{children}</TD>
           </TR>
         )}
       </TBody>

--- a/server/models/helpers/NotificationSettingsHelper.ts
+++ b/server/models/helpers/NotificationSettingsHelper.ts
@@ -4,7 +4,6 @@ import {
   NotificationEventType,
 } from "@shared/types";
 import env from "@server/env";
-import User from "../User";
 
 /**
  * Helper class for working with notification settings
@@ -24,22 +23,28 @@ export default class NotificationSettingsHelper {
    * to unsubscribe from a specific event without being signed in, for one-click
    * links in emails.
    *
-   * @param user The user to unsubscribe
+   * @param userId The user ID to unsubscribe
    * @param eventType The event type to unsubscribe from
    * @returns The unsubscribe URL
    */
-  public static unsubscribeUrl(user: User, eventType: NotificationEventType) {
+  public static unsubscribeUrl(
+    userId: string,
+    eventType: NotificationEventType
+  ) {
     return `${
       env.URL
     }/api/notifications.unsubscribe?token=${this.unsubscribeToken(
-      user,
+      userId,
       eventType
-    )}&userId=${user.id}&eventType=${eventType}`;
+    )}&userId=${userId}&eventType=${eventType}`;
   }
 
-  public static unsubscribeToken(user: User, eventType: NotificationEventType) {
+  public static unsubscribeToken(
+    userId: string,
+    eventType: NotificationEventType
+  ) {
     const hash = crypto.createHash("sha256");
-    hash.update(`${user.id}-${env.SECRET_KEY}-${eventType}`);
+    hash.update(`${userId}-${env.SECRET_KEY}-${eventType}`);
     return hash.digest("hex");
   }
 }

--- a/server/models/helpers/SubscriptionHelper.ts
+++ b/server/models/helpers/SubscriptionHelper.ts
@@ -1,0 +1,29 @@
+import crypto from "crypto";
+import env from "@server/env";
+
+/**
+ * Helper class for working with subscription settings
+ */
+export default class SubscriptionHelper {
+  /**
+   * Get the unsubscribe URL for a user and document. This url allows the user
+   * to unsubscribe from a specific document without being signed in, for one-click
+   * links in emails.
+   *
+   * @param userId The user ID to unsubscribe
+   * @param documentId The document ID to unsubscribe from
+   * @returns The unsubscribe URL
+   */
+  public static unsubscribeUrl(userId: string, documentId: string) {
+    return `${env.URL}/api/subscriptions.delete?token=${this.unsubscribeToken(
+      userId,
+      documentId
+    )}&userId=${userId}&documentId=${documentId}`;
+  }
+
+  public static unsubscribeToken(userId: string, documentId: string) {
+    const hash = crypto.createHash("sha256");
+    hash.update(`${userId}-${env.SECRET_KEY}-${documentId}`);
+    return hash.digest("hex");
+  }
+}

--- a/server/routes/api/notifications/notifications.ts
+++ b/server/routes/api/notifications/notifications.ts
@@ -33,9 +33,6 @@ const handleUnsubscribe = async (
   const userId = (ctx.input.body.userId ?? ctx.input.query.userId) as string;
   const token = (ctx.input.body.token ?? ctx.input.query.token) as string;
 
-  const user = await User.scope("withTeam").findByPk(userId, {
-    rejectOnEmpty: true,
-  });
   const unsubscribeToken = NotificationSettingsHelper.unsubscribeToken(
     userId,
     eventType
@@ -45,6 +42,10 @@ const handleUnsubscribe = async (
     ctx.redirect(`${env.URL}?notice=invalid-auth`);
     return;
   }
+
+  const user = await User.scope("withTeam").findByPk(userId, {
+    rejectOnEmpty: true,
+  });
 
   user.setNotificationEventType(eventType, false);
   await user.save();

--- a/server/routes/api/notifications/notifications.ts
+++ b/server/routes/api/notifications/notifications.ts
@@ -37,7 +37,7 @@ const handleUnsubscribe = async (
     rejectOnEmpty: true,
   });
   const unsubscribeToken = NotificationSettingsHelper.unsubscribeToken(
-    user,
+    userId,
     eventType
   );
 

--- a/server/routes/api/subscriptions/schema.ts
+++ b/server/routes/api/subscriptions/schema.ts
@@ -42,3 +42,15 @@ export const SubscriptionsDeleteSchema = BaseSchema.extend({
 });
 
 export type SubscriptionsDeleteReq = z.infer<typeof SubscriptionsDeleteSchema>;
+
+export const SubscriptionsDeleteTokenSchema = BaseSchema.extend({
+  query: z.object({
+    userId: z.string().uuid(),
+    documentId: z.string().uuid(),
+    token: z.string(),
+  }),
+});
+
+export type SubscriptionsDeleteTokenReq = z.infer<
+  typeof SubscriptionsDeleteTokenSchema
+>;

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -341,6 +341,7 @@
   "Indent": "Indent",
   "Outdent": "Outdent",
   "Could not import file": "Could not import file",
+  "Unsubscribed from document": "Unsubscribed from document",
   "Account": "Account",
   "API Tokens": "API Tokens",
   "Details": "Details",

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -218,6 +218,10 @@ export enum UnfurlType {
   Document = "document",
 }
 
+export enum QueryNotices {
+  UnsubscribeDocument = "unsubscribe-document",
+}
+
 export type OEmbedType = "photo" | "video" | "rich";
 
 export type Unfurl<T = OEmbedType> = {


### PR DESCRIPTION
- Removed need to query user on all outgoing emails with unsubscribe link
- Added document specific unsubscribe link to email footer
- Small refactor of `unsubscribeUrl` logic to match pattern
- Clean up types in emails

Follow on https://github.com/outline/outline/pull/5707