### PR TITLE
perf: Remove old usage of dynamic require statement in policy serialization

### DIFF
--- a/server/policies/index.ts
+++ b/server/policies/index.ts
@@ -1,12 +1,21 @@
-import {
+import type {
+  ApiKey,
   Attachment,
-  FileOperation,
-  Team,
-  User,
+  AuthenticationProvider,
   Collection,
   Comment,
   Document,
+  FileOperation,
+  Integration,
+  Pin,
+  SearchQuery,
+  Share,
+  Star,
+  Subscription,
+  User,
+  Team,
   Group,
+  WebhookSubscription,
   Notification,
   UserMembership,
 } from "@server/models";
@@ -51,14 +60,23 @@ export const abilities = _abilities;
 export function serialize(
   model: User,
   target:
+    | ApiKey
     | Attachment
+    | AuthenticationProvider
     | Collection
     | Comment
-    | FileOperation
-    | Team
     | Document
+    | FileOperation
+    | Integration
+    | Pin
+    | SearchQuery
+    | Share
+    | Star
+    | Subscription
     | User
+    | Team
     | Group
+    | WebhookSubscription
     | Notification
     | UserMembership
     | null

--- a/server/presenters/policy.ts
+++ b/server/presenters/policy.ts
@@ -1,6 +1,7 @@
 import compact from "lodash/compact";
 import { traceFunction } from "@server/logging/tracing";
 import { User } from "@server/models";
+import { serialize } from "../policies";
 
 type Policy = {
   id: string;
@@ -9,11 +10,8 @@ type Policy = {
 
 function presentPolicy(
   user: User,
-  objects: (Record<string, any> | null)[]
+  objects: (Parameters<typeof serialize>[1] | null)[]
 ): Policy[] {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { serialize } = require("../policies");
-
   return compact(objects).map((object) => ({
     id: object.id,
     abilities: serialize(user, object),


### PR DESCRIPTION
If there was a good reason for this to exist previously, it doesn't seem to be _required_ anymore.