### PR TITLE
Use transaction from middleware for more database queries

### DIFF
--- a/server/routes/api/attachments/attachments.ts
+++ b/server/routes/api/attachments/attachments.ts
@@ -38,6 +38,7 @@ router.post(
     } else if (preset === AttachmentPreset.DocumentAttachment && documentId) {
       const document = await Document.findByPk(documentId, {
         userId: user.id,
+        transaction,
       });
       authorize(user, "update", document);
     } else {

--- a/server/routes/api/collections/collections.ts
+++ b/server/routes/api/collections/collections.ts
@@ -165,7 +165,9 @@ router.post(
     const { user } = ctx.state.auth;
     authorize(user, "importCollection", user.team);
 
-    const attachment = await Attachment.findByPk(attachmentId);
+    const attachment = await Attachment.findByPk(attachmentId, {
+      transaction,
+    });
     authorize(user, "read", attachment);
 
     const fileOperation = await FileOperation.create(
@@ -373,7 +375,7 @@ router.post(
 
     const collection = await Collection.scope({
       method: ["withMembership", actor.id],
-    }).findByPk(id);
+    }).findByPk(id, { transaction });
     authorize(actor, "update", collection);
 
     const user = await User.findByPk(userId);
@@ -443,10 +445,10 @@ router.post(
 
     const collection = await Collection.scope({
       method: ["withMembership", actor.id],
-    }).findByPk(id);
+    }).findByPk(id, { transaction });
     authorize(actor, "update", collection);
 
-    const user = await User.findByPk(userId);
+    const user = await User.findByPk(userId, { transaction });
     authorize(actor, "read", user);
 
     await collection.$remove("user", user, { transaction });
@@ -545,12 +547,12 @@ router.post(
     const { id, format, includeAttachments } = ctx.input.body;
     const { user } = ctx.state.auth;
 
-    const team = await Team.findByPk(user.teamId);
+    const team = await Team.findByPk(user.teamId, { transaction });
     authorize(user, "createExport", team);
 
     const collection = await Collection.scope({
       method: ["withMembership", user.id],
-    }).findByPk(id);
+    }).findByPk(id, { transaction });
     authorize(user, "export", collection);
 
     const fileOperation = await collectionExporter({
@@ -582,7 +584,7 @@ router.post(
     const { transaction } = ctx.state;
     const { format, includeAttachments } = ctx.input.body;
     const { user } = ctx.state.auth;
-    const team = await Team.findByPk(user.teamId);
+    const team = await Team.findByPk(user.teamId, { transaction });
     authorize(user, "createExport", team);
 
     const fileOperation = await collectionExporter({

--- a/server/routes/api/comments/comments.ts
+++ b/server/routes/api/comments/comments.ts
@@ -103,6 +103,7 @@ router.post(
     });
     const document = await Document.findByPk(comment.documentId, {
       userId: user.id,
+      transaction,
     });
     authorize(user, "comment", document);
     authorize(user, "update", comment);
@@ -139,6 +140,7 @@ router.post(
     });
     const document = await Document.findByPk(comment.documentId, {
       userId: user.id,
+      transaction,
     });
     authorize(user, "comment", document);
     authorize(user, "delete", comment);

--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -955,6 +955,7 @@ router.post(
     const document = await Document.findByPk(id, {
       userId: user.id,
       includeState: true,
+      transaction,
     });
     collection = document?.collection;
     authorize(user, "update", document);
@@ -971,7 +972,7 @@ router.post(
         );
         collection = await Collection.scope({
           method: ["withMembership", user.id],
-        }).findByPk(collectionId!);
+        }).findByPk(collectionId!, { transaction });
       }
       authorize(user, "createDocument", collection);
     }
@@ -1025,13 +1026,14 @@ router.post(
 
     const document = await Document.findByPk(id, {
       userId: user.id,
+      transaction,
     });
     authorize(user, "read", document);
 
     const collection = collectionId
       ? await Collection.scope({
           method: ["withMembership", user.id],
-        }).findByPk(collectionId)
+        }).findByPk(collectionId, { transaction })
       : document?.collection;
 
     if (collection) {
@@ -1041,6 +1043,7 @@ router.post(
     if (parentDocumentId) {
       const parent = await Document.findByPk(parentDocumentId, {
         userId: user.id,
+        transaction,
       });
       authorize(user, "update", parent);
 
@@ -1083,17 +1086,19 @@ router.post(
     const { user } = ctx.state.auth;
     const document = await Document.findByPk(id, {
       userId: user.id,
+      transaction,
     });
     authorize(user, "move", document);
 
     const collection = await Collection.scope({
       method: ["withMembership", user.id],
-    }).findByPk(collectionId);
+    }).findByPk(collectionId, { transaction });
     authorize(user, "updateDocument", collection);
 
     if (parentDocumentId) {
       const parent = await Document.findByPk(parentDocumentId, {
         userId: user.id,
+        transaction,
       });
       authorize(user, "update", parent);
 
@@ -1293,6 +1298,7 @@ router.post(
         id: collectionId,
         teamId: user.teamId,
       },
+      transaction,
     });
     authorize(user, "createDocument", collection);
     let parentDocument;
@@ -1303,6 +1309,7 @@ router.post(
           id: parentDocumentId,
           collectionId: collection.id,
         },
+        transaction,
       });
       authorize(user, "read", parentDocument, {
         collection,
@@ -1376,6 +1383,7 @@ router.post(
           id: collectionId,
           teamId: user.teamId,
         },
+        transaction,
       });
       authorize(user, "createDocument", collection);
     }
@@ -1399,6 +1407,7 @@ router.post(
     if (templateId) {
       templateDocument = await Document.findByPk(templateId, {
         userId: user.id,
+        transaction,
       });
       authorize(user, "read", templateDocument);
     }

--- a/server/routes/api/fileOperations/fileOperations.ts
+++ b/server/routes/api/fileOperations/fileOperations.ts
@@ -114,6 +114,7 @@ router.post(
 
     const fileOperation = await FileOperation.unscoped().findByPk(id, {
       rejectOnEmpty: true,
+      transaction,
     });
     authorize(user, "delete", fileOperation);
 

--- a/server/routes/api/stars/stars.ts
+++ b/server/routes/api/stars/stars.ts
@@ -33,6 +33,7 @@ router.post(
     if (documentId) {
       const document = await Document.findByPk(documentId, {
         userId: user.id,
+        transaction,
       });
       authorize(user, "star", document);
     }
@@ -40,7 +41,7 @@ router.post(
     if (collectionId) {
       const collection = await Collection.scope({
         method: ["withMembership", user.id],
-      }).findByPk(collectionId);
+      }).findByPk(collectionId, { transaction });
       authorize(user, "star", collection);
     }
 

--- a/server/routes/api/teams/teams.ts
+++ b/server/routes/api/teams/teams.ts
@@ -32,6 +32,7 @@ router.post(
     const { user } = ctx.state.auth;
     const team = await Team.findByPk(user.teamId, {
       include: [{ model: TeamDomain }],
+      transaction,
     });
     authorize(user, "update", team);
 
@@ -121,6 +122,7 @@ router.post(
       "withAuthenticationProviders"
     ).findByPk(user.teamId, {
       rejectOnEmpty: true,
+      transaction,
     });
 
     authorize(user, "createTeam", existingTeam);


### PR DESCRIPTION
Closes #6042.

I also quickly searched through the code to identify similar cases and also changed them.

I made some observations that are probably covered by what was mentioned as the ongoing gradual migration to transaction in https://github.com/outline/outline/issues/6042#issuecomment-1773779264 but for completeness:

- Not every route that modifies the database has a transaction middleware yet. Even those that only read from the database could benefit from transaction isolation in PostgreSQL to get a consistent answer?
- Not every time a row is queried to be then modified a corresponding `UPDATE` lock is used. This may cause race conditions or loss of data in theory, but I did not thoroughly check if that is the case here.
- There are queries hidden inside functions, for example in `NotificationHelper.ts`, that do yet not receive a transaction parameter.