### PR TITLE
perf: Fix comments double rendering on mount

### DIFF
--- a/app/models/Comment.ts
+++ b/app/models/Comment.ts
@@ -26,7 +26,7 @@ class Comment extends Model {
    * The Prosemirror data representing the comment content
    */
   @Field
-  @observable
+  @observable.shallow
   data: ProsemirrorData;
 
   /**


### PR DESCRIPTION
There's more to improve here, but this is one of the main culprits.

Towards #7823