### PR TITLE
Duplicative method cleanup

### DIFF
--- a/app/components/WebsocketProvider.tsx
+++ b/app/components/WebsocketProvider.tsx
@@ -188,7 +188,7 @@ class WebsocketProvider extends React.Component<Props> {
                 err instanceof NotFoundError
               ) {
                 documents.removeCollectionDocuments(collectionId);
-                memberships.removeCollectionMemberships(collectionId);
+                memberships.removeAll({ collectionId });
                 collections.remove(collectionId);
                 return;
               }
@@ -302,7 +302,7 @@ class WebsocketProvider extends React.Component<Props> {
           policies.remove(doc.id);
         });
         documents.removeCollectionDocuments(collectionId);
-        memberships.removeCollectionMemberships(collectionId);
+        memberships.removeAll({ collectionId });
         collections.remove(collectionId);
       })
     );
@@ -398,7 +398,7 @@ class WebsocketProvider extends React.Component<Props> {
               err instanceof NotFoundError
             ) {
               collections.remove(event.collectionId);
-              memberships.revoke({
+              memberships.removeAll({
                 userId: event.userId,
                 collectionId: event.collectionId,
               });
@@ -408,7 +408,7 @@ class WebsocketProvider extends React.Component<Props> {
 
           documents.removeCollectionDocuments(event.collectionId);
         } else {
-          memberships.revoke({
+          memberships.removeAll({
             userId: event.userId,
             collectionId: event.collectionId,
           });

--- a/app/scenes/CollectionPermissions/index.tsx
+++ b/app/scenes/CollectionPermissions/index.tsx
@@ -267,10 +267,10 @@ function CollectionPermissions({ collectionId }: Props) {
           <CollectionGroupMemberListItem
             key={group.id}
             group={group}
-            collectionGroupMembership={collectionGroupMemberships.find(
-              collection.id,
-              group.id
-            )}
+            collectionGroupMembership={collectionGroupMemberships.find({
+              collectionId: collection.id,
+              groupId: group.id,
+            })}
             onRemove={() => handleRemoveGroup(group)}
             onUpdate={(permission) => handleUpdateGroup(group, permission)}
           />
@@ -286,7 +286,10 @@ function CollectionPermissions({ collectionId }: Props) {
           <MemberListItem
             key={item.id}
             user={item}
-            membership={memberships.find(collection.id, item.id)}
+            membership={memberships.find({
+              collectionId: collection.id,
+              userId: item.id,
+            })}
             canEdit={item.id !== user.id || user.isAdmin}
             onRemove={() => handleRemoveUser(item)}
             onUpdate={(permission) => handleUpdateUser(item, permission)}

--- a/app/scenes/Document/components/DocumentMeta.tsx
+++ b/app/scenes/Document/components/DocumentMeta.tsx
@@ -37,7 +37,7 @@ function TitleDocumentMeta({ to, document, revision, ...rest }: Props) {
   const Wrapper = viewsLoadedOnMount.current ? React.Fragment : Fade;
 
   const insightsPath = documentInsightsPath(document);
-  const commentsCount = comments.inDocument(document.id).length;
+  const commentsCount = comments.filter({ documentId: document.id }).length;
 
   return (
     <Meta document={document} revision={revision} to={to} replace {...rest}>

--- a/app/scenes/Document/components/History.tsx
+++ b/app/scenes/Document/components/History.tsx
@@ -22,7 +22,7 @@ function History() {
   const document = documents.getByUrl(match.params.documentSlug);
 
   const eventsInDocument = document
-    ? events.inDocument(document.id)
+    ? events.filter({ documentId: document.id })
     : EMPTY_ARRAY;
 
   const onCloseHistory = () => {

--- a/app/stores/CollectionGroupMembershipsStore.ts
+++ b/app/stores/CollectionGroupMembershipsStore.ts
@@ -71,32 +71,9 @@ export default class CollectionGroupMembershipsStore extends Store<CollectionGro
       id: collectionId,
       groupId,
     });
-    const membership = Array.from(this.data.values()).find(
-      (m) => m.groupId === groupId && m.collectionId === collectionId
-    );
-    if (membership) {
-      this.remove(membership.id);
-    }
-  }
-
-  @action
-  removeCollectionMemberships = (collectionId: string) => {
-    this.data.forEach((membership, key) => {
-      if (membership.collectionId === collectionId) {
-        this.remove(key);
-      }
+    this.removeAll({
+      collectionId,
+      groupId,
     });
-  };
-
-  /**
-   * Find a collection group membership by collectionId and groupId
-   *
-   * @param collectionId The collection ID
-   * @param groupId The group ID
-   * @returns The collection group membership or undefined if not found.
-   */
-  find = (collectionId: string, groupId: string) =>
-    Array.from(this.data.values()).find(
-      (m) => m.groupId === groupId && m.collectionId === collectionId
-    );
+  }
 }

--- a/app/stores/CommentsStore.ts
+++ b/app/stores/CommentsStore.ts
@@ -1,4 +1,3 @@
-import filter from "lodash/filter";
 import orderBy from "lodash/orderBy";
 import { action, computed } from "mobx";
 import Comment from "~/models/Comment";
@@ -18,8 +17,9 @@ export default class CommentsStore extends Store<Comment> {
    * @returns Array of comments
    */
   threadsInDocument(documentId: string): Comment[] {
-    return this.inDocument(documentId).filter(
-      (comment) => !comment.parentCommentId
+    return this.filter(
+      (comment: Comment) =>
+        comment.documentId === documentId && !comment.parentCommentId
     );
   }
 
@@ -30,23 +30,9 @@ export default class CommentsStore extends Store<Comment> {
    * @returns Array of comments
    */
   inThread(threadId: string): Comment[] {
-    return filter(
-      this.orderedData,
-      (comment) =>
+    return this.filter(
+      (comment: Comment) =>
         comment.parentCommentId === threadId || comment.id === threadId
-    );
-  }
-
-  /**
-   * Returns a list of comments in a document.
-   *
-   * @param documentId ID of the document to get comments for
-   * @returns Array of comments
-   */
-  inDocument(documentId: string): Comment[] {
-    return filter(
-      this.orderedData,
-      (comment) => comment.documentId === documentId
     );
   }
 

--- a/app/stores/EventsStore.ts
+++ b/app/stores/EventsStore.ts
@@ -1,5 +1,4 @@
-import filter from "lodash/filter";
-import sortBy from "lodash/sortBy";
+import orderBy from "lodash/orderBy";
 import { computed } from "mobx";
 import Event from "~/models/Event";
 import RootStore from "./RootStore";
@@ -14,10 +13,6 @@ export default class EventsStore extends Store<Event> {
 
   @computed
   get orderedData(): Event[] {
-    return sortBy(Array.from(this.data.values()), "createdAt").reverse();
-  }
-
-  inDocument(documentId: string): Event[] {
-    return filter(this.orderedData, (event) => event.documentId === documentId);
+    return orderBy(Array.from(this.data.values()), "createdAt", "asc");
   }
 }

--- a/app/stores/IntegrationsStore.ts
+++ b/app/stores/IntegrationsStore.ts
@@ -1,6 +1,4 @@
-import filter from "lodash/filter";
 import { computed } from "mobx";
-import { IntegrationService } from "@shared/types";
 import naturalSort from "@shared/utils/naturalSort";
 import RootStore from "~/stores/RootStore";
 import Store from "~/stores/base/Store";
@@ -14,13 +12,6 @@ class IntegrationsStore extends Store<Integration> {
   @computed
   get orderedData(): Integration[] {
     return naturalSort(Array.from(this.data.values()), "name");
-  }
-
-  @computed
-  get slackIntegrations(): Integration[] {
-    return filter(this.orderedData, {
-      service: IntegrationService.Slack,
-    });
   }
 }
 

--- a/app/stores/MembershipsStore.ts
+++ b/app/stores/MembershipsStore.ts
@@ -71,7 +71,7 @@ export default class MembershipsStore extends Store<Membership> {
       id: collectionId,
       userId,
     });
-    this.revoke({ userId, collectionId });
+    this.removeAll({ userId, collectionId });
   }
 
   @action
@@ -82,30 +82,4 @@ export default class MembershipsStore extends Store<Membership> {
       }
     });
   };
-
-  @action
-  revoke = ({
-    userId,
-    collectionId,
-  }: {
-    collectionId: string;
-    userId: string;
-  }) => {
-    const membership = this.find(collectionId, userId);
-    if (membership) {
-      this.remove(membership.id);
-    }
-  };
-
-  /**
-   * Find a collection user membership by collectionId and userId
-   *
-   * @param collectionId The collection ID
-   * @param userId The user ID
-   * @returns The collection user membership or undefined if not found.
-   */
-  find = (collectionId: string, userId: string) =>
-    Array.from(this.data.values()).find(
-      (m) => m.userId === userId && m.collectionId === collectionId
-    );
 }

--- a/app/stores/SharesStore.ts
+++ b/app/stores/SharesStore.ts
@@ -2,7 +2,7 @@ import invariant from "invariant";
 import filter from "lodash/filter";
 import find from "lodash/find";
 import isUndefined from "lodash/isUndefined";
-import sortBy from "lodash/sortBy";
+import orderBy from "lodash/orderBy";
 import { action, computed } from "mobx";
 import type { Required } from "utility-types";
 import type { JSONObject } from "@shared/types";
@@ -26,7 +26,7 @@ export default class SharesStore extends Store<Share> {
 
   @computed
   get orderedData(): Share[] {
-    return sortBy(Array.from(this.data.values()), "createdAt").reverse();
+    return orderBy(Array.from(this.data.values()), "createdAt", "asc");
   }
 
   @computed

--- a/app/stores/UsersStore.ts
+++ b/app/stores/UsersStore.ts
@@ -8,6 +8,15 @@ import { client } from "~/utils/ApiClient";
 import RootStore from "./RootStore";
 import Store, { RPCAction } from "./base/Store";
 
+type UserCounts = {
+  active: number;
+  admins: number;
+  all: number;
+  invited: number;
+  suspended: number;
+  viewers: number;
+};
+
 export default class UsersStore extends Store<User> {
   actions = [
     RPCAction.Info,
@@ -19,14 +28,7 @@ export default class UsersStore extends Store<User> {
   ];
 
   @observable
-  counts: {
-    active: number;
-    admins: number;
-    all: number;
-    invited: number;
-    suspended: number;
-    viewers: number;
-  } = {
+  counts: UserCounts = {
     active: 0,
     admins: 0,
     all: 0,
@@ -159,8 +161,12 @@ export default class UsersStore extends Store<User> {
     });
 
   @action
-  fetchCounts = async (teamId: string): Promise<any> => {
-    const res = await client.post(`/users.count`, {
+  fetchCounts = async (
+    teamId: string
+  ): Promise<{
+    counts: UserCounts;
+  }> => {
+    const res = await client.post(`/≈`, {
       teamId,
     });
     invariant(res?.data, "Data should be available");

--- a/plugins/slack/client/Settings.tsx
+++ b/plugins/slack/client/Settings.tsx
@@ -1,9 +1,8 @@
-import find from "lodash/find";
 import { observer } from "mobx-react";
 import * as React from "react";
 import { useTranslation, Trans } from "react-i18next";
 import styled from "styled-components";
-import { IntegrationType } from "@shared/types";
+import { IntegrationService, IntegrationType } from "@shared/types";
 import Collection from "~/models/Collection";
 import Integration from "~/models/Integration";
 import Button from "~/components/Button";
@@ -38,14 +37,15 @@ function Slack() {
     });
   }, [collections, integrations]);
 
-  const commandIntegration = find(
-    integrations.slackIntegrations,
-    (i) => i.type === IntegrationType.Command
-  );
+  const commandIntegration = integrations.find({
+    type: IntegrationType.Command,
+    service: IntegrationService.Slack,
+  });
 
   const groupedCollections = collections.orderedData
     .map<[Collection, Integration | undefined]>((collection) => {
-      const integration = find(integrations.slackIntegrations, {
+      const integration = integrations.find({
+        service: IntegrationService.Slack,
         collectionId: collection.id,
       });
 


### PR DESCRIPTION
Ported from #5814 – removed `revoke` method language as it sounds like a mutation and is therefore confusing.