### PR TITLE
Add range header support to `files.get`

### DIFF
--- a/server/storage/files/BaseStorage.ts
+++ b/server/storage/files/BaseStorage.ts
@@ -32,7 +32,8 @@ export default abstract class BaseStorage {
    * @param key The path to the file
    */
   public abstract getFileStream(
-    key: string
+    key: string,
+    range?: { start?: number; end?: number }
   ): Promise<NodeJS.ReadableStream | null>;
 
   /**

--- a/server/storage/files/LocalStorage.ts
+++ b/server/storage/files/LocalStorage.ts
@@ -131,8 +131,12 @@ export default class LocalStorage extends BaseStorage {
     };
   }
 
-  public getFileStream(key: string) {
-    return Promise.resolve(fs.createReadStream(this.getFilePath(key)));
+  public getFileStream(key: string, range?: { start: number; end: number }) {
+    return Promise.resolve(fs.createReadStream(this.getFilePath(key), range));
+  }
+
+  public stat(key: string) {
+    return fs.stat(this.getFilePath(key));
   }
 
   private getFilePath(key: string) {

--- a/server/storage/files/S3Storage.ts
+++ b/server/storage/files/S3Storage.ts
@@ -201,12 +201,16 @@ export default class S3Storage extends BaseStorage {
     });
   }
 
-  public getFileStream(key: string): Promise<NodeJS.ReadableStream | null> {
+  public getFileStream(
+    key: string,
+    range?: { start: number; end: number }
+  ): Promise<NodeJS.ReadableStream | null> {
     return this.client
       .send(
         new GetObjectCommand({
           Bucket: this.getBucket(),
           Key: key,
+          Range: range ? `bytes=${range.start}-${range.end}` : undefined,
         })
       )
       .then((item) => item.Body as NodeJS.ReadableStream)


### PR DESCRIPTION
Fixes embedded videos unable to load in Safari.

closes #6949 