### PR TITLE
fixed wrong discord callback url

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -131,7 +131,7 @@ GITHUB_APP_PRIVATE_KEY=
 # => https://discord.com/developers/applications/
 #
 # When configuring the Client ID, add a redirect URL under "OAuth2":
-# https://<URL>/api/discord.callback
+# https://<URL>/auth/discord.callback
 DISCORD_CLIENT_ID=
 DISCORD_CLIENT_SECRET=
 


### PR DESCRIPTION
The Discord oAuth callback url example was wrong in the env example.