### PR TITLE
Add registering of client-side relationship properties

### DIFF
--- a/app/components/WebsocketProvider.tsx
+++ b/app/components/WebsocketProvider.tsx
@@ -254,9 +254,7 @@ class WebsocketProvider extends React.Component<Props> {
     });
 
     this.socket.on("comments.delete", (event: WebsocketEntityDeletedEvent) => {
-      comments.inThread(event.modelId).forEach((comment) => {
-        comments.remove(comment.id);
-      });
+      comments.remove(event.modelId);
     });
 
     this.socket.on("groups.create", (event: PartialWithId<Group>) => {

--- a/app/models/Comment.ts
+++ b/app/models/Comment.ts
@@ -35,6 +35,12 @@ class Comment extends Model {
   parentCommentId: string;
 
   /**
+   * The comment that this comment is a reply to.
+   */
+  @Relation(() => Comment, { onDelete: "cascade" })
+  parentComment?: Comment;
+
+  /**
    * The document to which this comment belongs.
    */
   @Field

--- a/app/models/Notification.ts
+++ b/app/models/Notification.ts
@@ -47,7 +47,7 @@ class Notification extends Model {
   /**
    * The document that the notification is associated with.
    */
-  @Relation(() => Document)
+  @Relation(() => Document, { onDelete: "cascade" })
   document?: Document;
 
   /**
@@ -58,7 +58,7 @@ class Notification extends Model {
   /**
    * The comment that the notification is associated with.
    */
-  @Relation(() => Comment)
+  @Relation(() => Comment, { onDelete: "cascade" })
   comment?: Comment;
 
   /**

--- a/app/models/base/Model.ts
+++ b/app/models/base/Model.ts
@@ -95,12 +95,12 @@ export default abstract class Model {
    */
   toAPI = (): Record<string, any> => {
     const fields = getFieldsForModel(this);
-    return pick(this, fields) || [];
+    return pick(this, fields);
   };
 
   /**
    * Returns a plain object representation of all the properties on the model
-   * overrides the inbuilt toJSON method to avoid attempting to serialize store
+   * overrides the native toJSON method to avoid attempting to serialize store
    *
    * @returns {Record<string, any>}
    */

--- a/app/models/decorators/Field.ts
+++ b/app/models/decorators/Field.ts
@@ -3,7 +3,7 @@ import type Model from "../base/Model";
 const fields = new Map<string, string[]>();
 
 export const getFieldsForModel = (target: Model) =>
-  fields.get(target.constructor.name);
+  fields.get(target.constructor.name) ?? [];
 
 /**
  * A decorator that records this key as a serializable field on the model.

--- a/app/models/decorators/Field.ts
+++ b/app/models/decorators/Field.ts
@@ -1,6 +1,6 @@
 import type Model from "../base/Model";
 
-const fields = new Map();
+const fields = new Map<string, string[]>();
 
 export const getFieldsForModel = (target: Model) =>
   fields.get(target.constructor.name);
@@ -14,7 +14,10 @@ export const getFieldsForModel = (target: Model) =>
  */
 const Field = <T>(target: any, propertyKey: keyof T) => {
   const className = target.constructor.name;
-  fields.set(className, [...(fields.get(className) || []), propertyKey]);
+  fields.set(className, [
+    ...(fields.get(className) || []),
+    propertyKey as string,
+  ]);
 };
 
 export default Field;

--- a/app/models/decorators/Relation.ts
+++ b/app/models/decorators/Relation.ts
@@ -4,6 +4,47 @@ import type Model from "../base/Model";
 type RelationOptions = {
   /** Whether this relation is required */
   required?: boolean;
+  /** Behavior of relationship on deletion */
+  onDelete: "cascade" | "null" | "ignore";
+};
+
+type RelationProperties = {
+  /** The name of the property on the model that stores the ID of the relation */
+  idKey: string;
+  /** The name of the class of the relation */
+  relationClassName: string;
+  /** Options for the relation */
+  options: RelationOptions;
+};
+
+type InverseRelationProperties = RelationProperties & {
+  /** The name of the model class that owns this relation */
+  modelName: string;
+};
+
+const relations = new Map<string, Map<string, RelationProperties>>(new Map());
+
+/**
+ * Returns the inverse relation properties for the given model class.
+ *
+ * @param targetClass The model class to get inverse relations for.
+ * @returns A map of inverse relation properties keyed by the property name.
+ */
+export const getInverseRelationsForModelClass = (targetClass: typeof Model) => {
+  const inverseRelations = new Map<string, InverseRelationProperties>();
+
+  relations.forEach((relation, modelName) => {
+    relation.forEach((properties, propertyName) => {
+      if (properties.relationClassName === targetClass.name) {
+        inverseRelations.set(propertyName, {
+          ...properties,
+          modelName,
+        });
+      }
+    });
+  });
+
+  return inverseRelations;
 };
 
 /**
@@ -22,6 +63,19 @@ export default function Relation<T extends typeof Model>(
     const idKey = `${String(propertyKey)}Id`;
     const relationClass = classResolver();
     const relationClassName = relationClass.name;
+
+    // If the relation has options provided then register them in a map for later lookup. We can use
+    // this to determine how to update relations when a model is deleted.
+    if (options) {
+      const configForClass =
+        relations.get(target.constructor.name) || new Map();
+      configForClass.set(propertyKey, {
+        options,
+        relationClassName,
+        idKey,
+      });
+      relations.set(target.constructor.name, configForClass);
+    }
 
     Object.defineProperty(target, propertyKey, {
       get() {


### PR DESCRIPTION
closes #5903 and creates a nice foundation for future improvements of model relationship definitions on client to match server.

Additional references can be added later to cleanup some custom logic, but keeping this small to land easily.