### PR TITLE
Move in-app notifications to instant, keep emails delayed

### DIFF
--- a/server/emails/templates/BaseEmail.tsx
+++ b/server/emails/templates/BaseEmail.tsx
@@ -92,6 +92,15 @@ export default abstract class BaseEmail<
       ? await Notification.unscoped().findByPk(this.metadata?.notificationId)
       : undefined;
 
+    if (notification?.viewedAt) {
+      Logger.info(
+        "email",
+        `Email ${templateName} not sent as already viewed`,
+        this.props
+      );
+      return;
+    }
+
     try {
       await mailer.sendMail({
         to: this.props.to,

--- a/server/queues/processors/EmailsProcessor.ts
+++ b/server/queues/processors/EmailsProcessor.ts
@@ -1,4 +1,5 @@
 import { NotificationEventType } from "@shared/types";
+import { Minute } from "@shared/utils/time";
 import CollectionCreatedEmail from "@server/emails/templates/CollectionCreatedEmail";
 import CollectionSharedEmail from "@server/emails/templates/CollectionSharedEmail";
 import CommentCreatedEmail from "@server/emails/templates/CommentCreatedEmail";
@@ -32,6 +33,7 @@ export default class EmailsProcessor extends BaseProcessor {
     switch (notification.event) {
       case NotificationEventType.UpdateDocument:
       case NotificationEventType.PublishDocument: {
+        // No need to delay email here as the notification itself is already delayed
         await new DocumentPublishedOrUpdatedEmail(
           {
             to: notification.user.email,
@@ -57,7 +59,9 @@ export default class EmailsProcessor extends BaseProcessor {
             actorName: notification.actor.name,
           },
           { notificationId }
-        ).schedule();
+        ).schedule({
+          delay: Minute,
+        });
         return;
       }
 
@@ -71,11 +75,14 @@ export default class EmailsProcessor extends BaseProcessor {
             actorName: notification.actor.name,
           },
           { notificationId }
-        ).schedule();
+        ).schedule({
+          delay: Minute,
+        });
         return;
       }
 
       case NotificationEventType.MentionedInDocument: {
+        // No need to delay email here as the notification itself is already delayed
         await new DocumentMentionedEmail(
           {
             to: notification.user.email,
@@ -99,7 +106,9 @@ export default class EmailsProcessor extends BaseProcessor {
             commentId: notification.commentId,
           },
           { notificationId: notification.id }
-        ).schedule();
+        ).schedule({
+          delay: Minute,
+        });
         return;
       }
 
@@ -112,7 +121,9 @@ export default class EmailsProcessor extends BaseProcessor {
             teamUrl: notification.team.url,
           },
           { notificationId: notification.id }
-        ).schedule();
+        ).schedule({
+          delay: Minute,
+        });
         return;
       }
 
@@ -127,7 +138,9 @@ export default class EmailsProcessor extends BaseProcessor {
             commentId: notification.commentId,
           },
           { notificationId: notification.id }
-        ).schedule();
+        ).schedule({
+          delay: Minute,
+        });
       }
     }
   }

--- a/server/queues/processors/NotificationsProcessor.ts
+++ b/server/queues/processors/NotificationsProcessor.ts
@@ -1,4 +1,3 @@
-import { Minute } from "@shared/utils/time";
 import {
   CollectionEvent,
   RevisionEvent,
@@ -65,10 +64,7 @@ export default class NotificationsProcessor extends BaseProcessor {
     if (!event.data.isNew || event.userId === event.actorId) {
       return;
     }
-
-    await DocumentAddUserNotificationsTask.schedule(event, {
-      delay: Minute,
-    });
+    await DocumentAddUserNotificationsTask.schedule(event);
   }
 
   async revisionCreated(event: RevisionEvent) {
@@ -93,20 +89,14 @@ export default class NotificationsProcessor extends BaseProcessor {
       return;
     }
 
-    await CollectionAddUserNotificationsTask.schedule(event, {
-      delay: Minute,
-    });
+    await CollectionAddUserNotificationsTask.schedule(event);
   }
 
   async commentCreated(event: CommentEvent) {
-    await CommentCreatedNotificationsTask.schedule(event, {
-      delay: Minute,
-    });
+    await CommentCreatedNotificationsTask.schedule(event);
   }
 
   async commentUpdated(event: CommentEvent) {
-    await CommentUpdatedNotificationsTask.schedule(event, {
-      delay: Minute,
-    });
+    await CommentUpdatedNotificationsTask.schedule(event);
   }
 }


### PR DESCRIPTION
closes #6478 – that was simpler than expected.