### PR TITLE
API - allow search of a group using its name

### DIFF
--- a/server/routes/api/groups/groups.test.ts
+++ b/server/routes/api/groups/groups.test.ts
@@ -258,6 +258,39 @@ describe("#groups.list", () => {
         .includes(anotherUser.id)
     ).toBe(true);
   });
+
+  it("should allow to find a group by its name", async () => {
+    const user = await buildUser();
+    const group = await buildGroup({
+      teamId: user.teamId,
+    });
+    const anotherGroup = await buildGroup({
+      teamId: user.teamId,
+    });
+
+    const unfilteredRes = await server.post("/api/groups.list", {
+      body: {
+        token: user.getJwtToken(),
+      },
+    });
+    const body = await unfilteredRes.json();
+
+    expect(unfilteredRes.status).toEqual(200);
+    expect(body.data.groups.length).toEqual(2);
+    expect(body.data.groups[0].id).toEqual(anotherGroup.id);
+    expect(body.data.groups[1].id).toEqual(group.id);
+
+    const anotherRes = await server.post("/api/groups.list", {
+      body: {
+        name: group.name,
+        token: user.getJwtToken(),
+      },
+    });
+    const anotherBody = await anotherRes.json();
+    expect(anotherRes.status).toEqual(200);
+    expect(anotherBody.data.groups.length).toEqual(1);
+    expect(anotherBody.data.groups[0].id).toEqual(group.id);
+  });
 });
 
 describe("#groups.info", () => {

--- a/server/routes/api/groups/schema.ts
+++ b/server/routes/api/groups/schema.ts
@@ -24,6 +24,9 @@ export const GroupsListSchema = z.object({
 
     /** Only list groups where this user is a member */
     userId: z.string().uuid().optional(),
+
+    /** Find group with matching name */
+    name: z.string().optional(),
   }),
 });
 


### PR DESCRIPTION
Hello it's me again. :)

We are still using the outline API to sync our internal groups with outline groups. We have an issue: we cannot create two groups with the same name, but we have no easy way to find the existing group with that name to update internal data.

Currently, I loop in Python on every result of `groups.list` until I find the matching name. I propose a way to filter this endpoint to lighten the load on our outline instance.