### PR TITLE
Render theme of Mermaid diagram properly

### DIFF
--- a/shared/editor/extensions/Mermaid.ts
+++ b/shared/editor/extensions/Mermaid.ts
@@ -33,11 +33,14 @@ class Cache {
     }
   }
 
-  private static maxSize = 10;
+  private static maxSize = 20;
   private static data: Map<string, string> = new Map();
 }
 
-type RendererFunc = (block: { node: Node; pos: number }) => void;
+type RendererFunc = (
+  block: { node: Node; pos: number },
+  isDark: boolean
+) => void;
 
 class MermaidRenderer {
   readonly diagramId: string;
@@ -53,11 +56,15 @@ class MermaidRenderer {
     this.element.classList.add("mermaid-diagram-wrapper");
   }
 
-  renderImmediately = async (block: { node: Node; pos: number }) => {
+  renderImmediately = async (
+    block: { node: Node; pos: number },
+    isDark: boolean
+  ) => {
     const element = this.element;
     const text = block.node.textContent;
 
-    const cache = Cache.get(text);
+    const cacheKey = `${isDark ? "dark" : "light"}-${text}`;
+    const cache = Cache.get(cacheKey);
     if (cache) {
       element.classList.remove("parse-error", "empty");
       element.innerHTML = cache;
@@ -66,13 +73,16 @@ class MermaidRenderer {
 
     try {
       const { default: mermaid } = await import("mermaid");
+      mermaid.mermaidAPI.setConfig({
+        theme: isDark ? "dark" : "default",
+      });
       mermaid.render(
         `mermaid-diagram-${this.diagramId}`,
         text,
         (svgCode, bindFunctions) => {
           this.currentTextContent = text;
           if (text) {
-            Cache.set(text, svgCode);
+            Cache.set(cacheKey, svgCode);
           }
           element.classList.remove("parse-error", "empty");
           element.innerHTML = svgCode;
@@ -190,7 +200,7 @@ function getNewState({
     const diagramDecoration = Decoration.widget(
       block.pos + block.node.nodeSize,
       () => {
-        void renderer.render(block);
+        void renderer.render(block, pluginState.isDark);
         return renderer.element;
       },
       {


### PR DESCRIPTION
# Motivation

Before we introduce cache system into Mermaid diagram renderer, it will apply Outline appearance onto the diagram.
But after patch #5852, diagram won't apply its theme to match Outline on initialization randomly, and won't apply theme update anymore.

# Representation Steps

- Insert multiple Mermaid diagram, for example 20 diagrams
- Set Outline appearance to dark
- Refresh page to see the result (A)
- Update Outline appearance to light to see the result (B)

# Expected behavior

- Result (A) should render each Mermaid diagrams in dark theme
- Result (B) should re-render each Mermaid diagrams in default (light) theme 

# Actual behavior

- Result (A) shows diagrams in dark or default randomly, see screenshots below

  ![image](https://github.com/outline/outline/assets/841969/24cde8ec-7f1f-4dd0-bd6d-7ee3ff636435)

- Result (B) won't trigger re-render and keeps as same as result (A)

  ![image](https://github.com/outline/outline/assets/841969/0e5ad0ae-43f4-4358-a7d6-a521464d7942)

# Root cause

This PR indicates two problems:

1. Mermaid initialization process is async, while render process is **not** waiting the initialization, this may cause dark theme is applied after the render process, which make diagram results in default theme (light) in dark page
  - https://github.com/outline/outline/blob/main/shared/editor/extensions/Mermaid.ts#L159
  - https://github.com/outline/outline/blob/main/shared/editor/extensions/Mermaid.ts#L193
2. Cache currently use whole code as cache key, but code won't change when appearance of Outline is updated, this cause Mermaid renderer just use cached diagram directly
  - https://github.com/outline/outline/blob/main/shared/editor/extensions/Mermaid.ts#L60
  - https://github.com/outline/outline/blob/main/shared/editor/extensions/Mermaid.ts#L75

# After the Fix

To fix two problems above, I've done these changes:

- Change cache key to pair of "appearance setting" and "whole mermaid code"
- Twice cache capacity because of the change above may increase number of results of diagrams
- Re-config theme of Mermaid before each render process to ensure each diagram is rendered with correct theme

Diagrams are rendered with correct theme on refreshing page and updates after applying this patch.

![image](https://github.com/outline/outline/assets/841969/200c0938-5fcc-404b-897e-df2a44460852)
![image](https://github.com/outline/outline/assets/841969/782fb542-d857-43be-ba71-b053ec8fbed7)

# Comments

Note that this PR **does not** change the mechanism of Mermaid initialization to ensure the render process happens before initialization. It's better to make a Promise object to keep the state of `initialized` and we can `await` or `.then` the Promise to ensure the ordering. If this idea is acceptable, I will send another PR to solve this problem.

Btw, feel free to adjust capacity of cache if 20 is not reasonable.