### PR TITLE
fix: set document's collection for determining policies

### DIFF
--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -1049,6 +1049,13 @@ router.post(
       ip: ctx.request.ip,
     });
 
+    collection = document.collectionId
+      ? await Collection.scope({
+          method: ["withMembership", user.id],
+        }).findByPk(document.collectionId, { transaction })
+      : null;
+    document.collection = collection;
+
     ctx.body = {
       data: await presentDocument(ctx, document),
       policies: presentPolicies(user, [document]),


### PR DESCRIPTION
Closes #7107 

Document permissions are set to `false` since the collection is not loaded for the document.

Fails here -> https://github.com/outline/outline/blob/main/server/policies/document.ts#L32

As an action item, we should add `policy` checks to all the API tests to prevent such regressions.