### PR TITLE
[docs] Remove dead link for Node Security Project

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -6,4 +6,4 @@ The Outline team takes security bugs seriously. We appreciate your efforts to re
 
 If you discover a security vulnerability in outline, please disclose it via [GitHub](https://github.com/outline/outline/security/advisories/new). The Outline maintainers will send a response indicating the next steps in handling your report. After the initial reply to your report you will be kept informed of the progress towards a fix and full announcement.
 
-Report security bugs in third-party dependencies to the person or team maintaining the module. You can also report a vulnerability through the [Node Security Project](https://nodesecurity.io/report).
+Report security bugs in third-party dependencies to the person or team maintaining the module.


### PR DESCRIPTION
The Node Security Project seems to be dead? The link leads to a squatted domain.