### PR TITLE
fix: Improve SmartText fraction regex pattern

### DIFF
--- a/app/editor/extensions/SmartText.ts
+++ b/app/editor/extensions/SmartText.ts
@@ -4,8 +4,8 @@ import { InputRule } from "@shared/editor/lib/InputRule";
 
 const rightArrow = new InputRule(/->$/, "→");
 const emdash = new InputRule(/--$/, "—");
-const oneHalf = new InputRule(/1\/2$/, "½");
-const threeQuarters = new InputRule(/3\/4$/, "¾");
+const oneHalf = new InputRule(/(?:^|\s)1\/2$/, "½");
+const threeQuarters = new InputRule(/(?:^|\s)3\/4$/, "¾");
 const copyright = new InputRule(/\(c\)$/, "©️");
 const registered = new InputRule(/\(r\)$/, "®️");
 const trademarked = new InputRule(/\(tm\)$/, "™️");


### PR DESCRIPTION
Modify fraction regex statements to not match if directly preceded by a character