### PR TITLE
API : allow filter user list via emails

### DIFF
--- a/server/routes/api/users/schema.ts
+++ b/server/routes/api/users/schema.ts
@@ -25,6 +25,8 @@ export const UsersListSchema = z.object({
 
     ids: z.array(z.string().uuid()).optional(),
 
+    emails: z.array(z.string().email()).optional(),
+
     query: z.string().optional(),
 
     filter: z

--- a/server/routes/api/users/users.test.ts
+++ b/server/routes/api/users/users.test.ts
@@ -150,6 +150,23 @@ describe("#users.list", () => {
     expect(body.data[0].id).toEqual(user.id);
   });
 
+  it("should allow filtering by email", async () => {
+    const team = await buildTeam();
+    const admin = await buildAdmin({ teamId: team.id });
+    const user = await buildUser({ teamId: team.id });
+
+    const res = await server.post("/api/users.list", {
+      body: {
+        token: admin.getJwtToken(),
+        emails: [user.email],
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.data.length).toEqual(1);
+    expect(body.data[0].id).toEqual(user.id);
+  });
+
   it("should require admin for detailed info", async () => {
     const team = await buildTeam();
     await buildAdmin({ teamId: team.id });

--- a/server/routes/api/users/users.ts
+++ b/server/routes/api/users/users.ts
@@ -35,7 +35,7 @@ router.post(
   pagination(),
   validate(T.UsersListSchema),
   async (ctx: APIContext<T.UsersListReq>) => {
-    const { sort, direction, query, filter, ids } = ctx.input.body;
+    const { sort, direction, query, filter, ids, emails } = ctx.input.body;
 
     const actor = ctx.state.auth.user;
     let where: WhereOptions<User> = {
@@ -126,6 +126,13 @@ router.post(
       where = {
         ...where,
         id: ids,
+      };
+    }
+
+    if (emails) {
+      where = {
+        ...where,
+        email: emails,
       };
     }
 


### PR DESCRIPTION
Hello !

We are using Outline API to create users and groups in outline from an external tool. We miss a way to find users' outline IDs from their email address (since "invite" does not work for already existing/invited users). We added it in users.list: this way we can fix our data and easily use the rest of the API. Would it be an interesting feature for others?

Thank you!