### PR TITLE
fix: Safari sidebar animation #5765

### DIFF
--- a/app/components/Sidebar/Right.tsx
+++ b/app/components/Sidebar/Right.tsx
@@ -4,7 +4,6 @@ import * as React from "react";
 import styled, { useTheme } from "styled-components";
 import breakpoint from "styled-components-breakpoint";
 import { depths, s } from "@shared/styles";
-import { isSafari } from "@shared/utils/browser";
 import ErrorBoundary from "~/components/ErrorBoundary";
 import Flex from "~/components/Flex";
 import ResizeBorder from "~/components/Sidebar/components/ResizeBorder";
@@ -96,18 +95,8 @@ function Right({ children, border, className }: Props) {
     },
   };
 
-  let display = "flex";
-  if (isSafari()) {
-    display = "block";
-  }
-
   return (
-    <Sidebar
-      {...animationProps}
-      $border={border}
-      $display={display}
-      className={className}
-    >
+    <Sidebar {...animationProps} $border={border} className={className}>
       <Position style={style} column>
         <ErrorBoundary>{children}</ErrorBoundary>
         {!isMobile && (
@@ -130,9 +119,8 @@ const Position = styled(Flex)`
 
 const Sidebar = styled(m.div)<{
   $border?: boolean;
-  $display?: string;
 }>`
-  display: ${(props) => props.$display || "flex"};
+  display: block;
   flex-shrink: 0;
   background: ${s("background")};
   max-width: 80%;
@@ -141,7 +129,7 @@ const Sidebar = styled(m.div)<{
   z-index: 1;
 
   ${breakpoint("mobile", "tablet")`
-    display: flex
+    display: flex;
     position: absolute;
     top: 0;
     right: 0;

--- a/app/components/Sidebar/Right.tsx
+++ b/app/components/Sidebar/Right.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import styled, { useTheme } from "styled-components";
 import breakpoint from "styled-components-breakpoint";
 import { depths, s } from "@shared/styles";
+import { isSafari } from "@shared/utils/browser";
 import ErrorBoundary from "~/components/ErrorBoundary";
 import Flex from "~/components/Flex";
 import ResizeBorder from "~/components/Sidebar/components/ResizeBorder";
@@ -95,8 +96,18 @@ function Right({ children, border, className }: Props) {
     },
   };
 
+  let display = "flex";
+  if (isSafari()) {
+    display = "block";
+  }
+
   return (
-    <Sidebar {...animationProps} $border={border} className={className}>
+    <Sidebar
+      {...animationProps}
+      $border={border}
+      $display={display}
+      className={className}
+    >
       <Position style={style} column>
         <ErrorBoundary>{children}</ErrorBoundary>
         {!isMobile && (
@@ -119,8 +130,9 @@ const Position = styled(Flex)`
 
 const Sidebar = styled(m.div)<{
   $border?: boolean;
+  $display?: string;
 }>`
-  display: flex;
+  display: ${(props) => props.$display || "flex"};
   flex-shrink: 0;
   background: ${s("background")};
   max-width: 80%;
@@ -129,6 +141,7 @@ const Sidebar = styled(m.div)<{
   z-index: 1;
 
   ${breakpoint("mobile", "tablet")`
+    display: flex
     position: absolute;
     top: 0;
     right: 0;

--- a/shared/utils/browser.ts
+++ b/shared/utils/browser.ts
@@ -11,17 +11,6 @@ export function isTouchDevice(): boolean {
 }
 
 /**
- *
- * @returns true if the client browser is Safari
- */
-export function isSafari(): boolean {
-  if (SSR) {
-    return false;
-  }
-  return /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-}
-
-/**
  * Returns true if the client is running on a Mac.
  */
 export function isMac(): boolean {

--- a/shared/utils/browser.ts
+++ b/shared/utils/browser.ts
@@ -11,6 +11,17 @@ export function isTouchDevice(): boolean {
 }
 
 /**
+ *
+ * @returns true if the client browser is Safari
+ */
+export function isSafari(): boolean {
+  if (SSR) {
+    return false;
+  }
+  return /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+}
+
+/**
  * Returns true if the client is running on a Mac.
  */
 export function isMac(): boolean {


### PR DESCRIPTION
- Add Safari browser detect func in utils
- Apply display:block to right sidebar only on Safari Desktop  

Fixes bug that would cause sidebar contents to not display sometimes on Safari #5765