### PR TITLE
Allow using `/` anywhere on a line or table

### DIFF
--- a/app/editor/extensions/BlockMenu.tsx
+++ b/app/editor/extensions/BlockMenu.tsx
@@ -12,8 +12,9 @@ import BlockMenu from "../components/BlockMenu";
 export default class BlockMenuExtension extends Suggestion {
   get defaultOptions() {
     return {
-      openRegex: /^\/(\w+)?$/,
-      closeRegex: /(^(?!\/(\w+)?)(.*)$|^\/(([\w\W]+)\s.*|\s)$|^\/((\W)+)$)/,
+      // ported from https://github.com/tc39/proposal-regexp-unicode-property-escapes#unicode-aware-version-of-w
+      openRegex: /(?:^|\s|\()\/([\p{L}\p{M}\d]+)?$/u,
+      closeRegex: /(?:^|\s|\()\/(([\p{L}\p{M}\d]*\s+)|(\s+[\p{L}\p{M}\d]+))$/u,
     };
   }
 

--- a/app/editor/extensions/EmojiMenu.tsx
+++ b/app/editor/extensions/EmojiMenu.tsx
@@ -24,7 +24,6 @@ export default class EmojiMenuExtension extends Suggestion {
       ),
       closeRegex:
         /(?:^|\s|\():(([0-9a-zA-Z_+-]*\s+)|(\s+[0-9a-zA-Z_+-]+)|[^0-9a-zA-Z_+-]+)$/,
-      enabledInTable: true,
     };
   }
 

--- a/app/editor/extensions/MentionMenu.tsx
+++ b/app/editor/extensions/MentionMenu.tsx
@@ -10,7 +10,6 @@ export default class MentionMenuExtension extends Suggestion {
       // ported from https://github.com/tc39/proposal-regexp-unicode-property-escapes#unicode-aware-version-of-w
       openRegex: /(?:^|\s|\()@([\p{L}\p{M}\d]+)?$/u,
       closeRegex: /(?:^|\s|\()@(([\p{L}\p{M}\d]*\s+)|(\s+[\p{L}\p{M}\d]+))$/u,
-      enabledInTable: true,
     };
   }
 

--- a/app/editor/extensions/Suggestion.ts
+++ b/app/editor/extensions/Suggestion.ts
@@ -2,7 +2,6 @@ import { action, observable } from "mobx";
 import { InputRule } from "prosemirror-inputrules";
 import { NodeType, Schema } from "prosemirror-model";
 import { EditorState, Plugin } from "prosemirror-state";
-import { isInTable } from "prosemirror-tables";
 import Extension from "@shared/editor/lib/Extension";
 import { SuggestionsMenuPlugin } from "@shared/editor/plugins/Suggestions";
 import { isInCode } from "@shared/editor/queries/isInCode";
@@ -50,8 +49,7 @@ export default class Suggestion extends Extension {
           match &&
           (parent.type.name === "paragraph" ||
             parent.type.name === "heading") &&
-          (!isInCode(state) || this.options.enabledInCode) &&
-          (!isInTable(state) || this.options.enabledInTable)
+          (!isInCode(state) || this.options.enabledInCode)
         ) {
           this.state.open = true;
           this.state.query = match[1];

--- a/shared/editor/plugins/Suggestions.ts
+++ b/shared/editor/plugins/Suggestions.ts
@@ -8,7 +8,6 @@ type Options = {
   openRegex: RegExp;
   closeRegex: RegExp;
   enabledInCode: true;
-  enabledInTable: true;
 };
 
 type ExtensionState = {


### PR DESCRIPTION
There are _some_ small oddities left here, but those will probably be okay left to a followup PR to land the majority here quickly.

For example, if you try to use `/notice` in a list item then it will fail as an individual list item cannot be converted to a notice – however the user intent here is to _insert_ a notice into the list.