### PR TITLE
doc editors can create child docs

### DIFF
--- a/server/policies/document.test.ts
+++ b/server/policies/document.test.ts
@@ -384,7 +384,7 @@ describe("read_write document", () => {
       expect(abilities.subscribe).toEqual(true);
       expect(abilities.unsubscribe).toEqual(true);
       expect(abilities.comment).toEqual(true);
-      expect(abilities.createChildDocument).toEqual(false);
+      expect(abilities.createChildDocument).toEqual(true);
       expect(abilities.manageUsers).toEqual(false);
       expect(abilities.archive).toEqual(false);
       expect(abilities.share).toEqual(false);

--- a/server/policies/document.ts
+++ b/server/policies/document.ts
@@ -134,15 +134,7 @@ allow(User, "move", Document, (actor, document) =>
 );
 
 allow(User, "createChildDocument", Document, (actor, document) =>
-  and(
-    can(actor, "update", document),
-    or(
-      includesMembership(document, [DocumentPermission.Admin]),
-      can(actor, "readDocument", document?.collection)
-    ),
-    !document?.isDraft,
-    !document?.template
-  )
+  and(can(actor, "update", document), !document?.isDraft, !document?.template)
 );
 
 allow(User, ["updateInsights", "pin", "unpin"], Document, (actor, document) =>


### PR DESCRIPTION
The change below also works, but deleting extra lines to just rely on the "update" permissions simplifies things.
```
allow(User, "createChildDocument", Document, (actor, document) =>
  and(
    can(actor, "update", document),
    or(
      includesMembership(document, [DocumentPermission.Admin, DocumentPermission.ReadWrite]),
      can(actor, "readDocument", document?.collection)
    ),
    !document?.isDraft,
    !document?.template
  )
  and(can(actor, "update", document), !document?.isDraft, !document?.template)
);
```