### PR TITLE
Do not load opensearch.xml from CDN, so it uses the correct team subdomain

### DIFF
--- a/server/static/index.html
+++ b/server/static/index.html
@@ -14,7 +14,7 @@
     {prefetch}
     <link rel="shortcut icon" type="image/png" href="{shortcut-icon}" sizes="32x32" />
     <link rel="apple-touch-icon" type="image/png" href="{cdn-url}/static/images/apple-touch-icon.png" sizes="192x192" />
-    <link rel="search" type="application/opensearchdescription+xml" href="{cdn-url}/opensearch.xml" title="Outline" />
+    <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Outline" />
     <style>
       @font-face {
         font-family: "Inter";


### PR DESCRIPTION
Fixes a bug that results in a broken opensearch.xml for team subdomains.

See https://github.com/outline/outline/issues/3470 -- that issue, with the same reproduction steps, is happening again due to a change in 3eabb309493a88473932ddabefa1fdff93c11bde. It changed the opensearch URL from `/opensearch.xml` to `{cdn-url}/opensearch.xml`.

The team subdomain's `/opensearch.xml` is correct, but because the `<link rel="search" ...` points to the CDN URL, this correct opensearch.xml is not used.