### PR TITLE
Add ability to sync groups with OIDC provider

### DIFF
--- a/plugins/oidc/server/auth/oidc.ts
+++ b/plugins/oidc/server/auth/oidc.ts
@@ -126,7 +126,7 @@ if (
                 "The groups claim in the profile parameter that was returned must be an array."
               );
             }
-            groups = (profile[env.OIDC_GROUPS_CLAIM] as unknown) as string[];
+            groups = profile[env.OIDC_GROUPS_CLAIM] as unknown as string[];
           }
 
           const result = await accountProvisioner({

--- a/plugins/oidc/server/auth/oidc.ts
+++ b/plugins/oidc/server/auth/oidc.ts
@@ -119,6 +119,16 @@ if (
             );
           }
 
+          let groups: undefined | string[];
+          if (env.OIDC_GROUPS_CLAIM && profile[env.OIDC_GROUPS_CLAIM]) {
+            if (!Array.isArray(profile[env.OIDC_GROUPS_CLAIM])) {
+              throw AuthenticationError(
+                "The groups claim in the profile parameter that was returned must be an array."
+              );
+            }
+            groups = (profile[env.OIDC_GROUPS_CLAIM] as unknown) as string[];
+          }
+
           const result = await accountProvisioner({
             ip: ctx.ip,
             team: {
@@ -137,6 +147,7 @@ if (
               name: providerName,
               providerId: domain,
             },
+            groups,
             authentication: {
               providerId,
               accessToken,

--- a/server/commands/accountProvisioner.ts
+++ b/server/commands/accountProvisioner.ts
@@ -7,8 +7,8 @@ import {
 import { traceFunction } from "@server/logging/tracing";
 import { AuthenticationProvider, Collection, Team, User } from "@server/models";
 import teamProvisioner from "./teamProvisioner";
-import userProvisioner from "./userProvisioner";
 import userGroupsUpdater from "./userGroupsUpdater";
+import userProvisioner from "./userProvisioner";
 
 type Props = {
   /** The IP address of the incoming request */

--- a/server/commands/accountProvisioner.ts
+++ b/server/commands/accountProvisioner.ts
@@ -8,6 +8,7 @@ import { traceFunction } from "@server/logging/tracing";
 import { AuthenticationProvider, Collection, Team, User } from "@server/models";
 import teamProvisioner from "./teamProvisioner";
 import userProvisioner from "./userProvisioner";
+import userGroupsUpdater from "./userGroupsUpdater";
 
 type Props = {
   /** The IP address of the incoming request */
@@ -37,6 +38,8 @@ type Props = {
     /** The public url of an image representing the team */
     avatarUrl?: string | null;
   };
+  /** Groups the user belongs to */
+  groups?: string[];
   /** Details of the authentication provider being used */
   authenticationProvider: {
     /** The name of the authentication provider, eg "google" */
@@ -70,6 +73,7 @@ async function accountProvisioner({
   ip,
   user: userParams,
   team: teamParams,
+  groups: groupsParam,
   authenticationProvider: authenticationProviderParams,
   authentication: authenticationParams,
 }: Props): Promise<AccountProvisionerResult> {
@@ -171,6 +175,10 @@ async function accountProvisioner({
     if (provision) {
       await team.provisionFirstCollection(user.id);
     }
+  }
+
+  if (groupsParam) {
+    await userGroupsUpdater(user, groupsParam);
   }
 
   return {

--- a/server/commands/userGroupsUpdater.ts
+++ b/server/commands/userGroupsUpdater.ts
@@ -3,48 +3,45 @@ import GroupUser from "@server/models/GroupUser";
 import User from "@server/models/User";
 
 export default async function userGroupsUpdater(
-    user: User,
-    groupNames: string[]
+  user: User,
+  groupNames: string[]
 ) {
-    groupNames = Array.from(new Set(groupNames));
-    const groups = [];
-    for (const groupName of groupNames) {
-        let group = await Group.findOne({
-            where: {
-                name: groupName,
-            },
-        });
-        if (!group) {
-            group = await Group.create({
-                name: groupName,
-                teamId: user.teamId,
-                createdById: user.id,
-            });
-        }
-        groups.push(group);
-    }
-    const nextGroupIds = groups.map((group) => group.id);
-
-    const oldGroupUsers = await GroupUser.findAll({
-        where: {
-            userId: user.id,
-        },
+  groupNames = Array.from(new Set(groupNames));
+  const groups = [];
+  for (const groupName of groupNames) {
+    let group = await Group.findOne({
+      where: {
+        name: groupName,
+      },
     });
-
-    const oldGroupIds = oldGroupUsers.map((groupUser) => groupUser.groupId);
-
-    for (const groupUser of oldGroupUsers) {
-        if (!nextGroupIds.includes(groupUser.groupId)) {
-            await groupUser.destroy();
-        }
+    if (!group) {
+      group = await Group.create({
+        name: groupName,
+        teamId: user.teamId,
+        createdById: user.id,
+      });
     }
-    for (const groupId of nextGroupIds) {
-        if (!oldGroupIds.includes(groupId)) {
-            await GroupUser.create({
-                groupId,
-                userId: user.id,
-                createdById: user.id,
-            });
-        }
+    groups.push(group);
+  }
+  const nextGroupIds = groups.map((group) => group.id);
+  const oldGroupUsers = await GroupUser.findAll({
+    where: {
+      userId: user.id,
+    },
+  });
+  const oldGroupIds = oldGroupUsers.map((groupUser) => groupUser.groupId);
+  for (const groupUser of oldGroupUsers) {
+    if (!nextGroupIds.includes(groupUser.groupId)) {
+      await groupUser.destroy();
     }
+  }
+  for (const groupId of nextGroupIds) {
+    if (!oldGroupIds.includes(groupId)) {
+      await GroupUser.create({
+        groupId,
+        userId: user.id,
+        createdById: user.id,
+      });
+    }
+  }
 }

--- a/server/commands/userGroupsUpdater.ts
+++ b/server/commands/userGroupsUpdater.ts
@@ -1,0 +1,50 @@
+import Group from "@server/models/Group";
+import GroupUser from "@server/models/GroupUser";
+import User from "@server/models/User";
+
+export default async function userGroupsUpdater(
+    user: User,
+    groupNames: string[]
+) {
+    groupNames = Array.from(new Set(groupNames));
+    const groups = [];
+    for (const groupName of groupNames) {
+        let group = await Group.findOne({
+            where: {
+                name: groupName,
+            },
+        });
+        if (!group) {
+            group = await Group.create({
+                name: groupName,
+                teamId: user.teamId,
+                createdById: user.id,
+            });
+        }
+        groups.push(group);
+    }
+    const nextGroupIds = groups.map((group) => group.id);
+
+    const oldGroupUsers = await GroupUser.findAll({
+        where: {
+            userId: user.id,
+        },
+    });
+
+    const oldGroupIds = oldGroupUsers.map((groupUser) => groupUser.groupId);
+
+    for (const groupUser of oldGroupUsers) {
+        if (!nextGroupIds.includes(groupUser.groupId)) {
+            await groupUser.destroy();
+        }
+    }
+    for (const groupId of nextGroupIds) {
+        if (!oldGroupIds.includes(groupId)) {
+            await GroupUser.create({
+                groupId,
+                userId: user.id,
+                createdById: user.id,
+            });
+        }
+    }
+}

--- a/server/env.ts
+++ b/server/env.ts
@@ -527,6 +527,16 @@ export class Environment {
     process.env.OIDC_USERNAME_CLAIM ?? "preferred_username";
 
   /**
+   * The OIDC profile field to use for groups claim. If set, this should
+   * contain an array of group names (as strings). The groups will be created
+   * if missing and the user's group memberships will be updated accordingly.
+   */
+  public OIDC_GROUPS_CLAIM = this.toOptionalString(
+    process.env.OIDC_GROUPS_CLAIM
+  );
+
+
+  /**
    * A space separated list of OIDC scopes to request. Defaults to "openid
    * profile email".
    */

--- a/server/env.ts
+++ b/server/env.ts
@@ -535,7 +535,6 @@ export class Environment {
     process.env.OIDC_GROUPS_CLAIM
   );
 
-
   /**
    * A space separated list of OIDC scopes to request. Defaults to "openid
    * profile email".


### PR DESCRIPTION
Currently there is no way to sync groups between OIDC and outline groups.

Adding a env var `OIDC_GROUPS_CLAIM` that, if set, will add any missing groups and add the user to them, then remove them from any groups they should no longer be in.

If the env var is not set, nothing will happen, so this entirely opt in.