### PR TITLE
feat: Adds team preference to disable user account removal

### DIFF
--- a/app/scenes/Settings/Preferences.tsx
+++ b/app/scenes/Settings/Preferences.tsx
@@ -166,20 +166,24 @@ function Preferences() {
         />
       </SettingRow>
 
-      <Heading as="h2">{t("Danger")}</Heading>
-      <SettingRow
-        name="delete"
-        label={t("Delete account")}
-        description={t(
-          "You may delete your account at any time, note that this is unrecoverable"
-        )}
-      >
-        <span>
-          <Button onClick={showDeleteAccount} neutral>
-            {t("Delete account")}…
-          </Button>
-        </span>
-      </SettingRow>
+      {team.getPreference(TeamPreference.MembersCanDeleteAccount) && (
+        <>
+          <Heading as="h2">{t("Danger")}</Heading>
+          <SettingRow
+            name="delete"
+            label={t("Delete account")}
+            description={t(
+              "You may delete your account at any time, note that this is unrecoverable"
+            )}
+          >
+            <span>
+              <Button onClick={showDeleteAccount} neutral>
+                {t("Delete account")}…
+              </Button>
+            </span>
+          </SettingRow>
+        </>
+      )}
     </Scene>
   );
 }

--- a/app/scenes/Settings/Preferences.tsx
+++ b/app/scenes/Settings/Preferences.tsx
@@ -14,6 +14,7 @@ import Switch from "~/components/Switch";
 import Text from "~/components/Text";
 import useCurrentTeam from "~/hooks/useCurrentTeam";
 import useCurrentUser from "~/hooks/useCurrentUser";
+import usePolicy from "~/hooks/usePolicy";
 import useStores from "~/hooks/useStores";
 import UserDelete from "../UserDelete";
 import SettingRow from "./components/SettingRow";
@@ -23,6 +24,7 @@ function Preferences() {
   const { ui, dialogs } = useStores();
   const user = useCurrentUser();
   const team = useCurrentTeam();
+  const can = usePolicy(user.id);
 
   const handlePreferenceChange =
     (inverted = false) =>
@@ -166,7 +168,7 @@ function Preferences() {
         />
       </SettingRow>
 
-      {team.getPreference(TeamPreference.MembersCanDeleteAccount) && (
+      {can.delete && (
         <>
           <Heading as="h2">{t("Danger")}</Heading>
           <SettingRow

--- a/app/scenes/Settings/Security.tsx
+++ b/app/scenes/Settings/Security.tsx
@@ -276,6 +276,19 @@ function Security() {
         />
       </SettingRow>
       <SettingRow
+        label={t("Users can delete account")}
+        name={TeamPreference.MembersCanDeleteAccount}
+        description={t(
+          "When enabled, users can delete their own account from the workspace"
+        )}
+      >
+        <Switch
+          id={TeamPreference.MembersCanDeleteAccount}
+          checked={team.getPreference(TeamPreference.MembersCanDeleteAccount)}
+          onChange={handlePreferenceChange}
+        />
+      </SettingRow>
+      <SettingRow
         label={t("Rich service embeds")}
         name="documentEmbeds"
         description={t(

--- a/server/policies/user.ts
+++ b/server/policies/user.ts
@@ -27,7 +27,10 @@ allow(User, ["update", "delete", "readDetails"], User, (actor, user) =>
   or(
     //
     isTeamAdmin(actor, user),
-    actor.id === user?.id
+    and(
+      actor.id === user?.id,
+      !!actor.team.getPreference(TeamPreference.MembersCanDeleteAccount)
+    )
   )
 );
 

--- a/server/routes/api/teams/schema.ts
+++ b/server/routes/api/teams/schema.ts
@@ -41,6 +41,8 @@ export const TeamsUpdateSchema = BaseSchema.extend({
         membersCanInvite: z.boolean().optional(),
         /** Whether members can create API keys. */
         membersCanCreateApiKey: z.boolean().optional(),
+        /** Whether members can delete their user account. */
+        membersCanDeleteAccount: z.boolean().optional(),
         /** Whether commenting is enabled */
         commenting: z.boolean().optional(),
         /** The custom theme for the team. */

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -20,6 +20,7 @@ export const TeamPreferenceDefaults: TeamPreferences = {
   [TeamPreference.ViewersCanExport]: true,
   [TeamPreference.MembersCanInvite]: false,
   [TeamPreference.MembersCanCreateApiKey]: true,
+  [TeamPreference.MembersCanDeleteAccount]: true,
   [TeamPreference.PublicBranding]: false,
   [TeamPreference.Commenting]: true,
   [TeamPreference.CustomTheme]: undefined,

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -965,6 +965,8 @@
   "When enabled, documents can be shared publicly on the internet by any member of the workspace": "When enabled, documents can be shared publicly on the internet by any member of the workspace",
   "Viewer document exports": "Viewer document exports",
   "When enabled, viewers can see download options for documents": "When enabled, viewers can see download options for documents",
+  "Users can delete account": "Users can delete account",
+  "When enabled, users can delete their own account from the workspace": "When enabled, users can delete their own account from the workspace",
   "Rich service embeds": "Rich service embeds",
   "Links to supported services are shown as rich embeds within your documents": "Links to supported services are shown as rich embeds within your documents",
   "Collection creation": "Collection creation",

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -206,6 +206,8 @@ export enum TeamPreference {
   MembersCanInvite = "membersCanInvite",
   /** Whether members can create API keys. */
   MembersCanCreateApiKey = "membersCanCreateApiKey",
+  /** Whether members can delete their user account. */
+  MembersCanDeleteAccount = "membersCanDeleteAccount",
   /** Whether users can comment on documents. */
   Commenting = "commenting",
   /** The custom theme for the team. */
@@ -220,6 +222,7 @@ export type TeamPreferences = {
   [TeamPreference.ViewersCanExport]?: boolean;
   [TeamPreference.MembersCanInvite]?: boolean;
   [TeamPreference.MembersCanCreateApiKey]?: boolean;
+  [TeamPreference.MembersCanDeleteAccount]?: boolean;
   [TeamPreference.Commenting]?: boolean;
   [TeamPreference.CustomTheme]?: Partial<CustomTheme>;
   [TeamPreference.TocPosition]?: TOCPosition;


### PR DESCRIPTION
It is often preferable to prevent individual users from deleting their own account, they can still be deleted by workspace admins.