### PR TITLE
logout for OIDC #6909

### DIFF
--- a/app/actions/definitions/navigation.tsx
+++ b/app/actions/definitions/navigation.tsx
@@ -216,7 +216,9 @@ export const logout = createAction({
   perform: async () => {
     await stores.auth.logout();
     if (env.OIDC_LOGOUT_URI) {
-      window.location.replace(env.OIDC_LOGOUT_URI);
+      setTimeout(() => {
+        window.location.replace(env.OIDC_LOGOUT_URI);
+      });
     }
   },
 });

--- a/app/actions/definitions/navigation.tsx
+++ b/app/actions/definitions/navigation.tsx
@@ -218,7 +218,7 @@ export const logout = createAction({
     if (env.OIDC_LOGOUT_URI) {
       setTimeout(() => {
         window.location.replace(env.OIDC_LOGOUT_URI);
-      });
+      }, 200);
     }
   },
 });

--- a/app/scenes/Logout.tsx
+++ b/app/scenes/Logout.tsx
@@ -10,7 +10,7 @@ const Logout = () => {
     if (env.OIDC_LOGOUT_URI) {
       setTimeout(() => {
         window.location.replace(env.OIDC_LOGOUT_URI);
-      });
+      }, 200);
     }
   });
 

--- a/app/scenes/Logout.tsx
+++ b/app/scenes/Logout.tsx
@@ -12,6 +12,9 @@ const Logout = () => {
     }
   });
 
+  if (env.OIDC_LOGOUT_URI) {
+    return null; // user will be redirected to logout URI after logout
+  }
   return <Redirect to="/" />;
 };
 

--- a/app/scenes/Logout.tsx
+++ b/app/scenes/Logout.tsx
@@ -8,7 +8,9 @@ const Logout = () => {
 
   void auth.logout().then(() => {
     if (env.OIDC_LOGOUT_URI) {
-      window.location.replace(env.OIDC_LOGOUT_URI);
+      setTimeout(() => {
+        window.location.replace(env.OIDC_LOGOUT_URI);
+      });
     }
   });
 


### PR DESCRIPTION
https://github.com/outline/outline/issues/6909

When you log out, auth.logout destroys the local session, and then the user is redirected to /. If the OIDC provider is the only configured authentication method, the user is immediately redirected to the OIDC provider’s authentication page. This triggers another window.location.replace call, which overwrites the previous destination. As a result, the user is not logged out of the OIDC provider and is instantly logged back in. You can observe this in the network requests, where the first window.location.replace is marked as canceled.

The fix simply prevents the redirect to the home page, allowing the browser enough time to complete the request.