### PR TITLE
Add icon column to document

### DIFF
--- a/server/commands/documentCreator.ts
+++ b/server/commands/documentCreator.ts
@@ -97,6 +97,8 @@ export default async function documentCreator({
       sourceMetadata,
       fullWidth: templateDocument ? templateDocument.fullWidth : fullWidth,
       emoji: templateDocument ? templateDocument.emoji : emoji,
+      icon: templateDocument ? templateDocument.emoji : emoji,
+      color: templateDocument ? templateDocument.color : null,
       title: TextHelper.replaceTemplateVariables(
         templateDocument ? templateDocument.title : title,
         user

--- a/server/commands/documentDuplicator.test.ts
+++ b/server/commands/documentDuplicator.test.ts
@@ -26,6 +26,7 @@ describe("documentDuplicator", () => {
     expect(response[0].title).toEqual(original.title);
     expect(response[0].text).toEqual(original.text);
     expect(response[0].emoji).toEqual(original.emoji);
+    expect(response[0].icon).toEqual(original.emoji);
     expect(response[0].publishedAt).toBeInstanceOf(Date);
   });
 
@@ -52,6 +53,7 @@ describe("documentDuplicator", () => {
     expect(response[0].title).toEqual("New title");
     expect(response[0].text).toEqual(original.text);
     expect(response[0].emoji).toEqual(original.emoji);
+    expect(response[0].icon).toEqual(original.emoji);
     expect(response[0].publishedAt).toBeInstanceOf(Date);
   });
 
@@ -106,6 +108,7 @@ describe("documentDuplicator", () => {
     expect(response[0].title).toEqual(original.title);
     expect(response[0].text).toEqual(original.text);
     expect(response[0].emoji).toEqual(original.emoji);
+    expect(response[0].icon).toEqual(original.emoji);
     expect(response[0].publishedAt).toBeNull();
   });
 });

--- a/server/commands/documentUpdater.ts
+++ b/server/commands/documentUpdater.ts
@@ -67,6 +67,7 @@ export default async function documentUpdater({
   }
   if (emoji !== undefined) {
     document.emoji = emoji;
+    document.icon = emoji;
   }
   if (editorVersion) {
     document.editorVersion = editorVersion;

--- a/server/migrations/20240617151506-add-icon-to-document.js
+++ b/server/migrations/20240617151506-add-icon-to-document.js
@@ -1,0 +1,58 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction(async transaction => {
+      await queryInterface.addColumn(
+        "documents",
+        "icon",
+        {
+          type: Sequelize.STRING,
+          allowNull: true,
+        },
+        {
+          transaction,
+        }
+      );
+      await queryInterface.addColumn(
+        "revisions",
+        "icon",
+        {
+          type: Sequelize.STRING,
+          allowNull: true,
+        },
+        {
+          transaction,
+        }
+      );
+      await queryInterface.addColumn(
+        "documents",
+        "color",
+        {
+          type: Sequelize.STRING,
+          allowNull: true,
+        },
+        { transaction }
+      );
+      await queryInterface.addColumn(
+        "revisions",
+        "color",
+        {
+          type: Sequelize.STRING,
+          allowNull: true,
+        },
+        { transaction }
+      );
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction(async transaction => {
+      await queryInterface.removeColumn("documents", "icon", { transaction });
+      await queryInterface.removeColumn("revisions", "icon", { transaction });
+      await queryInterface.removeColumn("documents", "color", { transaction });
+      await queryInterface.removeColumn("revisions", "color", { transaction });
+    });
+  },
+};

--- a/server/migrations/20240617151506-add-icon-to-document.js
+++ b/server/migrations/20240617151506-add-icon-to-document.js
@@ -45,6 +45,27 @@ module.exports = {
         { transaction }
       );
     });
+
+    if (process.env.DEPLOYMENT === "hosted") {
+      return;
+    }
+
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.sequelize.query(
+        `UPDATE documents SET icon = emoji`,
+        {
+          transaction,
+          type: queryInterface.sequelize.QueryTypes.UPDATE,
+        }
+      );
+      await queryInterface.sequelize.query(
+        `UPDATE revisions SET icon = emoji`,
+        {
+          transaction,
+          type: queryInterface.sequelize.QueryTypes.UPDATE,
+        }
+      );
+    });
   },
 
   async down(queryInterface, Sequelize) {

--- a/server/models/Document.ts
+++ b/server/models/Document.ts
@@ -64,6 +64,7 @@ import View from "./View";
 import ParanoidModel from "./base/ParanoidModel";
 import Fix from "./decorators/Fix";
 import { DocumentHelper } from "./helpers/DocumentHelper";
+import IsHexColor from "./validators/IsHexColor";
 import Length from "./validators/Length";
 
 export const DOCUMENT_VERSION = 2;
@@ -261,6 +262,18 @@ class Document extends ParanoidModel<
   })
   @Column
   emoji: string | null;
+
+  @Length({
+    max: 50,
+    msg: `icon must be 50 characters or less`,
+  })
+  @Column
+  icon: string | null;
+
+  /** The color of the icon. */
+  @IsHexColor
+  @Column
+  color: string | null;
 
   /**
    * The content of the document as Markdown.

--- a/server/models/Revision.ts
+++ b/server/models/Revision.ts
@@ -20,6 +20,7 @@ import Document from "./Document";
 import User from "./User";
 import IdModel from "./base/IdModel";
 import Fix from "./decorators/Fix";
+import IsHexColor from "./validators/IsHexColor";
 import Length from "./validators/Length";
 
 @DefaultScope(() => ({
@@ -77,6 +78,18 @@ class Revision extends IdModel<
   @Column
   emoji: string | null;
 
+  @Length({
+    max: 50,
+    msg: `icon must be 50 characters or less`,
+  })
+  @Column
+  icon: string | null;
+
+  /** The color of the icon. */
+  @IsHexColor
+  @Column
+  color: string | null;
+
   // associations
 
   @BelongsTo(() => Document, "documentId")
@@ -121,6 +134,8 @@ class Revision extends IdModel<
       title: document.title,
       text: document.text,
       emoji: document.emoji,
+      icon: document.emoji,
+      color: document.color,
       content: document.content,
       userId: document.lastModifiedById,
       editorVersion: document.editorVersion,

--- a/server/queues/tasks/ImportJSONTask.ts
+++ b/server/queues/tasks/ImportJSONTask.ts
@@ -80,6 +80,8 @@ export default class ImportJSONTask extends ImportTask {
           // structure directly in the future.
           text: serializer.serialize(Node.fromJSON(schema, node.data)),
           emoji: node.emoji,
+          icon: node.emoji,
+          color: null,
           createdAt: node.createdAt ? new Date(node.createdAt) : undefined,
           updatedAt: node.updatedAt ? new Date(node.updatedAt) : undefined,
           publishedAt: node.publishedAt ? new Date(node.publishedAt) : null,

--- a/server/queues/tasks/ImportMarkdownZipTask.ts
+++ b/server/queues/tasks/ImportMarkdownZipTask.ts
@@ -116,6 +116,7 @@ export default class ImportMarkdownZipTask extends ImportTask {
               id,
               title,
               emoji,
+              icon: emoji,
               text,
               collectionId,
               parentDocumentId,

--- a/server/queues/tasks/ImportNotionTask.ts
+++ b/server/queues/tasks/ImportNotionTask.ts
@@ -131,6 +131,7 @@ export default class ImportNotionTask extends ImportTask {
               id,
               title,
               emoji,
+              icon: emoji,
               text,
               collectionId,
               parentDocumentId,

--- a/server/queues/tasks/ImportTask.ts
+++ b/server/queues/tasks/ImportTask.ts
@@ -61,6 +61,8 @@ export type StructuredImportData = {
     urlId?: string;
     title: string;
     emoji?: string | null;
+    icon?: string | null;
+    color?: string | null;
     /**
      * The document text. To reference an attachment or image use the special
      * formatting <<attachmentId>>. It will be replaced with a reference to the


### PR DESCRIPTION
Pre-requisite for #7038 

- Add `icon` and `color` column to `documents` and `revisions` table.
- On document creation and updation, set `icon` from `emoji` and `color` to `null`.
- On revision creation, set `icon` from `emoji` and `color` to `null`.