### PR TITLE
fix: `files.create` permissions

### DIFF
--- a/plugins/storage/server/api/files.ts
+++ b/plugins/storage/server/api/files.ts
@@ -33,15 +33,11 @@ router.post(
     const file = ctx.input.file;
 
     const attachment = await Attachment.findOne({
-      where: { key },
+      where: { key, userId: actor.id },
       rejectOnEmpty: true,
     });
 
-    if (attachment.isPrivate) {
-      authorize(actor, "createAttachment", actor.team);
-    }
-
-    await attachment.overwriteFile(file);
+    await attachment.writeFile(file);
 
     ctx.body = {
       success: true,

--- a/server/models/Attachment.ts
+++ b/server/models/Attachment.ts
@@ -116,12 +116,12 @@ class Attachment extends IdModel {
 
   /**
    * Store the given file in storage at the location specified by the attachment key.
-   * If the attachment already exists, it will be overwritten.
+   * If the attachment already exists, an error will be thrown.
    *
    * @param file The file to store
    * @returns A promise resolving to the attachment
    */
-  async overwriteFile(file: File) {
+  async writeFile(file: File) {
     return FileStorage.store({
       body: createReadStream(file.filepath),
       contentLength: file.size,

--- a/server/storage/files/LocalStorage.ts
+++ b/server/storage/files/LocalStorage.ts
@@ -14,6 +14,7 @@ import invariant from "invariant";
 import JWT from "jsonwebtoken";
 import safeResolvePath from "resolve-path";
 import env from "@server/env";
+import { ValidationError } from "@server/errors";
 import Logger from "@server/logging/Logger";
 import BaseStorage from "./BaseStorage";
 
@@ -55,7 +56,7 @@ export default class LocalStorage extends BaseStorage {
   }) => {
     const exists = await pathExists(this.getFilePath(key));
     if (exists) {
-      throw new Error(`File already exists at ${key}`);
+      throw new ValidationError(`File already exists at ${key}`);
     }
 
     await mkdir(this.getFilePath(path.dirname(key)), {

--- a/server/storage/files/LocalStorage.ts
+++ b/server/storage/files/LocalStorage.ts
@@ -56,7 +56,7 @@ export default class LocalStorage extends BaseStorage {
   }) => {
     const exists = await pathExists(this.getFilePath(key));
     if (exists) {
-      throw new ValidationError(`File already exists at ${key}`);
+      throw ValidationError(`File already exists at ${key}`);
     }
 
     await mkdir(this.getFilePath(path.dirname(key)), {

--- a/server/storage/files/LocalStorage.ts
+++ b/server/storage/files/LocalStorage.ts
@@ -1,15 +1,15 @@
 import { Blob } from "buffer";
-import {
-  ReadStream,
-  closeSync,
-  createReadStream,
-  createWriteStream,
-  existsSync,
-  openSync,
-} from "fs";
 import { mkdir, unlink } from "fs/promises";
 import path from "path";
 import { Readable } from "stream";
+import {
+  ReadStream,
+  close,
+  pathExists,
+  createReadStream,
+  createWriteStream,
+  open,
+} from "fs-extra";
 import invariant from "invariant";
 import JWT from "jsonwebtoken";
 import safeResolvePath from "resolve-path";
@@ -53,12 +53,14 @@ export default class LocalStorage extends BaseStorage {
     key: string;
     acl?: string;
   }) => {
-    const subdir = key.split("/").slice(0, -1).join("/");
-    if (!existsSync(path.join(env.FILE_STORAGE_LOCAL_ROOT_DIR, subdir))) {
-      await mkdir(path.join(env.FILE_STORAGE_LOCAL_ROOT_DIR, subdir), {
-        recursive: true,
-      });
+    const exists = await pathExists(this.getFilePath(key));
+    if (exists) {
+      throw new Error(`File already exists at ${key}`);
     }
+
+    await mkdir(this.getFilePath(path.dirname(key)), {
+      recursive: true,
+    });
 
     let src: NodeJS.ReadableStream;
     if (body instanceof ReadStream) {
@@ -70,7 +72,9 @@ export default class LocalStorage extends BaseStorage {
     }
 
     const filePath = this.getFilePath(key);
-    closeSync(openSync(filePath, "w"));
+
+    // Create the file on disk first
+    await open(filePath, "w").then(close);
 
     return new Promise<string>((resolve, reject) => {
       const dest = createWriteStream(filePath)


### PR DESCRIPTION
- Adds additional strictness around unreleased `files.create` endpoint.
- Removes usage of sync nodejs methods
- Adds handling of client aborted upload part-way

Related #5763 