### PR TITLE
fix: replace document links when importing markdown

### DIFF
--- a/server/queues/tasks/ImportMarkdownZipTask.ts
+++ b/server/queues/tasks/ImportMarkdownZipTask.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import fs from "fs-extra";
 import escapeRegExp from "lodash/escapeRegExp";
 import mime from "mime-types";
@@ -42,6 +43,8 @@ export default class ImportMarkdownZipTask extends ImportTask {
       documents: [],
       attachments: [],
     };
+
+    const docPathToIdMap = new Map<string, string>();
 
     async function parseNodeChildren(
       children: FileTreeNode[],
@@ -102,6 +105,8 @@ export default class ImportMarkdownZipTask extends ImportTask {
           // When there is a file and a folder with the same name this handles
           // the case by combining the two into one document with nested children
           if (existingDocument) {
+            docPathToIdMap.set(child.path, existingDocument.id);
+
             if (existingDocument.text === "") {
               output.documents[existingDocumentIndex].text = text;
             }
@@ -112,6 +117,8 @@ export default class ImportMarkdownZipTask extends ImportTask {
               existingDocument.id
             );
           } else {
+            docPathToIdMap.set(child.path, id);
+
             output.documents.push({
               id,
               title,
@@ -146,9 +153,9 @@ export default class ImportMarkdownZipTask extends ImportTask {
       }
     }
 
-    // Check all of the attachments we've created against urls in the text
-    // and replace them out with attachment redirect urls before continuing.
     for (const document of output.documents) {
+      // Check all of the attachments we've created against urls in the text
+      // and replace them out with attachment redirect urls before continuing.
       for (const attachment of output.attachments) {
         const encodedPath = encodeURI(attachment.path);
 
@@ -169,6 +176,29 @@ export default class ImportMarkdownZipTask extends ImportTask {
             reference
           );
       }
+
+      const basePath = path.dirname(document.path);
+
+      // check internal document links in the text and replace them with placeholders.
+      // When persisting, the placeholders will be replaced with the right urls.
+      const internalLinks = [
+        ...document.text.matchAll(/\[[^\]]+\]\(([^)]+\.md)\)/g),
+      ];
+
+      internalLinks.forEach((match) => {
+        const referredDocPath = match[1];
+        const normalizedDocPath = decodeURI(
+          path.normalize(`${basePath}/${referredDocPath}`)
+        );
+
+        const referredDocId = docPathToIdMap.get(normalizedDocPath);
+        if (referredDocId) {
+          document.text = document.text.replace(
+            referredDocPath,
+            `<<${referredDocId}>>`
+          );
+        }
+      });
     }
 
     return output;


### PR DESCRIPTION
Closes #7089 