### PR TITLE
chore: Move processing of `documents.import` to async worker

### DIFF
--- a/server/queues/tasks/DocumentImportTask.ts
+++ b/server/queues/tasks/DocumentImportTask.ts
@@ -1,0 +1,83 @@
+import { SourceMetadata } from "@shared/types";
+import documentCreator from "@server/commands/documentCreator";
+import documentImporter from "@server/commands/documentImporter";
+import { User } from "@server/models";
+import { sequelize } from "@server/storage/database";
+import FileStorage from "@server/storage/files";
+import BaseTask, { TaskPriority } from "./BaseTask";
+
+type Props = {
+  userId: string;
+  sourceMetadata: Pick<Required<SourceMetadata>, "fileName" | "mimeType">;
+  publish?: boolean;
+  collectionId?: string;
+  parentDocumentId?: string;
+  ip: string;
+  key: string;
+};
+
+export type DocumentImportTaskResponse =
+  | {
+      documentId: string;
+    }
+  | {
+      error: string;
+    };
+
+export default class DocumentImportTask extends BaseTask<Props> {
+  public async perform({
+    key,
+    sourceMetadata,
+    ip,
+    publish,
+    collectionId,
+    parentDocumentId,
+    userId,
+  }: Props): Promise<DocumentImportTaskResponse> {
+    try {
+      const content = await FileStorage.getFileBuffer(key);
+
+      const document = await sequelize.transaction(async (transaction) => {
+        const user = await User.findByPk(userId, {
+          rejectOnEmpty: true,
+          transaction,
+        });
+
+        const { text, state, title, emoji } = await documentImporter({
+          user,
+          fileName: sourceMetadata.fileName,
+          mimeType: sourceMetadata.mimeType,
+          content,
+          ip,
+          transaction,
+        });
+
+        return documentCreator({
+          sourceMetadata,
+          title,
+          emoji,
+          text,
+          state,
+          publish,
+          collectionId,
+          parentDocumentId,
+          user,
+          ip,
+          transaction,
+        });
+      });
+      return { documentId: document.id };
+    } catch (err) {
+      return { error: err.message };
+    } finally {
+      await FileStorage.deleteFile(key);
+    }
+  }
+
+  public get options() {
+    return {
+      attempts: 1,
+      priority: TaskPriority.Normal,
+    };
+  }
+}

--- a/server/services/worker.ts
+++ b/server/services/worker.ts
@@ -143,7 +143,7 @@ export default function init() {
         const task = new TaskClass();
 
         try {
-          await task.perform(props);
+          return await task.perform(props);
         } catch (err) {
           Logger.error(`Error processing task in ${name}`, err, props);
           throw err;


### PR DESCRIPTION
Improves resiliency of document import process without changing API interface