### PR TITLE
Fix: Adapt to Figma's New Link Structure for Embedding Design Previews

### DIFF
--- a/shared/editor/embeds/index.tsx
+++ b/shared/editor/embeds/index.tsx
@@ -233,7 +233,7 @@ const embeds: EmbedDescriptor[] = [
     keywords: "design svg vector",
     regexMatch: [
       new RegExp(
-        "^https://([w.-]+\\.)?figma\\.com/(file|proto)/([0-9a-zA-Z]{22,128})(?:/.*)?$"
+        "^https://([w.-]+\\.)?figma\\.com/(file|proto|design)/([0-9a-zA-Z]{22,128})(?:/.*)?$"
       ),
     ],
     transformMatch: (matches) =>


### PR DESCRIPTION
### Description

Recently, Figma updated their link structure, changing the shareable links for design files from `www.figma.com/file` to `www.figma.com/design`. This change breaks the functionality that allows designers to embed Figma design previews in documents.

This PR addresses and resolves this issue, ensuring that the new Figma links are correctly parsed and embedded.

### Changes

-  Updated the link parsing logic to support the new Figma file paths.
-  Ensured backward compatibility with the old `www.figma.com/file` links.


### How to Test

1. Insert a Figma link with the new `www.figma.com/design` format into a supported document.
2. Verify that the Figma design preview is correctly embedded.
3. Repeat the test with an old `www.figma.com/file` link to ensure backward compatibility.
