### PR TITLE
fix: remember prev selected lang when creating new code block

### DIFF
--- a/shared/editor/nodes/CodeFence.ts
+++ b/shared/editor/nodes/CodeFence.ts
@@ -184,11 +184,15 @@ export default class CodeFence extends Node {
 
   commands({ type, schema }: { type: NodeType; schema: Schema }) {
     return {
-      code_block: (attrs: Record<string, Primitive>) =>
-        toggleBlockType(type, schema.nodes.paragraph, {
+      code_block: (attrs: Record<string, Primitive>) => {
+        if (attrs?.language) {
+          Storage.set(PERSISTENCE_KEY, attrs.language);
+        }
+        return toggleBlockType(type, schema.nodes.paragraph, {
           language: Storage.get(PERSISTENCE_KEY, DEFAULT_LANGUAGE),
           ...attrs,
-        }),
+        });
+      },
       copyToClipboard: (): Command => (state) => {
         const codeBlock = findParentNode(isCode)(state.selection);
 


### PR DESCRIPTION
Previously, on creating a new code block, Javascript was always the default option. This commit fixes that by remembering user's last language used and creating a new block with that language. 

We already had `rme-code-language` key to store users language preference. We were also checking and using the store value from this key if it existed. But we were not updating the storage to update this key when user changes the language. This commit fixes that.

Fixes #6040.