### PR TITLE
Make `react-devtools` extension work for outline in Firefox

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -195,3 +195,8 @@ RATE_LIMITER_DURATION_WINDOW=60
 # Iframely API config
 # IFRAMELY_URL=
 # IFRAMELY_API_KEY=
+
+# Enable unsafe-inline in script-src CSP directive
+# Setting it to true allows React dev tools add-on in
+# Firefox to successfully detect the project
+DEVELOPMENT_UNSAFE_INLINE_CSP=false

--- a/server/env.ts
+++ b/server/env.ts
@@ -687,6 +687,14 @@ export class Environment {
   public IFRAMELY_API_KEY = this.toOptionalString(process.env.IFRAMELY_API_KEY);
 
   /**
+   * Enable unsafe-inline in script-src CSP directive
+   */
+  @IsBoolean()
+  public DEVELOPMENT_UNSAFE_INLINE_CSP = this.toBoolean(
+    process.env.DEVELOPMENT_UNSAFE_INLINE_CSP ?? "false"
+  );
+
+  /**
    * The product name
    */
   public APP_NAME = "Outline";

--- a/server/services/web.ts
+++ b/server/services/web.ts
@@ -104,7 +104,12 @@ export default function init(app: Koa = new Koa(), server?: Server) {
       directives: {
         defaultSrc,
         styleSrc,
-        scriptSrc: [...scriptSrc, `'nonce-${ctx.state.cspNonce}'`],
+        scriptSrc: [
+          ...scriptSrc,
+          env.DEVELOPMENT_UNSAFE_INLINE_CSP
+            ? "'unsafe-inline'"
+            : `'nonce-${ctx.state.cspNonce}'`,
+        ],
         mediaSrc: ["*", "data:", "blob:"],
         imgSrc: ["*", "data:", "blob:"],
         frameSrc: ["*", "data:"],


### PR DESCRIPTION
Fixes #6119 

For now, the fix seems to be to relax CSP as hinted in https://github.com/facebook/react/issues/17997. Note that CSP is only changed for non-prod environments.