### PR TITLE
fix: Set redis expiry in seconds

### DIFF
--- a/plugins/github/server/index.ts
+++ b/plugins/github/server/index.ts
@@ -22,7 +22,7 @@ if (enabled) {
     },
     {
       type: Hook.UnfurlProvider,
-      value: { unfurl: GitHub.unfurl, cacheExpiry: Minute },
+      value: { unfurl: GitHub.unfurl, cacheExpiry: Minute / 1000 },
     },
     {
       type: Hook.Uninstall,

--- a/plugins/iframely/server/index.ts
+++ b/plugins/iframely/server/index.ts
@@ -19,7 +19,7 @@ if (enabled) {
   PluginManager.add([
     {
       type: Hook.UnfurlProvider,
-      value: { unfurl: Iframely.unfurl, cacheExpiry: Day },
+      value: { unfurl: Iframely.unfurl, cacheExpiry: Day / 1000 },
 
       // Make sure this is last in the stack to be evaluated after all other unfurl providers
       priority: PluginPriority.VeryLow,

--- a/server/utils/CacheHelper.ts
+++ b/server/utils/CacheHelper.ts
@@ -1,4 +1,4 @@
-import { Day } from "@shared/utils/time";
+import { Day, Second } from "@shared/utils/time";
 import Logger from "@server/logging/Logger";
 import Redis from "@server/storage/redis";
 
@@ -6,8 +6,8 @@ import Redis from "@server/storage/redis";
  * A Helper class for server-side cache management
  */
 export class CacheHelper {
-  // Default expiry time for cache data in ms
-  private static defaultDataExpiry = Day;
+  // Default expiry time for cache data in seconds
+  private static defaultDataExpiry = Day / Second;
 
   /**
    * Given a key, gets the data from cache store
@@ -32,7 +32,7 @@ export class CacheHelper {
    *
    * @param key Cache key
    * @param data Data to be saved against the key
-   * @param expiry Cache data expiry
+   * @param expiry Cache data expiry in seconds
    */
   public static async setData<T>(key: string, data: T, expiry?: number) {
     try {

--- a/server/utils/CacheHelper.ts
+++ b/server/utils/CacheHelper.ts
@@ -1,4 +1,4 @@
-import { Day, Second } from "@shared/utils/time";
+import { Day } from "@shared/utils/time";
 import Logger from "@server/logging/Logger";
 import Redis from "@server/storage/redis";
 
@@ -7,7 +7,7 @@ import Redis from "@server/storage/redis";
  */
 export class CacheHelper {
   // Default expiry time for cache data in seconds
-  private static defaultDataExpiry = Day / Second;
+  private static defaultDataExpiry = Day / 1000;
 
   /**
    * Given a key, gets the data from cache store


### PR DESCRIPTION
Came across this bug when working on Mattermost integration.
We've been using milliseconds for expiry when redis expects it in seconds.

redis: [doc](https://redis.io/docs/latest/commands/expire/)
ioredis: [doc](https://github.com/redis/ioredis?tab=readme-ov-file#expiration)
