### PR TITLE
fix: Use the default credential strategy in S3Client construction

### DIFF
--- a/server/storage/files/S3Storage.ts
+++ b/server/storage/files/S3Storage.ts
@@ -28,10 +28,6 @@ export default class S3Storage extends BaseStorage {
     this.client = new S3Client({
       bucketEndpoint: env.AWS_S3_ACCELERATE_URL ? true : false,
       forcePathStyle: env.AWS_S3_FORCE_PATH_STYLE,
-      credentials: {
-        accessKeyId: env.AWS_ACCESS_KEY_ID || "",
-        secretAccessKey: env.AWS_SECRET_ACCESS_KEY || "",
-      },
       region: env.AWS_REGION,
       endpoint: this.getEndpoint(),
     });


### PR DESCRIPTION
By omitting this option, we fall back to the hierarchy used by S3Client by default.  When defined, the provider chain will use the values of AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY (and AWS_SESSION_TOKEN); in their absence, the provider chain can retrieve credentials from a range of other sources, including e.g. ECS credentials.

Although there are no longer any application reads from `env.AWS_ACCESS_KEY_ID` and `env.AWS_SECRET_ACCESS_KEY`, they continue to serve a useful documentary role.

Resolves https://github.com/outline/outline/issues/7060.
