### PR TITLE
chore: Track `lastActiveAt` for teams

### DIFF
--- a/server/middlewares/authentication.ts
+++ b/server/middlewares/authentication.ts
@@ -122,9 +122,12 @@ export default function auth(options: AuthenticationOptions = {}) {
         }
       }
 
-      // not awaiting the promise here so that the request is not blocked
+      // not awaiting the promises here so that the request is not blocked
       user.updateActiveAt(ctx).catch((err) => {
         Logger.error("Failed to update user activeAt", err);
+      });
+      user.team?.updateActiveAt().catch((err) => {
+        Logger.error("Failed to update team activeAt", err);
       });
 
       ctx.state.auth = {

--- a/server/migrations/20240204185157-team-last-active-at.js
+++ b/server/migrations/20240204185157-team-last-active-at.js
@@ -1,0 +1,11 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn("teams", "lastActiveAt", {
+      type: Sequelize.DATE,
+      allowNull: true,
+    });
+  },
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn("teams", "lastActiveAt");
+  },
+};


### PR DESCRIPTION
This could be dynamically derived from users but it makes life a lot easier to have a column specifically for this.