### PR TITLE
chore: Moves ProseMirror NodeView to render within main React context

### DIFF
--- a/app/editor/components/NodeViewRenderer.tsx
+++ b/app/editor/components/NodeViewRenderer.tsx
@@ -1,0 +1,28 @@
+import isEqual from "lodash/isEqual";
+import { action, computed, observable } from "mobx";
+import React, { FunctionComponent } from "react";
+import { createPortal } from "react-dom";
+
+export class NodeViewRenderer<T extends object> {
+  @observable public props: T;
+
+  public constructor(
+    public element: HTMLElement,
+    private Component: FunctionComponent,
+    props: T
+  ) {
+    this.props = props;
+  }
+
+  @computed
+  public get content() {
+    return createPortal(<this.Component {...this.props} />, this.element);
+  }
+
+  @action
+  public updateProps(props: T) {
+    if (!isEqual(props, this.props)) {
+      this.props = props;
+    }
+  }
+}

--- a/app/editor/index.tsx
+++ b/app/editor/index.tsx
@@ -38,7 +38,7 @@ import Mark from "@shared/editor/marks/Mark";
 import { basicExtensions as extensions } from "@shared/editor/nodes";
 import Node from "@shared/editor/nodes/Node";
 import ReactNode from "@shared/editor/nodes/ReactNode";
-import { EventType } from "@shared/editor/types";
+import { ComponentProps, EventType } from "@shared/editor/types";
 import { ProsemirrorData, UserPreferences } from "@shared/types";
 import { ProsemirrorHelper } from "@shared/utils/ProsemirrorHelper";
 import EventEmitter from "@shared/utils/events";
@@ -50,6 +50,7 @@ import ComponentView from "./components/ComponentView";
 import EditorContext from "./components/EditorContext";
 import { SearchResult } from "./components/LinkEditor";
 import LinkToolbar from "./components/LinkToolbar";
+import { NodeViewRenderer } from "./components/NodeViewRenderer";
 import SelectionToolbar from "./components/SelectionToolbar";
 import WithTheme from "./components/WithTheme";
 
@@ -192,6 +193,7 @@ export class Editor extends React.PureComponent<
   };
 
   widgets: { [name: string]: (props: WidgetProps) => React.ReactElement };
+  renderers: Set<NodeViewRenderer<ComponentProps>> = new Set();
   nodes: { [name: string]: NodeSpec };
   marks: { [name: string]: MarkSpec };
   commands: Record<string, CommandFactory>;
@@ -838,6 +840,7 @@ export class Editor extends React.PureComponent<
               Object.values(this.widgets).map((Widget, index) => (
                 <Widget key={String(index)} rtl={isRTL} readOnly={readOnly} />
               ))}
+            {Array.from(this.renderers).map((view) => view.content)}
           </Flex>
         </EditorContext.Provider>
       </PortalContext.Provider>

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -32,12 +32,6 @@ void PluginManager.loadPlugins();
 initI18n(env.DEFAULT_LANGUAGE);
 const element = window.document.getElementById("root");
 
-history.listen(() => {
-  requestAnimationFrame(() =>
-    window.dispatchEvent(new Event("location-changed"))
-  );
-});
-
 if (env.SENTRY_DSN) {
   initSentry(history);
 }


### PR DESCRIPTION
Instead of creating a new root for each react node in the editor we portal them into the main React context, this allows using things like the store and theme provider without any extra plumbing. 

Minimal viable version, foundational for #7680 