### PR TITLE
perf: Avoid count query in search where possible

### DIFF
--- a/plugins/slack/server/api/hooks.ts
+++ b/plugins/slack/server/api/hooks.ts
@@ -235,7 +235,7 @@ router.post(
       return;
     }
 
-    const { results, totalCount } = await SearchHelper.searchForUser(
+    const { results, total } = await SearchHelper.searchForUser(
       user,
       text,
       options
@@ -246,7 +246,7 @@ router.post(
       teamId: user.teamId,
       source: "slack",
       query: text,
-      results: totalCount,
+      results: total,
     });
 
     // Map search results to the format expected by the Slack API

--- a/server/models/helpers/SearchHelper.test.ts
+++ b/server/models/helpers/SearchHelper.test.ts
@@ -120,8 +120,8 @@ describe("SearchHelper", () => {
         collectionId: collection.id,
         title: "test number 2",
       });
-      const { totalCount } = await SearchHelper.searchForTeam(team, "test");
-      expect(totalCount).toBe(2);
+      const { total } = await SearchHelper.searchForTeam(team, "test");
+      expect(total).toBe(2);
     });
 
     test("should return the document when searched with their previous titles", async () => {
@@ -136,11 +136,8 @@ describe("SearchHelper", () => {
       });
       document.title = "change";
       await document.save();
-      const { totalCount } = await SearchHelper.searchForTeam(
-        team,
-        "test number"
-      );
-      expect(totalCount).toBe(1);
+      const { total } = await SearchHelper.searchForTeam(team, "test number");
+      expect(total).toBe(1);
     });
 
     test("should not return the document when searched with neither the titles nor the previous titles", async () => {
@@ -155,11 +152,11 @@ describe("SearchHelper", () => {
       });
       document.title = "change";
       await document.save();
-      const { totalCount } = await SearchHelper.searchForTeam(
+      const { total } = await SearchHelper.searchForTeam(
         team,
         "title doesn't exist"
       );
-      expect(totalCount).toBe(0);
+      expect(total).toBe(0);
     });
   });
 
@@ -417,8 +414,8 @@ describe("SearchHelper", () => {
         collectionId: collection.id,
         title: "test number 2",
       });
-      const { totalCount } = await SearchHelper.searchForUser(user, "test");
-      expect(totalCount).toBe(2);
+      const { total } = await SearchHelper.searchForUser(user, "test");
+      expect(total).toBe(2);
     });
 
     test("should return the document when searched with their previous titles", async () => {
@@ -436,11 +433,8 @@ describe("SearchHelper", () => {
       });
       document.title = "change";
       await document.save();
-      const { totalCount } = await SearchHelper.searchForUser(
-        user,
-        "test number"
-      );
-      expect(totalCount).toBe(1);
+      const { total } = await SearchHelper.searchForUser(user, "test number");
+      expect(total).toBe(1);
     });
 
     test("should not return the document when searched with neither the titles nor the previous titles", async () => {
@@ -458,11 +452,11 @@ describe("SearchHelper", () => {
       });
       document.title = "change";
       await document.save();
-      const { totalCount } = await SearchHelper.searchForUser(
+      const { total } = await SearchHelper.searchForUser(
         user,
         "title doesn't exist"
       );
-      expect(totalCount).toBe(0);
+      expect(total).toBe(0);
     });
 
     test("should find exact phrases", async () => {
@@ -480,11 +474,8 @@ describe("SearchHelper", () => {
       });
       document.title = "change";
       await document.save();
-      const { totalCount } = await SearchHelper.searchForUser(
-        user,
-        `"test number"`
-      );
-      expect(totalCount).toBe(1);
+      const { total } = await SearchHelper.searchForUser(user, `"test number"`);
+      expect(total).toBe(1);
     });
 
     test("should correctly handle removal of trailing spaces", async () => {
@@ -502,8 +493,8 @@ describe("SearchHelper", () => {
       });
       document.title = "change";
       await document.save();
-      const { totalCount } = await SearchHelper.searchForUser(user, "env: ");
-      expect(totalCount).toBe(1);
+      const { total } = await SearchHelper.searchForUser(user, "env: ");
+      expect(total).toBe(1);
     });
   });
 

--- a/server/models/helpers/SearchHelper.ts
+++ b/server/models/helpers/SearchHelper.ts
@@ -69,12 +69,7 @@ export default class SearchHelper {
     query: string,
     options: SearchOptions = {}
   ): Promise<SearchResponse> {
-    const {
-      snippetMinWords = 20,
-      snippetMaxWords = 30,
-      limit = 15,
-      offset = 0,
-    } = options;
+    const { limit = 15, offset = 0 } = options;
 
     const where = await this.buildWhere(team, query, {
       ...options,
@@ -96,9 +91,8 @@ export default class SearchHelper {
       });
     }
 
-    const queryReplacements = {
+    const replacements = {
       query: this.webSearchQuery(query),
-      headlineOptions: `MaxFragments=1, MinWords=${snippetMinWords}, MaxWords=${snippetMaxWords}`,
     };
 
     const resultsQuery = Document.unscoped().findAll({
@@ -111,7 +105,7 @@ export default class SearchHelper {
           "searchRanking",
         ],
       ],
-      replacements: queryReplacements,
+      replacements,
       where,
       order: [
         ["searchRanking", "DESC"],
@@ -123,7 +117,7 @@ export default class SearchHelper {
 
     const countQuery = Document.unscoped().count({
       // @ts-expect-error Types are incorrect for count
-      replacements: queryReplacements,
+      replacements,
       where,
     }) as any as Promise<number>;
     const [results, count] = await Promise.all([resultsQuery, countQuery]);
@@ -207,18 +201,12 @@ export default class SearchHelper {
     query: string,
     options: SearchOptions = {}
   ): Promise<SearchResponse> {
-    const {
-      snippetMinWords = 20,
-      snippetMaxWords = 30,
-      limit = 15,
-      offset = 0,
-    } = options;
+    const { limit = 15, offset = 0 } = options;
 
     const where = await this.buildWhere(user, query, options);
 
     const queryReplacements = {
       query: this.webSearchQuery(query),
-      headlineOptions: `MaxFragments=1, MinWords=${snippetMinWords}, MaxWords=${snippetMaxWords}`,
     };
 
     const include = [

--- a/server/models/helpers/SearchHelper.ts
+++ b/server/models/helpers/SearchHelper.ts
@@ -270,9 +270,9 @@ export default class SearchHelper {
           id: map(results, "id"),
         },
       }),
-      results.length < limit || offset !== 0
-        ? countQuery
-        : Promise.resolve(results.length),
+      results.length < limit && offset === 0
+        ? Promise.resolve(results.length)
+        : countQuery,
     ]);
 
     return this.buildResponse(query, results, documents, count);

--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -885,7 +885,7 @@ router.post(
       });
     }
 
-    const { results, totalCount } = response;
+    const { results, total } = response;
     const documents = results.map((result) => result.document);
 
     const data = await Promise.all(
@@ -907,12 +907,12 @@ router.post(
         shareId: share?.id,
         source: ctx.state.auth.type || "app", // we'll consider anything that isn't "api" to be "app"
         query,
-        results: totalCount,
+        results: total,
       });
     }
 
     ctx.body = {
-      pagination: ctx.state.pagination,
+      pagination: { ...ctx.state.pagination, total },
       data,
       policies: user ? presentPolicies(user, documents) : null,
     };


### PR DESCRIPTION
A separate query for result count is not necessary if the number of results is less than the limit and the offset is 0, this covers the vast majority of search API requests.