### PR TITLE
fix: Admins cannot query permissions on private collections

### DIFF
--- a/app/components/Sharing/components/Suggestions.tsx
+++ b/app/components/Sharing/components/Suggestions.tsx
@@ -100,7 +100,7 @@ export const Suggestions = observer(
           : collection
           ? users.notInCollection(collection.id, query)
           : users.orderedData
-      ).filter((u) => u.id !== user.id && !u.isSuspended);
+      ).filter((u) => !u.isSuspended);
 
       if (isEmail(query)) {
         filtered.push(getSuggestionForEmail(query));

--- a/server/policies/collection.test.ts
+++ b/server/policies/collection.test.ts
@@ -27,7 +27,7 @@ describe("admin", () => {
     expect(abilities.updateDocument).toEqual(false);
     expect(abilities.createDocument).toEqual(false);
     expect(abilities.share).toEqual(false);
-    expect(abilities.read).toEqual(false);
+    expect(abilities.read).toEqual(true);
     expect(abilities.update).toEqual(true);
   });
 

--- a/server/policies/collection.ts
+++ b/server/policies/collection.ts
@@ -32,9 +32,24 @@ allow(User, "move", Collection, (actor, collection) =>
   )
 );
 
+allow(User, "read", Collection, (user, collection) => {
+  if (!collection || user.teamId !== collection.teamId) {
+    return false;
+  }
+  if (user.isAdmin) {
+    return true;
+  }
+
+  if (collection.isPrivate || user.isGuest) {
+    return includesMembership(collection, Object.values(CollectionPermission));
+  }
+
+  return true;
+});
+
 allow(
   User,
-  ["read", "readDocument", "star", "unstar"],
+  ["readDocument", "star", "unstar"],
   Collection,
   (user, collection) => {
     if (!collection || user.teamId !== collection.teamId) {

--- a/server/policies/document.ts
+++ b/server/policies/document.ts
@@ -138,7 +138,7 @@ allow(User, "createChildDocument", Document, (actor, document) =>
     can(actor, "update", document),
     or(
       includesMembership(document, [DocumentPermission.Admin]),
-      can(actor, "read", document?.collection)
+      can(actor, "readDocument", document?.collection)
     ),
     !document?.isDraft,
     !document?.template


### PR DESCRIPTION
This causes a bug in enterprise edition where collections cannot be properly managed.

closes OLN-460