### PR TITLE
Add AZURE_TENANT_ID enviroment variable for specific azure tenant.

### DIFF
--- a/plugins/azure/server/auth/azure.ts
+++ b/plugins/azure/server/auth/azure.ts
@@ -28,7 +28,8 @@ if (env.AZURE_CLIENT_ID && env.AZURE_CLIENT_SECRET) {
       clientID: env.AZURE_CLIENT_ID,
       clientSecret: env.AZURE_CLIENT_SECRET,
       callbackURL: `${env.URL}/auth/azure.callback`,
-      useCommonEndpoint: true,
+      useCommonEndpoint: env.AZURE_TENANT_ID ? false : true,
+      tenant: env.AZURE_TENANT_ID ? env.AZURE_TENANT_ID : undefined,
       passReqToCallback: true,
       resource: env.AZURE_RESOURCE_APP_ID,
       // @ts-expect-error StateStore

--- a/plugins/azure/server/env.ts
+++ b/plugins/azure/server/env.ts
@@ -25,9 +25,7 @@ class AzurePluginEnvironment extends Environment {
 
   @IsOptional()
   @CannotUseWithout("AZURE_CLIENT_ID")
-  public AZURE_TENANT_ID = this.toOptionalString(
-    environment.AZURE_TENANT_ID
-  );
+  public AZURE_TENANT_ID = this.toOptionalString(environment.AZURE_TENANT_ID);
 }
 
 export default new AzurePluginEnvironment();

--- a/plugins/azure/server/env.ts
+++ b/plugins/azure/server/env.ts
@@ -22,6 +22,18 @@ class AzurePluginEnvironment extends Environment {
   public AZURE_RESOURCE_APP_ID = this.toOptionalString(
     environment.AZURE_RESOURCE_APP_ID
   );
+
+  @IsOptional()
+  @CannotUseWithout("AZURE_CLIENT_ID")
+  public AZURE_TENANT_ID = this.toOptionalString(
+    environment.AZURE_TENANT_ID
+  );
+
+  @IsOptional()
+  @CannotUseWithout("AZURE_CLIENT_ID")
+  public AZURE_DISPLAY_NAME = this.toOptionalString(
+    environment.AZURE_DISPLAY_NAME
+  );
 }
 
 export default new AzurePluginEnvironment();

--- a/plugins/azure/server/env.ts
+++ b/plugins/azure/server/env.ts
@@ -28,12 +28,6 @@ class AzurePluginEnvironment extends Environment {
   public AZURE_TENANT_ID = this.toOptionalString(
     environment.AZURE_TENANT_ID
   );
-
-  @IsOptional()
-  @CannotUseWithout("AZURE_CLIENT_ID")
-  public AZURE_DISPLAY_NAME = this.toOptionalString(
-    environment.AZURE_DISPLAY_NAME
-  );
 }
 
 export default new AzurePluginEnvironment();


### PR DESCRIPTION
As seen here https://github.com/outline/passport-azure-ad-oauth2 the Azure plugin already has the needed code to specify an specific azure tenant when using the azure tenant login. Therefore i added an ENV variable for this.