### PR TITLE
Propagate Enter key events in SuggestionsMenu so that handleLinkInputKeydown() can handle it.

### DIFF
--- a/app/editor/components/SuggestionsMenu.tsx
+++ b/app/editor/components/SuggestionsMenu.tsx
@@ -467,7 +467,6 @@ function SuggestionsMenu<T extends MenuItem>(props: Props<T>) {
 
       if (event.key === "Enter") {
         event.preventDefault();
-        event.stopPropagation();
 
         const item = filtered[selectedIndex];
 


### PR DESCRIPTION
In SuggestionsMenu, Enter key events are not being propagated to handleLinkInputKeydown().