### PR TITLE
add H3 to editor formatting toolbar

### DIFF
--- a/app/editor/menus/formatting.tsx
+++ b/app/editor/menus/formatting.tsx
@@ -16,6 +16,7 @@ import {
   OutdentIcon,
   IndentIcon,
   CopyIcon,
+  Heading3Icon,
 } from "outline-icons";
 import { EditorState } from "prosemirror-state";
 import { isInTable } from "prosemirror-tables";
@@ -105,6 +106,14 @@ export default function formattingMenuItems(
       icon: <Heading2Icon />,
       active: isNodeActive(schema.nodes.heading, { level: 2 }),
       attrs: { level: 2 },
+      visible: allowBlocks && !isCode,
+    },
+    {
+      name: "heading",
+      tooltip: dictionary.subheading,
+      icon: <Heading3Icon />,
+      active: isNodeActive(schema.nodes.heading, { level: 3 }),
+      attrs: { level: 3 },
       visible: allowBlocks && !isCode,
     },
     {


### PR DESCRIPTION
This PR adds H3 option to the editor formatting toolbar.

As of now, the only way to change an existing heading level from H1/H2 to H3 is to remove the content and use the `slash directive` to insert a H3 node.