### PR TITLE
Make code block `Enter` behavior the same as quote block

### DIFF
--- a/shared/editor/commands/codeFence.ts
+++ b/shared/editor/commands/codeFence.ts
@@ -86,8 +86,7 @@ export const newlineInCode: Command = (state, dispatch) => {
     return false;
   }
   const { tr, selection } = state;
-  const text = selection?.$anchor?.nodeBefore?.text;
-
+  const text = selection.$anchor.nodeBefore?.text;
   let newText = "\n";
 
   if (text) {


### PR DESCRIPTION
Changes behavior of enter key in code blocks to match blockquotes.

- `Enter` on the last line should exit the code block if the line is empty
- `Shift`+`Enter` allows adding multiple newlines at end of code block

closes #5967 