### PR TITLE
fix: Adjust math delimiter to fix markdown import/export compatibility issue

### DIFF
--- a/shared/editor/nodes/Math.ts
+++ b/shared/editor/nodes/Math.ts
@@ -69,9 +69,9 @@ export default class Math extends Node {
   }
 
   toMarkdown(state: MarkdownSerializerState, node: ProsemirrorNode) {
-    state.write("$$");
+    state.write("$");
     state.text(node.textContent, false);
-    state.write("$$");
+    state.write("$");
   }
 
   parseMarkdown() {

--- a/shared/editor/nodes/MathBlock.ts
+++ b/shared/editor/nodes/MathBlock.ts
@@ -41,10 +41,10 @@ export default class MathBlock extends Node {
   }
 
   toMarkdown(state: MarkdownSerializerState, node: ProsemirrorNode) {
-    state.write("$$$\n");
+    state.write("$$\n");
     state.text(node.textContent, false);
     state.ensureNewLine();
-    state.write("$$$");
+    state.write("$$");
     state.closeBlock(node);
   }
 

--- a/shared/editor/rules/math.ts
+++ b/shared/editor/rules/math.ts
@@ -6,8 +6,8 @@ export const REGEX_INLINE_MATH_DOLLARS = /\$\$(.+)\$\$/;
 
 export const REGEX_BLOCK_MATH_DOLLARS = /\$\$\$\s+$/;
 
-const inlineMathDelimiter = "$$";
-const blockMathDelimiter = "$$$";
+const inlineMathDelimiter = "$";
+const blockMathDelimiter = "$$";
 
 // test if potential opening or closing delimiter
 // assumes that there is a "$" at state.src[pos]
@@ -85,7 +85,7 @@ function mathInline(state: StateInline, silent: boolean): boolean {
     return true;
   }
 
-  // check if we have empty content (ex. $$$$) do not parse
+  // check if we have empty content (ex. $$) do not parse
   if (match - start === 0) {
     if (!silent) {
       state.pending += inlineMathDelimiter + inlineMathDelimiter;


### PR DESCRIPTION
This PR is expected to fix the markdown import/export compatibility issue in #6650.

## Test cases

### Case 1: Import

Here is the test case, save as `.md` and use it to import document:

```plain
## Inline

Here is inline $x=y$

## Block

$$
y=x
$$
```

Excepted result in Outline editor:

<img width="713" alt="image" src="https://github.com/outline/outline/assets/19774268/07f6079a-3acd-41ee-8591-241f2c2e6163">

All general LaTeX texts should be converted to Outline `math_inline` or `math_block`.

### Case 2: Input and view in editor

This PR won't modify the input shortcut and trigger key. So the original trigger points (`$$` for inline, ```$$$ + Space``` for block) are preserved. And all imported or manaually inputed math nodes is still correct in `state`, only the generated `text` is changed.

### Case 3: Export

Export an Outline document which contains math inline/block to markdown.

The result `.md` shoule be like (All formulas can be rendered correctly in any other editors):

<img width="718" alt="image" src="https://github.com/outline/outline/assets/19774268/d8886946-bbd3-48fe-91d0-9d21be3e8039">

## Other notes

I'm new to contributing to this project, and after reading some of the source code and trying to modify it, I verified these test cases above locally.

This modification does not automatically fix documents that already have custom text cached in the Outline database (e.g. `$$$`), it only works for new incremental documents. Perhaps the core maintainer could help add a batch function for auto-fixing. The old text cache may only be affected if the export function is used. Viewing and editing in Outline still works fine for older documents.
