### PR TITLE
Fix Suspended User Login Error Redirect URL

### DIFF
--- a/plugins/email/server/auth/email.ts
+++ b/plugins/email/server/auth/email.ts
@@ -102,7 +102,7 @@ router.get("email.callback", async (ctx) => {
   }
 
   if (user.isSuspended) {
-    return ctx.redirect("/?notice=suspended");
+    return ctx.redirect("/?notice=user-suspended");
   }
 
   if (user.isInvited) {

--- a/server/middlewares/passport.ts
+++ b/server/middlewares/passport.ts
@@ -86,7 +86,7 @@ export default function createMiddleware(providerName: string) {
         }
 
         if (result.user.isSuspended) {
-          return ctx.redirect("/?notice=suspended");
+          return ctx.redirect("/?notice=user-suspended");
         }
 
         await signIn(ctx, providerName, result);


### PR DESCRIPTION
Redirect suspended user to `/?notice=user-suspended` in `email.ts` and `passport.ts`. 

Probably better to set redirect notice as constant somewhere and import it in both client and server. But this would be a much bigger refactoring.

## Test Plan
### Before
Previous behavior. Notice that the `notice` query parameter in `http://127.0.0.1:3000/?notice=suspended` is `suspended`
<img width="1917" alt="image" src="https://github.com/outline/outline/assets/35753861/21375be6-9d93-416b-a291-26a7cd123d4a">

### After 
Current behavior. The error message is now properly displayed
<img width="1917" alt="image" src="https://github.com/outline/outline/assets/35753861/714ed251-8e9f-4ac2-affd-93a201b8fc83">
