### PR TITLE
fix: allow user to remove document icon

### DIFF
--- a/server/routes/api/documents/documents.test.ts
+++ b/server/routes/api/documents/documents.test.ts
@@ -3182,6 +3182,29 @@ describe("#documents.update", () => {
     expect(body.data.color).toBe("#FFDDEE");
   });
 
+  it("should successfully remove the icon", async () => {
+    const user = await buildUser();
+    const document = await buildDocument({
+      userId: user.id,
+      teamId: user.teamId,
+      icon: "beaker",
+      color: "#FFDDEE",
+    });
+    const res = await server.post("/api/documents.update", {
+      body: {
+        token: user.getJwtToken(),
+        id: document.id,
+        icon: null,
+        color: null,
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.data.icon).toBeNull();
+    expect(body.data.emoji).toBeNull();
+    expect(body.data.color).toBeNull();
+  });
+
   it("should not add template to collection structure when publishing", async () => {
     const user = await buildUser();
     const collection = await buildCollection({

--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -1043,7 +1043,7 @@ router.post(
       document,
       user,
       ...input,
-      icon: input.icon ?? input.emoji,
+      icon: input.icon ?? input.emoji ?? null,
       publish,
       collectionId,
       insightsEnabled,


### PR DESCRIPTION
Regression from #7038 

With the fallback logic, `undefined` is being set which prevents the icon removal.