### PR TITLE
feat: Cache count of group members

### DIFF
--- a/plugins/webhooks/server/tasks/DeliverWebhookTask.ts
+++ b/plugins/webhooks/server/tasks/DeliverWebhookTask.ts
@@ -394,7 +394,7 @@ export default class DeliverWebhookTask extends BaseTask<Props> {
       subscription,
       payload: {
         id: event.modelId,
-        model: model && presentGroup(model),
+        model: model && (await presentGroup(model)),
       },
     });
   }
@@ -417,7 +417,7 @@ export default class DeliverWebhookTask extends BaseTask<Props> {
       payload: {
         id: `${event.userId}-${event.modelId}`,
         model: model && presentGroupUser(model),
-        group: model && presentGroup(model.group),
+        group: model && (await presentGroup(model.group)),
         user: model && presentUser(model.user),
       },
     });
@@ -510,7 +510,7 @@ export default class DeliverWebhookTask extends BaseTask<Props> {
         id: event.modelId,
         model: model && presentGroupMembership(model),
         collection,
-        group: model && presentGroup(model.group),
+        group: model && (await presentGroup(model.group)),
       },
     });
   }
@@ -613,7 +613,7 @@ export default class DeliverWebhookTask extends BaseTask<Props> {
         id: event.modelId,
         model: model && presentDocumentGroupMembership(model),
         document,
-        group: model && presentGroup(model.group),
+        group: model && (await presentGroup(model.group)),
       },
     });
   }

--- a/server/commands/documentPermanentDeleter.test.ts
+++ b/server/commands/documentPermanentDeleter.test.ts
@@ -4,7 +4,9 @@ import DeleteAttachmentTask from "@server/queues/tasks/DeleteAttachmentTask";
 import { buildAttachment, buildDocument } from "@server/test/factories";
 import documentPermanentDeleter from "./documentPermanentDeleter";
 
-jest.mock("@server/queues/tasks/DeleteAttachmentTask");
+jest.mock("@server/queues/tasks/DeleteAttachmentTask", () => ({
+  schedule: jest.fn(),
+}));
 
 describe("documentPermanentDeleter", () => {
   it("should destroy documents", async () => {

--- a/server/models/Group.ts
+++ b/server/models/Group.ts
@@ -6,7 +6,6 @@ import {
   Table,
   HasMany,
   BelongsToMany,
-  DefaultScope,
   DataType,
   Scopes,
 } from "sequelize-typescript";
@@ -20,26 +19,14 @@ import Fix from "./decorators/Fix";
 import Length from "./validators/Length";
 import NotContainsUrl from "./validators/NotContainsUrl";
 
-@DefaultScope(() => ({
-  include: [
-    {
-      association: "groupUsers",
-      required: false,
-    },
-  ],
-}))
 @Scopes(() => ({
-  withMember: (memberId: string) => ({
+  withMembership: (userId: string) => ({
     include: [
       {
         association: "groupUsers",
         required: true,
-      },
-      {
-        association: "members",
-        required: true,
         where: {
-          userId: memberId,
+          userId,
         },
       },
     ],
@@ -78,16 +65,15 @@ class Group extends ParanoidModel<
   @Column
   name: string;
 
-  static filterByMember(memberId: string | undefined) {
-    return memberId
-      ? this.scope({ method: ["withMember", memberId] })
+  static filterByMember(userId: string | undefined) {
+    return userId
+      ? this.scope({ method: ["withMembership", userId] })
       : this.scope("defaultScope");
   }
 
   // associations
 
   @HasMany(() => GroupUser, "groupId")
-  @HasMany(() => GroupUser, { as: "members", foreignKey: "groupId" })
   groupUsers: GroupUser[];
 
   @HasMany(() => GroupMembership, "groupId")

--- a/server/models/decorators/CounterCache.ts
+++ b/server/models/decorators/CounterCache.ts
@@ -1,0 +1,75 @@
+import { InferAttributes } from "sequelize";
+import { ModelClassGetter } from "sequelize-typescript";
+import { Day } from "@shared/utils/time";
+import { CacheHelper } from "@server/utils/CacheHelper";
+import Model from "../base/Model";
+
+type RelationOptions = {
+  /** Reference name used in cache key. */
+  as: string;
+  /** The foreign key to use for the relationship query. */
+  foreignKey: string;
+};
+
+/**
+ * A decorator that caches the count of a relationship and registers model lifecycle hooks
+ * to invalidate the cache when models are added or removed from the relationship.
+ */
+export function CounterCache<
+  TCreationAttributes extends InferAttributes<Model>,
+  TModelAttributes extends InferAttributes<Model>,
+  T extends typeof Model
+>(
+  classResolver: ModelClassGetter<TCreationAttributes, TModelAttributes>,
+  options: RelationOptions
+) {
+  return function (target: InstanceType<T>, _propertyKey: string) {
+    const modelClass = classResolver() as typeof Model;
+    const cacheKeyPrefix = `count:${target.constructor.name}:${options.as}`;
+
+    // Add hooks after model is added to the sequelize instance
+    setImmediate(() => {
+      const recalculateCache =
+        (offset: number) => async (model: InstanceType<T>) => {
+          const cacheKey = `${cacheKeyPrefix}:${model[options.foreignKey]}`;
+
+          const count = await modelClass.count({
+            where: {
+              [options.foreignKey]: model[options.foreignKey],
+            },
+          });
+          await CacheHelper.setData(cacheKey, count + offset, Day * 7);
+        };
+
+      // Because the transaction is not complete until after the response is sent, we need to
+      // offset the count by 1 to account for the record. TODO: Need to find a better way to handle
+      // this as a rollback would not decrement the count.
+      modelClass.addHook("afterCreate", recalculateCache(1));
+      modelClass.addHook("afterDestroy", recalculateCache(-1));
+    });
+
+    return {
+      get() {
+        const cacheKey = `${cacheKeyPrefix}:${this.id}`;
+
+        return CacheHelper.getData<number>(cacheKey).then((value) => {
+          if (value) {
+            return value;
+          }
+
+          // calculate and cache count
+          return modelClass
+            .count({
+              where: {
+                [options.foreignKey]: this.id,
+              },
+            })
+            .then((count) => {
+              void CacheHelper.setData(cacheKey, count);
+              return count;
+            });
+        });
+      },
+    } as any;
+  };
+}

--- a/server/models/decorators/CounterCache.ts
+++ b/server/models/decorators/CounterCache.ts
@@ -52,7 +52,7 @@ export function CounterCache<
         const cacheKey = `${cacheKeyPrefix}:${this.id}`;
 
         return CacheHelper.getData<number>(cacheKey).then((value) => {
-          if (value) {
+          if (value !== null) {
             return value;
           }
 

--- a/server/models/decorators/CounterCache.ts
+++ b/server/models/decorators/CounterCache.ts
@@ -1,6 +1,5 @@
 import { InferAttributes } from "sequelize";
 import { ModelClassGetter } from "sequelize-typescript";
-import { Day } from "@shared/utils/time";
 import { CacheHelper } from "@server/utils/CacheHelper";
 import Model from "../base/Model";
 
@@ -38,7 +37,7 @@ export function CounterCache<
               [options.foreignKey]: model[options.foreignKey],
             },
           });
-          await CacheHelper.setData(cacheKey, count + offset, Day * 7);
+          await CacheHelper.setData(cacheKey, count + offset);
         };
 
       // Because the transaction is not complete until after the response is sent, we need to

--- a/server/presenters/group.ts
+++ b/server/presenters/group.ts
@@ -4,7 +4,7 @@ export default async function presentGroup(group: Group) {
   return {
     id: group.id,
     name: group.name,
-    memberCount: await group.memberCount(),
+    memberCount: await group.memberCount,
     createdAt: group.createdAt,
     updatedAt: group.updatedAt,
   };

--- a/server/presenters/group.ts
+++ b/server/presenters/group.ts
@@ -1,10 +1,10 @@
 import Group from "@server/models/Group";
 
-export default function presentGroup(group: Group) {
+export default async function presentGroup(group: Group) {
   return {
     id: group.id,
     name: group.name,
-    memberCount: group.groupUsers.length,
+    memberCount: await group.memberCount(),
     createdAt: group.createdAt,
     updatedAt: group.updatedAt,
   };

--- a/server/queues/processors/WebsocketsProcessor.ts
+++ b/server/queues/processors/WebsocketsProcessor.ts
@@ -296,14 +296,13 @@ export default class WebsocketsProcessor {
       }
 
       case "collections.add_group": {
-        const group = await Group.findByPk(event.modelId);
-        if (!group) {
-          return;
-        }
+        const groupUsers = await GroupUser.findAll({
+          where: { groupId: event.modelId },
+        });
 
         // the users being added are not yet in the websocket channel for the collection
         // so they need to be notified separately
-        for (const groupUser of group.groupUsers) {
+        for (const groupUser of groupUsers) {
           socketio.to(`user-${groupUser.userId}`).emit("collections.add_user", {
             event: event.name,
             userId: groupUser.userId,
@@ -320,16 +319,14 @@ export default class WebsocketsProcessor {
       }
 
       case "collections.remove_group": {
-        const group = await Group.findByPk(event.modelId);
-        if (!group) {
-          return;
-        }
+        const [groupUsers, membershipUserIds] = await Promise.all([
+          GroupUser.findAll({
+            where: { groupId: event.modelId },
+          }),
+          Collection.membershipUserIds(event.collectionId),
+        ]);
 
-        const membershipUserIds = await Collection.membershipUserIds(
-          event.collectionId
-        );
-
-        for (const groupUser of group.groupUsers) {
+        for (const groupUser of groupUsers) {
           if (membershipUserIds.includes(groupUser.userId)) {
             // the user still has access through some means...
             // treat this like an add, so that the client re-syncs policies

--- a/server/queues/processors/WebsocketsProcessor.ts
+++ b/server/queues/processors/WebsocketsProcessor.ts
@@ -482,7 +482,7 @@ export default class WebsocketsProcessor {
         }
         return socketio
           .to(`team-${group.teamId}`)
-          .emit(event.name, presentGroup(group));
+          .emit(event.name, await presentGroup(group));
       }
 
       case "groups.add_user": {

--- a/server/routes/api/collections/collections.ts
+++ b/server/routes/api/collections/collections.ts
@@ -379,7 +379,9 @@ router.post(
         // `collectionGroupMemberships` retained for backwards compatibility – remove after version v0.79.0
         collectionGroupMemberships: groupMemberships,
         groupMemberships,
-        groups: memberships.map((membership) => presentGroup(membership.group)),
+        groups: await Promise.all(
+          memberships.map((membership) => presentGroup(membership.group))
+        ),
       },
     };
   }

--- a/server/routes/api/groups/groups.ts
+++ b/server/routes/api/groups/groups.ts
@@ -60,7 +60,7 @@ router.post(
     ctx.body = {
       pagination: ctx.state.pagination,
       data: {
-        groups: groups.map(presentGroup),
+        groups: await Promise.all(groups.map(presentGroup)),
         groupMemberships: groups
           .map((group) =>
             group.groupUsers
@@ -89,7 +89,7 @@ router.post(
     authorize(user, "read", group);
 
     ctx.body = {
-      data: presentGroup(group),
+      data: await presentGroup(group),
       policies: presentPolicies(user, [group]),
     };
   }
@@ -134,7 +134,7 @@ router.post(
     );
 
     ctx.body = {
-      data: presentGroup(group),
+      data: await presentGroup(group),
       policies: presentPolicies(user, [group]),
     };
   }
@@ -171,7 +171,7 @@ router.post(
     }
 
     ctx.body = {
-      data: presentGroup(group),
+      data: await presentGroup(group),
       policies: presentPolicies(user, [group]),
     };
   }
@@ -321,7 +321,7 @@ router.post(
       data: {
         users: [presentUser(user)],
         groupMemberships: [presentGroupUser(groupUser, { includeUser: true })],
-        groups: [presentGroup(group)],
+        groups: [await presentGroup(group)],
       },
     };
   }
@@ -362,7 +362,7 @@ router.post(
 
     ctx.body = {
       data: {
-        groups: [presentGroup(group)],
+        groups: [await presentGroup(group)],
       },
     };
   }

--- a/server/routes/api/groups/groups.ts
+++ b/server/routes/api/groups/groups.ts
@@ -74,6 +74,7 @@ router.post(
           )
         )
           .flat()
+          .filter((groupUser) => groupUser.user)
           .map((groupUser) =>
             presentGroupUser(groupUser, { includeUser: true })
           ),

--- a/server/routes/api/urls/urls.ts
+++ b/server/routes/api/urls/urls.ts
@@ -12,7 +12,7 @@ import validate from "@server/middlewares/validate";
 import { Document, Share, Team, User } from "@server/models";
 import { authorize } from "@server/policies";
 import presentUnfurl from "@server/presenters/unfurl";
-import { APIContext } from "@server/types";
+import { APIContext, Unfurl } from "@server/types";
 import { CacheHelper } from "@server/utils/CacheHelper";
 import { Hook, PluginManager } from "@server/utils/PluginManager";
 import { RateLimiterStrategy } from "@server/utils/RateLimiter";
@@ -84,7 +84,7 @@ router.post(
     }
 
     // External resources
-    const cachedData = await CacheHelper.getData(
+    const cachedData = await CacheHelper.getData<Unfurl>(
       CacheHelper.getUnfurlKey(actor.teamId, url)
     );
     if (cachedData) {
@@ -138,11 +138,11 @@ router.post(
     let addresses;
     try {
       addresses = await new Promise<string[]>((resolve, reject) => {
-        dns.resolveCname(hostname, (err, addresses) => {
+        dns.resolveCname(hostname, (err, res) => {
           if (err) {
             return reject(err);
           }
-          return resolve(addresses);
+          return resolve(res);
         });
       });
     } catch (err) {

--- a/server/storage/database.ts
+++ b/server/storage/database.ts
@@ -1,9 +1,7 @@
 import path from "path";
-import { InferAttributes, InferCreationAttributes } from "sequelize";
 import { Sequelize } from "sequelize-typescript";
 import { Umzug, SequelizeStorage, MigrationError } from "umzug";
 import env from "@server/env";
-import Model from "@server/models/base/Model";
 import Logger from "../logging/Logger";
 import * as models from "../models";
 
@@ -13,15 +11,7 @@ const poolMin = env.DATABASE_CONNECTION_POOL_MIN ?? 0;
 const url = env.DATABASE_CONNECTION_POOL_URL || env.DATABASE_URL;
 const schema = env.DATABASE_SCHEMA;
 
-export function createDatabaseInstance(
-  url: string,
-  models: {
-    [key: string]: typeof Model<
-      InferAttributes<Model>,
-      InferCreationAttributes<Model>
-    >;
-  }
-) {
+export function createDatabaseInstance() {
   return new Sequelize(url, {
     logging: (msg) =>
       process.env.DEBUG?.includes("database") && Logger.debug("database", msg),
@@ -115,7 +105,7 @@ export function createMigrationRunner(
   });
 }
 
-export const sequelize = createDatabaseInstance(url, models);
+export const sequelize = createDatabaseInstance();
 
 export const migrations = createMigrationRunner(sequelize, [
   "migrations/*.js",

--- a/server/utils/CacheHelper.ts
+++ b/server/utils/CacheHelper.ts
@@ -17,7 +17,7 @@ export class CacheHelper {
   public static async getData<T>(key: string): Promise<T | undefined> {
     try {
       const data = await Redis.defaultClient.get(key);
-      if (data) {
+      if (data !== null) {
         return JSON.parse(data);
       }
     } catch (err) {

--- a/server/utils/CacheHelper.ts
+++ b/server/utils/CacheHelper.ts
@@ -6,6 +6,7 @@ import Redis from "@server/storage/redis";
  * A Helper class for server-side cache management
  */
 export class CacheHelper {
+  // Default expiry time for cache data in ms
   private static defaultDataExpiry = Day;
 
   /**
@@ -48,16 +49,6 @@ export class CacheHelper {
   }
 
   /**
-   * Gets key against which unfurl response for the given url is stored
-   *
-   * @param teamId The team ID to generate a key for
-   * @param url The url to generate a key for
-   */
-  public static getUnfurlKey(teamId: string, url = "") {
-    return `unfurl:${teamId}:${url}`;
-  }
-
-  /**
    * Clears all cache data with the given prefix
    *
    * @param prefix Prefix to clear cache data
@@ -70,5 +61,17 @@ export class CacheHelper {
         await Redis.defaultClient.del(key);
       })
     );
+  }
+
+  // keys
+
+  /**
+   * Gets key against which unfurl response for the given url is stored
+   *
+   * @param teamId The team ID to generate a key for
+   * @param url The url to generate a key for
+   */
+  public static getUnfurlKey(teamId: string, url = "") {
+    return `unfurl:${teamId}:${url}`;
   }
 }


### PR DESCRIPTION
This PR also adds a decorator to make it easy to cache any relationship count on any model going forward. 

This is useful foundational work towards https://github.com/outline/outline/pull/7275 as we really need to stop querying and returning all of the group memberships for performance (and reuse that for association for document memberships).