### PR TITLE
fix: unset active collection id when navigating away from a document

### DIFF
--- a/app/stores/UiStore.ts
+++ b/app/stores/UiStore.ts
@@ -193,6 +193,10 @@ class UiStore {
   clearActiveDocument = (): void => {
     this.activeDocumentId = undefined;
     this.observingUserId = undefined;
+
+    // Unset when navigating away from a document (e.g. to another document, home, settings, etc.)
+    // Next document's onMount will set the right activeCollectionId.
+    this.activeCollectionId = undefined;
   };
 
   @action


### PR DESCRIPTION
This PR fixes a bug where it was possible to act on a collection in command bar after navigating from a document to a non-collection space (eg. home, trash, settings).
 