### PR TITLE
Add template section in collection description page

### DIFF
--- a/app/scenes/Collection.tsx
+++ b/app/scenes/Collection.tsx
@@ -182,6 +182,9 @@ function CollectionScene() {
                   <Tab to={collectionPath(collection.url)} exact>
                     {t("Documents")}
                   </Tab>
+                  <Tab to={collectionPath(collection.url, "templates")} exact>
+                    {t("Templates")}
+                  </Tab>
                   <Tab to={collectionPath(collection.url, "updated")} exact>
                     {t("Recently updated")}
                   </Tab>
@@ -247,6 +250,16 @@ function CollectionScene() {
                       documents={documents.recentlyUpdatedInCollection(
                         collection.id
                       )}
+                      fetch={documents.fetchRecentlyUpdated}
+                      options={{
+                        collectionId: collection.id,
+                      }}
+                    />
+                  </Route>
+                  <Route path={collectionPath(collection.url, "templates")}>
+                    <PaginatedDocumentList
+                      key="templates"
+                      documents={documents.templatesInCollection(collection.id)}
                       fetch={documents.fetchRecentlyUpdated}
                       options={{
                         collectionId: collection.id,


### PR DESCRIPTION
Have added template section in the collection page which contains template associated with that collection:

[Screencast from 29-10-23 05:43:47 PM IST.webm](https://github.com/outline/outline/assets/99068054/f281dad1-306c-4f65-8e56-51e10a05b22b)

