### PR TITLE
fix: Remove docker version in compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   redis:
     image: redis


### PR DESCRIPTION
`the attribute version is obsolete, it will be ignored, please remove it to avoid potential confusion`

[Reference in the compose-spec](https://github.com/compose-spec/compose-spec/blob/main/spec.md#version-and-name-top-level-elements)

Also needs updating in the documentation here - https://docs.getoutline.com/s/hosting/doc/docker-7pfeLP5a8t