### PR TITLE
fix: markdown-it bug for incorrect strong tag closing

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "markdown-it": "^13.0.1",
     "markdown-it-container": "^3.0.0",
     "markdown-it-emoji": "^2.0.0",
+    "markdown-match-pairs": "^1.0.2",
     "mermaid": "9.3.0",
     "mime-types": "^2.1.35",
     "mobx": "^4.15.4",

--- a/shared/editor/marks/Bold.ts
+++ b/shared/editor/marks/Bold.ts
@@ -1,3 +1,4 @@
+import matchPairs from "markdown-match-pairs";
 import { toggleMark } from "prosemirror-commands";
 import { InputRule } from "prosemirror-inputrules";
 import { MarkSpec, MarkType } from "prosemirror-model";
@@ -30,6 +31,10 @@ export default class Bold extends Mark {
       ],
       toDOM: () => ["strong"],
     };
+  }
+
+  get rulePlugins() {
+    return [matchPairs];
   }
 
   inputRules({ type }: { type: MarkType }): InputRule[] {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9892,6 +9892,11 @@ markdown-it@^14.0.0:
     punycode.js "^2.3.1"
     uc.micro "^2.0.0"
 
+markdown-match-pairs@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/markdown-match-pairs/-/markdown-match-pairs-1.0.2.tgz#74d8816501028e4392fa5be782f3d7cac36cbda7"
+  integrity sha512-poLuBPzw9TB4aiHQMZXV1R7OQawU/dKXFF5OVumrR87ezsn6u6poHyd+QkKlmpiqTL3nBQ8Y5IRievE4fDkE3A==
+
 matcher-collection@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/matcher-collection/-/matcher-collection-2.0.1.tgz#90be1a4cf58d6f2949864f65bb3b0f3e41303b29"


### PR DESCRIPTION
## Problem

By default, markdown-it identifies whether `**` can be closed based on the following rules:

- If there is a space on the left, then `open = true`
- If there is a space on the right, then `close = true`
- If neither side has a space, it checks for special characters such as `+-=` or other language separators for example Chinese semicolons `：`. If these symbols are present, they are treated as spaces.

The last rule leads to the following parsing results:

```js
render('**==foo==**') === '<p>**<mark>foo</mark>**</p>';
render('**中文：**中文') === '<p>**中文：**中文</p>';
```

In these two examples, the second `**` is preceded by `=` and `：`, which are recognized as delimiters, identified as an open tag, causing the preceding `**` to not close properly, so it is output directly.

In reality, we expect both cases to output a strong tag.

> Similar issues #6683.

## Fix logic

The implementation logic is as follows: insert a function before `balance_pairs`. After completing inline rule parsing, adjust the delimiters. After adjustment, whether `**` can be closed depends on whether there was an open `**` before it.

After using this plugin, the above examples will output as follows:

```js
render('**==foo==**') === '<p><strong><mark>foo</mark></strong></p>';
render(' **Chinese:** Chinese ') === ' < p > < strong > Chinese: </ strong > Chinese </ p > ';
```

> For more details, please refer to the implementation of the [match-pairs](https://github.com/shepherdwind/match-pairs) package.