### PR TITLE
fix: wait for shared document to load

### DIFF
--- a/app/scenes/Document/Shared.tsx
+++ b/app/scenes/Document/Shared.tsx
@@ -172,7 +172,7 @@ function SharedDocumentScene(props: Props) {
     }
   }
 
-  if (!response) {
+  if (!response?.sharedTree) {
     return <Loading location={props.location} />;
   }
 


### PR DESCRIPTION
This PR fixes a bug where the first load of a publicly shared doc(with sub docs) causes the main content to slide into the view.

By waiting until the first response is available, we ensure the app doesn't have a chance to render without a sidebar.