### PR TITLE
fix: User updates are not synced between clients

### DIFF
--- a/app/components/WebsocketProvider.tsx
+++ b/app/components/WebsocketProvider.tsx
@@ -88,6 +88,7 @@ class WebsocketProvider extends React.Component<Props> {
       pins,
       stars,
       memberships,
+      users,
       userMemberships,
       policies,
       comments,
@@ -508,6 +509,10 @@ class WebsocketProvider extends React.Component<Props> {
         subscriptions.remove(event.modelId);
       }
     );
+
+    this.socket.on("users.update", (event: PartialWithId<User>) => {
+      users.add(event);
+    });
 
     this.socket.on("users.demote", async (event: PartialWithId<User>) => {
       if (event.id === auth.user?.id) {

--- a/plugins/webhooks/server/tasks/DeliverWebhookTask.ts
+++ b/plugins/webhooks/server/tasks/DeliverWebhookTask.ts
@@ -184,6 +184,8 @@ export default class DeliverWebhookTask extends BaseTask<Props> {
         await this.handleIntegrationEvent(subscription, event);
         return;
       case "teams.create":
+      case "teams.delete":
+      case "teams.destroy":
         // Ignored
         return;
       case "teams.update":

--- a/server/migrations/20240204171556-add-event-changeset.js
+++ b/server/migrations/20240204171556-add-event-changeset.js
@@ -1,0 +1,14 @@
+"use strict";
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn("events", "changes", {
+      type: Sequelize.JSONB,
+      allowNull: true,
+    });
+    
+  },
+  async down(queryInterface) {
+    await queryInterface.removeColumn("events", "changes");
+  },
+};

--- a/server/models/Team.ts
+++ b/server/models/Team.ts
@@ -230,8 +230,10 @@ class Team extends ParanoidModel<
     }
 
     // Do not mutate the original object here or it will mess up change tracking.
-    this.preferences = { ...this.preferences, [preference]: value };
-    this.changed("preferences", true);
+    this.preferences = {
+      ...this.preferences,
+      [preference]: value,
+    };
 
     return this.preferences;
   };

--- a/server/models/Team.ts
+++ b/server/models/Team.ts
@@ -228,7 +228,9 @@ class Team extends ParanoidModel<
     if (!this.preferences) {
       this.preferences = {};
     }
-    this.preferences[preference] = value;
+
+    // Do not mutate the original object here or it will mess up change tracking.
+    this.preferences = { ...this.preferences, [preference]: value };
     this.changed("preferences", true);
 
     return this.preferences;

--- a/server/models/Team.ts
+++ b/server/models/Team.ts
@@ -229,7 +229,6 @@ class Team extends ParanoidModel<
       this.preferences = {};
     }
 
-    // Do not mutate the original object here or it will mess up change tracking.
     this.preferences = {
       ...this.preferences,
       [preference]: value,

--- a/server/models/User.ts
+++ b/server/models/User.ts
@@ -290,8 +290,10 @@ class User extends ParanoidModel<
     type: NotificationEventType,
     value = true
   ) => {
-    this.notificationSettings[type] = value;
-    this.changed("notificationSettings", true);
+    this.notificationSettings = {
+      ...this.notificationSettings,
+      [type]: value,
+    };
   };
 
   /**
@@ -318,8 +320,10 @@ class User extends ParanoidModel<
     }
     const binary = value ? 1 : 0;
     if (this.flags[flag] !== binary) {
-      this.flags[flag] = binary;
-      this.changed("flags", true);
+      this.flags = {
+        ...this.flags,
+        [flag]: binary,
+      };
     }
 
     return this.flags;
@@ -345,9 +349,10 @@ class User extends ParanoidModel<
     if (!this.flags) {
       this.flags = {};
     }
-    this.flags[flag] = (this.flags[flag] ?? 0) + value;
-    this.changed("flags", true);
-
+    this.flags = {
+      ...this.flags,
+      [flag]: (this.flags[flag] ?? 0) + value,
+    };
     return this.flags;
   };
 
@@ -362,9 +367,10 @@ class User extends ParanoidModel<
     if (!this.preferences) {
       this.preferences = {};
     }
-    this.preferences[preference] = value;
-    this.changed("preferences", true);
-
+    this.preferences = {
+      ...this.preferences,
+      [preference]: value,
+    };
     return this.preferences;
   };
 

--- a/server/models/base/Model.test.ts
+++ b/server/models/base/Model.test.ts
@@ -1,0 +1,39 @@
+import { TeamPreference } from "@shared/types";
+import { buildTeam } from "@server/test/factories";
+
+describe("Model", () => {
+  describe("changeset", () => {
+    it("should return attributes changed since last save", async () => {
+      const team = await buildTeam({
+        name: "Test Team",
+      });
+      team.name = "New Name";
+      expect(Object.keys(team.changeset.attributes).length).toEqual(1);
+      expect(Object.keys(team.changeset.previousAttributes).length).toEqual(1);
+      expect(team.changeset.attributes.name).toEqual("New Name");
+      expect(team.changeset.previousAttributes.name).toEqual("Test Team");
+
+      await team.save();
+      expect(team.changeset.attributes).toEqual({});
+      expect(team.changeset.previousAttributes).toEqual({});
+    });
+
+    it("should return partial of objects", async () => {
+      const team = await buildTeam();
+      team.setPreference(TeamPreference.Commenting, false);
+      expect(team.changeset.attributes.preferences).toEqual({
+        commenting: false,
+      });
+      expect(team.changeset.previousAttributes.preferences).toEqual({});
+    });
+
+    it("should return boolean values", async () => {
+      const team = await buildTeam({
+        guestSignin: false,
+      });
+      team.guestSignin = true;
+      expect(team.changeset.attributes.guestSignin).toEqual(true);
+      expect(team.changeset.previousAttributes.guestSignin).toEqual(false);
+    });
+  });
+});

--- a/server/models/base/Model.test.ts
+++ b/server/models/base/Model.test.ts
@@ -10,13 +10,13 @@ describe("Model", () => {
       });
       team.name = "New Name";
       expect(Object.keys(team.changeset.attributes).length).toEqual(1);
-      expect(Object.keys(team.changeset.previousAttributes).length).toEqual(1);
+      expect(Object.keys(team.changeset.previous).length).toEqual(1);
       expect(team.changeset.attributes.name).toEqual("New Name");
-      expect(team.changeset.previousAttributes.name).toEqual("Test Team");
+      expect(team.changeset.previous.name).toEqual("Test Team");
 
       await team.save();
       expect(team.changeset.attributes).toEqual({});
-      expect(team.changeset.previousAttributes).toEqual({});
+      expect(team.changeset.previous).toEqual({});
     });
 
     it("should return partial of objects", async () => {
@@ -25,7 +25,7 @@ describe("Model", () => {
       expect(team.changeset.attributes.preferences).toEqual({
         commenting: false,
       });
-      expect(team.changeset.previousAttributes.preferences).toEqual({});
+      expect(team.changeset.previous.preferences).toEqual({});
     });
 
     it("should return boolean values", async () => {
@@ -34,10 +34,10 @@ describe("Model", () => {
       });
       team.guestSignin = true;
       expect(team.changeset.attributes.guestSignin).toEqual(true);
-      expect(team.changeset.previousAttributes.guestSignin).toEqual(false);
+      expect(team.changeset.previous.guestSignin).toEqual(false);
     });
 
-    it("should return full array if changed", async () => {
+    it("should return full array if value changed", async () => {
       const collaboratorId = uuid();
       const document = await buildDocument();
       const prev = document.collaboratorIds;
@@ -46,9 +46,7 @@ describe("Model", () => {
       expect(document.changeset.attributes.collaboratorIds).toEqual(
         document.collaboratorIds
       );
-      expect(document.changeset.previousAttributes.collaboratorIds).toEqual(
-        prev
-      );
+      expect(document.changeset.previous.collaboratorIds).toEqual(prev);
     });
   });
 });

--- a/server/models/base/Model.test.ts
+++ b/server/models/base/Model.test.ts
@@ -1,5 +1,6 @@
+import { v4 as uuid } from "uuid";
 import { TeamPreference } from "@shared/types";
-import { buildTeam } from "@server/test/factories";
+import { buildDocument, buildTeam } from "@server/test/factories";
 
 describe("Model", () => {
   describe("changeset", () => {
@@ -34,6 +35,20 @@ describe("Model", () => {
       team.guestSignin = true;
       expect(team.changeset.attributes.guestSignin).toEqual(true);
       expect(team.changeset.previousAttributes.guestSignin).toEqual(false);
+    });
+
+    it("should return full array if changed", async () => {
+      const collaboratorId = uuid();
+      const document = await buildDocument();
+      const prev = document.collaboratorIds;
+
+      document.collaboratorIds = [...document.collaboratorIds, collaboratorId];
+      expect(document.changeset.attributes.collaboratorIds).toEqual(
+        document.collaboratorIds
+      );
+      expect(document.changeset.previousAttributes.collaboratorIds).toEqual(
+        prev
+      );
     });
   });
 });

--- a/server/models/base/Model.ts
+++ b/server/models/base/Model.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
+import { isArray } from "lodash";
 import isEqual from "lodash/isEqual";
+import isObject from "lodash/isObject";
 import pick from "lodash/pick";
 import { FindOptions } from "sequelize";
 import { Model as SequelizeModel } from "sequelize-typescript";
@@ -59,10 +61,10 @@ class Model<
       const current = this.getDataValue(change);
 
       if (
-        typeof previous === "object" &&
-        typeof current === "object" &&
-        previous !== null &&
-        current !== null
+        isObject(previous) &&
+        isObject(current) &&
+        !isArray(previous) &&
+        !isArray(current)
       ) {
         const difference = Object.keys(previous)
           .concat(Object.keys(current))

--- a/server/models/base/Model.ts
+++ b/server/models/base/Model.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/ban-types */
-import { isArray } from "lodash";
+import isArray from "lodash/isArray";
 import isEqual from "lodash/isEqual";
 import isObject from "lodash/isObject";
 import pick from "lodash/pick";
-import { FindOptions } from "sequelize";
+import { FindOptions, NonAttribute } from "sequelize";
 import { Model as SequelizeModel } from "sequelize-typescript";
 
 class Model<
@@ -39,20 +39,20 @@ class Model<
   /**
    * Returns the attributes that have changed since the last save and their previous values.
    *
-   * @returns An object with `attributes` and `previousAttributes` keys.
+   * @returns An object with `attributes` and `previous` keys.
    */
-  public get changeset(): {
+  public get changeset(): NonAttribute<{
     attributes: Partial<TModelAttributes>;
-    previousAttributes: Partial<TModelAttributes>;
-  } {
+    previous: Partial<TModelAttributes>;
+  }> {
     const changes = this.changed() as Array<keyof TModelAttributes> | false;
     const attributes: Partial<TModelAttributes> = {};
-    const previousAttributes: Partial<TModelAttributes> = {};
+    const previous: Partial<TModelAttributes> = {};
 
     if (!changes) {
       return {
         attributes,
-        previousAttributes,
+        previous,
       };
     }
 
@@ -70,7 +70,7 @@ class Model<
           .concat(Object.keys(current))
           .filter((key) => !isEqual(previous[key], current[key]));
 
-        previousAttributes[change] = pick(
+        previous[change] = pick(
           previous,
           difference
         ) as TModelAttributes[keyof TModelAttributes];
@@ -79,14 +79,14 @@ class Model<
           difference
         ) as TModelAttributes[keyof TModelAttributes];
       } else {
-        previousAttributes[change] = previous;
+        previous[change] = previous;
         attributes[change] = current;
       }
     }
 
     return {
       attributes,
-      previousAttributes,
+      previous,
     };
   }
 }

--- a/server/models/base/Model.ts
+++ b/server/models/base/Model.ts
@@ -39,7 +39,7 @@ class Model<
   /**
    * Returns the attributes that have changed since the last save and their previous values.
    *
-   * @returns An object with `attributes` and `previous` keys.
+   * @returns An object with `attributes` and `previousAttributes` keys.
    */
   public get changeset(): NonAttribute<{
     attributes: Partial<TModelAttributes>;
@@ -47,12 +47,12 @@ class Model<
   }> {
     const changes = this.changed() as Array<keyof TModelAttributes> | false;
     const attributes: Partial<TModelAttributes> = {};
-    const previous: Partial<TModelAttributes> = {};
+    const previousAttributes: Partial<TModelAttributes> = {};
 
     if (!changes) {
       return {
         attributes,
-        previous,
+        previous: previousAttributes,
       };
     }
 
@@ -70,7 +70,7 @@ class Model<
           .concat(Object.keys(current))
           .filter((key) => !isEqual(previous[key], current[key]));
 
-        previous[change] = pick(
+        previousAttributes[change] = pick(
           previous,
           difference
         ) as TModelAttributes[keyof TModelAttributes];
@@ -79,14 +79,14 @@ class Model<
           difference
         ) as TModelAttributes[keyof TModelAttributes];
       } else {
-        previous[change] = previous;
+        previousAttributes[change] = previous;
         attributes[change] = current;
       }
     }
 
     return {
       attributes,
-      previous,
+      previous: previousAttributes,
     };
   }
 }

--- a/server/queues/processors/WebsocketsProcessor.ts
+++ b/server/queues/processors/WebsocketsProcessor.ts
@@ -15,6 +15,7 @@ import {
   Subscription,
   Notification,
   UserMembership,
+  User,
 } from "@server/models";
 import {
   presentComment,
@@ -27,6 +28,7 @@ import {
   presentSubscription,
   presentTeam,
   presentMembership,
+  presentUser,
 } from "@server/presenters";
 import presentNotification from "@server/presenters/notification";
 import { Event } from "../../types";
@@ -665,6 +667,19 @@ export default class WebsocketsProcessor {
         return socketio
           .to(`team-${event.teamId}`)
           .emit(event.name, presentTeam(team));
+      }
+
+      case "users.update": {
+        const user = await User.findByPk(event.userId);
+        if (!user) {
+          return;
+        }
+        socketio
+          .to(`user-${event.userId}`)
+          .emit(event.name, presentUser(user, { includeDetails: true }));
+
+        socketio.to(`team-${user.teamId}`).emit(event.name, presentUser(user));
+        return;
       }
 
       case "users.demote": {

--- a/server/routes/api/users/users.ts
+++ b/server/routes/api/users/users.ts
@@ -226,17 +226,17 @@ router.post(
         user.setPreference(key, preferences[key] as boolean);
       }
     }
-    await user.save({ transaction });
-    await Event.create(
+
+    await Event.createFromContext(
+      ctx,
       {
         name: "users.update",
-        actorId: user.id,
         userId: user.id,
-        teamId: user.teamId,
-        ip: ctx.request.ip,
+        changes: user.changeset,
       },
       { transaction }
     );
+    await user.save({ transaction });
 
     ctx.body = {
       data: presentUser(user, {
@@ -547,9 +547,18 @@ router.post(
   async (ctx: APIContext<T.UsersNotificationsSubscribeReq>) => {
     const { eventType } = ctx.input.body;
     const { transaction } = ctx.state;
-
     const { user } = ctx.state.auth;
     user.setNotificationEventType(eventType, true);
+
+    await Event.createFromContext(
+      ctx,
+      {
+        name: "users.update",
+        userId: user.id,
+        changes: user.changeset,
+      },
+      { transaction }
+    );
     await user.save({ transaction });
 
     ctx.body = {
@@ -566,9 +575,18 @@ router.post(
   async (ctx: APIContext<T.UsersNotificationsUnsubscribeReq>) => {
     const { eventType } = ctx.input.body;
     const { transaction } = ctx.state;
-
     const { user } = ctx.state.auth;
     user.setNotificationEventType(eventType, false);
+
+    await Event.createFromContext(
+      ctx,
+      {
+        name: "users.update",
+        userId: user.id,
+        changes: user.changeset,
+      },
+      { transaction }
+    );
     await user.save({ transaction });
 
     ctx.body = {


### PR DESCRIPTION
- Fixed user model updates are not synced between clients
- Added `Model.changeset` to calculate difference since last persisted
- Added `Event.changes` column to store the above
- Added `Event.createFromContext` to simplify common creation pattern

Related https://github.com/outline/outline/pull/5909