### PR TITLE
fix: assorted comment bugs

### DIFF
--- a/app/components/WebsocketProvider.tsx
+++ b/app/components/WebsocketProvider.tsx
@@ -339,12 +339,12 @@ class WebsocketProvider extends React.Component<Props> {
     this.socket.on("comments.update", (event: PartialExcept<Comment, "id">) => {
       const comment = comments.get(event.id);
 
-      // Fetch the latest version to update policies when the resolution status has changed and we don't have the latest version.
+      // Existing policy becomes invalid when the resolution status has changed and we don't have the latest version.
       if (comment?.resolvedAt !== event.resolvedAt) {
-        void comments.fetch(event.id, { force: true });
-      } else {
-        comments.add(event);
+        policies.remove(event.id);
       }
+
+      comments.add(event);
     });
 
     this.socket.on("comments.delete", (event: WebsocketEntityDeletedEvent) => {

--- a/app/components/WebsocketProvider.tsx
+++ b/app/components/WebsocketProvider.tsx
@@ -337,7 +337,14 @@ class WebsocketProvider extends React.Component<Props> {
     });
 
     this.socket.on("comments.update", (event: PartialExcept<Comment, "id">) => {
-      comments.add(event);
+      const comment = comments.get(event.id);
+
+      // Fetch the latest version to update policies when the resolution status has changed and we don't have the latest version.
+      if (comment?.resolvedAt !== event.resolvedAt) {
+        void comments.fetch(event.id, { force: true });
+      } else {
+        comments.add(event);
+      }
     });
 
     this.socket.on("comments.delete", (event: WebsocketEntityDeletedEvent) => {

--- a/app/menus/CommentMenu.tsx
+++ b/app/menus/CommentMenu.tsx
@@ -75,7 +75,7 @@ function CommentMenu({
               title: `${t("Edit")}…`,
               icon: <EditIcon />,
               onClick: onEdit,
-              visible: can.update,
+              visible: can.update && !comment.isResolved,
             },
             actionToMenuItem(
               resolveCommentFactory({

--- a/app/models/Comment.ts
+++ b/app/models/Comment.ts
@@ -99,8 +99,8 @@ class Comment extends Model {
    * Whether the comment is resolved
    */
   @computed
-  public get isResolved() {
-    return !!this.resolvedAt;
+  public get isResolved(): boolean {
+    return !!this.resolvedAt || !!this.parentComment?.isResolved;
   }
 
   /**

--- a/app/scenes/Document/components/CommentThread.tsx
+++ b/app/scenes/Document/components/CommentThread.tsx
@@ -80,6 +80,8 @@ function CommentThread({
   });
   const can = usePolicy(document);
 
+  const canReply = can.comment && !thread.isResolved;
+
   const highlightedCommentMarks = editor
     ?.getComments()
     .filter((comment) => comment.id === thread.id);
@@ -105,7 +107,7 @@ function CommentThread({
   const handleClickThread = () => {
     history.replace({
       // Clear any commentId from the URL when explicitly focusing a thread
-      search: "",
+      search: thread.isResolved ? "resolved=" : "",
       pathname: location.pathname.replace(/\/history$/, ""),
       state: { commentId: thread.id },
     });
@@ -214,7 +216,7 @@ function CommentThread({
         ))}
 
       <ResizingHeightContainer hideOverflow={false} ref={replyRef}>
-        {(focused || draft || commentsInThread.length === 0) && can.comment && (
+        {(focused || draft || commentsInThread.length === 0) && canReply && (
           <Fade timing={100}>
             <CommentForm
               onSaveDraft={onSaveDraft}
@@ -232,7 +234,7 @@ function CommentThread({
           </Fade>
         )}
       </ResizingHeightContainer>
-      {!focused && !recessed && !draft && can.comment && (
+      {!focused && !recessed && !draft && canReply && (
         <Reply onClick={() => setAutoFocus(true)}>{t("Reply")}…</Reply>
       )}
     </Thread>

--- a/app/utils/routeHelpers.ts
+++ b/app/utils/routeHelpers.ts
@@ -25,7 +25,9 @@ export function settingsPath(section?: string): string {
 }
 
 export function commentPath(document: Document, comment: Comment): string {
-  return `${documentPath(document)}?commentId=${comment.id}`;
+  return `${documentPath(document)}?commentId=${comment.id}${
+    comment.isResolved ? "&resolved=" : ""
+  }`;
 }
 
 export function collectionPath(url: string, section?: string): string {

--- a/server/routes/api/comments/comments.test.ts
+++ b/server/routes/api/comments/comments.test.ts
@@ -522,6 +522,7 @@ describe("#comments.resolve", () => {
     const body = await res.json();
 
     expect(res.status).toEqual(200);
+    expect(body.data.updatedAt).toEqual(comment.updatedAt.toISOString());
     expect(body.data.resolvedAt).toBeTruthy();
     expect(body.data.resolvedById).toEqual(user.id);
     expect(body.data.resolvedBy.id).toEqual(user.id);
@@ -592,6 +593,7 @@ describe("#comments.unresolve", () => {
     const body = await res.json();
 
     expect(res.status).toEqual(200);
+    expect(body.data.updatedAt).toEqual(comment.updatedAt.toISOString());
     expect(body.data.resolvedAt).toEqual(null);
     expect(body.data.resolvedBy).toEqual(null);
     expect(body.data.resolvedById).toEqual(null);

--- a/server/routes/api/comments/comments.ts
+++ b/server/routes/api/comments/comments.ts
@@ -293,7 +293,7 @@ router.post(
 
     comment.resolve(user);
     const changes = comment.changeset;
-    await comment.save({ transaction });
+    await comment.save({ transaction, silent: true });
 
     await Event.createFromContext(
       ctx,
@@ -340,7 +340,7 @@ router.post(
 
     comment.unresolve();
     const changes = comment.changeset;
-    await comment.save({ transaction });
+    await comment.save({ transaction, silent: true });
 
     await Event.createFromContext(
       ctx,


### PR DESCRIPTION
- [x] Skip updating `updatedAt` column when resolving / unresolving comments.
- [x] Show the correct `MarkAsResolved` / `MarkAsUnresolved` menu item for comments updated through a websocket event.
- [x] Show `Resolved comments` view when a resolved comment link is opened directly.
- [x] Don't allow edits for resolved comments.
- [x] Don't allow replies for resolved comments.