### PR TITLE
Add `role` parameter to `users.list` endpoint

### DIFF
--- a/server/routes/api/users/schema.ts
+++ b/server/routes/api/users/schema.ts
@@ -29,6 +29,16 @@ export const UsersListSchema = z.object({
 
     query: z.string().optional(),
 
+    /** The user's role */
+    role: z.nativeEnum(UserRole).optional(),
+
+    /**
+     * Filter the users by their status – passing a user role is deprecated here, instead use the
+     * `role` parameter, which will allow filtering by role and status, eg invited members, or
+     * suspended admins.
+     *
+     * @deprecated
+     */
     filter: z
       .enum([
         "invited",

--- a/server/routes/api/users/users.test.ts
+++ b/server/routes/api/users/users.test.ts
@@ -40,6 +40,26 @@ describe("#users.list", () => {
     expect(body.data[0].id).toEqual(user.id);
   });
 
+  it("should allow filtering by role", async () => {
+    const user = await buildUser({
+      name: "Tester",
+    });
+    const admin = await buildAdmin({
+      name: "Admin",
+      teamId: user.teamId,
+    });
+    const res = await server.post("/api/users.list", {
+      body: {
+        role: UserRole.Admin,
+        token: user.getJwtToken(),
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.data.length).toEqual(1);
+    expect(body.data[0].id).toEqual(admin.id);
+  });
+
   it("should allow filtering to suspended users", async () => {
     const admin = await buildAdmin();
     await buildUser({

--- a/server/routes/api/users/users.ts
+++ b/server/routes/api/users/users.ts
@@ -35,7 +35,8 @@ router.post(
   pagination(),
   validate(T.UsersListSchema),
   async (ctx: APIContext<T.UsersListReq>) => {
-    const { sort, direction, query, filter, ids, emails } = ctx.input.body;
+    const { sort, direction, query, role, filter, ids, emails } =
+      ctx.input.body;
 
     const actor = ctx.state.auth.user;
     let where: WhereOptions<User> = {
@@ -111,6 +112,13 @@ router.post(
         };
         break;
       }
+    }
+
+    if (role) {
+      where = {
+        ...where,
+        role,
+      };
     }
 
     if (query) {


### PR DESCRIPTION
Allows filering the users by their permissions, separating from the status filter allows filtering by role and status, eg invited members, or suspended admins.