### PR TITLE
fix: Case where email platform will spend the email signin link

### DIFF
--- a/plugins/email/server/auth/email.ts
+++ b/plugins/email/server/auth/email.ts
@@ -90,7 +90,15 @@ router.get(
   "email.callback",
   validate(T.EmailCallbackSchema),
   async (ctx: APIContext<T.EmailCallbackReq>) => {
-    const { token, client } = ctx.input.query;
+    const { token, client, follow } = ctx.input.query;
+
+    // The link in the email does not include the follow query param, this
+    // is to help prevent anti-virus, and email clients from pre-fetching the link
+    // and spending the token before the user clicks on it. Instead we redirect
+    // to the same URL with the follow query param added from the client side.
+    if (!follow) {
+      return ctx.redirectOnClient(ctx.request.href + "&follow=true");
+    }
 
     let user!: User;
 

--- a/plugins/email/server/auth/schema.ts
+++ b/plugins/email/server/auth/schema.ts
@@ -15,6 +15,7 @@ export const EmailCallbackSchema = BaseSchema.extend({
   query: z.object({
     token: z.string(),
     client: z.nativeEnum(Client).default(Client.Web),
+    follow: z.string().default(""),
   }),
 });
 


### PR DESCRIPTION
Fix case where email platform will spend the email signin link before the user has a chance to click it.