### PR TITLE
fix: remove attachment signing for document export

### DIFF
--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -552,7 +552,6 @@ router.post(
     if (accept?.includes("text/html")) {
       contentType = "text/html";
       content = await DocumentHelper.toHTML(document, {
-        signedUrls: true,
         centered: true,
         includeMermaid: true,
       });


### PR DESCRIPTION
Closes #7076 

Signing is not needed anymore since the attachments are part of the zip.