### PR TITLE
Untranslated button: Notification settings

### DIFF
--- a/app/menus/NotificationMenu.tsx
+++ b/app/menus/NotificationMenu.tsx
@@ -24,7 +24,7 @@ const NotificationMenu: React.FC = () => {
       actionToMenuItem(markNotificationsAsArchived, context),
       {
         type: "button",
-        title: "Notification settings",
+        title: t("Notification settings"),
         visible: true,
         onClick: () => performAction(navigateToNotificationSettings, context),
       },

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -89,6 +89,7 @@
   "Download {{ platform }} app": "Download {{ platform }} app",
   "Log out": "Log out",
   "Mark notifications as read": "Mark notifications as read",
+  "Notification settings": "Notification settings",
   "Archive all notifications": "Archive all notifications",
   "Restore revision": "Restore revision",
   "Link copied": "Link copied",


### PR DESCRIPTION
The Notification settings were not added to the i18n translation.
![企业微信截图_1713172241831](https://github.com/outline/outline/assets/72010312/28ae175c-a389-47ee-8f8e-8c4d04ba0b59)

Has been tested on the latest instance.
![企业微信截图_17131722019876](https://github.com/outline/outline/assets/72010312/957c3607-62f1-4840-827b-33427973544b)
