### PR TITLE
fix: Unable to scroll elements in latest chrome

### DIFF
--- a/app/components/Button.tsx
+++ b/app/components/Button.tsx
@@ -105,7 +105,7 @@ const RealButton = styled(ActionButton)<RealProps>`
         background: ${lighten(0.05, props.theme.danger)};
       }
 
-      &.focus-visible {
+      &:focus-visible {
         outline-color: ${darken(0.2, props.theme.danger)} !important;
       }
   `};

--- a/app/components/ContextMenu/MenuItem.tsx
+++ b/app/components/ContextMenu/MenuItem.tsx
@@ -152,7 +152,7 @@ export const MenuAnchorCSS = css<MenuAnchorProps>`
   @media (hover: hover) {
     &:hover,
     &:focus,
-    &.focus-visible {
+    &:focus-visible {
       color: ${props.theme.accentText};
       background: ${props.dangerous ? props.theme.danger : props.theme.accent};
       box-shadow: none;

--- a/app/components/ContextMenu/index.tsx
+++ b/app/components/ContextMenu/index.tsx
@@ -223,7 +223,7 @@ export const Position = styled.div`
   position: absolute;
   z-index: ${depths.menu};
 
-  &.focus-visible {
+  &:focus-visible {
     transition-delay: 250ms;
     transition-property: outline-width;
     transition-duration: 0;

--- a/app/components/InputSelect.tsx
+++ b/app/components/InputSelect.tsx
@@ -352,7 +352,7 @@ const Wrapper = styled.label<{ short?: boolean }>`
 `;
 
 export const Positioner = styled(Position)`
-  &.focus-visible {
+  &:focus-visible {
     ${StyledSelectOption} {
       &[aria-selected="true"] {
         color: ${(props) => props.theme.white};

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,6 +1,5 @@
 // eslint-disable-next-line import/no-unresolved
 import "vite/modulepreload-polyfill";
-import "focus-visible";
 import { LazyMotion } from "framer-motion";
 import { KBarProvider } from "kbar";
 import { Provider } from "mobx-react";

--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
     "fast-deep-equal": "^3.1.3",
     "fetch-retry": "^5.0.6",
     "fetch-with-proxy": "^3.0.1",
-    "focus-visible": "^5.2.0",
     "form-data": "^4.0.0",
     "fractional-index": "^1.0.0",
     "framer-motion": "^4.1.17",

--- a/shared/styles/globals.ts
+++ b/shared/styles/globals.ts
@@ -105,12 +105,7 @@ export default createGlobalStyle<Props>`
     border-top: 1px solid ${s("divider")};
   }
 
-  .js-focus-visible :focus:not(.focus-visible) {
-    outline: none;
-    outline-width: 0;
-  }
-
-  .js-focus-visible .focus-visible {
+  :focus-visible {
     outline-color: ${s("accent")};
     outline-offset: -1px;
     outline-width: initial;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8635,11 +8635,6 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity "sha1-JsrYAXlnrqhzG8QpYdBKPVmIrMw= sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
 
-focus-visible@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-5.2.0.tgz#3a9e41fccf587bd25dcc2ef045508284f0a4d6b3"
-  integrity "sha1-Op5B/M9Ye9JdzC7wRVCChPCk1rM= sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ=="
-
 follow-redirects@^1.15.6:
   version "1.15.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"


### PR DESCRIPTION
Removes the `focus-visible` polyfill as this caused a conflict with ProseMirror's DOM management in Chrome 127+ which made scrollable areas focusable.

Thankfully `:focus-visible` enjoys support in all major browser versions now, so this polyfill is no longer required and can be removed and usage replaced with the psuedo class.