### PR TITLE
feat: Archive all notifications

### DIFF
--- a/app/actions/definitions/notifications.tsx
+++ b/app/actions/definitions/notifications.tsx
@@ -1,4 +1,4 @@
-import { MarkAsReadIcon } from "outline-icons";
+import { ArchiveIcon, MarkAsReadIcon } from "outline-icons";
 import * as React from "react";
 import { createAction } from "..";
 import { NotificationSection } from "../sections";
@@ -13,4 +13,16 @@ export const markNotificationsAsRead = createAction({
   visible: ({ stores }) => stores.notifications.approximateUnreadCount > 0,
 });
 
-export const rootNotificationActions = [markNotificationsAsRead];
+export const markNotificationsAsArchived = createAction({
+  name: ({ t }) => t("Archive all notifications"),
+  analyticsName: "Mark notifications as archived",
+  section: NotificationSection,
+  icon: <ArchiveIcon />,
+  perform: ({ stores }) => stores.notifications.markAllAsArchived(),
+  visible: ({ stores }) => stores.notifications.orderedData.length > 0,
+});
+
+export const rootNotificationActions = [
+  markNotificationsAsRead,
+  markNotificationsAsArchived,
+];

--- a/app/actions/definitions/notifications.tsx
+++ b/app/actions/definitions/notifications.tsx
@@ -18,6 +18,7 @@ export const markNotificationsAsArchived = createAction({
   analyticsName: "Mark notifications as archived",
   section: NotificationSection,
   icon: <ArchiveIcon />,
+  iconInContextMenu: false,
   perform: ({ stores }) => stores.notifications.markAllAsArchived(),
   visible: ({ stores }) => stores.notifications.orderedData.length > 0,
 });

--- a/app/components/ContextMenu/index.tsx
+++ b/app/components/ContextMenu/index.tsx
@@ -38,6 +38,8 @@ export type Placement =
 
 type Props = MenuStateReturn & {
   "aria-label"?: string;
+  /** Reference to the rendered menu div element */
+  menuRef?: React.RefObject<HTMLDivElement>;
   /** The parent menu state if this is a submenu. */
   parentMenuState?: Omit<MenuStateReturn, "items">;
   /** Called when the context menu is opened. */
@@ -52,6 +54,7 @@ type Props = MenuStateReturn & {
 };
 
 const ContextMenu: React.FC<Props> = ({
+  menuRef,
   children,
   onOpen,
   onClose,
@@ -96,16 +99,21 @@ const ContextMenu: React.FC<Props> = ({
     t,
   ]);
 
-  // Perf win – don't render anything until the menu has been opened
+  // Perf win – render an empty menu until the menu has been opened
   if (!rest.visible && !previousVisible) {
-    return null;
+    return <Menu {...rest} />;
   }
 
   // sets the menu height based on the available space between the disclosure/
   // trigger and the bottom of the window
   return (
     <>
-      <Menu hideOnClickOutside={!isMobile} preventBodyScroll={false} {...rest}>
+      <Menu
+        ref={menuRef}
+        hideOnClickOutside={!isMobile}
+        preventBodyScroll={false}
+        {...rest}
+      >
         {(props) => (
           <InnerContextMenu
             // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/app/components/ContextMenu/index.tsx
+++ b/app/components/ContextMenu/index.tsx
@@ -99,9 +99,9 @@ const ContextMenu: React.FC<Props> = ({
     t,
   ]);
 
-  // Perf win – render an empty menu until the menu has been opened
+  // Perf win – don't render anything until the menu has been opened
   if (!rest.visible && !previousVisible) {
-    return <Menu {...rest} />;
+    return null;
   }
 
   // sets the menu height based on the available space between the disclosure/

--- a/app/components/Notifications/Notifications.tsx
+++ b/app/components/Notifications/Notifications.tsx
@@ -1,14 +1,14 @@
 import { observer } from "mobx-react";
-import { MarkAsReadIcon, SettingsIcon } from "outline-icons";
+import { MarkAsReadIcon } from "outline-icons";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { s } from "@shared/styles";
 import Notification from "~/models/Notification";
-import { navigateToNotificationSettings } from "~/actions/definitions/navigation";
 import { markNotificationsAsRead } from "~/actions/definitions/notifications";
 import useActionContext from "~/hooks/useActionContext";
 import useStores from "~/hooks/useStores";
+import NotificationMenu from "~/menus/NotificationMenu";
 import { hover } from "~/styles";
 import Desktop from "~/utils/Desktop";
 import Empty from "../Empty";
@@ -56,7 +56,7 @@ function Notifications(
           <Text weight="bold" as="span">
             {t("Notifications")}
           </Text>
-          <Text color="textSecondary" as={Flex} gap={8}>
+          <Flex gap={8}>
             {notifications.approximateUnreadCount > 0 && (
               <Tooltip delay={500} content={t("Mark all as read")}>
                 <Button action={markNotificationsAsRead} context={context}>
@@ -64,17 +64,14 @@ function Notifications(
                 </Button>
               </Tooltip>
             )}
-            <Tooltip delay={500} content={t("Settings")}>
-              <Button action={navigateToNotificationSettings} context={context}>
-                <SettingsIcon />
-              </Button>
-            </Tooltip>
-          </Text>
+            <NotificationMenu />
+          </Flex>
         </Header>
         <React.Suspense fallback={null}>
           <Scrollable ref={ref} flex topShadow>
             <PaginatedList
               fetch={notifications.fetchPage}
+              options={{ archived: false }}
               items={notifications.orderedData}
               renderItem={(item: Notification) => (
                 <NotificationListItem
@@ -113,7 +110,7 @@ const Button = styled(NudeButton)`
 
 const Header = styled(Flex)`
   padding: 8px 12px 12px;
-  height: 44px;
+  min-height: 44px;
 
   ${Button} {
     opacity: 0.75;

--- a/app/menus/NotificationMenu.tsx
+++ b/app/menus/NotificationMenu.tsx
@@ -1,0 +1,76 @@
+import { t } from "i18next";
+import { MoreIcon, SettingsIcon } from "outline-icons";
+import React from "react";
+import { MenuButton, useMenuState } from "reakit/Menu";
+import styled from "styled-components";
+import { s } from "@shared/styles";
+import ContextMenu from "~/components/ContextMenu";
+import Template from "~/components/ContextMenu/Template";
+import NudeButton from "~/components/NudeButton";
+import { actionToMenuItem, performAction } from "~/actions";
+import { navigateToNotificationSettings } from "~/actions/definitions/navigation";
+import { markNotificationsAsArchived } from "~/actions/definitions/notifications";
+import useActionContext from "~/hooks/useActionContext";
+import useOnClickOutside from "~/hooks/useOnClickOutside";
+import { hover } from "~/styles";
+import { MenuItem } from "~/types";
+
+const NotificationMenu: React.FC = () => {
+  const menuRef = React.useRef<HTMLDivElement>(null);
+  const menu = useMenuState({
+    modal: true,
+  });
+  const context = useActionContext();
+  const items: MenuItem[] = React.useMemo(
+    () => [
+      actionToMenuItem(markNotificationsAsArchived, context),
+      {
+        type: "button",
+        title: "Notification settings",
+        visible: true,
+        onClick: () => performAction(navigateToNotificationSettings, context),
+        icon: <SettingsIcon />,
+      },
+    ],
+    [context]
+  );
+
+  useOnClickOutside(
+    menuRef,
+    (event) => {
+      if (menu.visible) {
+        event.stopPropagation();
+        event.preventDefault();
+        menu.hide();
+      }
+    },
+    { capture: true }
+  );
+
+  return (
+    <>
+      <MenuButton {...menu}>
+        {(props) => (
+          <Button {...props}>
+            <MoreIcon />
+          </Button>
+        )}
+      </MenuButton>
+      <ContextMenu {...menu} menuRef={menuRef} aria-label={t("Notification")}>
+        <Template {...menu} items={items} />
+      </ContextMenu>
+    </>
+  );
+};
+
+const Button = styled(NudeButton)`
+  color: ${s("textSecondary")};
+
+  &:${hover},
+  &:active {
+    color: ${s("text")};
+    background: ${s("sidebarControlHoverBackground")};
+  }
+`;
+
+export default NotificationMenu;

--- a/app/menus/NotificationMenu.tsx
+++ b/app/menus/NotificationMenu.tsx
@@ -17,9 +17,7 @@ import { MenuItem } from "~/types";
 
 const NotificationMenu: React.FC = () => {
   const menuRef = React.useRef<HTMLDivElement>(null);
-  const menu = useMenuState({
-    modal: true,
-  });
+  const menu = useMenuState();
   const context = useActionContext();
   const items: MenuItem[] = React.useMemo(
     () => [

--- a/app/menus/NotificationMenu.tsx
+++ b/app/menus/NotificationMenu.tsx
@@ -1,5 +1,5 @@
 import { t } from "i18next";
-import { MoreIcon, SettingsIcon } from "outline-icons";
+import { MoreIcon } from "outline-icons";
 import React from "react";
 import { MenuButton, useMenuState } from "reakit/Menu";
 import styled from "styled-components";
@@ -27,7 +27,6 @@ const NotificationMenu: React.FC = () => {
         title: "Notification settings",
         visible: true,
         onClick: () => performAction(navigateToNotificationSettings, context),
-        icon: <SettingsIcon />,
       },
     ],
     [context]

--- a/app/stores/NotificationsStore.ts
+++ b/app/stores/NotificationsStore.ts
@@ -55,6 +55,20 @@ export default class NotificationsStore extends Store<Notification> {
   };
 
   /**
+   * Mark all notifications as archived.
+   */
+  @action
+  markAllAsArchived = async () => {
+    await client.post("/notifications.update_all", {
+      archivedAt: new Date().toISOString(),
+    });
+
+    runInAction("NotificationsStore#markAllAsArchived", () => {
+      this.clear();
+    });
+  };
+
+  /**
    * Returns the approximate number of unread notifications.
    */
   @computed

--- a/server/routes/api/notifications/notifications.ts
+++ b/server/routes/api/notifications/notifications.ts
@@ -1,4 +1,5 @@
 import Router from "koa-router";
+import { isNil } from "lodash";
 import isNull from "lodash/isNull";
 import isUndefined from "lodash/isUndefined";
 import { WhereOptions, Op } from "sequelize";
@@ -80,12 +81,16 @@ router.post(
     if (eventType) {
       where = { ...where, event: eventType };
     }
-    if (archived) {
+    if (!isNil(archived)) {
       where = {
         ...where,
-        archivedAt: {
-          [Op.ne]: null,
-        },
+        archivedAt: archived
+          ? {
+              [Op.ne]: null,
+            }
+          : {
+              [Op.eq]: null,
+            },
       };
     }
     const [notifications, total, unseen] = await Promise.all([

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -86,6 +86,7 @@
   "Download {{ platform }} app": "Download {{ platform }} app",
   "Log out": "Log out",
   "Mark notifications as read": "Mark notifications as read",
+  "Archive all notifications": "Archive all notifications",
   "Restore revision": "Restore revision",
   "Link copied": "Link copied",
   "Dark": "Dark",


### PR DESCRIPTION
Closes #6463 

### Changelog
- Add an action "Archive all notifications".
- Add a menu inside `Notifications` popover which contains the `Archive` and `Settings` options.
- Filter the archived / non-archived notifications in the `notifications.list` API.
- Fetch only the non-archived notifications in the `Notifications` popover.