### PR TITLE
Feat/5870 list all comments

### DIFF
--- a/server/routes/api/comments/__snapshots__/comments.test.ts.snap
+++ b/server/routes/api/comments/__snapshots__/comments.test.ts.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`#comments.list should require authentication 1`] = `
+{
+  "error": "authentication_required",
+  "message": "Authentication required",
+  "ok": false,
+  "status": 401,
+}
+`;

--- a/server/routes/api/comments/comments.test.ts
+++ b/server/routes/api/comments/comments.test.ts
@@ -42,6 +42,37 @@ describe("#comments.list", () => {
     expect(body.policies.length).toEqual(1);
     expect(body.policies[0].abilities.read).toEqual(true);
   });
+  it("should return all comments for a collection", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const collection = await buildCollection({
+      userId: user.id,
+      teamId: team.id,
+    });
+    const document = await buildDocument({
+      userId: user.id,
+      teamId: user.teamId,
+      collectionId: collection.id,
+    });
+    const comment = await buildComment({
+      userId: user.id,
+      teamId: team.id,
+      documentId: document.id,
+    });
+    const res = await server.post("/api/comments.list", {
+      body: {
+        token: user.getJwtToken(),
+        collectionId: collection.id,
+      },
+    });
+    const body = await res.json();
+
+    expect(res.status).toEqual(200);
+    expect(body.data.length).toEqual(1);
+    expect(body.data[0].id).toEqual(comment.id);
+    expect(body.policies.length).toEqual(1);
+    expect(body.policies[0].abilities.read).toEqual(true);
+  });
   it("should return all comments", async () => {
     const team = await buildTeam();
     const user = await buildUser({ teamId: team.id });

--- a/server/routes/api/comments/comments.test.ts
+++ b/server/routes/api/comments/comments.test.ts
@@ -1,0 +1,92 @@
+import {
+  buildCollection,
+  buildComment,
+  buildDocument,
+  buildTeam,
+  buildUser,
+} from "@server/test/factories";
+import { getTestServer } from "@server/test/support";
+
+const server = getTestServer();
+
+describe("#comments.list", () => {
+  it("should require authentication", async () => {
+    const res = await server.post("/api/comments.list");
+    const body = await res.json();
+    expect(res.status).toEqual(401);
+    expect(body).toMatchSnapshot();
+  });
+  it("should return all comments for a document", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const document = await buildDocument({
+      userId: user.id,
+      teamId: user.teamId,
+    });
+    const comment = await buildComment({
+      userId: user.id,
+      teamId: team.id,
+      documentId: document.id,
+    });
+    const res = await server.post("/api/comments.list", {
+      body: {
+        token: user.getJwtToken(),
+        documentId: document.id,
+      },
+    });
+    const body = await res.json();
+
+    expect(res.status).toEqual(200);
+    expect(body.data.length).toEqual(1);
+    expect(body.data[0].id).toEqual(comment.id);
+    expect(body.policies.length).toEqual(1);
+    expect(body.policies[0].abilities.read).toEqual(true);
+  });
+  it("should return all comments", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const collection1 = await buildCollection({
+      userId: user.id,
+      teamId: team.id,
+    });
+    const collection2 = await buildCollection({
+      userId: user.id,
+      teamId: team.id,
+    });
+    const document1 = await buildDocument({
+      userId: user.id,
+      teamId: user.teamId,
+      collectionId: collection1.id,
+    });
+    const document2 = await buildDocument({
+      userId: user.id,
+      teamId: user.teamId,
+      collectionId: collection2.id,
+    });
+    const comment1 = await buildComment({
+      userId: user.id,
+      teamId: team.id,
+      documentId: document1.id,
+    });
+    const comment2 = await buildComment({
+      userId: user.id,
+      teamId: team.id,
+      documentId: document2.id,
+    });
+    const res = await server.post("/api/comments.list", {
+      body: {
+        token: user.getJwtToken(),
+      },
+    });
+    const body = await res.json();
+
+    expect(res.status).toEqual(200);
+    expect(body.data.length).toEqual(2);
+    expect([body.data[0].id, body.data[1].id].sort()).toEqual(
+      [comment1.id, comment2.id].sort()
+    );
+    expect(body.policies.length).toEqual(2);
+    expect(body.policies[0].abilities.read).toEqual(true);
+    expect(body.policies[1].abilities.read).toEqual(true);
+  });
+});

--- a/server/routes/api/comments/schema.ts
+++ b/server/routes/api/comments/schema.ts
@@ -57,7 +57,7 @@ export type CommentsDeleteReq = z.infer<typeof CommentsDeleteSchema>;
 export const CollectionsListSchema = BaseSchema.extend({
   body: CollectionsSortParamsSchema.extend({
     /** Id of a document to list comments for */
-    documentId: z.string(),
+    documentId: z.string().optional(),
   }),
 });
 

--- a/server/routes/api/comments/schema.ts
+++ b/server/routes/api/comments/schema.ts
@@ -58,6 +58,7 @@ export const CollectionsListSchema = BaseSchema.extend({
   body: CollectionsSortParamsSchema.extend({
     /** Id of a document to list comments for */
     documentId: z.string().optional(),
+    collectionId: z.string().uuid().optional(),
   }),
 });
 

--- a/server/test/factories.ts
+++ b/server/test/factories.ts
@@ -32,6 +32,7 @@ import {
   Notification,
   SearchQuery,
   Pin,
+  Comment,
 } from "@server/models";
 import AttachmentHelper from "@server/models/helpers/AttachmentHelper";
 
@@ -393,6 +394,34 @@ export async function buildDocument(
   }
 
   return document;
+}
+
+export async function buildComment(overrides: {
+  userId: string;
+  teamId: string;
+  documentId: string;
+}) {
+  const comment = await Comment.create({
+    teamId: overrides.teamId,
+    documentId: overrides.documentId,
+    data: {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "test",
+            },
+          ],
+        },
+      ],
+    },
+    createdById: overrides.userId,
+  });
+
+  return comment;
 }
 
 export async function buildFileOperation(


### PR DESCRIPTION
Previously documentId was a required field in the 'comments.list' api.
This commit changes that by making the documentId field optional, and
returning all comments in published documents if documentId is not
passed. Refer #5870
Fixes #5871.