### PR TITLE
Add error state for broken images

### DIFF
--- a/app/editor/components/FloatingToolbar.tsx
+++ b/app/editor/components/FloatingToolbar.tsx
@@ -5,6 +5,7 @@ import { Portal as ReactPortal } from "react-portal";
 import styled, { css } from "styled-components";
 import { isCode } from "@shared/editor/lib/isCode";
 import { findParentNode } from "@shared/editor/queries/findParentNode";
+import { EditorStyleHelper } from "@shared/editor/styles/EditorStyleHelper";
 import { depths, s } from "@shared/styles";
 import { Portal } from "~/components/Portal";
 import useComponentSize from "~/hooks/useComponentSize";
@@ -131,10 +132,10 @@ function usePosition({
   if (isImageSelection) {
     const element = view.nodeDOM(selection.from);
 
-    // Images are wrapped which impacts positioning - need to traverse through
-    // p > span > div.image
-    const imageElement = (element as HTMLElement).getElementsByTagName(
-      "img"
+    // Images are wrapped which impacts positioning - need to get the element
+    // specifically tagged as the handle
+    const imageElement = (element as HTMLElement).getElementsByClassName(
+      EditorStyleHelper.imageHandle
     )[0];
     const { left, top, width } = imageElement.getBoundingClientRect();
 

--- a/shared/editor/styles/EditorStyleHelper.ts
+++ b/shared/editor/styles/EditorStyleHelper.ts
@@ -2,6 +2,10 @@
  * Class names and values used by the editor.
  */
 export class EditorStyleHelper {
+  // Images
+
+  static readonly imageHandle = "image-handle";
+
   // Comments
 
   static readonly comment = "comment-marker";


### PR DESCRIPTION
Broken images can happen when pasting external content, in this case they are hard to select and remove

closes #7195 