### PR TITLE
Move `editorToolbar` below `header`

### DIFF
--- a/shared/styles/depths.ts
+++ b/shared/styles/depths.ts
@@ -1,8 +1,8 @@
 const depths = {
   toc: 100,
+  editorToolbar: 780,
   header: 800,
   sidebar: 900,
-  editorToolbar: 925,
   mobileSidebar: 930,
   hoverPreview: 950,
   // Note: editor lightbox is z-index 999


### PR DESCRIPTION
Closes #7826

On top of `FloatingToolbar`, this change also affects the `SuggestionMenu`, but the fix makes sense there as well.