### PR TITLE
In `documents.archived`, allow `sort: "index"` in request

### DIFF
--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -247,21 +247,65 @@ router.post(
   pagination(),
   validate(T.DocumentsArchivedSchema),
   async (ctx: APIContext<T.DocumentsArchivedReq>) => {
-    const { sort, direction } = ctx.input.body;
+    let { sort } = ctx.input.body;
+    const { direction, collectionId } = ctx.input.body;
+
     const { user } = ctx.state.auth;
-    const collectionIds = await user.collectionIds();
-    const documents = await Document.defaultScopeWithUser(user.id).findAll({
-      where: {
-        teamId: user.teamId,
-        collectionId: collectionIds,
-        archivedAt: {
-          [Op.ne]: null,
-        },
+
+    let where: WhereOptions<Document> = {
+      teamId: user.teamId,
+      archivedAt: {
+        [Op.ne]: null,
       },
+    };
+
+    let documentIds: string[] = [];
+
+    // if a specific collection is passed then we need to check auth to view it
+    if (collectionId) {
+      where = { ...where, collectionId };
+      const collection = await Collection.scope({
+        method: ["withMembership", user.id],
+      }).findByPk(collectionId);
+      authorize(user, "readDocument", collection);
+
+      // index sort is special because it uses the order of the documents in the
+      // collection.documentStructure rather than a database column
+      if (sort === "index") {
+        documentIds = (collection?.documentStructure || [])
+          .map((node) => node.id)
+          .slice(ctx.state.pagination.offset, ctx.state.pagination.limit);
+        where = { ...where, id: documentIds };
+      } // otherwise, filter by all collections the user has access to
+    } else {
+      const collectionIds = await user.collectionIds();
+      where = {
+        ...where,
+        collectionId: collectionIds,
+      };
+    }
+
+    // this needs to be done otherwise findAll below will throw telling
+    // that the column "document"."index" doesn't exist – value of sort
+    // is required to be a column name
+    if (sort === "index") {
+      sort = "updatedAt";
+    }
+
+    const documents = await Document.defaultScopeWithUser(user.id).findAll({
+      where,
       order: [[sort, direction]],
       offset: ctx.state.pagination.offset,
       limit: ctx.state.pagination.limit,
     });
+
+    if (documentIds.length) {
+      // sort again so as to retain the order of documents as in collection.documentStructure
+      documents.sort(
+        (a, b) => documentIds.indexOf(a.id) - documentIds.indexOf(b.id)
+      );
+    }
+
     const data = await Promise.all(
       documents.map((document) => presentDocument(ctx, document))
     );

--- a/server/routes/api/documents/schema.ts
+++ b/server/routes/api/documents/schema.ts
@@ -82,7 +82,10 @@ export const DocumentsListSchema = BaseSchema.extend({
 export type DocumentsListReq = z.infer<typeof DocumentsListSchema>;
 
 export const DocumentsArchivedSchema = BaseSchema.extend({
-  body: DocumentsSortParamsSchema.extend({}),
+  body: DocumentsSortParamsSchema.extend({
+    /** Id of the collection to which archived documents should belong */
+    collectionId: z.string().uuid().optional(),
+  }),
 });
 
 export type DocumentsArchivedReq = z.infer<typeof DocumentsArchivedSchema>;


### PR DESCRIPTION
Also, enables filtering archived docs by `collectionId`.

closes #7627 