### PR TITLE
Bring Mermaid diagram priority higher than heading's anchor

### DIFF
--- a/shared/editor/extensions/Mermaid.ts
+++ b/shared/editor/extensions/Mermaid.ts
@@ -196,6 +196,7 @@ function getNewState({
       {
         diagramId: renderer.diagramId,
         renderer,
+        side: -10,
       }
     );
 


### PR DESCRIPTION
## Motivation

If we insert Mermaid diagram right before heading, anchor of the heading will be inserted between code block and mermaid diagram preview, this will cause diagram won't hide when section is folded.

## Representation Steps

1. Create a code block with Mermaid diagram
2. Create any level of heading right after the diagram 

## Expect behavior

- Mermaid diagram works properly

## Actual behavior

- Mermaid diagram still show but with some bugs as described above

## Root cause

![image](https://github.com/outline/outline/assets/841969/d6573885-a063-45aa-892f-6b0fd2921eb8)

As you can see in the screenshot, anchor of the heading has been inserted between the code block and the diagram, this will break css sibling tricks here:

https://github.com/outline/outline/blob/main/shared/editor/components/Styles.ts#L1496C1-L1496C43

That's because heading node will insert a invisible anchor right before the heading with priority (side: -1) higher than Mermaid diagram (side: 0 (which is default))

https://github.com/outline/outline/blob/main/shared/editor/nodes/Heading.ts#L252C15-L252C23

https://github.com/outline/outline/blob/main/shared/editor/extensions/Mermaid.ts#L196C1-L199C8

About the priority, see the document of ProseMirror:

https://prosemirror.net/docs/ref/#view.Decoration%5Ewidget%5Espec.side

## After the Fix

In this patch, I've raise the priority of Mermaid diagram to higher (side: -10) than anchor of headings, and the diagram will stick with the code block properly :tada:

![image](https://github.com/outline/outline/assets/841969/a015455c-b70a-4d89-ad8c-1de283e6b5b1)


## Comments

Feel free to discuss if the solution is not properly (stupidly raise diagram's priority)