### PR TITLE
fix: Open permissions for guests that have collection manage permission

### DIFF
--- a/server/policies/document.test.ts
+++ b/server/policies/document.test.ts
@@ -316,112 +316,121 @@ describe("archived document", () => {
 });
 
 describe("read document", () => {
-  it("should allow read permissions for team member", async () => {
-    const team = await buildTeam();
-    const user = await buildUser({ teamId: team.id });
-    const collection = await buildCollection({
-      teamId: team.id,
-      permission: null,
-    });
-    const doc = await buildDocument({
-      teamId: team.id,
-      collectionId: collection.id,
-    });
-    await UserMembership.create({
-      userId: user.id,
-      documentId: doc.id,
-      permission: DocumentPermission.Read,
-      createdById: user.id,
-    });
+  for (const role of Object.values(UserRole)) {
+    it(`should allow read permissions for ${role}`, async () => {
+      const team = await buildTeam();
+      const user = await buildUser({ teamId: team.id });
+      const collection = await buildCollection({
+        teamId: team.id,
+        permission: null,
+      });
+      const doc = await buildDocument({
+        teamId: team.id,
+        collectionId: collection.id,
+      });
+      await UserMembership.create({
+        userId: user.id,
+        documentId: doc.id,
+        permission: DocumentPermission.Read,
+        createdById: user.id,
+      });
 
-    // reload to get membership
-    const document = await Document.findByPk(doc.id, { userId: user.id });
-    const abilities = serialize(user, document);
-    expect(abilities.read).toEqual(true);
-    expect(abilities.download).toEqual(true);
-    expect(abilities.subscribe).toEqual(true);
-    expect(abilities.unsubscribe).toEqual(true);
-    expect(abilities.comment).toEqual(true);
-    expect(abilities.update).toEqual(false);
-    expect(abilities.createChildDocument).toEqual(false);
-    expect(abilities.manageUsers).toEqual(false);
-    expect(abilities.archive).toEqual(false);
-    expect(abilities.delete).toEqual(false);
-    expect(abilities.share).toEqual(false);
-    expect(abilities.move).toEqual(false);
-  });
+      // reload to get membership
+      const document = await Document.findByPk(doc.id, { userId: user.id });
+      const abilities = serialize(user, document);
+      expect(abilities.read).toEqual(true);
+      expect(abilities.download).toEqual(true);
+      expect(abilities.subscribe).toEqual(true);
+      expect(abilities.unsubscribe).toEqual(true);
+      expect(abilities.comment).toEqual(true);
+      expect(abilities.update).toEqual(false);
+      expect(abilities.createChildDocument).toEqual(false);
+      expect(abilities.manageUsers).toEqual(false);
+      expect(abilities.archive).toEqual(false);
+      expect(abilities.delete).toEqual(false);
+      expect(abilities.share).toEqual(false);
+      expect(abilities.move).toEqual(false);
+    });
+  }
 });
 
 describe("read_write document", () => {
-  it("should allow write permissions for team member", async () => {
-    const team = await buildTeam();
-    const user = await buildUser({ teamId: team.id });
-    const collection = await buildCollection({
-      teamId: team.id,
-      permission: null,
-    });
-    const doc = await buildDocument({
-      teamId: team.id,
-      collectionId: collection.id,
-    });
-    await UserMembership.create({
-      userId: user.id,
-      documentId: doc.id,
-      permission: DocumentPermission.ReadWrite,
-      createdById: user.id,
-    });
+  for (const role of Object.values(UserRole)) {
+    it(`should allow write permissions for ${role}`, async () => {
+      const team = await buildTeam();
+      const user = await buildUser({ teamId: team.id, role });
+      const collection = await buildCollection({
+        teamId: team.id,
+        permission: null,
+      });
+      const doc = await buildDocument({
+        teamId: team.id,
+        collectionId: collection.id,
+      });
+      await UserMembership.create({
+        userId: user.id,
+        documentId: doc.id,
+        permission: DocumentPermission.ReadWrite,
+        createdById: user.id,
+      });
 
-    // reload to get membership
-    const document = await Document.findByPk(doc.id, { userId: user.id });
-    const abilities = serialize(user, document);
-    expect(abilities.read).toEqual(true);
-    expect(abilities.download).toEqual(true);
-    expect(abilities.update).toEqual(true);
-    expect(abilities.delete).toEqual(true);
-    expect(abilities.subscribe).toEqual(true);
-    expect(abilities.unsubscribe).toEqual(true);
-    expect(abilities.comment).toEqual(true);
-    expect(abilities.createChildDocument).toEqual(false);
-    expect(abilities.manageUsers).toEqual(false);
-    expect(abilities.archive).toEqual(false);
-    expect(abilities.share).toEqual(false);
-    expect(abilities.move).toEqual(false);
-  });
+      // reload to get membership
+      const document = await Document.findByPk(doc.id, { userId: user.id });
+      const abilities = serialize(user, document);
+      expect(abilities.read).toEqual(true);
+      expect(abilities.download).toEqual(true);
+      expect(abilities.update).toEqual(true);
+      expect(abilities.delete).toEqual(true);
+      expect(abilities.subscribe).toEqual(true);
+      expect(abilities.unsubscribe).toEqual(true);
+      expect(abilities.comment).toEqual(true);
+      expect(abilities.createChildDocument).toEqual(false);
+      expect(abilities.manageUsers).toEqual(false);
+      expect(abilities.archive).toEqual(false);
+      expect(abilities.share).toEqual(false);
+      expect(abilities.move).toEqual(false);
+    });
+  }
 });
 
 describe("manage document", () => {
-  it("should allow write permissions, user management, and sub-document creation", async () => {
-    const team = await buildTeam();
-    const user = await buildUser({ teamId: team.id });
-    const collection = await buildCollection({
-      teamId: team.id,
-      permission: null,
-    });
-    const doc = await buildDocument({
-      teamId: team.id,
-      collectionId: collection.id,
-    });
-    await UserMembership.create({
-      userId: user.id,
-      documentId: doc.id,
-      permission: DocumentPermission.Admin,
-      createdById: user.id,
-    });
+  for (const role of Object.values(UserRole)) {
+    it(`should allow write permissions, user management, and sub-document creation for ${role}`, async () => {
+      const team = await buildTeam();
+      const user = await buildUser({
+        teamId: team.id,
+        role,
+      });
+      const collection = await buildCollection({
+        teamId: team.id,
+        permission: null,
+      });
+      const doc = await buildDocument({
+        teamId: team.id,
+        collectionId: collection.id,
+      });
+      await UserMembership.create({
+        userId: user.id,
+        documentId: doc.id,
+        permission: DocumentPermission.Admin,
+        createdById: user.id,
+      });
 
-    // reload to get membership
-    const document = await Document.findByPk(doc.id, { userId: user.id });
-    const abilities = serialize(user, document);
-    expect(abilities.read).toEqual(true);
-    expect(abilities.download).toEqual(true);
-    expect(abilities.update).toEqual(true);
-    expect(abilities.delete).toEqual(true);
-    expect(abilities.subscribe).toEqual(true);
-    expect(abilities.unsubscribe).toEqual(true);
-    expect(abilities.comment).toEqual(true);
-    expect(abilities.createChildDocument).toEqual(true);
-    expect(abilities.manageUsers).toEqual(true);
-    expect(abilities.archive).toEqual(true);
-    expect(abilities.move).toEqual(true);
-    expect(abilities.share).toEqual(false);
-  });
+      // reload to get membership
+      const document = await Document.findByPk(doc.id, { userId: user.id });
+      const abilities = serialize(user, document);
+      expect(abilities.read).toEqual(true);
+      expect(abilities.download).toEqual(true);
+      expect(abilities.update).toEqual(true);
+      expect(abilities.delete).toEqual(true);
+      expect(abilities.subscribe).toEqual(true);
+      expect(abilities.unsubscribe).toEqual(true);
+      expect(abilities.comment).toEqual(true);
+      expect(abilities.createChildDocument).toEqual(true);
+      expect(abilities.manageUsers).toEqual(true);
+      expect(abilities.archive).toEqual(true);
+      expect(abilities.move).toEqual(false);
+      expect(abilities.share).toEqual(false);
+    });
+  }
 });

--- a/server/policies/document.ts
+++ b/server/policies/document.ts
@@ -198,7 +198,6 @@ allow(User, ["restore", "permanentDelete"], Document, (actor, document) =>
 
 allow(User, "archive", Document, (actor, document) =>
   and(
-    !actor.isGuest,
     !document?.template,
     !document?.isDraft,
     !!document?.isActive,
@@ -212,7 +211,6 @@ allow(User, "archive", Document, (actor, document) =>
 
 allow(User, "unarchive", Document, (actor, document) =>
   and(
-    !actor.isGuest,
     !document?.template,
     !document?.isDraft,
     !document?.isDeleted,

--- a/server/policies/document.ts
+++ b/server/policies/document.ts
@@ -1,6 +1,10 @@
 import invariant from "invariant";
 import some from "lodash/some";
-import { DocumentPermission, TeamPreference } from "@shared/types";
+import {
+  CollectionPermission,
+  DocumentPermission,
+  TeamPreference,
+} from "@shared/types";
 import { Document, Revision, User, Team } from "@server/models";
 import { allow, _cannot as cannot, _can as can } from "./cancan";
 import { and, isTeamAdmin, isTeamModel, isTeamMutable, or } from "./utils";
@@ -254,7 +258,7 @@ allow(User, "unpublish", Document, (user, document) => {
 
 function includesMembership(
   document: Document | null,
-  permissions: DocumentPermission[]
+  permissions: (DocumentPermission | CollectionPermission)[]
 ) {
   if (!document) {
     return false;


### PR DESCRIPTION
Currently guests that have been given more permissions at collection or document level are hard-coded to not have access to some functionality