### PR TITLE
fix: Set doc slug on importing collections

### DIFF
--- a/server/models/Collection.ts
+++ b/server/models/Collection.ts
@@ -3,7 +3,6 @@ import find from "lodash/find";
 import findIndex from "lodash/findIndex";
 import remove from "lodash/remove";
 import uniq from "lodash/uniq";
-import randomstring from "randomstring";
 import {
   Identifier,
   Transaction,
@@ -39,6 +38,7 @@ import { sortNavigationNodes } from "@shared/utils/collections";
 import slugify from "@shared/utils/slugify";
 import { CollectionValidation } from "@shared/validations";
 import { ValidationError } from "@server/errors";
+import { generateUrlId } from "@server/utils/url";
 import Document from "./Document";
 import FileOperation from "./FileOperation";
 import Group from "./Group";
@@ -267,7 +267,7 @@ class Collection extends ParanoidModel<
 
   @BeforeValidate
   static async onBeforeValidate(model: Collection) {
-    model.urlId = model.urlId || randomstring.generate(10);
+    model.urlId = model.urlId || generateUrlId();
   }
 
   @BeforeSave

--- a/server/models/Document.ts
+++ b/server/models/Document.ts
@@ -51,7 +51,7 @@ import { UrlHelper } from "@shared/utils/UrlHelper";
 import slugify from "@shared/utils/slugify";
 import { DocumentValidation } from "@shared/validations";
 import { ValidationError } from "@server/errors";
-import { generateDocUrlId } from "@server/utils/url";
+import { generateUrlId } from "@server/utils/url";
 import Backlink from "./Backlink";
 import Collection from "./Collection";
 import FileOperation from "./FileOperation";
@@ -425,7 +425,7 @@ class Document extends ParanoidModel<
 
   @BeforeValidate
   static createUrlId(model: Document) {
-    return (model.urlId = model.urlId || generateDocUrlId());
+    return (model.urlId = model.urlId || generateUrlId());
   }
 
   @BeforeCreate

--- a/server/models/Document.ts
+++ b/server/models/Document.ts
@@ -2,7 +2,6 @@
 import compact from "lodash/compact";
 import isNil from "lodash/isNil";
 import uniq from "lodash/uniq";
-import randomstring from "randomstring";
 import type {
   Identifier,
   InferAttributes,
@@ -52,6 +51,7 @@ import { UrlHelper } from "@shared/utils/UrlHelper";
 import slugify from "@shared/utils/slugify";
 import { DocumentValidation } from "@shared/validations";
 import { ValidationError } from "@server/errors";
+import { generateDocUrlId } from "@server/utils/url";
 import Backlink from "./Backlink";
 import Collection from "./Collection";
 import FileOperation from "./FileOperation";
@@ -356,6 +356,13 @@ class Document extends ParanoidModel<
     );
   }
 
+  static getPath({ title, urlId }: { title: string; urlId: string }) {
+    if (!title.length) {
+      return `/doc/untitled-${urlId}`;
+    }
+    return `/doc/${slugify(title)}-${urlId}`;
+  }
+
   // hooks
 
   @BeforeSave
@@ -418,7 +425,7 @@ class Document extends ParanoidModel<
 
   @BeforeValidate
   static createUrlId(model: Document) {
-    return (model.urlId = model.urlId || randomstring.generate(10));
+    return (model.urlId = model.urlId || generateDocUrlId());
   }
 
   @BeforeCreate

--- a/server/queues/tasks/ExportDocumentTreeTask.ts
+++ b/server/queues/tasks/ExportDocumentTreeTask.ts
@@ -213,6 +213,10 @@ export default abstract class ExportDocumentTreeTask extends ExportTask {
 
       map.set(node.url, filePath);
 
+      // If this is an imported document, the references to this doc are in the 'doc/{docId}' format.
+      // Set this format to replace them with relative URLs in the zip.
+      map.set(`/doc/${node.id}`, filePath);
+
       if (node.children?.length) {
         this.addDocumentTreeToPathMap(
           map,

--- a/server/queues/tasks/ImportTask.ts
+++ b/server/queues/tasks/ImportTask.ts
@@ -25,7 +25,7 @@ import {
 } from "@server/models";
 import { sequelize } from "@server/storage/database";
 import ZipHelper from "@server/utils/ZipHelper";
-import { generateDocUrlId } from "@server/utils/url";
+import { generateUrlId } from "@server/utils/url";
 import BaseTask, { TaskPriority } from "./BaseTask";
 
 type Props = {
@@ -563,7 +563,7 @@ export default abstract class ImportTask extends BaseTask<Props> {
         }
       }
 
-      doc.urlId = generateDocUrlId();
+      doc.urlId = generateUrlId();
     }
   }
 }

--- a/server/queues/tasks/ImportTask.ts
+++ b/server/queues/tasks/ImportTask.ts
@@ -25,6 +25,7 @@ import {
 } from "@server/models";
 import { sequelize } from "@server/storage/database";
 import ZipHelper from "@server/utils/ZipHelper";
+import { generateDocUrlId } from "@server/utils/url";
 import BaseTask, { TaskPriority } from "./BaseTask";
 
 type Props = {
@@ -298,6 +299,8 @@ export default abstract class ImportTask extends BaseTask<Props> {
     const ip = user.lastActiveIp || undefined;
 
     try {
+      await this.preprocessDocUrlIds(data);
+
       // Collections
       for (const item of data.collections) {
         await sequelize.transaction(async (transaction) => {
@@ -324,13 +327,11 @@ export default abstract class ImportTask extends BaseTask<Props> {
             }
 
             // Check all of the document we've created against urls in the text
-            // and replace them out with a valid internal link. Because we are doing
-            // this before saving, we can't use the document slug, but we can take
-            // advantage of the fact that the document id will redirect in the client
+            // and replace them out with a valid internal link.
             for (const ditem of data.documents) {
               description = description.replace(
                 new RegExp(`<<${ditem.id}>>`, "g"),
-                `/doc/${ditem.id}`
+                Document.getPath({ title: ditem.title, urlId: ditem.urlId! })
               );
             }
           }
@@ -442,34 +443,15 @@ export default abstract class ImportTask extends BaseTask<Props> {
             }
 
             // Check all of the document we've created against urls in the text
-            // and replace them out with a valid internal link. Because we are doing
-            // this before saving, we can't use the document slug, but we can take
-            // advantage of the fact that the document id will redirect in the client
+            // and replace them out with a valid internal link.
             for (const ditem of data.documents) {
               text = text.replace(
                 new RegExp(`<<${ditem.id}>>`, "g"),
-                `/doc/${ditem.id}`
+                Document.getPath({ title: ditem.title, urlId: ditem.urlId! })
               );
             }
 
-            const options: { urlId?: string } = {};
-            if (item.urlId) {
-              const existing = await Document.unscoped().findOne({
-                attributes: ["id"],
-                paranoid: false,
-                transaction,
-                where: {
-                  urlId: item.urlId,
-                },
-              });
-
-              if (!existing) {
-                options.urlId = item.urlId;
-              }
-            }
-
             const document = await documentCreator({
-              ...options,
               sourceMetadata: {
                 fileName: path.basename(item.path),
                 mimeType: item.mimeType,
@@ -478,6 +460,7 @@ export default abstract class ImportTask extends BaseTask<Props> {
               },
               id: item.id,
               title: item.title,
+              urlId: item.urlId,
               text,
               collectionId: item.collectionId,
               createdAt: item.createdAt,
@@ -561,5 +544,26 @@ export default abstract class ImportTask extends BaseTask<Props> {
       priority: TaskPriority.Low,
       attempts: 1,
     };
+  }
+
+  private async preprocessDocUrlIds(data: StructuredImportData) {
+    for (const doc of data.documents) {
+      // check DB only if urlId is present in the input.
+      if (doc.urlId) {
+        const existing = await Document.unscoped().findOne({
+          attributes: ["id"],
+          paranoid: false,
+          where: {
+            urlId: doc.urlId,
+          },
+        });
+
+        if (!existing) {
+          continue;
+        }
+      }
+
+      doc.urlId = generateDocUrlId();
+    }
   }
 }

--- a/server/utils/url.ts
+++ b/server/utils/url.ts
@@ -1,0 +1,5 @@
+import randomstring from "randomstring";
+
+const DocumentUrlIdLen = 10;
+
+export const generateDocUrlId = () => randomstring.generate(DocumentUrlIdLen);

--- a/server/utils/url.ts
+++ b/server/utils/url.ts
@@ -1,5 +1,5 @@
 import randomstring from "randomstring";
 
-const DocumentUrlIdLen = 10;
+const UrlIdLength = 10;
 
-export const generateDocUrlId = () => randomstring.generate(DocumentUrlIdLen);
+export const generateUrlId = () => randomstring.generate(UrlIdLength);


### PR DESCRIPTION
This PR removes the `doc/{docId}` format and sets the doc slug when collections are imported.

Documents which use `doc/{docId}` to link other documents do not have these references replaced with relative URLs when exported. This PR fixes this as well.

Bug mentioned [here](https://github.com/outline/outline/pull/7259#discussion_r1679128685)

Related #7259 