### PR TITLE
feat: create toast for websocket notification

### DIFF
--- a/app/components/Toasts.tsx
+++ b/app/components/Toasts.tsx
@@ -3,26 +3,30 @@ import * as React from "react";
 import { Toaster } from "sonner";
 import styled, { useTheme } from "styled-components";
 import useStores from "~/hooks/useStores";
+import WebsocketToasts from "./WebsocketToasts";
 
 function Toasts() {
   const { ui } = useStores();
   const theme = useTheme();
 
   return (
-    <StyledToaster
-      theme={ui.resolvedTheme as any}
-      closeButton
-      toastOptions={{
-        duration: 5000,
-        style: {
-          color: theme.toastText,
-          background: theme.toastBackground,
-          border: `1px solid ${theme.divider}`,
-          fontFamily: theme.fontFamily,
-          fontSize: "14px",
-        },
-      }}
-    />
+    <>
+      <StyledToaster
+        theme={ui.resolvedTheme as any}
+        closeButton
+        toastOptions={{
+          duration: 5000,
+          style: {
+            color: theme.toastText,
+            background: theme.toastBackground,
+            border: `1px solid ${theme.divider}`,
+            fontFamily: theme.fontFamily,
+            fontSize: "14px",
+          },
+        }}
+      />
+      <WebsocketToasts />
+    </>
   );
 }
 

--- a/app/components/WebsocketProvider.tsx
+++ b/app/components/WebsocketProvider.tsx
@@ -6,7 +6,11 @@ import * as React from "react";
 import { withTranslation, WithTranslation } from "react-i18next";
 import { io, Socket } from "socket.io-client";
 import { toast } from "sonner";
-import { FileOperationState, FileOperationType } from "@shared/types";
+import {
+  FileOperationState,
+  FileOperationType,
+  NotificationSource,
+} from "@shared/types";
 import RootStore from "~/stores/RootStore";
 import Collection from "~/models/Collection";
 import Comment from "~/models/Comment";
@@ -469,14 +473,14 @@ class WebsocketProvider extends React.Component<Props> {
     this.socket.on(
       "notifications.create",
       (event: PartialExcept<Notification, "id">) => {
-        notifications.add(event);
+        notifications.add({ ...event, source: NotificationSource.Websocket });
       }
     );
 
     this.socket.on(
       "notifications.update",
       (event: PartialExcept<Notification, "id">) => {
-        notifications.add(event);
+        notifications.add({ ...event, source: NotificationSource.Websocket });
       }
     );
 

--- a/app/components/WebsocketToasts.tsx
+++ b/app/components/WebsocketToasts.tsx
@@ -46,7 +46,7 @@ const WebsocketToasts = () => {
                       name: notification.actor?.name ?? t("Unknown"),
                     });
 
-              toast.success(content, {
+              toast.message(content, {
                 icon: (
                   <div style={{ marginTop: "7px" }}>
                     <CommentIcon size={AvatarSize.Toast} />

--- a/app/components/WebsocketToasts.tsx
+++ b/app/components/WebsocketToasts.tsx
@@ -1,0 +1,77 @@
+import { reaction } from "mobx";
+import { observer } from "mobx-react";
+import { CommentIcon } from "outline-icons";
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { useHistory } from "react-router-dom";
+import { toast } from "sonner";
+import { NotificationEventType, NotificationSource } from "@shared/types";
+import useStores from "~/hooks/useStores";
+import { commentPath } from "~/utils/routeHelpers";
+import { AvatarSize } from "./Avatar";
+
+const WebsocketToasts = () => {
+  const { t } = useTranslation();
+  const history = useHistory();
+  const { notifications, ui } = useStores();
+
+  React.useEffect(
+    () =>
+      reaction(
+        () => notifications.latestNotification,
+        (notification) => {
+          if (
+            !notification ||
+            notification.isRead ||
+            notification.source !== NotificationSource.Websocket
+          ) {
+            return;
+          }
+
+          const activeDocument = ui.activeDocumentId;
+
+          if (!activeDocument || notification.documentId !== activeDocument) {
+            return;
+          }
+
+          switch (notification.event) {
+            case NotificationEventType.CreateComment:
+            case NotificationEventType.MentionedInComment: {
+              const content =
+                notification.event === NotificationEventType.CreateComment
+                  ? t("{{ name }} added a comment", {
+                      name: notification.actor?.name ?? t("Unknown"),
+                    })
+                  : t("{{ name }} mentioned you in a comment", {
+                      name: notification.actor?.name ?? t("Unknown"),
+                    });
+
+              toast.success(content, {
+                icon: (
+                  <div style={{ marginTop: "7px" }}>
+                    <CommentIcon size={AvatarSize.Toast} />
+                  </div>
+                ),
+                action: {
+                  label: t("View"),
+                  onClick: () => {
+                    void notification.markAsRead();
+                    history.push(
+                      commentPath(notification.document!, notification.comment!)
+                    );
+                  },
+                },
+                onDismiss: () => void notification.markAsRead(),
+              });
+              return;
+            }
+          }
+        }
+      ),
+    [t, history, notifications, ui]
+  );
+
+  return null;
+};
+
+export default observer(WebsocketToasts);

--- a/app/models/Notification.ts
+++ b/app/models/Notification.ts
@@ -1,6 +1,6 @@
 import { TFunction } from "i18next";
 import { action, computed, observable } from "mobx";
-import { NotificationEventType } from "@shared/types";
+import { NotificationEventType, NotificationSource } from "@shared/types";
 import {
   collectionPath,
   commentPath,
@@ -78,6 +78,11 @@ class Notification extends Model {
   event: NotificationEventType;
 
   /**
+   * The source of the notification.
+   */
+  source: NotificationSource;
+
+  /**
    * Mark the notification as read or unread
    *
    * @returns A promise that resolves when the notification has been saved.
@@ -146,6 +151,22 @@ class Notification extends Model {
       return this.collection?.name ?? "a collection";
     }
     return "Unknown";
+  }
+
+  /**
+   * Returns whether the notification is read by the user.
+   */
+  @computed
+  get isRead() {
+    return !!this.viewedAt;
+  }
+
+  /**
+   * Returns whether the notification is unread by the user.
+   */
+  @computed
+  get isUnread() {
+    return !this.isRead;
   }
 
   /**

--- a/app/stores/NotificationsStore.ts
+++ b/app/stores/NotificationsStore.ts
@@ -2,6 +2,7 @@ import invariant from "invariant";
 import orderBy from "lodash/orderBy";
 import sortBy from "lodash/sortBy";
 import { action, computed, runInAction } from "mobx";
+import { NotificationSource } from "@shared/types";
 import Notification from "~/models/Notification";
 import { PaginationParams } from "~/types";
 import { client } from "~/utils/ApiClient";
@@ -27,7 +28,10 @@ export default class NotificationsStore extends Store<Notification> {
 
       let models: Notification[] = [];
       runInAction("NotificationsStore#fetchPage", () => {
-        models = res.data.notifications.map(this.add);
+        // @ts-expect-error notification from server response
+        models = res.data.notifications.map((notification) =>
+          this.add({ ...notification, source: NotificationSource.Api })
+        );
         this.isLoaded = true;
       });
 
@@ -88,5 +92,13 @@ export default class NotificationsStore extends Store<Notification> {
         item.viewedAt ? 1 : -1;
       }
     );
+  }
+
+  /**
+   * Returns the latest notification, if available.
+   */
+  @computed
+  get latestNotification(): Notification | undefined {
+    return this.orderedData[0];
   }
 }

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -386,6 +386,8 @@
   "New name": "New name",
   "Name can't be empty": "Name can't be empty",
   "Your import completed": "Your import completed",
+  "{{ name }} added a comment": "{{ name }} added a comment",
+  "{{ name }} mentioned you in a comment": "{{ name }} mentioned you in a comment",
   "Previous match": "Previous match",
   "Next match": "Next match",
   "Find and replace": "Find and replace",

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -264,6 +264,11 @@ export type CollectionSort = {
   direction: "asc" | "desc";
 };
 
+export enum NotificationSource {
+  Api = "api",
+  Websocket = "websocket",
+}
+
 export enum NotificationEventType {
   PublishDocument = "documents.publish",
   UpdateDocument = "documents.update",


### PR DESCRIPTION
Closes #7723 

**Follow-on tasks**
- Post #7790 merge, add the reaction events to `WebsocketToasts`.
- Use the `Notification.isRead` and `Notification.isUnread` methods in place of raw `Notification.viewedAt` comparisons.