### PR TITLE
fix: don't show comment marks for other users' drafts

### DIFF
--- a/app/editor/index.tsx
+++ b/app/editor/index.tsx
@@ -690,7 +690,10 @@ export class Editor extends React.PureComponent<
    * @param commentId The id of the comment to remove
    * @param attrs The attributes to update
    */
-  public updateComment = (commentId: string, attrs: { resolved: boolean }) => {
+  public updateComment = (
+    commentId: string,
+    attrs: { resolved?: boolean; draft?: boolean }
+  ) => {
     const { state, dispatch } = this.view;
     const tr = state.tr;
 

--- a/app/scenes/Document/components/CommentForm.tsx
+++ b/app/scenes/Document/components/CommentForm.tsx
@@ -27,6 +27,8 @@ import { Bubble } from "./CommentThreadItem";
 import { HighlightedText } from "./HighlightText";
 
 type Props = {
+  /** Callback when the form is submitted. */
+  onSubmit?: () => void;
   /** Callback when the draft should be saved. */
   onSaveDraft: (data: ProsemirrorData | undefined) => void;
   /** A draft comment for this thread. */
@@ -59,6 +61,7 @@ function CommentForm({
   documentId,
   thread,
   draft,
+  onSubmit,
   onSaveDraft,
   onTyping,
   onFocus,
@@ -118,6 +121,7 @@ function CommentForm({
         documentId,
         data: draft,
       })
+      .then(() => onSubmit?.())
       .catch(() => {
         comment.isNew = true;
         toast.error(t("Error creating comment"));
@@ -151,11 +155,14 @@ function CommentForm({
     comment.id = uuidv4();
     comments.add(comment);
 
-    comment.save().catch(() => {
-      comments.remove(comment.id);
-      comment.isNew = true;
-      toast.error(t("Error creating comment"));
-    });
+    comment
+      .save()
+      .then(() => onSubmit?.())
+      .catch(() => {
+        comments.remove(comment.id);
+        comment.isNew = true;
+        toast.error(t("Error creating comment"));
+      });
 
     // optimistically update the comment model
     comment.isNew = false;

--- a/app/scenes/Document/components/CommentThread.tsx
+++ b/app/scenes/Document/components/CommentThread.tsx
@@ -80,6 +80,11 @@ function CommentThread({
   });
   const can = usePolicy(document);
 
+  const [draft, onSaveDraft] = usePersistedState<ProsemirrorData | undefined>(
+    `draft-${document.id}-${thread.id}`,
+    undefined
+  );
+
   const canReply = can.comment && !thread.isResolved;
 
   const highlightedCommentMarks = editor
@@ -103,6 +108,10 @@ function CommentThread({
       });
     }
   });
+
+  const handleSubmit = React.useCallback(() => {
+    editor?.updateComment(thread.id, { draft: false });
+  }, [editor, thread.id]);
 
   const handleClickThread = () => {
     history.replace({
@@ -167,11 +176,6 @@ function CommentThread({
     }
   }, [focused, focusedOnMount, thread.id]);
 
-  const [draft, onSaveDraft] = usePersistedState<ProsemirrorData | undefined>(
-    `draft-${document.id}-${thread.id}`,
-    undefined
-  );
-
   return (
     <Thread
       ref={topRef}
@@ -219,6 +223,7 @@ function CommentThread({
         {(focused || draft || commentsInThread.length === 0) && canReply && (
           <Fade timing={100}>
             <CommentForm
+              onSubmit={handleSubmit}
               onSaveDraft={onSaveDraft}
               draft={draft}
               documentId={document.id}

--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -12,6 +12,7 @@ export type Props = {
   editorStyle?: React.CSSProperties;
   grow?: boolean;
   theme: DefaultTheme;
+  userId?: string;
 };
 
 export const fadeIn = keyframes`
@@ -885,7 +886,9 @@ h6 {
 }
 
 .${EditorStyleHelper.comment} {
-  &:not([data-resolved]) {
+  &:not([data-resolved]):not([data-draft]), &[data-draft][data-user-id="${
+    props.userId ?? ""
+  }"]  {
     border-bottom: 2px solid ${props.theme.commentMarkBackground};
     transition: background 100ms ease-in-out;
     border-radius: 2px;

--- a/shared/editor/marks/Comment.ts
+++ b/shared/editor/marks/Comment.ts
@@ -22,6 +22,9 @@ export default class Comment extends Mark {
         resolved: {
           default: false,
         },
+        draft: {
+          default: false,
+        },
       },
       inclusive: false,
       parseDOM: [
@@ -38,6 +41,7 @@ export default class Comment extends Mark {
               id: dom.getAttribute("id")?.replace("comment-", ""),
               userId: dom.getAttribute("data-user-id"),
               resolved: !!dom.getAttribute("data-resolved"),
+              draft: !!dom.getAttribute("data-draft"),
             };
           },
         },
@@ -48,6 +52,7 @@ export default class Comment extends Mark {
           class: EditorStyleHelper.comment,
           id: `comment-${node.attrs.id}`,
           "data-resolved": node.attrs.resolved ? "true" : undefined,
+          "data-draft": node.attrs.draft ? "true" : undefined,
           "data-user-id": node.attrs.userId,
           "data-document-id": this.editor?.props.id,
         },
@@ -64,9 +69,10 @@ export default class Comment extends Mark {
       ? {
           "Mod-Alt-m": (state, dispatch) => {
             if (
-              isMarkActive(state.schema.marks.comment, { resolved: false })(
-                state
-              )
+              isMarkActive(state.schema.marks.comment, {
+                resolved: false,
+                draft: true,
+              })(state)
             ) {
               return false;
             }
@@ -75,6 +81,7 @@ export default class Comment extends Mark {
               toggleMark(type, {
                 id: uuidv4(),
                 userId: this.options.userId,
+                draft: true,
               }),
               collapseSelection()
             )(state, dispatch);
@@ -89,7 +96,10 @@ export default class Comment extends Mark {
     return this.options.onCreateCommentMark
       ? (): Command => (state, dispatch) => {
           if (
-            isMarkActive(state.schema.marks.comment, { resolved: false })(state)
+            isMarkActive(state.schema.marks.comment, {
+              resolved: false,
+              draft: true,
+            })(state)
           ) {
             return false;
           }
@@ -98,6 +108,7 @@ export default class Comment extends Mark {
             addMark(type, {
               id: uuidv4(),
               userId: this.options.userId,
+              draft: true,
             }),
             collapseSelection()
           )(state, dispatch);
@@ -174,7 +185,11 @@ export default class Comment extends Mark {
 
               const commentId = comment.id.replace("comment-", "");
               const resolved = comment.getAttribute("data-resolved");
-              if (commentId && !resolved) {
+              const draftByUser =
+                comment.getAttribute("data-draft") &&
+                comment.getAttribute("data-user-id") === this.options.userId;
+
+              if ((commentId && !resolved) || draftByUser) {
                 this.options?.onClickCommentMark?.(commentId);
               }
 

--- a/shared/editor/marks/Comment.ts
+++ b/shared/editor/marks/Comment.ts
@@ -71,7 +71,6 @@ export default class Comment extends Mark {
             if (
               isMarkActive(state.schema.marks.comment, {
                 resolved: false,
-                draft: true,
               })(state)
             ) {
               return false;
@@ -98,7 +97,6 @@ export default class Comment extends Mark {
           if (
             isMarkActive(state.schema.marks.comment, {
               resolved: false,
-              draft: true,
             })(state)
           ) {
             return false;


### PR DESCRIPTION
Closes #7470 

Note that this PR provides a forward fix. I don't think it's simple/straight-forward to fix the existing cases - need to load the localstorage in the comment mark instance. I guess the drafts count should be fairly low to ignore them.