### PR TITLE
Client lifecycle hooks

### DIFF
--- a/app/models/Collection.ts
+++ b/app/models/Collection.ts
@@ -12,7 +12,9 @@ import type CollectionsStore from "~/stores/CollectionsStore";
 import Document from "~/models/Document";
 import ParanoidModel from "~/models/base/ParanoidModel";
 import { client } from "~/utils/ApiClient";
+import Logger from "~/utils/Logger";
 import Field from "./decorators/Field";
+import { AfterUpdate } from "./decorators/Lifecycle";
 
 export default class Collection extends ParanoidModel {
   static modelName = "Collection";
@@ -324,4 +326,11 @@ export default class Collection extends ParanoidModel {
       format,
       includeAttachments,
     });
+
+  // hooks
+
+  @AfterUpdate
+  static testing(model: Collection) {
+    Logger.info("lifecycle", "AfterUpdate", { model });
+  }
 }

--- a/app/models/base/Model.ts
+++ b/app/models/base/Model.ts
@@ -4,6 +4,7 @@ import { JSONObject } from "@shared/types";
 import type Store from "~/stores/base/Store";
 import Logger from "~/utils/Logger";
 import { getFieldsForModel } from "../decorators/Field";
+import { LifecycleManager } from "../decorators/Lifecycle";
 import { getRelationsForModelClass } from "../decorators/Relation";
 
 export default abstract class Model {
@@ -92,6 +93,8 @@ export default abstract class Model {
         params = this.toAPI();
       }
 
+      LifecycleManager.executeHooks(this.constructor, "beforeUpdate", this);
+
       const model = await this.store.save(
         {
           ...params,
@@ -107,6 +110,7 @@ export default abstract class Model {
       set(this, { ...params, ...model, isNew: false });
 
       this.persistedAttributes = this.toAPI();
+      LifecycleManager.executeHooks(this.constructor, "afterUpdate", this);
 
       return model;
     } finally {

--- a/app/models/decorators/Lifecycle.ts
+++ b/app/models/decorators/Lifecycle.ts
@@ -53,10 +53,10 @@ export function AfterUpdate(target: any, propertyKey: string) {
   LifecycleManager.registerHook(target, propertyKey, "afterUpdate");
 }
 
-export function BeforeDestroy(target: any, propertyKey: string) {
-  LifecycleManager.registerHook(target, propertyKey, "beforeDestroy");
+export function BeforeDelete(target: any, propertyKey: string) {
+  LifecycleManager.registerHook(target, propertyKey, "beforeDelete");
 }
 
-export function AfterDestroy(target: any, propertyKey: string) {
-  LifecycleManager.registerHook(target, propertyKey, "afterDestroy");
+export function AfterDelete(target: any, propertyKey: string) {
+  LifecycleManager.registerHook(target, propertyKey, "afterDelete");
 }

--- a/app/models/decorators/Lifecycle.ts
+++ b/app/models/decorators/Lifecycle.ts
@@ -1,0 +1,62 @@
+export class LifecycleManager {
+  private static hooks = new Map();
+
+  public static getHooks(target: any, lifecycle: string) {
+    const key = `lifecycle:${lifecycle}`;
+    const modelHooks = this.hooks.get(target.name);
+    return modelHooks?.get(key) || [];
+  }
+
+  public static executeHooks(target: any, lifecycle: string, ...args: any[]) {
+    const hooks = this.getHooks(target, lifecycle);
+    hooks.forEach((hook: keyof typeof target) => {
+      target[hook](...args);
+    });
+  }
+
+  public static registerHook(
+    target: any,
+    propertyKey: string,
+    lifecycle: string
+  ) {
+    const key = `lifecycle:${lifecycle}`;
+    let modelHooks = this.hooks.get(target.name);
+
+    if (!modelHooks) {
+      modelHooks = new Map();
+      this.hooks.set(target.name, modelHooks);
+    }
+
+    let lifecycleHooks = modelHooks.get(key);
+    if (!lifecycleHooks) {
+      lifecycleHooks = [];
+      modelHooks.set(key, lifecycleHooks);
+    }
+
+    lifecycleHooks.push(propertyKey);
+  }
+}
+
+export function BeforeCreate(target: any, propertyKey: string) {
+  LifecycleManager.registerHook(target, propertyKey, "beforeCreate");
+}
+
+export function AfterCreate(target: any, propertyKey: string) {
+  LifecycleManager.registerHook(target, propertyKey, "afterCreate");
+}
+
+export function BeforeUpdate(target: any, propertyKey: string) {
+  LifecycleManager.registerHook(target, propertyKey, "beforeUpdate");
+}
+
+export function AfterUpdate(target: any, propertyKey: string) {
+  LifecycleManager.registerHook(target, propertyKey, "afterUpdate");
+}
+
+export function BeforeDestroy(target: any, propertyKey: string) {
+  LifecycleManager.registerHook(target, propertyKey, "beforeDestroy");
+}
+
+export function AfterDestroy(target: any, propertyKey: string) {
+  LifecycleManager.registerHook(target, propertyKey, "afterDestroy");
+}


### PR DESCRIPTION
We have over time created a bundle of imperative code handling side effects, this adds frontend model lifecycle hooks in the same format as the backend hooks provided by Sequelize to allow us to tidy these things up.