### PR TITLE
fix: URL RegExp for embeds

### DIFF
--- a/shared/utils/urls.ts
+++ b/shared/utils/urls.ts
@@ -152,5 +152,7 @@ export function urlRegex(url: string | null | undefined): RegExp | undefined {
 
   const urlObj = new URL(sanitizeUrl(url) as string);
 
-  return new RegExp(escapeRegExp(`${urlObj.protocol}//${urlObj.host}`));
+  return new RegExp(
+    "^" + escapeRegExp(`${urlObj.protocol}//${urlObj.host}`) + "/(.+)$"
+  );
 }


### PR DESCRIPTION
This is a simple fix that allows embedded URLs of integrations with a `url` parameter set in their preferences (currently Draw.io and Grist) to be matched again.

Closes #6451