### PR TITLE
fix(app.json): add UTILS_SECRET env var

### DIFF
--- a/app.json
+++ b/app.json
@@ -33,6 +33,11 @@
       "generator": "secret",
       "required": true
     },
+    "UTILS_SECRET": {
+      "description": "A 32-character secret key, generate with openssl rand -hex 32",
+      "generator": "secret",
+      "required": true
+    },
     "ENABLE_UPDATES": {
       "value": "true",
       "required": true


### PR DESCRIPTION
Add the required `UTILS_SECRET` environment variable to `app.json`, so Outline can be deployed on PaaS such as Heroku or Scalingo.