### PR TITLE
Fix optional authentication

### DIFF
--- a/server/middlewares/authentication.ts
+++ b/server/middlewares/authentication.ts
@@ -57,14 +57,14 @@ export default function auth(options: AuthenticationOptions = {}) {
       token = ctx.cookies.get("accessToken");
     }
 
-    if (!token && options.optional !== true) {
-      throw AuthenticationError("Authentication required");
-    }
+    try {
+      if (!token) {
+        throw AuthenticationError("Authentication required");
+      }
 
-    let user: User | null;
-    let type: AuthenticationType;
+      let user: User | null;
+      let type: AuthenticationType;
 
-    if (token) {
       if (ApiKey.match(String(token))) {
         type = AuthenticationType.API;
         let apiKey;
@@ -146,8 +146,12 @@ export default function auth(options: AuthenticationOptions = {}) {
           getRootSpanFromRequestContext(ctx)
         );
       }
-    } else {
-      ctx.state.auth = {};
+    } catch (err) {
+      if (options.optional) {
+        ctx.state.auth = {};
+      } else {
+        throw err;
+      }
     }
 
     return next();


### PR DESCRIPTION
Related to #6061 

When accessing a public link with a stale `accessToken` in cookies, the `/documents.info` endpoint returns a 401 `Invalid token` and the public document can't be accessed (you need to go to the homepage re-login the instance first or clear your cookies/use a private browsing session).
This PR tries to fix this issue by enforcing the `optional` field in the auth middleware even when an `accessToken` is present.

(Auth source: Keycloak OpenID Connect)