### PR TITLE
Add hashed column for API keys

### DIFF
--- a/app/components/Text.ts
+++ b/app/components/Text.ts
@@ -16,6 +16,8 @@ type Props = {
   italic?: boolean;
   /** Whether the text should be truncated with an ellipsis */
   ellipsis?: boolean;
+  /** Whether the text should be monospaced */
+  monospace?: boolean;
 };
 
 /**
@@ -59,6 +61,8 @@ const Text = styled.span<Props>`
     `}
 
   font-style: ${(props) => (props.italic ? "italic" : "normal")};
+  font-family: ${(props) =>
+    props.monospace ? props.theme.fontFamilyMono : "inherit"};
 
   white-space: normal;
   user-select: ${(props) => (props.selectable ? "text" : "none")};

--- a/app/models/ApiKey.ts
+++ b/app/models/ApiKey.ts
@@ -1,40 +1,32 @@
 import { isPast } from "date-fns";
 import { computed, observable } from "mobx";
-import Model from "./base/Model";
+import ParanoidModel from "./base/ParanoidModel";
 import Field from "./decorators/Field";
 
-class ApiKey extends Model {
+class ApiKey extends ParanoidModel {
   static modelName = "ApiKey";
 
-  @Field
-  @observable
-  id: string;
-
-  /**
-   * The user chosen name of the API key.
-   */
+  /** The user chosen name of the API key. */
   @Field
   @observable
   name: string;
 
-  /**
-   * An optional datetime that the API key expires.
-   */
+  /** An optional datetime that the API key expires. */
   @Field
   @observable
   expiresAt?: string;
 
-  /**
-   * An optional datetime that the API key was last used at.
-   */
+  /** An optional datetime that the API key was last used at. */
   @observable
   lastActiveAt?: string;
 
-  secret: string;
+  /** The plain text value of the API key, only available on creation. */
+  value: string;
 
-  /**
-   * Whether the API key has an expiry in the past.
-   */
+  /** A preview of the last 4 characters of the API key. */
+  last4: string;
+
+  /** Whether the API key has an expiry in the past. */
   @computed
   get isExpired() {
     return this.expiresAt ? isPast(new Date(this.expiresAt)) : false;

--- a/app/models/ApiKey.ts
+++ b/app/models/ApiKey.ts
@@ -31,6 +31,14 @@ class ApiKey extends ParanoidModel {
   get isExpired() {
     return this.expiresAt ? isPast(new Date(this.expiresAt)) : false;
   }
+
+  @computed
+  get obfuscatedValue() {
+    if (this.createdAt < new Date("2022-12-03").toISOString()) {
+      return `...${this.last4}`;
+    }
+    return `ol...${this.last4}`;
+  }
 }
 
 export default ApiKey;

--- a/app/scenes/ApiKeyNew/index.tsx
+++ b/app/scenes/ApiKeyNew/index.tsx
@@ -71,7 +71,11 @@ function ApiKeyNew({ onSubmit }: Props) {
           name,
           expiresAt: expiresAt?.toISOString(),
         });
-        toast.success(t("API key created"));
+        toast.success(
+          t(
+            "API key created. Please copy the value now as it will not be shown again."
+          )
+        );
         onSubmit();
       } catch (err) {
         toast.error(err.message);

--- a/app/scenes/Settings/components/ApiKeyListItem.tsx
+++ b/app/scenes/Settings/components/ApiKeyListItem.tsx
@@ -61,11 +61,11 @@ const ApiKeyListItem = ({ apiKey, isCopied, onCopy }: Props) => {
           )}
           <Text
             type="tertiary"
-            size="small"
+            size="xsmall"
             style={{ marginRight: 8 }}
             monospace
           >
-            ol...{apiKey.last4}
+            {apiKey.obfuscatedValue}
           </Text>
           <ApiKeyMenu apiKey={apiKey} />
         </Flex>

--- a/app/scenes/Settings/components/ApiKeyListItem.tsx
+++ b/app/scenes/Settings/components/ApiKeyListItem.tsx
@@ -52,11 +52,21 @@ const ApiKeyListItem = ({ apiKey, isCopied, onCopy }: Props) => {
       subtitle={subtitle}
       actions={
         <Flex align="center" gap={8}>
-          <CopyToClipboard text={apiKey.secret} onCopy={handleCopy}>
-            <Button type="button" icon={<CopyIcon />} neutral borderOnHover>
-              {isCopied ? t("Copied") : t("Copy")}
-            </Button>
-          </CopyToClipboard>
+          {apiKey.value && (
+            <CopyToClipboard text={apiKey.value} onCopy={handleCopy}>
+              <Button type="button" icon={<CopyIcon />} neutral borderOnHover>
+                {isCopied ? t("Copied") : t("Copy")}
+              </Button>
+            </CopyToClipboard>
+          )}
+          <Text
+            type="tertiary"
+            size="small"
+            style={{ marginRight: 8 }}
+            monospace
+          >
+            ol...{apiKey.last4}
+          </Text>
           <ApiKeyMenu apiKey={apiKey} />
         </Flex>
       }

--- a/server/middlewares/authentication.test.ts
+++ b/server/middlewares/authentication.test.ts
@@ -1,7 +1,11 @@
 import { DefaultState } from "koa";
 import randomstring from "randomstring";
-import ApiKey from "@server/models/ApiKey";
-import { buildUser, buildTeam, buildAdmin } from "@server/test/factories";
+import {
+  buildUser,
+  buildTeam,
+  buildAdmin,
+  buildApiKey,
+} from "@server/test/factories";
 import auth from "./authentication";
 
 describe("Authentication middleware", () => {
@@ -51,14 +55,12 @@ describe("Authentication middleware", () => {
       const state = {} as DefaultState;
       const user = await buildUser();
       const authMiddleware = auth();
-      const key = await ApiKey.create({
-        userId: user.id,
-      });
+      const key = await buildApiKey({ userId: user.id });
       await authMiddleware(
         {
           // @ts-expect-error mock request
           request: {
-            get: jest.fn(() => `Bearer ${key.secret}`),
+            get: jest.fn(() => `Bearer ${key.value}`),
           },
           state,
           cache: {},

--- a/server/middlewares/authentication.ts
+++ b/server/middlewares/authentication.ts
@@ -70,11 +70,7 @@ export default function auth(options: AuthenticationOptions = {}) {
         let apiKey;
 
         try {
-          apiKey = await ApiKey.findOne({
-            where: {
-              secret: token,
-            },
-          });
+          apiKey = await ApiKey.findByToken(token);
         } catch (err) {
           throw AuthenticationError("Invalid API key");
         }

--- a/server/migrations/20240929194201-add-hash-to-api-key.js
+++ b/server/migrations/20240929194201-add-hash-to-api-key.js
@@ -1,0 +1,35 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction(async transaction => {
+      await queryInterface.addColumn("apiKeys", "hash", {
+        type: Sequelize.STRING,
+        allowNull: true,
+        unique: true,
+      }, { transaction });
+
+      await queryInterface.addColumn("apiKeys", "last4", {
+        type: Sequelize.STRING(4),
+        allowNull: true,
+      }, { transaction });
+
+      await queryInterface.changeColumn("apiKeys", "secret", {
+        type: Sequelize.STRING,
+        allowNull: true,
+      }, { transaction });
+    });
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction(async transaction => {
+      await queryInterface.removeColumn("apiKeys", "hash", { transaction });
+      await queryInterface.removeColumn("apiKeys", "last4", { transaction });
+      await queryInterface.changeColumn("apiKeys", "secret", {
+        type: Sequelize.STRING,
+        allowNull: false,
+      }, { transaction });
+    });
+  }
+};

--- a/server/models/ApiKey.test.ts
+++ b/server/models/ApiKey.test.ts
@@ -5,10 +5,8 @@ import ApiKey from "./ApiKey";
 describe("#ApiKey", () => {
   describe("match", () => {
     test("should match an API secret", async () => {
-      const apiKey = await buildApiKey({
-        name: "Dev",
-      });
-      expect(ApiKey.match(apiKey?.secret)).toBe(true);
+      const apiKey = await buildApiKey();
+      expect(ApiKey.match(apiKey.value!)).toBe(true);
       expect(ApiKey.match(`${randomstring.generate(38)}`)).toBe(true);
     });
 
@@ -20,23 +18,30 @@ describe("#ApiKey", () => {
 
   describe("lastActiveAt", () => {
     test("should update lastActiveAt", async () => {
-      const apiKey = await buildApiKey({
-        name: "Dev",
-      });
+      const apiKey = await buildApiKey();
       await apiKey.updateActiveAt();
       expect(apiKey.lastActiveAt).toBeTruthy();
     });
 
     test("should not update lastActiveAt within 5 minutes", async () => {
-      const apiKey = await buildApiKey({
-        name: "Dev",
-      });
+      const apiKey = await buildApiKey();
       await apiKey.updateActiveAt();
       expect(apiKey.lastActiveAt).toBeTruthy();
 
       const lastActiveAt = apiKey.lastActiveAt;
       await apiKey.updateActiveAt();
       expect(apiKey.lastActiveAt).toEqual(lastActiveAt);
+    });
+  });
+
+  describe("findByToken", () => {
+    test("should find by hash", async () => {
+      const apiKey = await buildApiKey({
+        name: "Dev",
+      });
+      const found = await ApiKey.findByToken(apiKey.value!);
+      expect(found?.id).toEqual(apiKey.id);
+      expect(found?.last4).toEqual(apiKey.value!.slice(-4));
     });
   });
 });

--- a/server/models/ApiKey.ts
+++ b/server/models/ApiKey.ts
@@ -1,6 +1,8 @@
+import crypto from "crypto";
 import { subMinutes } from "date-fns";
 import randomstring from "randomstring";
-import { InferAttributes, InferCreationAttributes } from "sequelize";
+import { InferAttributes, InferCreationAttributes, Op } from "sequelize";
+import { type BuildOptions } from "sequelize";
 import {
   Column,
   Table,
@@ -9,6 +11,8 @@ import {
   BelongsTo,
   ForeignKey,
   IsDate,
+  DataType,
+  BeforeSave,
 } from "sequelize-typescript";
 import { ApiKeyValidation } from "@shared/validations";
 import User from "./User";
@@ -24,6 +28,18 @@ class ApiKey extends ParanoidModel<
 > {
   static prefix = "ol_api_";
 
+  constructor(
+    values?: Partial<InferCreationAttributes<ApiKey>>,
+    options?: BuildOptions
+  ) {
+    // Temporary until last4 is backfilled and secret is removed.
+    if (values?.secret) {
+      values.last4 = values.secret.slice(-4);
+    }
+
+    super(values, options);
+  }
+
   @Length({
     min: ApiKeyValidation.minNameLength,
     max: ApiKeyValidation.maxNameLength,
@@ -32,9 +48,23 @@ class ApiKey extends ParanoidModel<
   @Column
   name: string;
 
+  /** @deprecated The plain text value of the API key, removed soon. */
   @Unique
   @Column
   secret: string;
+
+  /** The cached plain text value. Only available when creating the API key */
+  @Column(DataType.VIRTUAL)
+  value: string | null;
+
+  /** The hashed value of the API key */
+  @Unique
+  @Column
+  hash: string;
+
+  /** The last 4 characters of the API key */
+  @Column
+  last4: string;
 
   @IsDate
   @Column
@@ -47,10 +77,30 @@ class ApiKey extends ParanoidModel<
   // hooks
 
   @BeforeValidate
-  static async generateSecret(model: ApiKey) {
-    if (!model.secret) {
-      model.secret = `${ApiKey.prefix}${randomstring.generate(38)}`;
+  public static async generateSecret(model: ApiKey) {
+    if (!model.hash) {
+      const secret = `${ApiKey.prefix}${randomstring.generate(38)}`;
+      model.value = model.secret || secret;
+      model.hash = this.hash(model.value);
     }
+  }
+
+  @BeforeSave
+  public static async updateLast4(model: ApiKey) {
+    const value = model.value || model.secret;
+    if (value) {
+      model.last4 = value.slice(-4);
+    }
+  }
+
+  /**
+   * Generates a hashed API key for the given input key.
+   *
+   * @param key The input string to hash
+   * @returns The hashed API key
+   */
+  private static hash(key: string) {
+    return crypto.createHash("sha256").update(key).digest("hex");
   }
 
   /**
@@ -60,8 +110,24 @@ class ApiKey extends ParanoidModel<
    * @param text The text to validate
    * @returns True if likely an API key
    */
-  static match(text: string) {
+  public static match(text: string) {
+    // cannot guarantee prefix here as older keys do not include it.
     return !!text.replace(ApiKey.prefix, "").match(/^[\w]{38}$/);
+  }
+
+  /**
+   * Finds an API key by the given input string. This will check both the
+   * secret and hash fields.
+   *
+   * @param input The input string to search for
+   * @returns The API key if found
+   */
+  public static findByToken(input: string) {
+    return this.findOne({
+      where: {
+        [Op.or]: [{ secret: input }, { hash: this.hash(input) }],
+      },
+    });
   }
 
   // associations
@@ -72,6 +138,8 @@ class ApiKey extends ParanoidModel<
   @ForeignKey(() => User)
   @Column
   userId: string;
+
+  // methods
 
   updateActiveAt = async () => {
     const fiveMinutesAgo = subMinutes(new Date(), 5);

--- a/server/presenters/apiKey.ts
+++ b/server/presenters/apiKey.ts
@@ -1,13 +1,14 @@
 import ApiKey from "@server/models/ApiKey";
 
-export default function presentApiKey(key: ApiKey) {
+export default function presentApiKey(apiKey: ApiKey) {
   return {
-    id: key.id,
-    name: key.name,
-    secret: key.secret,
-    createdAt: key.createdAt,
-    updatedAt: key.updatedAt,
-    expiresAt: key.expiresAt,
-    lastActiveAt: key.lastActiveAt,
+    id: apiKey.id,
+    name: apiKey.name,
+    value: apiKey.value,
+    last4: apiKey.last4,
+    createdAt: apiKey.createdAt,
+    updatedAt: apiKey.updatedAt,
+    expiresAt: apiKey.expiresAt,
+    lastActiveAt: apiKey.lastActiveAt,
   };
 }

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -536,7 +536,7 @@
   "shared": "shared",
   "invited you to": "invited you to",
   "Choose a date": "Choose a date",
-  "API key created": "API key created",
+  "API key created. Please copy the value now as it will not be shown again.": "API key created. Please copy the value now as it will not be shown again.",
   "Name your key something that will help you to remember it's use in the future, for example \"local development\" or \"continuous integration\".": "Name your key something that will help you to remember it's use in the future, for example \"local development\" or \"continuous integration\".",
   "Expiration": "Expiration",
   "Never expires": "Never expires",


### PR DESCRIPTION
Towards #7675 – adds news column for storing the API key as a hashed value, and a preview of that value.