### PR TITLE
Comments: scroll to most-recent during load and when switching sort setting

### DIFF
--- a/app/scenes/Document/components/Comments.tsx
+++ b/app/scenes/Document/components/Comments.tsx
@@ -72,11 +72,13 @@ function Comments() {
   };
 
   const handleScroll = () => {
+    const BUFFER_PX = 50;
+
     if (scrollableRef.current) {
       const sh = scrollableRef.current.scrollHeight;
       const st = scrollableRef.current.scrollTop;
       const ch = scrollableRef.current.clientHeight;
-      isAtBottom.current = Math.abs(sh - (st + ch)) <= 1;
+      isAtBottom.current = Math.abs(sh - (st + ch)) <= BUFFER_PX;
 
       if (isAtBottom.current) {
         setShowJumpToRecentBtn(false);

--- a/app/scenes/Document/components/Comments.tsx
+++ b/app/scenes/Document/components/Comments.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { useRouteMatch } from "react-router-dom";
 import styled from "styled-components";
 import { ProsemirrorData, UserPreference } from "@shared/types";
+import ButtonSmall from "~/components/ButtonSmall";
 import { useDocumentContext } from "~/components/DocumentContext";
 import Empty from "~/components/Empty";
 import Flex from "~/components/Flex";
@@ -152,7 +153,9 @@ function Comments() {
             </NoComments>
           )}
           {showJumpToRecentBtn && (
-            <ScrollToRecent onClick={scrollToBottom}>↓</ScrollToRecent>
+            <JumpToRecent onClick={scrollToBottom}>
+              {t("New comments ↓")}
+            </JumpToRecent>
           )}
         </Wrapper>
       </Scrollable>
@@ -189,22 +192,11 @@ const Wrapper = styled.div<{ $hasComments: boolean }>`
   height: ${(props) => (props.$hasComments ? "auto" : "100%")};
 `;
 
-const ScrollToRecentSize = "32px";
-
-const ScrollToRecent = styled.div`
+const JumpToRecent = styled(ButtonSmall)`
   position: sticky;
   bottom: 12px;
-  margin-top: -${ScrollToRecentSize};
-  width: ${ScrollToRecentSize};
-  height: ${ScrollToRecentSize};
   left: 50%;
   transform: translateX(-50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: ${(props) => props.theme.accent};
-  border-radius: 50%;
-  cursor: pointer;
   opacity: 0.7;
 
   &:hover {

--- a/app/scenes/Document/components/Comments.tsx
+++ b/app/scenes/Document/components/Comments.tsx
@@ -50,18 +50,16 @@ function Comments() {
     : { type: CommentSortType.MostRecent };
 
   const viewingResolved = params.get("resolved") === "";
-  const resolvedThreads = document
+  const threads = !document
+    ? []
+    : viewingResolved
     ? comments.resolvedThreadsInDocument(document.id, sortOption)
-    : [];
+    : comments.unresolvedThreadsInDocument(document.id, sortOption);
+  const hasComments = threads.length > 0;
 
   if (!document || !isEditorInitialized) {
     return null;
   }
-
-  const threads = viewingResolved
-    ? resolvedThreads
-    : comments.unresolvedThreadsInDocument(document.id, sortOption);
-  const hasComments = threads.length > 0;
 
   return (
     <Sidebar

--- a/app/scenes/Document/components/Comments.tsx
+++ b/app/scenes/Document/components/Comments.tsx
@@ -1,5 +1,6 @@
 import { AnimatePresence } from "framer-motion";
 import { observer } from "mobx-react";
+import { ArrowIcon } from "outline-icons";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { useRouteMatch } from "react-router-dom";
@@ -8,6 +9,7 @@ import { ProsemirrorData, UserPreference } from "@shared/types";
 import ButtonSmall from "~/components/ButtonSmall";
 import { useDocumentContext } from "~/components/DocumentContext";
 import Empty from "~/components/Empty";
+import Fade from "~/components/Fade";
 import Flex from "~/components/Flex";
 import Scrollable from "~/components/Scrollable";
 import useCurrentUser from "~/hooks/useCurrentUser";
@@ -107,7 +109,7 @@ function Comments() {
       }
     }
     prevThreadCount.current = threads.length;
-  }, [threads.length]);
+  }, [sortOption.type, threads.length]);
 
   if (!document || !isEditorInitialized) {
     return null;
@@ -153,9 +155,14 @@ function Comments() {
             </NoComments>
           )}
           {showJumpToRecentBtn && (
-            <JumpToRecent onClick={scrollToBottom}>
-              {t("New comments ↓")}
-            </JumpToRecent>
+            <Fade>
+              <JumpToRecent onClick={scrollToBottom}>
+                <Flex align="center">
+                  {t("New comments")}&nbsp;
+                  <ArrowDownIcon size={20} />
+                </Flex>
+              </JumpToRecent>
+            </Fade>
           )}
         </Wrapper>
       </Scrollable>
@@ -197,11 +204,17 @@ const JumpToRecent = styled(ButtonSmall)`
   bottom: 12px;
   left: 50%;
   transform: translateX(-50%);
-  opacity: 0.7;
+  opacity: 0.8;
+  border-radius: 12px;
+  padding: 0 4px;
 
   &:hover {
     opacity: 1;
   }
+`;
+
+const ArrowDownIcon = styled(ArrowIcon)`
+  transform: rotate(90deg);
 `;
 
 const NewCommentForm = styled(CommentForm)<{ dir?: "ltr" | "rtl" }>`

--- a/app/scenes/Document/components/Comments.tsx
+++ b/app/scenes/Document/components/Comments.tsx
@@ -33,7 +33,6 @@ function Comments() {
   const focusedComment = useFocusedComment();
   const can = usePolicy(document);
 
-  const readyToDisplay = Boolean(document && isEditorInitialized);
   const scrollableRef = React.useRef<HTMLDivElement | null>(null);
   const prevThreadCount = React.useRef(0);
   const isAtBottom = React.useRef(true);
@@ -88,10 +87,11 @@ function Comments() {
 
   React.useEffect(() => {
     // Handles: 1. on refresh 2. when switching sort setting
+    const readyToDisplay = Boolean(document && isEditorInitialized);
     if (readyToDisplay && sortOption.type === CommentSortType.MostRecent) {
       scrollToBottom();
     }
-  }, [sortOption.type, readyToDisplay]);
+  }, [sortOption.type, document, isEditorInitialized]);
 
   React.useEffect(() => {
     setShowJumpToRecentBtn(false);
@@ -108,7 +108,7 @@ function Comments() {
     prevThreadCount.current = threads.length;
   }, [threads.length]);
 
-  if (!readyToDisplay) {
+  if (!document || !isEditorInitialized) {
     return null;
   }
 
@@ -120,7 +120,7 @@ function Comments() {
           <CommentSortMenu />
         </Flex>
       }
-      onClose={() => ui.collapseComments(document!.id)}
+      onClose={() => ui.collapseComments(document?.id)}
       scrollable={false}
     >
       <Scrollable
@@ -137,7 +137,7 @@ function Comments() {
               <CommentThread
                 key={thread.id}
                 comment={thread}
-                document={document!}
+                document={document}
                 recessed={!!focusedComment && focusedComment.id !== thread.id}
                 focused={focusedComment?.id === thread.id}
               />
@@ -161,10 +161,10 @@ function Comments() {
           <NewCommentForm
             draft={draft}
             onSaveDraft={onSaveDraft}
-            documentId={document!.id}
+            documentId={document.id}
             placeholder={`${t("Add a comment")}…`}
             autoFocus={false}
-            dir={document!.dir}
+            dir={document.dir}
             animatePresence
             standalone
           />

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -582,7 +582,7 @@
   "Upload image": "Upload image",
   "No resolved comments": "No resolved comments",
   "No comments yet": "No comments yet",
-  "New comments ↓": "New comments ↓",
+  "New comments": "New comments",
   "Sort comments": "Sort comments",
   "Most recent": "Most recent",
   "Order in doc": "Order in doc",

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -582,6 +582,7 @@
   "Upload image": "Upload image",
   "No resolved comments": "No resolved comments",
   "No comments yet": "No comments yet",
+  "New comments ↓": "New comments ↓",
   "Sort comments": "Sort comments",
   "Most recent": "Most recent",
   "Order in doc": "Order in doc",


### PR DESCRIPTION
## Ticket
Closes #7818

## Notes
- Factored out `readyToDisplay` to use as the dependency since refs can't be one. The effect then covers both the mounting + switching cases.
    - It also ensures `document` can never be null, hence the typescript suppression.
- Due to the `50vh` bottom padding, the last comment appears in the middle of the screen. But I think this is the expected style given the padding.  If not, the scroll position can be adjusted further.
    - In addition, the lack of a scrollbar might make it look like there are less comments, but again, I think this is expected (I got the same feeling when I opened the `/` command popup for the first time).

_p/s: I skipped the pre-PR discussion part given the size of the PR. I'm totally ok with re-doing/scrapping/dropping, etc._