### PR TITLE
A sentence that is not properly translated under the member option in Settings

### DIFF
--- a/app/scenes/Settings/Members.tsx
+++ b/app/scenes/Settings/Members.tsx
@@ -186,7 +186,7 @@ function Members() {
         <Trans>
           Everyone that has signed into {{ appName }} is listed here. It’s
           possible that there are other users who have access through{" "}
-          {team.signinMethods} but haven’t signed in yet.
+          {{ signinMethods: team.signinMethods, }}{" "}but haven’t signed in yet.
         </Trans>
       </Text>
       <Flex gap={8}>

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -858,7 +858,7 @@
   "Import pages from a Confluence instance": "Import pages from a Confluence instance",
   "Enterprise": "Enterprise",
   "Recent imports": "Recent imports",
-  "Everyone that has signed into {{appName}} is listed here. It’s possible that there are other users who have access through {team.signinMethods} but haven’t signed in yet.": "Everyone that has signed into {{appName}} is listed here. It’s possible that there are other users who have access through {team.signinMethods} but haven’t signed in yet.",
+  "Everyone that has signed into {{appName}} is listed here. It’s possible that there are other users who have access through {{signinMethods}} but haven’t signed in yet.": "Everyone that has signed into {{appName}} is listed here. It’s possible that there are other users who have access through {{signinMethods}} but haven’t signed in yet.",
   "Filter": "Filter",
   "Receive a notification whenever a new document is published": "Receive a notification whenever a new document is published",
   "Document updated": "Document updated",


### PR DESCRIPTION
` {team.signinMethods} ` The variable call was not recognized by i18n, so the sentence was not translated

![1712748299176](https://github.com/outline/outline/assets/72010312/a13d63a4-54c8-4e91-b34f-eb7ddbe00e78)

`{{ signinMethods: team.signinMethods, }}` Using this variable can translate normally

![1712748564511](https://github.com/outline/outline/assets/72010312/b064ed4e-ae7c-4e7e-9358-81024a8c6b2c)


