### PR TITLE
Add ability to logout from OIDC

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -103,6 +103,7 @@ OIDC_CLIENT_SECRET=
 OIDC_AUTH_URI=
 OIDC_TOKEN_URI=
 OIDC_USERINFO_URI=
+OIDC_LOGOUT_URI=
 
 # Specify which claims to derive user information from
 # Supports any valid JSON path with the JWT payload

--- a/app.json
+++ b/app.json
@@ -81,6 +81,10 @@
       "description": "",
       "required": false
     },
+    "OIDC_LOGOUT_URI": {
+      "description": "",
+      "required": false
+    },
     "OIDC_USERNAME_CLAIM": {
       "description": "Specify which claims to derive user information from. Supports any valid JSON path with the JWT payload",
       "value": "preferred_username",

--- a/app/actions/definitions/navigation.tsx
+++ b/app/actions/definitions/navigation.tsx
@@ -211,7 +211,7 @@ export const logout = createAction({
   section: NavigationSection,
   icon: <LogoutIcon />,
   perform: () => {
-    stores.auth.logout();
+    void stores.auth.logout();
     if (env.OIDC_LOGOUT_URI) {
       window.location.replace(env.OIDC_LOGOUT_URI);
     }

--- a/app/actions/definitions/navigation.tsx
+++ b/app/actions/definitions/navigation.tsx
@@ -26,6 +26,7 @@ import SearchQuery from "~/models/SearchQuery";
 import KeyboardShortcuts from "~/scenes/KeyboardShortcuts";
 import { createAction } from "~/actions";
 import { NavigationSection, RecentSearchesSection } from "~/actions/sections";
+import env from "~/env";
 import Desktop from "~/utils/Desktop";
 import history from "~/utils/history";
 import isCloudHosted from "~/utils/isCloudHosted";
@@ -209,7 +210,11 @@ export const logout = createAction({
   analyticsName: "Log out",
   section: NavigationSection,
   icon: <LogoutIcon />,
-  perform: () => stores.auth.logout(),
+  perform: () => {
+    stores.auth.logout();
+    if (env.OIDC_LOGOUT_URI)
+      window.location.replace(env.OIDC_LOGOUT_URI);
+  },
 });
 
 export const rootNavigationActions = [

--- a/app/actions/definitions/navigation.tsx
+++ b/app/actions/definitions/navigation.tsx
@@ -212,8 +212,9 @@ export const logout = createAction({
   icon: <LogoutIcon />,
   perform: () => {
     stores.auth.logout();
-    if (env.OIDC_LOGOUT_URI)
+    if (env.OIDC_LOGOUT_URI) {
       window.location.replace(env.OIDC_LOGOUT_URI);
+    }
   },
 });
 

--- a/app/scenes/Logout.tsx
+++ b/app/scenes/Logout.tsx
@@ -8,6 +8,7 @@ const Logout = () => {
   void auth.logout();
   if (env.OIDC_LOGOUT_URI) {
     window.location.replace(env.OIDC_LOGOUT_URI);
+    return null;
   }
   return <Redirect to="/" />;
 };

--- a/app/scenes/Logout.tsx
+++ b/app/scenes/Logout.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Redirect } from "react-router-dom";
-import env from "@shared/env";
+import env from "~/env";
 import useStores from "~/hooks/useStores";
 
 const Logout = () => {

--- a/app/scenes/Logout.tsx
+++ b/app/scenes/Logout.tsx
@@ -1,3 +1,4 @@
+import env from "@shared/env";
 import * as React from "react";
 import { Redirect } from "react-router-dom";
 import useStores from "~/hooks/useStores";
@@ -5,6 +6,8 @@ import useStores from "~/hooks/useStores";
 const Logout = () => {
   const { auth } = useStores();
   void auth.logout();
+  if (env.OIDC_LOGOUT_URI)
+    window.location.replace(env.OIDC_LOGOUT_URI);
   return <Redirect to="/" />;
 };
 

--- a/app/scenes/Logout.tsx
+++ b/app/scenes/Logout.tsx
@@ -1,6 +1,6 @@
-import env from "@shared/env";
 import * as React from "react";
 import { Redirect } from "react-router-dom";
+import env from "@shared/env";
 import useStores from "~/hooks/useStores";
 
 const Logout = () => {

--- a/app/scenes/Logout.tsx
+++ b/app/scenes/Logout.tsx
@@ -6,8 +6,9 @@ import useStores from "~/hooks/useStores";
 const Logout = () => {
   const { auth } = useStores();
   void auth.logout();
-  if (env.OIDC_LOGOUT_URI)
+  if (env.OIDC_LOGOUT_URI) {
     window.location.replace(env.OIDC_LOGOUT_URI);
+  }
   return <Redirect to="/" />;
 };
 

--- a/server/env.ts
+++ b/server/env.ts
@@ -500,6 +500,18 @@ export class Environment {
   );
 
   /**
+   * The OIDC logout endpoint.
+   */
+  @IsOptional()
+  @IsUrl({
+    require_tld: false,
+    allow_underscores: true,
+  })
+  public OIDC_LOGOUT_URI = this.toOptionalString(
+    process.env.OIDC_LOGOUT_URI
+  );
+
+  /**
    * The OIDC profile field to use as the username. The default value is
    * "preferred_username".
    */

--- a/server/env.ts
+++ b/server/env.ts
@@ -507,9 +507,7 @@ export class Environment {
     require_tld: false,
     allow_underscores: true,
   })
-  public OIDC_LOGOUT_URI = this.toOptionalString(
-    process.env.OIDC_LOGOUT_URI
-  );
+  public OIDC_LOGOUT_URI = this.toOptionalString(process.env.OIDC_LOGOUT_URI);
 
   /**
    * The OIDC profile field to use as the username. The default value is

--- a/server/presenters/env.ts
+++ b/server/presenters/env.ts
@@ -33,6 +33,7 @@ export default function present(
       process.env.SOURCE_COMMIT || process.env.SOURCE_VERSION || undefined,
     APP_NAME: env.APP_NAME,
     ROOT_SHARE_ID: options.rootShareId || undefined,
+    OIDC_LOGOUT_URI: env.OIDC_LOGOUT_URI || undefined,
 
     analytics: {
       service: options.analytics?.service,

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -61,6 +61,7 @@ export type PublicEnv = {
   RELEASE: string | undefined;
   APP_NAME: string;
   ROOT_SHARE_ID?: string;
+  OIDC_LOGOUT_URI?: string;
   analytics: {
     service?: IntegrationService | UserCreatableIntegrationService;
     settings?: IntegrationSettings<IntegrationType.Analytics>;


### PR DESCRIPTION
Adds ability to add OIDC_LOGOUT_URI to .env to enable logout redirect. 

Closes #3954 

May need to be adjusted to check how the user was logged in? Currently whenever the user logs out, if OIDC_LOGOUT_URL is set, it will redirect to the OIDC logout endpoint, regardless of how the user logged in.
If the app only has OIDC authentication, this won't be an issue, but could be if the app has multiple authentication methods.