### PR TITLE
fix: Refactor sidebar context management

### DIFF
--- a/app/actions/definitions/documents.tsx
+++ b/app/actions/definitions/documents.tsx
@@ -104,9 +104,9 @@ export const createDocument = createAction({
       !!currentTeamId && stores.policies.abilities(currentTeamId).createDocument
     );
   },
-  perform: ({ activeCollectionId, inStarredSection }) =>
+  perform: ({ activeCollectionId, sidebarContext }) =>
     history.push(newDocumentPath(activeCollectionId), {
-      starred: inStarredSection,
+      sidebarContext,
     }),
 });
 
@@ -121,11 +121,11 @@ export const createDocumentFromTemplate = createAction({
     !!activeDocumentId &&
     !!stores.documents.get(activeDocumentId)?.template &&
     stores.policies.abilities(currentTeamId).createDocument,
-  perform: ({ activeCollectionId, activeDocumentId, inStarredSection }) =>
+  perform: ({ activeCollectionId, activeDocumentId, sidebarContext }) =>
     history.push(
       newDocumentPath(activeCollectionId, { templateId: activeDocumentId }),
       {
-        starred: inStarredSection,
+        sidebarContext,
       }
     ),
 });
@@ -141,9 +141,9 @@ export const createNestedDocument = createAction({
     !!activeDocumentId &&
     stores.policies.abilities(currentTeamId).createDocument &&
     stores.policies.abilities(activeDocumentId).createChildDocument,
-  perform: ({ activeDocumentId, inStarredSection }) =>
+  perform: ({ activeDocumentId, sidebarContext }) =>
     history.push(newNestedDocumentPath(activeDocumentId), {
-      starred: inStarredSection,
+      sidebarContext,
     }),
 });
 

--- a/app/components/Sidebar/components/CollectionLink.tsx
+++ b/app/components/Sidebar/components/CollectionLink.tsx
@@ -22,8 +22,8 @@ import CollectionMenu from "~/menus/CollectionMenu";
 import DropToImport from "./DropToImport";
 import EditableTitle, { RefHandle } from "./EditableTitle";
 import Relative from "./Relative";
+import { SidebarContextType, useSidebarContext } from "./SidebarContext";
 import SidebarLink, { DragObject } from "./SidebarLink";
-import { useStarredContext } from "./StarredContext";
 
 type Props = {
   collection: Collection;
@@ -48,7 +48,7 @@ const CollectionLink: React.FC<Props> = ({
   const can = usePolicy(collection);
   const { t } = useTranslation();
   const history = useHistory();
-  const inStarredSection = useStarredContext();
+  const sidebarContext = useSidebarContext();
   const editableTitleRef = React.useRef<RefHandle>(null);
 
   const handleTitleChange = React.useCallback(
@@ -122,7 +122,7 @@ const CollectionLink: React.FC<Props> = ({
 
   const context = useActionContext({
     activeCollectionId: collection.id,
-    inStarredSection,
+    sidebarContext,
   });
 
   return (
@@ -131,7 +131,7 @@ const CollectionLink: React.FC<Props> = ({
         <SidebarLink
           to={{
             pathname: collection.path,
-            state: { starred: inStarredSection },
+            state: { sidebarContext },
           }}
           expanded={expanded}
           onDisclosureClick={onDisclosureClick}
@@ -139,9 +139,10 @@ const CollectionLink: React.FC<Props> = ({
           icon={<CollectionIcon collection={collection} expanded={expanded} />}
           showActions={menuOpen}
           isActiveDrop={isOver && canDrop}
-          isActive={(match, location: Location<{ starred?: boolean }>) =>
-            !!match && location.state?.starred === inStarredSection
-          }
+          isActive={(
+            match,
+            location: Location<{ sidebarContext?: SidebarContextType }>
+          ) => !!match && location.state?.sidebarContext === sidebarContext}
           label={
             <EditableTitle
               title={collection.name}

--- a/app/components/Sidebar/components/DocumentLink.tsx
+++ b/app/components/Sidebar/components/DocumentLink.tsx
@@ -27,9 +27,8 @@ import DropToImport from "./DropToImport";
 import EditableTitle, { RefHandle } from "./EditableTitle";
 import Folder from "./Folder";
 import Relative from "./Relative";
-import { useSharedContext } from "./SharedContext";
+import { SidebarContextType, useSidebarContext } from "./SidebarContext";
 import SidebarLink, { DragObject } from "./SidebarLink";
-import { useStarredContext } from "./StarredContext";
 
 type Props = {
   node: NavigationNode;
@@ -65,18 +64,20 @@ function InnerDocumentLink(
   const { fetchChildDocuments } = documents;
   const [isEditing, setIsEditing] = React.useState(false);
   const editableTitleRef = React.useRef<RefHandle>(null);
-  const inStarredSection = useStarredContext();
-  const inSharedSection = useSharedContext();
+  const sidebarContext = useSidebarContext();
 
   React.useEffect(() => {
-    if (isActiveDocument && (hasChildDocuments || inSharedSection)) {
+    if (
+      isActiveDocument &&
+      (hasChildDocuments || sidebarContext !== "collections")
+    ) {
       void fetchChildDocuments(node.id);
     }
   }, [
     fetchChildDocuments,
     node.id,
     hasChildDocuments,
-    inSharedSection,
+    sidebarContext,
     isActiveDocument,
   ]);
 
@@ -338,8 +339,7 @@ function InnerDocumentLink(
                   pathname: node.url,
                   state: {
                     title: node.title,
-                    starred: inStarredSection,
-                    sharedWithMe: inSharedSection,
+                    sidebarContext,
                   },
                 }}
                 icon={icon && <Icon value={icon} color={color} />}
@@ -356,14 +356,10 @@ function InnerDocumentLink(
                 isActive={(
                   match,
                   location: Location<{
-                    starred?: boolean;
-                    sharedWithMe?: boolean;
+                    sidebarContext?: SidebarContextType;
                   }>
                 ) => {
-                  if (inStarredSection !== location.state?.starred) {
-                    return false;
-                  }
-                  if (inSharedSection !== location.state?.sharedWithMe) {
+                  if (sidebarContext !== location.state?.sidebarContext) {
                     return false;
                   }
                   return (
@@ -375,7 +371,7 @@ function InnerDocumentLink(
                 depth={depth}
                 exact={false}
                 showActions={menuOpen}
-                scrollIntoViewIfNeeded={!inStarredSection && !inSharedSection}
+                scrollIntoViewIfNeeded={sidebarContext === "collections"}
                 isDraft={isDraft}
                 ref={ref}
                 menu={

--- a/app/components/Sidebar/components/DraggableCollectionLink.tsx
+++ b/app/components/Sidebar/components/DraggableCollectionLink.tsx
@@ -3,17 +3,18 @@ import { observer } from "mobx-react";
 import * as React from "react";
 import { useDrop, useDrag, DropTargetMonitor } from "react-dnd";
 import { getEmptyImage } from "react-dnd-html5-backend";
-import { useLocation } from "react-router-dom";
 import styled from "styled-components";
 import Collection from "~/models/Collection";
 import Document from "~/models/Document";
 import CollectionIcon from "~/components/Icons/CollectionIcon";
 import usePolicy from "~/hooks/usePolicy";
 import useStores from "~/hooks/useStores";
+import { useLocationState } from "../hooks/useLocationState";
 import CollectionLink from "./CollectionLink";
 import CollectionLinkChildren from "./CollectionLinkChildren";
 import DropCursor from "./DropCursor";
 import Relative from "./Relative";
+import { useSidebarContext } from "./SidebarContext";
 import { DragObject } from "./SidebarLink";
 
 type Props = {
@@ -23,23 +24,18 @@ type Props = {
   belowCollection: Collection | void;
 };
 
-function useLocationStateStarred() {
-  const location = useLocation<{
-    starred?: boolean;
-  }>();
-  return location.state?.starred;
-}
-
 function DraggableCollectionLink({
   collection,
   activeDocument,
   prefetchDocument,
   belowCollection,
 }: Props) {
-  const locationStateStarred = useLocationStateStarred();
+  const locationSidebarContext = useLocationState();
+  const sidebarContext = useSidebarContext();
   const { ui, collections } = useStores();
   const [expanded, setExpanded] = React.useState(
-    collection.id === ui.activeCollectionId && !locationStateStarred
+    collection.id === ui.activeCollectionId &&
+      sidebarContext === locationSidebarContext
   );
   const can = usePolicy(collection);
   const belowCollectionIndex = belowCollection ? belowCollection.index : null;
@@ -86,10 +82,18 @@ function DraggableCollectionLink({
   // If the current collection is active and relevant to the sidebar section we
   // are in then expand it automatically
   React.useEffect(() => {
-    if (collection.id === ui.activeCollectionId && !locationStateStarred) {
+    if (
+      collection.id === ui.activeCollectionId &&
+      sidebarContext === locationSidebarContext
+    ) {
       setExpanded(true);
     }
-  }, [collection.id, ui.activeCollectionId, locationStateStarred]);
+  }, [
+    collection.id,
+    ui.activeCollectionId,
+    sidebarContext,
+    locationSidebarContext,
+  ]);
 
   const handleDisclosureClick = React.useCallback((ev) => {
     ev?.preventDefault();

--- a/app/components/Sidebar/components/GroupLink.tsx
+++ b/app/components/Sidebar/components/GroupLink.tsx
@@ -5,6 +5,7 @@ import Group from "~/models/Group";
 import Folder from "./Folder";
 import Relative from "./Relative";
 import SharedWithMeLink from "./SharedWithMeLink";
+import SidebarContext from "./SidebarContext";
 import SidebarLink from "./SidebarLink";
 
 type Props = {
@@ -29,15 +30,17 @@ const GroupLink: React.FC<Props> = ({ group }) => {
         onClick={handleDisclosureClick}
         depth={0}
       />
-      <Folder expanded={expanded}>
-        {group.documentMemberships.map((membership) => (
-          <SharedWithMeLink
-            key={membership.id}
-            membership={membership}
-            depth={1}
-          />
-        ))}
-      </Folder>
+      <SidebarContext.Provider value={group.id}>
+        <Folder expanded={expanded}>
+          {group.documentMemberships.map((membership) => (
+            <SharedWithMeLink
+              key={membership.id}
+              membership={membership}
+              depth={1}
+            />
+          ))}
+        </Folder>
+      </SidebarContext.Provider>
     </Relative>
   );
 };

--- a/app/components/Sidebar/components/SharedContext.ts
+++ b/app/components/Sidebar/components/SharedContext.ts
@@ -1,7 +1,0 @@
-import * as React from "react";
-
-const SharedContext = React.createContext<boolean>(false);
-
-export const useSharedContext = () => React.useContext(SharedContext);
-
-export default SharedContext;

--- a/app/components/Sidebar/components/SharedWithMe.tsx
+++ b/app/components/Sidebar/components/SharedWithMe.tsx
@@ -16,8 +16,8 @@ import GroupLink from "./GroupLink";
 import Header from "./Header";
 import PlaceholderCollections from "./PlaceholderCollections";
 import Relative from "./Relative";
-import SharedContext from "./SharedContext";
 import SharedWithMeLink from "./SharedWithMeLink";
+import SidebarContext from "./SidebarContext";
 import SidebarLink from "./SidebarLink";
 import { useDropToReorderUserMembership } from "./useDragAndDrop";
 
@@ -52,7 +52,7 @@ function SharedWithMe() {
   }
 
   return (
-    <SharedContext.Provider value={true}>
+    <SidebarContext.Provider value="shared">
       <Flex column>
         <Header id="shared" title={t("Shared with me")}>
           {user.groupsWithDocumentMemberships.map((group) => (
@@ -89,7 +89,7 @@ function SharedWithMe() {
           </Relative>
         </Header>
       </Flex>
-    </SharedContext.Provider>
+    </SidebarContext.Provider>
   );
 }
 

--- a/app/components/Sidebar/components/SidebarContext.ts
+++ b/app/components/Sidebar/components/SidebarContext.ts
@@ -1,0 +1,9 @@
+import * as React from "react";
+
+export type SidebarContextType = "collections" | "starred" | string | undefined;
+
+const SidebarContext = React.createContext<SidebarContextType>(undefined);
+
+export const useSidebarContext = () => React.useContext(SidebarContext);
+
+export default SidebarContext;

--- a/app/components/Sidebar/components/Starred.tsx
+++ b/app/components/Sidebar/components/Starred.tsx
@@ -11,8 +11,8 @@ import DropCursor from "./DropCursor";
 import Header from "./Header";
 import PlaceholderCollections from "./PlaceholderCollections";
 import Relative from "./Relative";
+import SidebarContext from "./SidebarContext";
 import SidebarLink from "./SidebarLink";
-import StarredContext from "./StarredContext";
 import StarredLink from "./StarredLink";
 import { useDropToCreateStar, useDropToReorderStar } from "./useDragAndDrop";
 
@@ -39,7 +39,7 @@ function Starred() {
   }
 
   return (
-    <StarredContext.Provider value={true}>
+    <SidebarContext.Provider value="starred">
       <Flex column>
         <Header id="starred" title={t("Starred")}>
           <Relative>
@@ -80,7 +80,7 @@ function Starred() {
           </Relative>
         </Header>
       </Flex>
-    </StarredContext.Provider>
+    </SidebarContext.Provider>
   );
 }
 

--- a/app/components/Sidebar/components/StarredContext.ts
+++ b/app/components/Sidebar/components/StarredContext.ts
@@ -1,7 +1,0 @@
-import * as React from "react";
-
-const StarredContext = React.createContext<boolean>(false);
-
-export const useStarredContext = () => React.useContext(StarredContext);
-
-export default StarredContext;

--- a/app/components/Sidebar/components/StarredLink.tsx
+++ b/app/components/Sidebar/components/StarredLink.tsx
@@ -4,19 +4,23 @@ import { observer } from "mobx-react";
 import { StarredIcon } from "outline-icons";
 import * as React from "react";
 import { useEffect, useState } from "react";
-import { useLocation } from "react-router-dom";
 import styled, { useTheme } from "styled-components";
 import Star from "~/models/Star";
 import Fade from "~/components/Fade";
 import useBoolean from "~/hooks/useBoolean";
 import useStores from "~/hooks/useStores";
 import DocumentMenu from "~/menus/DocumentMenu";
+import { useLocationState } from "../hooks/useLocationState";
 import CollectionLink from "./CollectionLink";
 import CollectionLinkChildren from "./CollectionLinkChildren";
 import DocumentLink from "./DocumentLink";
 import DropCursor from "./DropCursor";
 import Folder from "./Folder";
 import Relative from "./Relative";
+import SidebarContext, {
+  SidebarContextType,
+  useSidebarContext,
+} from "./SidebarContext";
 import SidebarLink from "./SidebarLink";
 import {
   useDragStar,
@@ -29,29 +33,32 @@ type Props = {
   star: Star;
 };
 
-function useLocationState() {
-  const location = useLocation<{
-    starred?: boolean;
-  }>();
-  return location.state?.starred;
-}
-
 function StarredLink({ star }: Props) {
   const theme = useTheme();
   const { ui, collections, documents } = useStores();
   const [menuOpen, handleMenuOpen, handleMenuClose] = useBoolean();
   const { documentId, collectionId } = star;
   const collection = collections.get(collectionId);
-  const locationStateStarred = useLocationState();
+  const locationSidebarContext = useLocationState();
+  const sidebarContext = useSidebarContext();
   const [expanded, setExpanded] = useState(
-    star.collectionId === ui.activeCollectionId && !!locationStateStarred
+    star.collectionId === ui.activeCollectionId &&
+      sidebarContext === locationSidebarContext
   );
 
   React.useEffect(() => {
-    if (star.collectionId === ui.activeCollectionId && locationStateStarred) {
+    if (
+      star.collectionId === ui.activeCollectionId &&
+      sidebarContext === locationSidebarContext
+    ) {
       setExpanded(true);
     }
-  }, [star.collectionId, ui.activeCollectionId, locationStateStarred]);
+  }, [
+    star.collectionId,
+    ui.activeCollectionId,
+    sidebarContext,
+    locationSidebarContext,
+  ]);
 
   useEffect(() => {
     if (documentId) {
@@ -120,14 +127,15 @@ function StarredLink({ star }: Props) {
             depth={0}
             to={{
               pathname: document.url,
-              state: { starred: true },
+              state: { sidebarContext },
             }}
             expanded={hasChildDocuments && !isDragging ? expanded : undefined}
             onDisclosureClick={handleDisclosureClick}
             icon={icon}
-            isActive={(match, location: Location<{ starred?: boolean }>) =>
-              !!match && location.state?.starred === true
-            }
+            isActive={(
+              match,
+              location: Location<{ sidebarContext?: SidebarContextType }>
+            ) => !!match && location.state?.sidebarContext === sidebarContext}
             label={label}
             exact={false}
             showActions={menuOpen}
@@ -144,22 +152,24 @@ function StarredLink({ star }: Props) {
             }
           />
         </Draggable>
-        <Relative>
-          <Folder expanded={displayChildDocuments}>
-            {childDocuments.map((node, index) => (
-              <DocumentLink
-                key={node.id}
-                node={node}
-                collection={collection}
-                activeDocument={documents.active}
-                isDraft={node.isDraft}
-                depth={2}
-                index={index}
-              />
-            ))}
-          </Folder>
-          {cursor}
-        </Relative>
+        <SidebarContext.Provider value={document.id}>
+          <Relative>
+            <Folder expanded={displayChildDocuments}>
+              {childDocuments.map((node, index) => (
+                <DocumentLink
+                  key={node.id}
+                  node={node}
+                  collection={collection}
+                  activeDocument={documents.active}
+                  isDraft={node.isDraft}
+                  depth={2}
+                  index={index}
+                />
+              ))}
+            </Folder>
+            {cursor}
+          </Relative>
+        </SidebarContext.Provider>
       </>
     );
   }
@@ -176,13 +186,15 @@ function StarredLink({ star }: Props) {
             isDraggingAnyCollection={reorderStarMonitor.isDragging}
           />
         </Draggable>
-        <Relative>
-          <CollectionLinkChildren
-            collection={collection}
-            expanded={displayChildDocuments}
-          />
-          {cursor}
-        </Relative>
+        <SidebarContext.Provider value={collection.id}>
+          <Relative>
+            <CollectionLinkChildren
+              collection={collection}
+              expanded={displayChildDocuments}
+            />
+            {cursor}
+          </Relative>
+        </SidebarContext.Provider>
       </>
     );
   }

--- a/app/components/Sidebar/hooks/useLocationState.ts
+++ b/app/components/Sidebar/hooks/useLocationState.ts
@@ -1,0 +1,12 @@
+import { useLocation } from "react-router-dom";
+import { SidebarContextType } from "../components/SidebarContext";
+
+/**
+ * Hook to retrieve the sidebar context from the current location state.
+ */
+export function useLocationState() {
+  const location = useLocation<{
+    sidebarContext?: SidebarContextType;
+  }>();
+  return location.state?.sidebarContext;
+}

--- a/app/hooks/useTemplateActions.tsx
+++ b/app/hooks/useTemplateActions.tsx
@@ -27,13 +27,13 @@ const useTemplatesActions = () => {
             <NewDocumentIcon />
           ),
           keywords: "create",
-          perform: ({ activeCollectionId, inStarredSection }) =>
+          perform: ({ activeCollectionId, sidebarContext }) =>
             history.push(
               newDocumentPath(item.collectionId ?? activeCollectionId, {
                 templateId: item.id,
               }),
               {
-                starred: inStarredSection,
+                sidebarContext,
               }
             ),
         })

--- a/app/types.ts
+++ b/app/types.ts
@@ -7,6 +7,7 @@ import {
   DocumentPermission,
 } from "@shared/types";
 import RootStore from "~/stores/RootStore";
+import { SidebarContextType } from "./components/Sidebar/components/SidebarContext";
 import Document from "./models/Document";
 import FileOperation from "./models/FileOperation";
 import Pin from "./models/Pin";
@@ -82,7 +83,7 @@ export type ActionContext = {
   isContextMenu: boolean;
   isCommandBar: boolean;
   isButton: boolean;
-  inStarredSection?: boolean;
+  sidebarContext?: SidebarContextType;
   activeCollectionId?: string | undefined;
   activeDocumentId: string | undefined;
   currentUserId: string | undefined;


### PR DESCRIPTION
This fixes several bugs where a document could be active highlighted in multiple locations and simplifies the logic for any number of sidebar "sections" going forward.

Each sub-tree of the sidebar must be wrapped in a `SidebarContext.Provider`.