### PR TITLE
Refactor Editor components to be injected by associated extension

### DIFF
--- a/app/components/CollectionDescription.tsx
+++ b/app/components/CollectionDescription.tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import styled from "styled-components";
+import { richExtensions } from "@shared/editor/nodes";
 import { s } from "@shared/styles";
 import Collection from "~/models/Collection";
 import Arrow from "~/components/Arrow";
@@ -12,8 +13,18 @@ import ButtonLink from "~/components/ButtonLink";
 import Editor from "~/components/Editor";
 import LoadingIndicator from "~/components/LoadingIndicator";
 import NudeButton from "~/components/NudeButton";
+import BlockMenuExtension from "~/editor/extensions/BlockMenu";
+import EmojiMenuExtension from "~/editor/extensions/EmojiMenu";
+import HoverPreviewsExtension from "~/editor/extensions/HoverPreviews";
 import usePolicy from "~/hooks/usePolicy";
 import useStores from "~/hooks/useStores";
+
+const extensions = [
+  ...richExtensions,
+  BlockMenuExtension,
+  EmojiMenuExtension,
+  HoverPreviewsExtension,
+];
 
 type Props = {
   collection: Collection;
@@ -104,6 +115,7 @@ function CollectionDescription({ collection }: Props) {
                 readOnly={!isEditing}
                 autoFocus={isEditing}
                 onBlur={handleStopEditing}
+                extensions={extensions}
                 maxLength={1000}
                 embedsDisabled
                 canUpdate

--- a/app/components/Editor.tsx
+++ b/app/components/Editor.tsx
@@ -19,7 +19,6 @@ import { AttachmentValidation } from "@shared/validations";
 import Document from "~/models/Document";
 import ClickablePadding from "~/components/ClickablePadding";
 import ErrorBoundary from "~/components/ErrorBoundary";
-import HoverPreview from "~/components/HoverPreview";
 import type { Props as EditorProps, Editor as SharedEditor } from "~/editor";
 import useCurrentUser from "~/hooks/useCurrentUser";
 import useDictionary from "~/hooks/useDictionary";
@@ -47,7 +46,6 @@ export type Props = Optional<
 > & {
   shareId?: string | undefined;
   embedsDisabled?: boolean;
-  previewsDisabled?: boolean;
   onHeadingsChange?: (headings: Heading[]) => void;
   onSynced?: () => Promise<void>;
   onPublish?: (event: React.MouseEvent) => void;
@@ -62,7 +60,6 @@ function Editor(props: Props, ref: React.RefObject<SharedEditor> | null) {
     onHeadingsChange,
     onCreateCommentMark,
     onDeleteCommentMark,
-    previewsDisabled,
   } = props;
   const userLocale = useUserLocale();
   const locale = dateLocale(userLocale);
@@ -73,21 +70,7 @@ function Editor(props: Props, ref: React.RefObject<SharedEditor> | null) {
   const localRef = React.useRef<SharedEditor>();
   const preferences = useCurrentUser({ rejectOnEmpty: false })?.preferences;
   const previousHeadings = React.useRef<Heading[] | null>(null);
-  const [activeLinkElement, setActiveLink] =
-    React.useState<HTMLAnchorElement | null>(null);
   const previousCommentIds = React.useRef<string[]>();
-
-  const handleLinkActive = React.useCallback(
-    (element: HTMLAnchorElement | null) => {
-      setActiveLink(element);
-      return false;
-    },
-    []
-  );
-
-  const handleLinkInactive = React.useCallback(() => {
-    setActiveLink(null);
-  }, []);
 
   const handleSearchLink = React.useCallback(
     async (term: string) => {
@@ -339,7 +322,6 @@ function Editor(props: Props, ref: React.RefObject<SharedEditor> | null) {
           userPreferences={preferences}
           dictionary={dictionary}
           {...props}
-          onHoverLink={previewsDisabled ? undefined : handleLinkActive}
           onClickLink={handleClickLink}
           onSearchLink={handleSearchLink}
           onChange={handleChange}
@@ -352,12 +334,6 @@ function Editor(props: Props, ref: React.RefObject<SharedEditor> | null) {
             onDrop={handleDrop}
             onDragOver={handleDragOver}
             minHeight={props.editorStyle.paddingBottom}
-          />
-        )}
-        {!shareId && (
-          <HoverPreview
-            element={activeLinkElement}
-            onClose={handleLinkInactive}
           />
         )}
       </>

--- a/app/components/HoverPreview/HoverPreview.tsx
+++ b/app/components/HoverPreview/HoverPreview.tsx
@@ -24,7 +24,7 @@ const POINTER_WIDTH = 22;
 
 type Props = {
   /** The HTML element that is being hovered over, or null if none. */
-  element: HTMLAnchorElement | null;
+  element: HTMLElement | null;
   /** A callback on close of the hover preview. */
   onClose: () => void;
 };
@@ -35,7 +35,7 @@ enum Direction {
 }
 
 function HoverPreviewDesktop({ element, onClose }: Props) {
-  const url = element?.href || element?.dataset.url;
+  const url = element?.getAttribute("href") || element?.dataset.url;
   const previousUrl = usePrevious(url, true);
   const [isVisible, setVisible] = React.useState(false);
   const timerClose = React.useRef<ReturnType<typeof setTimeout>>();
@@ -200,7 +200,7 @@ function useHoverPosition({
   isVisible,
 }: {
   cardRef: React.RefObject<HTMLDivElement>;
-  element: HTMLAnchorElement | null;
+  element: HTMLElement | null;
   isVisible: boolean;
 }) {
   const [cardLeft, setCardLeft] = React.useState(0);

--- a/app/components/Notifications/NotificationListItem.tsx
+++ b/app/components/Notifications/NotificationListItem.tsx
@@ -64,7 +64,6 @@ function NotificationListItem({ notification, onNavigate }: Props) {
           {notification.comment && (
             <StyledCommentEditor
               defaultValue={toJS(notification.comment.data)}
-              previewsDisabled
             />
           )}
         </Flex>

--- a/app/editor/components/BlockMenu.tsx
+++ b/app/editor/components/BlockMenu.tsx
@@ -10,7 +10,7 @@ type Props = Omit<
   SuggestionsMenuProps,
   "renderMenuItem" | "items" | "trigger"
 > &
-  Required<Pick<SuggestionsMenuProps, "onLinkToolbarOpen" | "embeds">>;
+  Required<Pick<SuggestionsMenuProps, "embeds">>;
 
 function BlockMenu(props: Props) {
   const dictionary = useDictionary();

--- a/app/editor/components/EmojiMenu.tsx
+++ b/app/editor/components/EmojiMenu.tsx
@@ -28,7 +28,7 @@ let searcher: FuzzySearch<TEmoji>;
 
 type Props = Omit<
   SuggestionsMenuProps<Emoji>,
-  "renderMenuItem" | "items" | "onLinkToolbarOpen" | "embeds" | "trigger"
+  "renderMenuItem" | "items" | "embeds" | "trigger"
 >;
 
 const EmojiMenu = (props: Props) => {

--- a/app/editor/components/MentionMenu.tsx
+++ b/app/editor/components/MentionMenu.tsx
@@ -33,7 +33,7 @@ interface MentionItem extends MenuItem {
 
 type Props = Omit<
   SuggestionsMenuProps<MentionItem>,
-  "renderMenuItem" | "items" | "onLinkToolbarOpen" | "embeds" | "trigger"
+  "renderMenuItem" | "items" | "embeds" | "trigger"
 >;
 
 function MentionMenu({ search, isActive, ...rest }: Props) {

--- a/app/editor/components/SuggestionsMenu.tsx
+++ b/app/editor/components/SuggestionsMenu.tsx
@@ -60,7 +60,6 @@ export type Props<T extends MenuItem = MenuItem> = {
   uploadFile?: (file: File) => Promise<string>;
   onFileUploadStart?: () => void;
   onFileUploadStop?: () => void;
-  onLinkToolbarOpen?: () => void;
   onClose: (insertNewLine?: boolean) => void;
   embeds?: EmbedDescriptor[];
   renderMenuItem: (
@@ -252,17 +251,11 @@ function SuggestionsMenu<T extends MenuItem>(props: Props<T>) {
           return triggerFilePick("*");
         case "embed":
           return triggerLinkInput(item);
-        case "link": {
-          handleClearSearch();
-          props.onClose();
-          props.onLinkToolbarOpen?.();
-          return;
-        }
         default:
           insertNode(item);
       }
     },
-    [insertNode, handleClearSearch, props]
+    [insertNode]
   );
 
   const close = React.useCallback(() => {

--- a/app/editor/extensions/BlockMenu.tsx
+++ b/app/editor/extensions/BlockMenu.tsx
@@ -3,10 +3,10 @@ import { Plugin } from "prosemirror-state";
 import { Decoration, DecorationSet } from "prosemirror-view";
 import * as React from "react";
 import ReactDOM from "react-dom";
-import { SuggestionsMenuType } from "../plugins/Suggestions";
-import { findParentNode } from "../queries/findParentNode";
-import { EventType } from "../types";
-import Suggestion from "./Suggestion";
+import Suggestion from "@shared/editor/extensions/Suggestion";
+import { SuggestionsMenuType } from "@shared/editor/plugins/Suggestions";
+import { findParentNode } from "@shared/editor/queries/findParentNode";
+import { EventType } from "@shared/editor/types";
 
 export default class BlockMenu extends Suggestion {
   get defaultOptions() {

--- a/app/editor/extensions/BlockMenu.tsx
+++ b/app/editor/extensions/BlockMenu.tsx
@@ -4,22 +4,20 @@ import { Plugin } from "prosemirror-state";
 import { Decoration, DecorationSet } from "prosemirror-view";
 import * as React from "react";
 import ReactDOM from "react-dom";
-import Suggestion from "@shared/editor/extensions/Suggestion";
-import { SuggestionsMenuType } from "@shared/editor/plugins/Suggestions";
 import { findParentNode } from "@shared/editor/queries/findParentNode";
+import Suggestion from "~/editor/extensions/Suggestion";
 import BlockMenu from "../components/BlockMenu";
 
 export default class BlockMenuExtension extends Suggestion {
   get defaultOptions() {
     return {
-      type: SuggestionsMenuType.Block,
       openRegex: /^\/(\w+)?$/,
       closeRegex: /(^(?!\/(\w+)?)(.*)$|^\/(([\w\W]+)\s.*|\s)$|^\/((\W)+)$)/,
     };
   }
 
   get name() {
-    return "blockmenu";
+    return "block-menu";
   }
 
   get plugins() {

--- a/app/editor/extensions/BlockMenu.tsx
+++ b/app/editor/extensions/BlockMenu.tsx
@@ -4,6 +4,7 @@ import { Plugin } from "prosemirror-state";
 import { Decoration, DecorationSet } from "prosemirror-view";
 import * as React from "react";
 import ReactDOM from "react-dom";
+import { WidgetProps } from "@shared/editor/lib/Extension";
 import { findParentNode } from "@shared/editor/queries/findParentNode";
 import Suggestion from "~/editor/extensions/Suggestion";
 import BlockMenu from "../components/BlockMenu";
@@ -96,11 +97,11 @@ export default class BlockMenuExtension extends Suggestion {
     ];
   }
 
-  widget = () => {
+  widget = ({ rtl }: WidgetProps) => {
     const { props, view } = this.editor;
     return (
       <BlockMenu
-        rtl={false} // TODO
+        rtl={rtl}
         isActive={this.state.open}
         search={this.state.query}
         onClose={action((insertNewLine) => {

--- a/app/editor/extensions/EmojiMenu.tsx
+++ b/app/editor/extensions/EmojiMenu.tsx
@@ -1,0 +1,44 @@
+import { action } from "mobx";
+import * as React from "react";
+import Suggestion from "~/editor/extensions/Suggestion";
+import EmojiMenu from "../components/EmojiMenu";
+
+/**
+ * Languages using the colon character with a space in front in standard
+ * punctuation. In this case the trigger is only matched once there is additional
+ * text after the colon.
+ */
+const languagesUsingColon = ["fr"];
+
+export default class EmojiMenuExtension extends Suggestion {
+  get defaultOptions() {
+    const languageIsUsingColon =
+      typeof window === "undefined"
+        ? false
+        : languagesUsingColon.includes(window.navigator.language.slice(0, 2));
+
+    return {
+      openRegex: new RegExp(
+        `(?:^|\\s):([0-9a-zA-Z_+-]+)${languageIsUsingColon ? "" : "?"}$`
+      ),
+      closeRegex:
+        /(?:^|\s):(([0-9a-zA-Z_+-]*\s+)|(\s+[0-9a-zA-Z_+-]+)|[^0-9a-zA-Z_+-]+)$/,
+      enabledInTable: true,
+    };
+  }
+
+  get name() {
+    return "emoji-menu";
+  }
+
+  widget = () => (
+    <EmojiMenu
+      rtl={false} // TODO
+      isActive={this.state.open}
+      search={this.state.query}
+      onClose={action(() => {
+        this.state.open = false;
+      })}
+    />
+  );
+}

--- a/app/editor/extensions/EmojiMenu.tsx
+++ b/app/editor/extensions/EmojiMenu.tsx
@@ -1,5 +1,6 @@
 import { action } from "mobx";
 import * as React from "react";
+import { WidgetProps } from "@shared/editor/lib/Extension";
 import Suggestion from "~/editor/extensions/Suggestion";
 import EmojiMenu from "../components/EmojiMenu";
 
@@ -31,9 +32,9 @@ export default class EmojiMenuExtension extends Suggestion {
     return "emoji-menu";
   }
 
-  widget = () => (
+  widget = ({ rtl }: WidgetProps) => (
     <EmojiMenu
-      rtl={false} // TODO
+      rtl={rtl}
       isActive={this.state.open}
       search={this.state.query}
       onClose={action(() => {

--- a/app/editor/extensions/FindAndReplace.ts
+++ b/app/editor/extensions/FindAndReplace.ts
@@ -3,7 +3,7 @@ import { Node } from "prosemirror-model";
 import { Command, Plugin, PluginKey } from "prosemirror-state";
 import { Decoration, DecorationSet } from "prosemirror-view";
 import scrollIntoView from "smooth-scroll-into-view-if-needed";
-import Extension from "../lib/Extension";
+import Extension from "@shared/editor/lib/Extension";
 
 const pluginKey = new PluginKey("find-and-replace");
 

--- a/app/editor/extensions/FindAndReplace.tsx
+++ b/app/editor/extensions/FindAndReplace.tsx
@@ -2,12 +2,14 @@ import escapeRegExp from "lodash/escapeRegExp";
 import { Node } from "prosemirror-model";
 import { Command, Plugin, PluginKey } from "prosemirror-state";
 import { Decoration, DecorationSet } from "prosemirror-view";
+import * as React from "react";
 import scrollIntoView from "smooth-scroll-into-view-if-needed";
 import Extension from "@shared/editor/lib/Extension";
+import FindAndReplace from "../components/FindAndReplace";
 
 const pluginKey = new PluginKey("find-and-replace");
 
-export default class FindAndReplace extends Extension {
+export default class FindAndReplaceExtension extends Extension {
   public get name() {
     return "find-and-replace";
   }
@@ -291,6 +293,10 @@ export default class FindAndReplace extends Extension {
       }),
     ];
   }
+
+  public widget = () => (
+    <FindAndReplace readOnly={this.editor.props.readOnly} />
+  );
 
   private results: { from: number; to: number }[] = [];
   private currentResultIndex = 0;

--- a/app/editor/extensions/HoverPreviews.tsx
+++ b/app/editor/extensions/HoverPreviews.tsx
@@ -2,8 +2,8 @@ import { action, observable } from "mobx";
 import { Plugin } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 import * as React from "react";
+import Extension from "@shared/editor/lib/Extension";
 import HoverPreview from "~/components/HoverPreview";
-import Extension from "../lib/Extension";
 
 interface HoverPreviewsOptions {
   /** Delay before the target is considered "hovered" and callback is triggered. */

--- a/app/editor/extensions/MentionMenu.tsx
+++ b/app/editor/extensions/MentionMenu.tsx
@@ -1,0 +1,30 @@
+import { action } from "mobx";
+import * as React from "react";
+import Suggestion from "~/editor/extensions/Suggestion";
+import MentionMenu from "../components/MentionMenu";
+
+export default class MentionMenuExtension extends Suggestion {
+  get defaultOptions() {
+    return {
+      // ported from https://github.com/tc39/proposal-regexp-unicode-property-escapes#unicode-aware-version-of-w
+      openRegex: /(?:^|\s)@([\p{L}\p{M}\d]+)?$/u,
+      closeRegex: /(?:^|\s)@(([\p{L}\p{M}\d]*\s+)|(\s+[\p{L}\p{M}\d]+))$/u,
+      enabledInTable: true,
+    };
+  }
+
+  get name() {
+    return "mention-menu";
+  }
+
+  widget = () => (
+    <MentionMenu
+      rtl={false} // TODO
+      isActive={this.state.open}
+      search={this.state.query}
+      onClose={action(() => {
+        this.state.open = false;
+      })}
+    />
+  );
+}

--- a/app/editor/extensions/MentionMenu.tsx
+++ b/app/editor/extensions/MentionMenu.tsx
@@ -1,5 +1,6 @@
 import { action } from "mobx";
 import * as React from "react";
+import { WidgetProps } from "@shared/editor/lib/Extension";
 import Suggestion from "~/editor/extensions/Suggestion";
 import MentionMenu from "../components/MentionMenu";
 
@@ -17,9 +18,9 @@ export default class MentionMenuExtension extends Suggestion {
     return "mention-menu";
   }
 
-  widget = () => (
+  widget = ({ rtl }: WidgetProps) => (
     <MentionMenu
-      rtl={false} // TODO
+      rtl={rtl}
       isActive={this.state.open}
       search={this.state.query}
       onClose={action(() => {

--- a/app/editor/extensions/Suggestion.ts
+++ b/app/editor/extensions/Suggestion.ts
@@ -3,9 +3,9 @@ import { InputRule } from "prosemirror-inputrules";
 import { NodeType, Schema } from "prosemirror-model";
 import { EditorState, Plugin } from "prosemirror-state";
 import { isInTable } from "prosemirror-tables";
-import Extension from "../lib/Extension";
-import { SuggestionsMenuPlugin } from "../plugins/Suggestions";
-import isInCode from "../queries/isInCode";
+import Extension from "@shared/editor/lib/Extension";
+import { SuggestionsMenuPlugin } from "@shared/editor/plugins/Suggestions";
+import isInCode from "@shared/editor/queries/isInCode";
 
 export default class Suggestion extends Extension {
   state: {
@@ -17,7 +17,7 @@ export default class Suggestion extends Extension {
   });
 
   get plugins(): Plugin[] {
-    return [new SuggestionsMenuPlugin(this.editor, this.options, this.state)];
+    return [new SuggestionsMenuPlugin(this.options, this.state)];
   }
 
   keys() {

--- a/app/editor/index.tsx
+++ b/app/editor/index.tsx
@@ -26,7 +26,10 @@ import styled, { css, DefaultTheme, ThemeProps } from "styled-components";
 import insertFiles from "@shared/editor/commands/insertFiles";
 import Styles from "@shared/editor/components/Styles";
 import { EmbedDescriptor } from "@shared/editor/embeds";
-import Extension, { CommandFactory } from "@shared/editor/lib/Extension";
+import Extension, {
+  CommandFactory,
+  WidgetProps,
+} from "@shared/editor/lib/Extension";
 import ExtensionManager from "@shared/editor/lib/ExtensionManager";
 import { MarkdownSerializer } from "@shared/editor/lib/markdown/serializer";
 import textBetween from "@shared/editor/lib/textBetween";
@@ -143,8 +146,6 @@ type State = {
   selectionToolbarOpen: boolean;
   /** If the insert link toolbar is visible */
   linkToolbarOpen: boolean;
-  /** The query for the suggestion menu */
-  query: string;
 };
 
 /**
@@ -175,7 +176,6 @@ export class Editor extends React.PureComponent<
     isEditorFocused: false,
     selectionToolbarOpen: false,
     linkToolbarOpen: false,
-    query: "",
   };
 
   isBlurred = true;
@@ -194,7 +194,7 @@ export class Editor extends React.PureComponent<
     [name: string]: NodeViewConstructor;
   };
 
-  widgets: { [name: string]: () => React.ReactElement };
+  widgets: { [name: string]: (props: WidgetProps) => React.ReactElement };
   nodes: { [name: string]: NodeSpec };
   marks: { [name: string]: MarkSpec };
   commands: Record<string, CommandFactory>;
@@ -688,7 +688,6 @@ export class Editor extends React.PureComponent<
     this.setState((state) => ({
       ...state,
       selectionToolbarOpen: true,
-      query: "",
     }));
   };
 
@@ -706,7 +705,6 @@ export class Editor extends React.PureComponent<
     this.setState((state) => ({
       ...state,
       linkToolbarOpen: true,
-      query: "",
     }));
   };
 
@@ -768,7 +766,7 @@ export class Editor extends React.PureComponent<
             )}
             {this.widgets &&
               Object.values(this.widgets).map((Widget, index) => (
-                <Widget key={String(index)} />
+                <Widget key={String(index)} rtl={isRTL} />
               ))}
           </Flex>
         </EditorContext.Provider>

--- a/app/editor/index.tsx
+++ b/app/editor/index.tsx
@@ -43,7 +43,6 @@ import Flex from "~/components/Flex";
 import { PortalContext } from "~/components/Portal";
 import { Dictionary } from "~/hooks/useDictionary";
 import Logger from "~/utils/Logger";
-import BlockMenu from "./components/BlockMenu";
 import ComponentView from "./components/ComponentView";
 import EditorContext from "./components/EditorContext";
 import EmojiMenu from "./components/EmojiMenu";
@@ -854,24 +853,6 @@ export class Editor extends React.PureComponent<
                     }
                   />
                 )}
-                <BlockMenu
-                  rtl={isRTL}
-                  isActive={
-                    this.state.suggestionsMenuOpen === SuggestionsMenuType.Block
-                  }
-                  search={this.state.query}
-                  onClose={(insertNewLine) =>
-                    this.handleCloseSuggestionsMenu(
-                      SuggestionsMenuType.Block,
-                      insertNewLine
-                    )
-                  }
-                  uploadFile={this.props.uploadFile}
-                  onLinkToolbarOpen={this.handleOpenLinkToolbar}
-                  onFileUploadStart={this.props.onFileUploadStart}
-                  onFileUploadStop={this.props.onFileUploadStop}
-                  embeds={this.props.embeds}
-                />
               </>
             )}
             {this.widgets &&

--- a/app/editor/index.tsx
+++ b/app/editor/index.tsx
@@ -124,8 +124,6 @@ export type Props = {
     href: string,
     event: MouseEvent | React.MouseEvent<HTMLButtonElement>
   ) => void;
-  /** Callback when user hovers on any link in the document */
-  onHoverLink?: (element: HTMLAnchorElement | null) => boolean;
   /** Callback when user presses any key with document focused */
   onKeyDown?: (event: React.KeyboardEvent<HTMLDivElement>) => void;
   /** Collection of embed types to render in the document */
@@ -204,6 +202,7 @@ export class Editor extends React.PureComponent<
     [name: string]: NodeViewConstructor;
   };
 
+  widgets: { [name: string]: () => React.ReactElement };
   nodes: { [name: string]: NodeSpec };
   marks: { [name: string]: MarkSpec };
   commands: Record<string, CommandFactory>;
@@ -310,6 +309,7 @@ export class Editor extends React.PureComponent<
     this.nodes = this.createNodes();
     this.marks = this.createMarks();
     this.schema = this.createSchema();
+    this.widgets = this.createWidgets();
     this.plugins = this.createPlugins();
     this.rulePlugins = this.createRulePlugins();
     this.keymaps = this.createKeymaps();
@@ -376,6 +376,10 @@ export class Editor extends React.PureComponent<
       schema: this.schema,
       view: this.view,
     });
+  }
+
+  private createWidgets() {
+    return this.extensions.widgets;
   }
 
   private createNodes() {
@@ -870,6 +874,10 @@ export class Editor extends React.PureComponent<
                 />
               </>
             )}
+            {this.widgets &&
+              Object.values(this.widgets).map((Widget, index) => (
+                <Widget key={String(index)} />
+              ))}
           </Flex>
         </EditorContext.Provider>
       </PortalContext.Provider>

--- a/app/editor/index.tsx
+++ b/app/editor/index.tsx
@@ -34,7 +34,7 @@ import ExtensionManager from "@shared/editor/lib/ExtensionManager";
 import { MarkdownSerializer } from "@shared/editor/lib/markdown/serializer";
 import textBetween from "@shared/editor/lib/textBetween";
 import Mark from "@shared/editor/marks/Mark";
-import { basicExtensions } from "@shared/editor/nodes";
+import { basicExtensions as extensions } from "@shared/editor/nodes";
 import Node from "@shared/editor/nodes/Node";
 import ReactNode from "@shared/editor/nodes/ReactNode";
 import { EventType } from "@shared/editor/types";
@@ -51,10 +51,6 @@ import { SearchResult } from "./components/LinkEditor";
 import LinkToolbar from "./components/LinkToolbar";
 import SelectionToolbar from "./components/SelectionToolbar";
 import WithTheme from "./components/WithTheme";
-
-const extensions = basicExtensions;
-
-export { default as Extension } from "@shared/editor/lib/Extension";
 
 export type Props = {
   /** An optional identifier for the editor context. It is used to persist local settings */

--- a/app/editor/index.tsx
+++ b/app/editor/index.tsx
@@ -46,7 +46,6 @@ import Logger from "~/utils/Logger";
 import ComponentView from "./components/ComponentView";
 import EditorContext from "./components/EditorContext";
 import EmojiMenu from "./components/EmojiMenu";
-import FindAndReplace from "./components/FindAndReplace";
 import { SearchResult } from "./components/LinkEditor";
 import LinkToolbar from "./components/LinkToolbar";
 import MentionMenu from "./components/MentionMenu";
@@ -795,20 +794,17 @@ export class Editor extends React.PureComponent<
               ref={this.elementRef}
             />
             {this.view && (
-              <>
-                <SelectionToolbar
-                  rtl={isRTL}
-                  readOnly={readOnly}
-                  canComment={this.props.canComment}
-                  isTemplate={this.props.template === true}
-                  onOpen={this.handleOpenSelectionToolbar}
-                  onClose={this.handleCloseSelectionToolbar}
-                  onSearchLink={this.props.onSearchLink}
-                  onClickLink={this.props.onClickLink}
-                  onCreateLink={this.props.onCreateLink}
-                />
-                {this.commands.find && <FindAndReplace readOnly={readOnly} />}
-              </>
+              <SelectionToolbar
+                rtl={isRTL}
+                readOnly={readOnly}
+                canComment={this.props.canComment}
+                isTemplate={this.props.template === true}
+                onOpen={this.handleOpenSelectionToolbar}
+                onClose={this.handleCloseSelectionToolbar}
+                onSearchLink={this.props.onSearchLink}
+                onClickLink={this.props.onClickLink}
+                onCreateLink={this.props.onCreateLink}
+              />
             )}
             {!readOnly && this.view && (
               <>

--- a/app/editor/index.tsx
+++ b/app/editor/index.tsx
@@ -31,7 +31,7 @@ import ExtensionManager from "@shared/editor/lib/ExtensionManager";
 import { MarkdownSerializer } from "@shared/editor/lib/markdown/serializer";
 import textBetween from "@shared/editor/lib/textBetween";
 import Mark from "@shared/editor/marks/Mark";
-import { richExtensions, withComments } from "@shared/editor/nodes";
+import { basicExtensions } from "@shared/editor/nodes";
 import Node from "@shared/editor/nodes/Node";
 import ReactNode from "@shared/editor/nodes/ReactNode";
 import { SuggestionsMenuType } from "@shared/editor/plugins/Suggestions";
@@ -54,7 +54,7 @@ import MentionMenu from "./components/MentionMenu";
 import SelectionToolbar from "./components/SelectionToolbar";
 import WithTheme from "./components/WithTheme";
 
-const extensions = withComments(richExtensions);
+const extensions = basicExtensions;
 
 export { default as Extension } from "@shared/editor/lib/Extension";
 

--- a/app/editor/menus/block.tsx
+++ b/app/editor/menus/block.tsx
@@ -14,7 +14,6 @@ import {
   StarredIcon,
   WarningIcon,
   InfoIcon,
-  LinkIcon,
   AttachmentIcon,
   ClockIcon,
   CalendarIcon,
@@ -94,13 +93,6 @@ export default function blockMenuItems(dictionary: Dictionary): MenuItem[] {
       title: dictionary.image,
       icon: <ImageIcon />,
       keywords: "picture photo",
-    },
-    {
-      name: "link",
-      title: dictionary.link,
-      icon: <LinkIcon />,
-      shortcut: `${metaDisplay} k`,
-      keywords: "link url uri href",
     },
     {
       name: "video",

--- a/app/scenes/Document/components/CommentEditor.tsx
+++ b/app/scenes/Document/components/CommentEditor.tsx
@@ -2,8 +2,14 @@ import * as React from "react";
 import { basicExtensions, withComments } from "@shared/editor/nodes";
 import Editor, { Props as EditorProps } from "~/components/Editor";
 import type { Editor as SharedEditor } from "~/editor";
+import EmojiMenuExtension from "~/editor/extensions/EmojiMenu";
+import MentionMenuExtension from "~/editor/extensions/MentionMenu";
 
-const extensions = withComments(basicExtensions);
+const extensions = [
+  ...withComments(basicExtensions),
+  EmojiMenuExtension,
+  MentionMenuExtension,
+];
 
 const CommentEditor = (
   props: EditorProps,

--- a/app/scenes/Document/components/Editor.tsx
+++ b/app/scenes/Document/components/Editor.tsx
@@ -3,6 +3,9 @@ import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { mergeRefs } from "react-merge-refs";
 import { useHistory, useRouteMatch } from "react-router-dom";
+import BlockMenuExtension from "@shared/editor/extensions/BlockMenu";
+import FindAndReplaceExtension from "@shared/editor/extensions/FindAndReplace";
+import HoverPreviewsExtension from "@shared/editor/extensions/HoverPreviews";
 import { richExtensions, withComments } from "@shared/editor/nodes";
 import { TeamPreference } from "@shared/types";
 import Comment from "~/models/Comment";
@@ -25,9 +28,14 @@ import MultiplayerEditor from "./AsyncMultiplayerEditor";
 import DocumentMeta from "./DocumentMeta";
 import DocumentTitle from "./DocumentTitle";
 
-const extensions = withComments(richExtensions);
+const extensions = [
+  ...withComments(richExtensions),
+  BlockMenuExtension,
+  FindAndReplaceExtension,
+  HoverPreviewsExtension,
+];
 
-type Props = Omit<EditorProps, "extensions" | "editorStyle"> & {
+type Props = Omit<EditorProps, "editorStyle"> & {
   onChangeTitle: (title: string) => void;
   onChangeEmoji: (emoji: string | null) => void;
   id: string;

--- a/app/scenes/Document/components/Editor.tsx
+++ b/app/scenes/Document/components/Editor.tsx
@@ -3,16 +3,17 @@ import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { mergeRefs } from "react-merge-refs";
 import { useHistory, useRouteMatch } from "react-router-dom";
-import BlockMenuExtension from "@shared/editor/extensions/BlockMenu";
-import FindAndReplaceExtension from "@shared/editor/extensions/FindAndReplace";
-import HoverPreviewsExtension from "@shared/editor/extensions/HoverPreviews";
 import { richExtensions, withComments } from "@shared/editor/nodes";
 import { TeamPreference } from "@shared/types";
 import Comment from "~/models/Comment";
 import Document from "~/models/Document";
 import { RefHandle } from "~/components/ContentEditable";
+import { useDocumentContext } from "~/components/DocumentContext";
 import Editor, { Props as EditorProps } from "~/components/Editor";
 import Flex from "~/components/Flex";
+import BlockMenuExtension from "~/editor/extensions/BlockMenu";
+import FindAndReplaceExtension from "~/editor/extensions/FindAndReplace";
+import HoverPreviewsExtension from "~/editor/extensions/HoverPreviews";
 import useCurrentTeam from "~/hooks/useCurrentTeam";
 import useCurrentUser from "~/hooks/useCurrentUser";
 import useFocusedComment from "~/hooks/useFocusedComment";
@@ -23,7 +24,6 @@ import {
   documentPath,
   matchDocumentHistory,
 } from "~/utils/routeHelpers";
-import { useDocumentContext } from "../../../components/DocumentContext";
 import MultiplayerEditor from "./AsyncMultiplayerEditor";
 import DocumentMeta from "./DocumentMeta";
 import DocumentTitle from "./DocumentTitle";

--- a/app/scenes/Document/components/Editor.tsx
+++ b/app/scenes/Document/components/Editor.tsx
@@ -12,8 +12,10 @@ import { useDocumentContext } from "~/components/DocumentContext";
 import Editor, { Props as EditorProps } from "~/components/Editor";
 import Flex from "~/components/Flex";
 import BlockMenuExtension from "~/editor/extensions/BlockMenu";
+import EmojiMenuExtension from "~/editor/extensions/EmojiMenu";
 import FindAndReplaceExtension from "~/editor/extensions/FindAndReplace";
 import HoverPreviewsExtension from "~/editor/extensions/HoverPreviews";
+import MentionMenuExtension from "~/editor/extensions/MentionMenu";
 import useCurrentTeam from "~/hooks/useCurrentTeam";
 import useCurrentUser from "~/hooks/useCurrentUser";
 import useFocusedComment from "~/hooks/useFocusedComment";
@@ -31,6 +33,8 @@ import DocumentTitle from "./DocumentTitle";
 const extensions = [
   ...withComments(richExtensions),
   BlockMenuExtension,
+  EmojiMenuExtension,
+  MentionMenuExtension,
   FindAndReplaceExtension,
   HoverPreviewsExtension,
 ];

--- a/shared/editor/extensions/HoverPreviews.tsx
+++ b/shared/editor/extensions/HoverPreviews.tsx
@@ -1,16 +1,22 @@
+import { action, observable } from "mobx";
 import { Plugin } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
+import * as React from "react";
+import HoverPreview from "~/components/HoverPreview";
 import Extension from "../lib/Extension";
 
 interface HoverPreviewsOptions {
-  /** Callback when a hover target is found or lost. */
-  onHoverLink?: (target: Element | null) => void;
-
   /** Delay before the target is considered "hovered" and callback is triggered. */
   delay: number;
 }
 
 export default class HoverPreviews extends Extension {
+  state: {
+    activeLinkElement: HTMLElement | null;
+  } = observable({
+    activeLinkElement: null,
+  });
+
   get defaultOptions(): HoverPreviewsOptions {
     return {
       delay: 500,
@@ -38,27 +44,37 @@ export default class HoverPreviews extends Extension {
                 ".use-hover-preview"
               );
               if (isHoverTarget(target, view)) {
-                if (this.options.onHoverLink) {
-                  hoveringTimeout = setTimeout(() => {
-                    this.options.onHoverLink?.(target);
-                  }, this.options.delay);
-                }
+                hoveringTimeout = setTimeout(
+                  action(() => {
+                    this.state.activeLinkElement = target as HTMLElement;
+                  }),
+                  this.options.delay
+                );
               }
               return false;
             },
-            mouseout: (view: EditorView, event: MouseEvent) => {
+            mouseout: action((view: EditorView, event: MouseEvent) => {
               const target = (event.target as HTMLElement)?.closest(
                 ".use-hover-preview"
               );
               if (isHoverTarget(target, view)) {
                 clearTimeout(hoveringTimeout);
-                this.options.onHoverLink?.(null);
+                this.state.activeLinkElement = null;
               }
               return false;
-            },
+            }),
           },
         },
       }),
     ];
   }
+
+  widget = () => (
+    <HoverPreview
+      element={this.state.activeLinkElement}
+      onClose={action(() => {
+        this.state.activeLinkElement = null;
+      })}
+    />
+  );
 }

--- a/shared/editor/lib/Extension.ts
+++ b/shared/editor/lib/Extension.ts
@@ -7,6 +7,8 @@ import { Editor } from "../../../app/editor";
 
 export type CommandFactory = (attrs?: Record<string, Primitive>) => Command;
 
+export type WidgetProps = { rtl: boolean };
+
 export default class Extension {
   options: any;
   editor: Editor;
@@ -57,7 +59,7 @@ export default class Extension {
    *
    * @returns A React component
    */
-  widget(): JSX.Element | undefined {
+  widget(_props: WidgetProps): React.ReactElement | undefined {
     return undefined;
   }
 

--- a/shared/editor/lib/Extension.ts
+++ b/shared/editor/lib/Extension.ts
@@ -50,6 +50,10 @@ export default class Extension {
     return true;
   }
 
+  widget(): JSX.Element | undefined {
+    return undefined;
+  }
+
   keys(_options: {
     type?: NodeType | MarkType;
     schema: Schema;

--- a/shared/editor/lib/Extension.ts
+++ b/shared/editor/lib/Extension.ts
@@ -50,10 +50,22 @@ export default class Extension {
     return true;
   }
 
+  /**
+   * A widget is a React component to be rendered in the editor's context, independent of any
+   * specific node or mark. It can be used to render things like toolbars, menus, etc. Note that
+   * all widgets are observed automatically, so you can use observable values.
+   *
+   * @returns A React component
+   */
   widget(): JSX.Element | undefined {
     return undefined;
   }
 
+  /**
+   * A map of ProseMirror keymap bindings. It can be used to bind keyboard shortcuts to commands.
+   *
+   * @returns An object mapping key bindings to commands
+   */
   keys(_options: {
     type?: NodeType | MarkType;
     schema: Schema;
@@ -61,6 +73,12 @@ export default class Extension {
     return {};
   }
 
+  /**
+   * A map of ProseMirror input rules. It can be used to automatically replace certain patterns
+   * while typing.
+   *
+   * @returns An array of input rules
+   */
   inputRules(_options: {
     type?: NodeType | MarkType;
     schema: Schema;
@@ -68,6 +86,12 @@ export default class Extension {
     return [];
   }
 
+  /**
+   * A map of ProseMirror commands. It can be used to expose commands to the editor. If a single
+   * command is returned, it will be available under the extension's name.
+   *
+   * @returns An object mapping command names to command factories, or a command factory
+   */
   commands(_options: {
     type?: NodeType | MarkType;
     schema: Schema;

--- a/shared/editor/lib/ExtensionManager.ts
+++ b/shared/editor/lib/ExtensionManager.ts
@@ -44,7 +44,7 @@ export default class ExtensionManager {
 
   get widgets() {
     return this.extensions
-      .filter((extension) => extension.widget())
+      .filter((extension) => extension.widget({ rtl: false }))
       .reduce(
         (nodes, node: Node) => ({
           ...nodes,

--- a/shared/editor/lib/ExtensionManager.ts
+++ b/shared/editor/lib/ExtensionManager.ts
@@ -1,4 +1,5 @@
 import { PluginSimple } from "markdown-it";
+import { observer } from "mobx-react";
 import { keymap } from "prosemirror-keymap";
 import { MarkdownParser } from "prosemirror-markdown";
 import { Schema } from "prosemirror-model";
@@ -39,6 +40,18 @@ export default class ExtensionManager {
 
       this.extensions.push(extension);
     });
+  }
+
+  get widgets() {
+    return this.extensions
+      .filter((extension) => extension.widget())
+      .reduce(
+        (nodes, node: Node) => ({
+          ...nodes,
+          [node.name]: observer(node.widget as any),
+        }),
+        {}
+      );
   }
 
   get nodes() {

--- a/shared/editor/lib/ExtensionManager.ts
+++ b/shared/editor/lib/ExtensionManager.ts
@@ -55,7 +55,7 @@ export default class ExtensionManager {
   }
 
   get nodes() {
-    return this.extensions
+    const nodes = this.extensions
       .filter((extension) => extension.type === "node")
       .reduce(
         (nodes, node: Node) => ({
@@ -64,6 +64,19 @@ export default class ExtensionManager {
         }),
         {}
       );
+
+    for (const i in nodes) {
+      if (nodes[i].marks) {
+        // We must filter marks from the marks list that are not defined
+        // in the schema for the current editor.
+        nodes[i].marks = nodes[i].marks
+          .split(" ")
+          .filter((m: string) => Object.keys(nodes).includes(m))
+          .join(" ");
+      }
+    }
+
+    return nodes;
   }
 
   get marks() {

--- a/shared/editor/nodes/Emoji.tsx
+++ b/shared/editor/nodes/Emoji.tsx
@@ -7,39 +7,14 @@ import {
 } from "prosemirror-model";
 import { Command, TextSelection } from "prosemirror-state";
 import { Primitive } from "utility-types";
-import Suggestion from "../extensions/Suggestion";
+import Extension from "../lib/Extension";
 import { getEmojiFromName } from "../lib/emoji";
 import { MarkdownSerializerState } from "../lib/markdown/serializer";
-import { SuggestionsMenuType } from "../plugins/Suggestions";
 import emojiRule from "../rules/emoji";
 
-/**
- * Languages using the colon character with a space in front in standard
- * punctuation. In this case the trigger is only matched once there is additional
- * text after the colon.
- */
-const languagesUsingColon = ["fr"];
-
-export default class Emoji extends Suggestion {
+export default class Emoji extends Extension {
   get type() {
     return "node";
-  }
-
-  get defaultOptions() {
-    const languageIsUsingColon =
-      typeof window === "undefined"
-        ? false
-        : languagesUsingColon.includes(window.navigator.language.slice(0, 2));
-
-    return {
-      type: SuggestionsMenuType.Emoji,
-      openRegex: new RegExp(
-        `(?:^|\\s):([0-9a-zA-Z_+-]+)${languageIsUsingColon ? "" : "?"}$`
-      ),
-      closeRegex:
-        /(?:^|\s):(([0-9a-zA-Z_+-]*\s+)|(\s+[0-9a-zA-Z_+-]+)|[^0-9a-zA-Z_+-]+)$/,
-      enabledInTable: true,
-    };
   }
 
   get name() {

--- a/shared/editor/nodes/Mention.ts
+++ b/shared/editor/nodes/Mention.ts
@@ -7,24 +7,13 @@ import {
 } from "prosemirror-model";
 import { Command, TextSelection } from "prosemirror-state";
 import { Primitive } from "utility-types";
-import Suggestion from "../extensions/Suggestion";
+import Extension from "../lib/Extension";
 import { MarkdownSerializerState } from "../lib/markdown/serializer";
-import { SuggestionsMenuType } from "../plugins/Suggestions";
 import mentionRule from "../rules/mention";
 
-export default class Mention extends Suggestion {
+export default class Mention extends Extension {
   get type() {
     return "node";
-  }
-
-  get defaultOptions() {
-    return {
-      type: SuggestionsMenuType.Mention,
-      // ported from https://github.com/tc39/proposal-regexp-unicode-property-escapes#unicode-aware-version-of-w
-      openRegex: /(?:^|\s)@([\p{L}\p{M}\d]+)?$/u,
-      closeRegex: /(?:^|\s)@(([\p{L}\p{M}\d]*\s+)|(\s+[\p{L}\p{M}\d]+))$/u,
-      enabledInTable: true,
-    };
   }
 
   get name() {

--- a/shared/editor/nodes/index.ts
+++ b/shared/editor/nodes/index.ts
@@ -1,9 +1,6 @@
-import BlockMenu from "../extensions/BlockMenu";
 import ClipboardTextSerializer from "../extensions/ClipboardTextSerializer";
 import DateTime from "../extensions/DateTime";
-import FindAndReplace from "../extensions/FindAndReplace";
 import History from "../extensions/History";
-import HoverPreviews from "../extensions/HoverPreviews";
 import Keys from "../extensions/Keys";
 import MaxLength from "../extensions/MaxLength";
 import PasteHandler from "../extensions/PasteHandler";
@@ -109,12 +106,9 @@ export const richExtensions: Nodes = [
   TableRow,
   Highlight,
   TemplatePlaceholder,
-  BlockMenu,
   Math,
   MathBlock,
   PreventTab,
-  FindAndReplace,
-  HoverPreviews,
 ];
 
 /**

--- a/shared/editor/plugins/Suggestions.ts
+++ b/shared/editor/plugins/Suggestions.ts
@@ -1,7 +1,7 @@
+import { action } from "mobx";
 import { EditorState, Plugin } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 import type { Editor } from "../../../app/editor";
-import { EventType } from "../types";
 
 const MAX_MATCH = 500;
 
@@ -19,8 +19,17 @@ type Options = {
   enabledInTable: true;
 };
 
+type ExtensionState = {
+  open: boolean;
+  query: string;
+};
+
 export class SuggestionsMenuPlugin extends Plugin {
-  constructor(editor: Editor, options: Options) {
+  constructor(
+    editor: Editor,
+    options: Options,
+    extensionState: ExtensionState
+  ) {
     super({
       props: {
         handleClick: () => {
@@ -41,20 +50,16 @@ export class SuggestionsMenuPlugin extends Plugin {
                 pos,
                 pos,
                 options.openRegex,
-                (state, match) => {
+                action((_, match) => {
                   if (match) {
-                    editor.events.emit(EventType.SuggestionsMenuOpen, {
-                      type: options.type,
-                      query: match[1],
-                    });
+                    extensionState.open = true;
+                    extensionState.query = match[1];
                   } else {
-                    editor.events.emit(
-                      EventType.SuggestionsMenuClose,
-                      options.type
-                    );
+                    extensionState.open = false;
+                    extensionState.query = "";
                   }
                   return null;
-                }
+                })
               );
             });
           }

--- a/shared/editor/plugins/Suggestions.ts
+++ b/shared/editor/plugins/Suggestions.ts
@@ -1,18 +1,10 @@
 import { action } from "mobx";
 import { EditorState, Plugin } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
-import type { Editor } from "../../../app/editor";
 
 const MAX_MATCH = 500;
 
-export enum SuggestionsMenuType {
-  Emoji = "emoji",
-  Block = "block",
-  Mention = "mention",
-}
-
 type Options = {
-  type: SuggestionsMenuType;
   openRegex: RegExp;
   closeRegex: RegExp;
   enabledInCode: true;
@@ -25,17 +17,9 @@ type ExtensionState = {
 };
 
 export class SuggestionsMenuPlugin extends Plugin {
-  constructor(
-    editor: Editor,
-    options: Options,
-    extensionState: ExtensionState
-  ) {
+  constructor(options: Options, extensionState: ExtensionState) {
     super({
       props: {
-        handleClick: () => {
-          editor.events.emit(options.type);
-          return false;
-        },
         handleKeyDown: (view, event) => {
           // Prosemirror input rules are not triggered on backspace, however
           // we need them to be evaluted for the filter trigger to work


### PR DESCRIPTION
This reduces a lot of plumbing and callbacks, as the extension can control the component directly rather than needing to pipe data through callbacks to the Editor state. It also means that components are only in the React tree when the extension is used, automatically.

- [x] Framework
- [x] Hover previews
- [x] Blocks
- [x] Find and replace
- [x] Emojis
- [x] Mentions

Next up, link and selection toolbars – these will need a little more thought as they interact with `isEditorFocused` state and will need to share state, leaving for a separate PR.