### PR TITLE
fix: Consider port in `isInternalUrl` util

### DIFF
--- a/shared/utils/domains.test.ts
+++ b/shared/utils/domains.test.ts
@@ -12,16 +12,19 @@ describe("#parseDomain", () => {
     expect(parseDomain("http://example.com")).toMatchObject({
       teamSubdomain: "",
       host: "example.com",
+      port: undefined,
       custom: false,
     });
     expect(parseDomain("//example.com")).toMatchObject({
       teamSubdomain: "",
       host: "example.com",
+      port: undefined,
       custom: false,
     });
-    expect(parseDomain("https://example.com")).toMatchObject({
+    expect(parseDomain("https://example.com:3030")).toMatchObject({
       teamSubdomain: "",
       host: "example.com",
+      port: "3030",
       custom: false,
     });
   });

--- a/shared/utils/domains.ts
+++ b/shared/utils/domains.ts
@@ -4,6 +4,7 @@ import env from "../env";
 type Domain = {
   teamSubdomain: string;
   host: string;
+  port?: string;
   custom: boolean;
 };
 
@@ -44,6 +45,14 @@ export function parseDomain(url: string): Domain {
     throw new TypeError("a non-empty url is required");
   }
 
+  let port;
+  try {
+    const parsedUrl = new URL(url);
+    port = parsedUrl.port || undefined;
+  } catch (e) {
+    // ignore
+  }
+
   const host = normalizeUrl(url);
   const baseDomain = getBaseDomain();
 
@@ -51,7 +60,7 @@ export function parseDomain(url: string): Domain {
   const baseUrlStart = host === baseDomain ? 0 : host.indexOf(`.${baseDomain}`);
 
   if (baseUrlStart === -1) {
-    return { teamSubdomain: "", host, custom: true };
+    return { teamSubdomain: "", host, port: undefined, custom: true };
   }
 
   // we consider anything in front of the baseUrl to be the subdomain
@@ -61,6 +70,7 @@ export function parseDomain(url: string): Domain {
   return {
     teamSubdomain: isReservedSubdomain ? "" : subdomain,
     host,
+    port,
     custom: false,
   };
 }

--- a/shared/utils/urls.test.ts
+++ b/shared/utils/urls.test.ts
@@ -1,3 +1,4 @@
+import env from "../env";
 import * as urlsUtils from "./urls";
 import { urlRegex } from "./urls";
 
@@ -46,8 +47,16 @@ describe("isBase64Url", () => {
 });
 
 describe("isInternalUrl", () => {
+  beforeEach(() => {
+    env.URL = "https://example.com:3000";
+  });
+
   it("should return false if empty string", () => {
     expect(urlsUtils.isInternalUrl("")).toBe(false);
+  });
+
+  it("should return false if port is different", () => {
+    expect(urlsUtils.isInternalUrl("https://example.com:4000")).toBe(false);
   });
 
   it("should return true if starting with relative path", () => {

--- a/shared/utils/urls.ts
+++ b/shared/utils/urls.ts
@@ -36,7 +36,7 @@ export function isInternalUrl(href: string) {
   const domain = parseDomain(href);
 
   return (
-    outline.host === domain.host ||
+    (outline.host === domain.host && outline.port === domain.port) ||
     (typeof window !== "undefined" && window.location.hostname === domain.host)
   );
 }


### PR DESCRIPTION
URL with a different port should not be considered "internal"

closes #7245 