### PR TITLE
fix: `document.content` column not updated when sending text attribute through API

### DIFF
--- a/server/commands/documentUpdater.test.ts
+++ b/server/commands/documentUpdater.test.ts
@@ -48,4 +48,37 @@ describe("documentUpdater", () => {
 
     expect(document.lastModifiedById).not.toEqual(user.id);
   });
+
+  it("should update document content when changing text", async () => {
+    const user = await buildUser();
+    let document = await buildDocument({
+      teamId: user.teamId,
+    });
+
+    document = await sequelize.transaction(async (transaction) =>
+      documentUpdater({
+        text: "Changed",
+        document,
+        user,
+        ip,
+        transaction,
+      })
+    );
+
+    expect(document.text).toEqual("Changed");
+    expect(document.content).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "Changed",
+            },
+          ],
+        },
+      ],
+    });
+  });
 });

--- a/server/models/helpers/DocumentHelper.tsx
+++ b/server/models/helpers/DocumentHelper.tsx
@@ -1,6 +1,5 @@
 import {
   updateYFragment,
-  yDocToProsemirror,
   yDocToProsemirrorJSON,
 } from "@getoutline/y-prosemirror";
 import { JSDOM } from "jsdom";
@@ -442,6 +441,7 @@ export class DocumentHelper {
   ) {
     document.text = append ? document.text + text : text;
     const doc = parser.parse(document.text);
+    document.content = doc.toJSON();
 
     if (document.state) {
       const ydoc = new Y.Doc();
@@ -456,13 +456,9 @@ export class DocumentHelper {
       updateYFragment(type.doc, type, doc, new Map());
 
       const state = Y.encodeStateAsUpdate(ydoc);
-      const node = yDocToProsemirror(schema, ydoc);
 
-      document.content = node.toJSON();
       document.state = Buffer.from(state);
       document.changed("state", true);
-    } else if (doc) {
-      document.content = doc.toJSON();
     }
 
     return document;


### PR DESCRIPTION
closes #7624 