### PR TITLE
Allow returning team API keys for admins from `apiKeys.list`

### DIFF
--- a/app/models/ApiKey.ts
+++ b/app/models/ApiKey.ts
@@ -16,9 +16,12 @@ class ApiKey extends ParanoidModel {
   @observable
   expiresAt?: string;
 
-  /** An optional datetime that the API key was last used at. */
+  /** Timestamp that the API key was last used. */
   @observable
   lastActiveAt?: string;
+
+  /** The user ID that the API key belongs to. */
+  userId: string;
 
   /** The plain text value of the API key, only available on creation. */
   value: string;

--- a/app/scenes/Settings/ApiKeys.tsx
+++ b/app/scenes/Settings/ApiKeys.tsx
@@ -81,7 +81,7 @@ function ApiKeys() {
       </Text>
       <PaginatedList
         fetch={apiKeys.fetchPage}
-        items={apiKeys.orderedData}
+        items={apiKeys.personalApiKeys}
         options={{ userId: user.id }}
         heading={<h2>{t("Personal keys")}</h2>}
         renderItem={(apiKey: ApiKey) => (

--- a/app/scenes/Settings/ApiKeys.tsx
+++ b/app/scenes/Settings/ApiKeys.tsx
@@ -13,12 +13,14 @@ import Text from "~/components/Text";
 import { createApiKey } from "~/actions/definitions/apiKeys";
 import useActionContext from "~/hooks/useActionContext";
 import useCurrentTeam from "~/hooks/useCurrentTeam";
+import useCurrentUser from "~/hooks/useCurrentUser";
 import usePolicy from "~/hooks/usePolicy";
 import useStores from "~/hooks/useStores";
 import ApiKeyListItem from "./components/ApiKeyListItem";
 
 function ApiKeys() {
   const team = useCurrentTeam();
+  const user = useCurrentUser();
   const { t } = useTranslation();
   const { apiKeys } = useStores();
   const can = usePolicy(team);
@@ -80,6 +82,7 @@ function ApiKeys() {
       <PaginatedList
         fetch={apiKeys.fetchPage}
         items={apiKeys.orderedData}
+        options={{ userId: user.id }}
         heading={<h2>{t("Personal keys")}</h2>}
         renderItem={(apiKey: ApiKey) => (
           <ApiKeyListItem

--- a/app/stores/ApiKeysStore.ts
+++ b/app/stores/ApiKeysStore.ts
@@ -1,3 +1,4 @@
+import { computed } from "mobx";
 import ApiKey from "~/models/ApiKey";
 import RootStore from "./RootStore";
 import Store, { RPCAction } from "./base/Store";
@@ -7,5 +8,13 @@ export default class ApiKeysStore extends Store<ApiKey> {
 
   constructor(rootStore: RootStore) {
     super(rootStore, ApiKey);
+  }
+
+  @computed
+  get personalApiKeys() {
+    const userId = this.rootStore.auth.user?.id;
+    return userId
+      ? this.orderedData.filter((key) => key.userId === userId)
+      : [];
   }
 }

--- a/server/policies/apiKey.ts
+++ b/server/policies/apiKey.ts
@@ -5,7 +5,6 @@ import { and, isOwner, isTeamModel, isTeamMutable } from "./utils";
 
 allow(User, "createApiKey", Team, (actor, team) =>
   and(
-    //
     isTeamModel(actor, team),
     isTeamMutable(actor),
     !actor.isViewer,
@@ -16,4 +15,18 @@ allow(User, "createApiKey", Team, (actor, team) =>
   )
 );
 
-allow(User, ["read", "update", "delete"], ApiKey, isOwner);
+allow(User, "listApiKeys", Team, (actor, team) =>
+  and(
+    //
+    isTeamModel(actor, team),
+    actor.isAdmin
+  )
+);
+
+allow(User, ["read", "update", "delete"], ApiKey, (actor, apiKey) =>
+  and(
+    isOwner(actor, apiKey),
+    actor.isAdmin ||
+      !!actor.team?.getPreference(TeamPreference.MembersCanCreateApiKey)
+  )
+);

--- a/server/policies/user.ts
+++ b/server/policies/user.ts
@@ -23,7 +23,7 @@ allow(User, "inviteUser", Team, (actor, team) =>
   )
 );
 
-allow(User, ["update", "readDetails"], User, (actor, user) =>
+allow(User, ["update", "readDetails", "listApiKeys"], User, (actor, user) =>
   or(
     //
     isTeamAdmin(actor, user),

--- a/server/presenters/apiKey.ts
+++ b/server/presenters/apiKey.ts
@@ -3,6 +3,7 @@ import ApiKey from "@server/models/ApiKey";
 export default function presentApiKey(apiKey: ApiKey) {
   return {
     id: apiKey.id,
+    userId: apiKey.userId,
     name: apiKey.name,
     value: apiKey.value,
     last4: apiKey.last4,

--- a/server/routes/api/apiKeys/apiKeys.ts
+++ b/server/routes/api/apiKeys/apiKeys.ts
@@ -1,10 +1,11 @@
 import Router from "koa-router";
+import { WhereOptions } from "sequelize";
 import { UserRole } from "@shared/types";
 import auth from "@server/middlewares/authentication";
 import { transaction } from "@server/middlewares/transaction";
 import validate from "@server/middlewares/validate";
-import { ApiKey, Event } from "@server/models";
-import { authorize } from "@server/policies";
+import { ApiKey, Event, User } from "@server/models";
+import { authorize, cannot } from "@server/policies";
 import { presentApiKey } from "@server/presenters";
 import { APIContext, AuthenticationType } from "@server/types";
 import pagination from "../middlewares/pagination";
@@ -54,12 +55,40 @@ router.post(
   "apiKeys.list",
   auth({ role: UserRole.Member }),
   pagination(),
-  async (ctx: APIContext) => {
-    const { user } = ctx.state.auth;
+  validate(T.APIKeysListSchema),
+  async (ctx: APIContext<T.APIKeysListReq>) => {
+    const { userId } = ctx.input.body;
+    const actor = ctx.state.auth.user;
+
+    let where: WhereOptions<User> = {
+      teamId: actor.teamId,
+    };
+
+    if (cannot(actor, "listApiKeys", actor.team)) {
+      where = {
+        ...where,
+        id: actor.id,
+      };
+    }
+
+    if (userId) {
+      const user = await User.findByPk(userId);
+      authorize(actor, "listApiKeys", user);
+
+      where = {
+        ...where,
+        id: userId,
+      };
+    }
+
     const keys = await ApiKey.findAll({
-      where: {
-        userId: user.id,
-      },
+      include: [
+        {
+          model: User,
+          required: true,
+          where,
+        },
+      ],
       order: [["createdAt", "DESC"]],
       offset: ctx.state.pagination.offset,
       limit: ctx.state.pagination.limit,

--- a/server/routes/api/apiKeys/schema.ts
+++ b/server/routes/api/apiKeys/schema.ts
@@ -12,6 +12,15 @@ export const APIKeysCreateSchema = BaseSchema.extend({
 
 export type APIKeysCreateReq = z.infer<typeof APIKeysCreateSchema>;
 
+export const APIKeysListSchema = BaseSchema.extend({
+  body: z.object({
+    /** The owner of the API key */
+    userId: z.string().uuid().optional(),
+  }),
+});
+
+export type APIKeysListReq = z.infer<typeof APIKeysListSchema>;
+
 export const APIKeysDeleteSchema = BaseSchema.extend({
   body: z.object({
     /** API Key Id */


### PR DESCRIPTION
Updates API key list endpoint to allow listing all API keys at the team level for admins. As this changes the default endpoint behavior there is a small chance of admins seeing API keys listed for other users under "Personal keys" until the app is reloaded.

The screen for listing team API keys is to follow

towards #7675 
follow on https://github.com/outline/outline/pull/7699