### PR TITLE
fix: Refactor `postLoginRedirect` logic for reliability

### DIFF
--- a/app/hooks/useLastVisitedPath.tsx
+++ b/app/hooks/useLastVisitedPath.tsx
@@ -1,13 +1,17 @@
 import * as React from "react";
+import { getCookie, removeCookie, setCookie } from "tiny-cookie";
 import usePersistedState from "~/hooks/usePersistedState";
+import Logger from "~/utils/Logger";
+import history from "~/utils/history";
+import { isValidPostLoginRedirect } from "~/utils/urls";
 
 /**
- * Hook to set locally and return the path that the user last visited. This is
- * used to redirect the user back to the last page they were on if preferred.
+ * Hook to set locally and return the document or collection that the user last visited. This is
+ * used to redirect the user back to the last page they were on, if preferred.
  *
  * @returns A tuple of the last visited path and a method to set it.
  */
-export default function useLastVisitedPath(): [string, (path: string) => void] {
+export function useLastVisitedPath(): [string, (path: string) => void] {
   const [lastVisitedPath, setLastVisitedPath] = usePersistedState<string>(
     "lastVisitedPath",
     "/",
@@ -21,5 +25,49 @@ export default function useLastVisitedPath(): [string, (path: string) => void] {
     [lastVisitedPath, setLastVisitedPath]
   );
 
-  return [lastVisitedPath, setPathAsLastVisitedPath];
+  return [lastVisitedPath, setPathAsLastVisitedPath] as const;
+}
+
+/**
+ * Sets the path that the user visited before being asked to login.
+ *
+ * @param path The path to set as the post login path.
+ */
+export function setPostLoginPath(path: string) {
+  if (isValidPostLoginRedirect(path)) {
+    setCookie("postLoginRedirectPath", path, { expires: 1 });
+  }
+}
+
+/**
+ * Hook to set locally and return the path that the user visited before being asked
+ * to login.
+ *
+ * @returns A tuple of getter and setter for the post login path.
+ */
+export function usePostLoginPath() {
+  const key = "postLoginRedirectPath";
+
+  const getter = React.useCallback(() => {
+    const path = getCookie(key);
+
+    if (path) {
+      Logger.info("lifecycle", "Spending post login path", { path });
+
+      // Remove the cookie once the app has been navigated to the post login path. We dont
+      // do this immediately as React StrictMode will render multiple times.
+      const cleanup = history.listen(() => {
+        removeCookie(key);
+        cleanup?.();
+      });
+
+      if (isValidPostLoginRedirect(path)) {
+        return path;
+      }
+    }
+
+    return undefined;
+  }, []);
+
+  return [getter, setPostLoginPath] as const;
 }

--- a/app/scenes/Collection/index.tsx
+++ b/app/scenes/Collection/index.tsx
@@ -34,7 +34,7 @@ import Tabs from "~/components/Tabs";
 import Tooltip from "~/components/Tooltip";
 import { editCollection } from "~/actions/definitions/collections";
 import useCommandBarActions from "~/hooks/useCommandBarActions";
-import useLastVisitedPath from "~/hooks/useLastVisitedPath";
+import { useLastVisitedPath } from "~/hooks/useLastVisitedPath";
 import usePolicy from "~/hooks/usePolicy";
 import useStores from "~/hooks/useStores";
 import { Feature, FeatureFlags } from "~/utils/FeatureFlags";

--- a/app/scenes/Document/Shared.tsx
+++ b/app/scenes/Document/Shared.tsx
@@ -5,7 +5,6 @@ import { Helmet } from "react-helmet-async";
 import { useTranslation } from "react-i18next";
 import { RouteComponentProps, useLocation } from "react-router-dom";
 import styled, { ThemeProvider } from "styled-components";
-import { setCookie } from "tiny-cookie";
 import { s } from "@shared/styles";
 import { NavigationNode, PublicTeam, TOCPosition } from "@shared/types";
 import type { Theme } from "~/stores/UiStore";
@@ -19,6 +18,7 @@ import Text from "~/components/Text";
 import env from "~/env";
 import useBuildTheme from "~/hooks/useBuildTheme";
 import useCurrentUser from "~/hooks/useCurrentUser";
+import { usePostLoginPath } from "~/hooks/useLastVisitedPath";
 import useStores from "~/hooks/useStores";
 import { AuthorizationError, OfflineError } from "~/utils/errors";
 import isCloudHosted from "~/utils/isCloudHosted";
@@ -94,6 +94,7 @@ function SharedDocumentScene(props: Props) {
   const [response, setResponse] = React.useState<Response>();
   const [error, setError] = React.useState<Error | null | undefined>();
   const { documents } = useStores();
+  const [, setPostLoginPath] = usePostLoginPath();
   const { shareId = env.ROOT_SHARE_ID, documentSlug } = props.match.params;
   const documentId = useDocumentId(documentSlug, response);
   const themeOverride = ["dark", "light"].includes(
@@ -144,7 +145,7 @@ function SharedDocumentScene(props: Props) {
     if (error instanceof OfflineError) {
       return <ErrorOffline />;
     } else if (error instanceof AuthorizationError) {
-      setCookie("postLoginRedirectPath", props.location.pathname);
+      setPostLoginPath(props.location.pathname);
       return (
         <Login>
           {(config) =>

--- a/app/scenes/Document/index.tsx
+++ b/app/scenes/Document/index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { StaticContext } from "react-router";
 import { RouteComponentProps } from "react-router-dom";
-import useLastVisitedPath from "~/hooks/useLastVisitedPath";
+import { useLastVisitedPath } from "~/hooks/useLastVisitedPath";
 import useStores from "~/hooks/useStores";
 import DataLoader from "./components/DataLoader";
 import Document from "./components/Document";

--- a/app/scenes/Home.tsx
+++ b/app/scenes/Home.tsx
@@ -2,7 +2,7 @@ import { observer } from "mobx-react";
 import { HomeIcon } from "outline-icons";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import { Switch, Route } from "react-router-dom";
+import { Switch, Route, Redirect } from "react-router-dom";
 import styled from "styled-components";
 import { s } from "@shared/styles";
 import { Action } from "~/components/Actions";
@@ -18,6 +18,7 @@ import Tab from "~/components/Tab";
 import Tabs from "~/components/Tabs";
 import useCurrentTeam from "~/hooks/useCurrentTeam";
 import useCurrentUser from "~/hooks/useCurrentUser";
+import { usePostLoginPath } from "~/hooks/useLastVisitedPath";
 import usePolicy from "~/hooks/usePolicy";
 import useStores from "~/hooks/useStores";
 import NewDocumentMenu from "~/menus/NewDocumentMenu";
@@ -26,14 +27,20 @@ function Home() {
   const { documents, pins, ui } = useStores();
   const team = useCurrentTeam();
   const user = useCurrentUser();
-  const userId = user?.id;
   const { t } = useTranslation();
+  const [spendPostLoginPath] = usePostLoginPath();
+  const userId = user?.id;
 
   React.useEffect(() => {
     void pins.fetchPage();
   }, [pins]);
 
   const can = usePolicy(team);
+
+  const postLoginPath = spendPostLoginPath();
+  if (postLoginPath) {
+    return <Redirect to={postLoginPath} />;
+  }
 
   return (
     <Scene

--- a/app/scenes/Login/index.tsx
+++ b/app/scenes/Login/index.tsx
@@ -23,13 +23,17 @@ import TeamLogo from "~/components/TeamLogo";
 import Text from "~/components/Text";
 import env from "~/env";
 import useCurrentUser from "~/hooks/useCurrentUser";
-import useLastVisitedPath from "~/hooks/useLastVisitedPath";
+import {
+  useLastVisitedPath,
+  usePostLoginPath,
+} from "~/hooks/useLastVisitedPath";
 import useQuery from "~/hooks/useQuery";
 import useStores from "~/hooks/useStores";
 import { draggableOnDesktop } from "~/styles";
 import Desktop from "~/utils/Desktop";
 import isCloudHosted from "~/utils/isCloudHosted";
 import { detectLanguage } from "~/utils/language";
+import { homePath } from "~/utils/routeHelpers";
 import AuthenticationProvider from "./components/AuthenticationProvider";
 import BackButton from "./components/BackButton";
 import Notices from "./components/Notices";
@@ -55,6 +59,7 @@ function Login({ children }: Props) {
     UserPreference.RememberLastPath
   );
   const [lastVisitedPath] = useLastVisitedPath();
+  const [spendPostLoginPath] = usePostLoginPath();
 
   const handleReset = React.useCallback(() => {
     setEmailLinkSentTo("");
@@ -84,20 +89,21 @@ function Login({ children }: Props) {
     }
   }, [query]);
 
-  if (
-    auth.authenticated &&
-    rememberLastPath &&
-    lastVisitedPath !== location.pathname
-  ) {
-    return <Redirect to={lastVisitedPath} />;
-  }
-
-  if (auth.authenticated && auth.team?.defaultCollectionId) {
-    return <Redirect to={`/collection/${auth.team?.defaultCollectionId}`} />;
-  }
-
   if (auth.authenticated) {
-    return <Redirect to="/home" />;
+    const postLoginPath = spendPostLoginPath();
+    if (postLoginPath) {
+      return <Redirect to={postLoginPath} />;
+    }
+
+    if (rememberLastPath && lastVisitedPath !== location.pathname) {
+      return <Redirect to={lastVisitedPath} />;
+    }
+
+    if (auth.team?.defaultCollectionId) {
+      return <Redirect to={`/collection/${auth.team?.defaultCollectionId}`} />;
+    }
+
+    return <Redirect to={homePath()} />;
   }
 
   if (error) {

--- a/app/stores/AuthStore.ts
+++ b/app/stores/AuthStore.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/react";
 import invariant from "invariant";
 import { observable, action, computed, autorun, runInAction } from "mobx";
-import { getCookie, setCookie, removeCookie } from "tiny-cookie";
+import { getCookie, setCookie } from "tiny-cookie";
 import { CustomTheme } from "@shared/types";
 import Storage from "@shared/utils/Storage";
 import { getCookieDomain, parseDomain } from "@shared/utils/domains";
@@ -10,15 +10,13 @@ import Policy from "~/models/Policy";
 import Team from "~/models/Team";
 import User from "~/models/User";
 import env from "~/env";
+import { setPostLoginPath } from "~/hooks/useLastVisitedPath";
 import { PartialWithId } from "~/types";
 import { client } from "~/utils/ApiClient";
 import Desktop from "~/utils/Desktop";
 import Logger from "~/utils/Logger";
 import isCloudHosted from "~/utils/isCloudHosted";
 import Store from "./base/Store";
-
-const AUTH_STORE = "AUTH_STORE";
-const NO_REDIRECT_PATHS = ["/", "/create", "/home", "/logout"];
 
 type PersistedData = {
   user?: PartialWithId<User>;
@@ -49,21 +47,23 @@ export type Config = {
 };
 
 export default class AuthStore extends Store<Team> {
+  private name = "AUTH_STORE";
+
   /* The ID of the user that is currently signed in. */
   @observable
-  currentUserId?: string | null;
+  public currentUserId?: string | null;
 
   /* The ID of the team that is currently signed in. */
   @observable
-  currentTeamId?: string | null;
+  public currentTeamId?: string | null;
 
   /* A short-lived token to be used to authenticate with the collaboration server. */
   @observable
-  collaborationToken?: string | null;
+  public collaborationToken?: string | null;
 
   /* A list of teams that the current user has access to. */
   @observable
-  availableTeams?: {
+  public availableTeams?: {
     id: string;
     name: string;
     avatarUrl: string;
@@ -73,19 +73,19 @@ export default class AuthStore extends Store<Team> {
 
   /* The authentication provider the user signed in with. */
   @observable
-  lastSignedIn?: string | null;
+  public lastSignedIn?: string | null;
 
   /* Whether the user is currently suspended. */
   @observable
-  isSuspended = false;
+  public isSuspended = false;
 
   /* The email address to contact if the user is suspended. */
   @observable
-  suspendedContactEmail?: string | null;
+  public suspendedContactEmail?: string | null;
 
   /* The auth configuration for the current domain. */
   @observable
-  config: Config | null | undefined;
+  public config: Config | null | undefined;
 
   rootStore: RootStore;
 
@@ -93,21 +93,22 @@ export default class AuthStore extends Store<Team> {
     super(rootStore, Team);
 
     this.rootStore = rootStore;
+
     // attempt to load the previous state of this store from localstorage
-    const data: PersistedData = Storage.get(AUTH_STORE) || {};
+    const data: PersistedData = Storage.get(this.name) || {};
 
     this.rehydrate(data);
     void this.fetchAuth();
 
     // persists this entire store to localstorage whenever any keys are changed
     autorun(() => {
-      Storage.set(AUTH_STORE, this.asJson);
+      Storage.set(this.name, this.asJson);
     });
 
     // listen to the localstorage value changing in other tabs to react to
     // signin/signout events in other tabs and follow suite.
     window.addEventListener("storage", (event) => {
-      if (event.key === AUTH_STORE && event.newValue) {
+      if (event.key === this.name && event.newValue) {
         const newData: PersistedData | null = JSON.parse(event.newValue);
 
         // data may be null if key is deleted in localStorage
@@ -236,17 +237,6 @@ export default class AuthStore extends Store<Team> {
           window.location.href = `${data.team.url}${pathname}`;
           return;
         }
-
-        // If we came from a redirect then send the user immediately there
-        const postLoginRedirectPath = getCookie("postLoginRedirectPath");
-
-        if (postLoginRedirectPath) {
-          removeCookie("postLoginRedirectPath");
-
-          if (!NO_REDIRECT_PATHS.includes(postLoginRedirectPath)) {
-            window.location.href = postLoginRedirectPath;
-          }
-        }
       });
     } catch (err) {
       if (err.error === "user_suspended") {
@@ -315,11 +305,7 @@ export default class AuthStore extends Store<Team> {
     // if this logout was forced from an authenticated route then
     // save the current path so we can go back there once signed in
     if (savePath) {
-      const pathName = window.location.pathname;
-
-      if (!NO_REDIRECT_PATHS.includes(pathName)) {
-        setCookie("postLoginRedirectPath", pathName);
-      }
+      setPostLoginPath(window.location.pathname);
     }
 
     if (tryRevokingToken) {

--- a/app/utils/urls.ts
+++ b/app/utils/urls.ts
@@ -27,6 +27,20 @@ export function decodeURIComponentSafe(text: string) {
     : text;
 }
 
+/**
+ * Redirects to a new page
+ *
+ * @param url
+ */
 export function redirectTo(url: string) {
   window.location.href = url;
 }
+
+/**
+ * Check if the path is a valid redirect after login
+ *
+ * @param path
+ * @returns boolean indicating if the path is a valid redirect
+ */
+export const isValidPostLoginRedirect = (path: string) =>
+  !["/", "/create", "/home", "/logout"].includes(path);


### PR DESCRIPTION
- Ensures that the `postLoginRedirect` cookie is not removed until it is used in edge cases.
- Ensures that the `postLoginRedirect` cookie is considered when returning to `/home`

closes #7423