### PR TITLE
Make from address for authentication related emails unguessable

### DIFF
--- a/server/emails/mailer.tsx
+++ b/server/emails/mailer.tsx
@@ -1,5 +1,4 @@
-import addressparser from "addressparser";
-import invariant from "invariant";
+import { EmailAddress } from "addressparser";
 import nodemailer, { Transporter } from "nodemailer";
 import SMTPTransport from "nodemailer/lib/smtp-transport";
 import Oy from "oy-vey";
@@ -12,7 +11,7 @@ const useTestEmailService = env.isDevelopment && !env.SMTP_USERNAME;
 
 type SendMailOptions = {
   to: string;
-  fromName?: string;
+  from?: EmailAddress | string;
   replyTo?: string;
   messageId?: string;
   references?: string[];
@@ -143,20 +142,8 @@ export class Mailer {
     try {
       Logger.info("email", `Sending email "${data.subject}" to ${data.to}`);
 
-      invariant(
-        env.SMTP_FROM_EMAIL,
-        "SMTP_FROM_EMAIL is required to send emails"
-      );
-
-      const from = addressparser(env.SMTP_FROM_EMAIL)[0];
-
       const info = await transporter.sendMail({
-        from: data.fromName
-          ? {
-              name: data.fromName,
-              address: from.address,
-            }
-          : env.SMTP_FROM_EMAIL,
+        from: data.from ?? env.SMTP_FROM_EMAIL,
         replyTo: data.replyTo ?? env.SMTP_REPLY_EMAIL ?? env.SMTP_FROM_EMAIL,
         to: data.to,
         messageId: data.messageId,

--- a/server/emails/templates/BaseEmail.tsx
+++ b/server/emails/templates/BaseEmail.tsx
@@ -1,6 +1,10 @@
+import addressparser from "addressparser";
 import Bull from "bull";
+import invariant from "invariant";
+import randomstring from "randomstring";
 import * as React from "react";
 import mailer from "@server/emails/mailer";
+import env from "@server/env";
 import Logger from "@server/logging/Logger";
 import Metrics from "@server/logging/Metrics";
 import Notification from "@server/models/Notification";
@@ -8,6 +12,13 @@ import { taskQueue } from "@server/queues";
 import { TaskPriority } from "@server/queues/tasks/BaseTask";
 import { NotificationMetadata } from "@server/types";
 import { getEmailMessageId } from "@server/utils/emails";
+
+export enum EmailMessageCategory {
+  Authentication = "authentication",
+  Invitation = "invitation",
+  Notification = "notification",
+  Marketing = "marketing",
+}
 
 export interface EmailProps {
   to: string | null;
@@ -19,6 +30,9 @@ export default abstract class BaseEmail<
 > {
   private props: T;
   private metadata?: NotificationMetadata;
+
+  /** The message category for the email. */
+  protected abstract get category(): EmailMessageCategory;
 
   /**
    * Schedule this email type to be sent asyncronously by a worker.
@@ -113,7 +127,7 @@ export default abstract class BaseEmail<
     try {
       await mailer.sendMail({
         to: this.props.to,
-        fromName: this.fromName?.(data),
+        from: this.from(data),
         subject: this.subject(data),
         messageId,
         references,
@@ -146,6 +160,31 @@ export default abstract class BaseEmail<
         Logger.error(`Failed to update notification`, err, this.metadata);
       }
     }
+  }
+
+  private from(props: S & T) {
+    invariant(
+      env.SMTP_FROM_EMAIL,
+      "SMTP_FROM_EMAIL is required to send emails"
+    );
+
+    const parsedFrom = addressparser(env.SMTP_FROM_EMAIL)[0];
+
+    if (this.category === EmailMessageCategory.Authentication) {
+      const domain = parsedFrom.address.split("@")[1];
+      return {
+        name: parsedFrom.name,
+        address: `noreply-${randomstring.generate(24)}@${domain}`,
+      };
+    }
+
+    const name = this.fromName?.(props);
+    return name
+      ? {
+          name,
+          address: parsedFrom.address,
+        }
+      : parsedFrom;
   }
 
   private pixel(notification: Notification) {

--- a/server/emails/templates/BaseEmail.tsx
+++ b/server/emails/templates/BaseEmail.tsx
@@ -169,22 +169,20 @@ export default abstract class BaseEmail<
     );
 
     const parsedFrom = addressparser(env.SMTP_FROM_EMAIL)[0];
+    const name = this.fromName?.(props);
 
     if (this.category === EmailMessageCategory.Authentication) {
       const domain = parsedFrom.address.split("@")[1];
       return {
-        name: parsedFrom.name,
+        name: name ?? parsedFrom.name,
         address: `noreply-${randomstring.generate(24)}@${domain}`,
       };
     }
 
-    const name = this.fromName?.(props);
-    return name
-      ? {
-          name,
-          address: parsedFrom.address,
-        }
-      : parsedFrom;
+    return {
+      name: name ?? parsedFrom.name,
+      address: parsedFrom.address,
+    };
   }
 
   private pixel(notification: Notification) {

--- a/server/emails/templates/CollectionCreatedEmail.tsx
+++ b/server/emails/templates/CollectionCreatedEmail.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { NotificationEventType } from "@shared/types";
 import { Collection } from "@server/models";
 import NotificationSettingsHelper from "@server/models/helpers/NotificationSettingsHelper";
-import BaseEmail, { EmailProps } from "./BaseEmail";
+import BaseEmail, { EmailMessageCategory, EmailProps } from "./BaseEmail";
 import Body from "./components/Body";
 import Button from "./components/Button";
 import EmailTemplate from "./components/EmailLayout";
@@ -32,6 +32,10 @@ export default class CollectionCreatedEmail extends BaseEmail<
   InputProps,
   BeforeSend
 > {
+  protected get category() {
+    return EmailMessageCategory.Notification;
+  }
+
   protected async beforeSend(props: InputProps) {
     const collection = await Collection.scope("withUser").findByPk(
       props.collectionId

--- a/server/emails/templates/CollectionSharedEmail.tsx
+++ b/server/emails/templates/CollectionSharedEmail.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { CollectionPermission } from "@shared/types";
 import { Collection, UserMembership } from "@server/models";
-import BaseEmail, { EmailProps } from "./BaseEmail";
+import BaseEmail, { EmailMessageCategory, EmailProps } from "./BaseEmail";
 import Body from "./components/Body";
 import Button from "./components/Button";
 import EmailTemplate from "./components/EmailLayout";
@@ -29,6 +29,10 @@ export default class CollectionSharedEmail extends BaseEmail<
   InputProps,
   BeforeSend
 > {
+  protected get category() {
+    return EmailMessageCategory.Notification;
+  }
+
   protected async beforeSend({ userId, collectionId }: InputProps) {
     const collection = await Collection.findByPk(collectionId);
     if (!collection) {

--- a/server/emails/templates/CommentCreatedEmail.tsx
+++ b/server/emails/templates/CommentCreatedEmail.tsx
@@ -6,7 +6,7 @@ import HTMLHelper from "@server/models/helpers/HTMLHelper";
 import NotificationSettingsHelper from "@server/models/helpers/NotificationSettingsHelper";
 import { ProsemirrorHelper } from "@server/models/helpers/ProsemirrorHelper";
 import { TextHelper } from "@server/models/helpers/TextHelper";
-import BaseEmail, { EmailProps } from "./BaseEmail";
+import BaseEmail, { EmailMessageCategory, EmailProps } from "./BaseEmail";
 import Body from "./components/Body";
 import Button from "./components/Button";
 import Diff from "./components/Diff";
@@ -43,6 +43,10 @@ export default class CommentCreatedEmail extends BaseEmail<
   InputProps,
   BeforeSend
 > {
+  protected get category() {
+    return EmailMessageCategory.Notification;
+  }
+
   protected async beforeSend(props: InputProps) {
     const { documentId, commentId } = props;
     const document = await Document.unscoped().findByPk(documentId);

--- a/server/emails/templates/CommentMentionedEmail.tsx
+++ b/server/emails/templates/CommentMentionedEmail.tsx
@@ -6,7 +6,7 @@ import HTMLHelper from "@server/models/helpers/HTMLHelper";
 import NotificationSettingsHelper from "@server/models/helpers/NotificationSettingsHelper";
 import { ProsemirrorHelper } from "@server/models/helpers/ProsemirrorHelper";
 import { TextHelper } from "@server/models/helpers/TextHelper";
-import BaseEmail, { EmailProps } from "./BaseEmail";
+import BaseEmail, { EmailMessageCategory, EmailProps } from "./BaseEmail";
 import Body from "./components/Body";
 import Button from "./components/Button";
 import Diff from "./components/Diff";
@@ -41,6 +41,10 @@ export default class CommentMentionedEmail extends BaseEmail<
   InputProps,
   BeforeSend
 > {
+  protected get category() {
+    return EmailMessageCategory.Notification;
+  }
+
   protected async beforeSend(props: InputProps) {
     const { documentId, commentId } = props;
     const document = await Document.unscoped().findByPk(documentId);

--- a/server/emails/templates/ConfirmTeamDeleteEmail.tsx
+++ b/server/emails/templates/ConfirmTeamDeleteEmail.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import env from "@server/env";
-import BaseEmail, { EmailProps } from "./BaseEmail";
+import BaseEmail, { EmailMessageCategory, EmailProps } from "./BaseEmail";
 import Body from "./components/Body";
 import CopyableCode from "./components/CopyableCode";
 import EmailTemplate from "./components/EmailLayout";
@@ -17,6 +17,10 @@ type Props = EmailProps & {
  * Email sent to a user when they request to delete their workspace.
  */
 export default class ConfirmTeamDeleteEmail extends BaseEmail<Props> {
+  protected get category() {
+    return EmailMessageCategory.Notification;
+  }
+
   protected subject() {
     return `Your workspace deletion request`;
   }

--- a/server/emails/templates/ConfirmUserDeleteEmail.tsx
+++ b/server/emails/templates/ConfirmUserDeleteEmail.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import env from "@server/env";
-import BaseEmail, { EmailProps } from "./BaseEmail";
+import BaseEmail, { EmailMessageCategory, EmailProps } from "./BaseEmail";
 import Body from "./components/Body";
 import CopyableCode from "./components/CopyableCode";
 import EmailTemplate from "./components/EmailLayout";
@@ -17,6 +17,10 @@ type Props = EmailProps & {
  * Email sent to a user when they request to delete their account.
  */
 export default class ConfirmUserDeleteEmail extends BaseEmail<Props> {
+  protected get category() {
+    return EmailMessageCategory.Notification;
+  }
+
   protected subject() {
     return `Your account deletion request`;
   }

--- a/server/emails/templates/DocumentMentionedEmail.tsx
+++ b/server/emails/templates/DocumentMentionedEmail.tsx
@@ -6,7 +6,7 @@ import { DocumentHelper } from "@server/models/helpers/DocumentHelper";
 import HTMLHelper from "@server/models/helpers/HTMLHelper";
 import { ProsemirrorHelper } from "@server/models/helpers/ProsemirrorHelper";
 import { TextHelper } from "@server/models/helpers/TextHelper";
-import BaseEmail, { EmailProps } from "./BaseEmail";
+import BaseEmail, { EmailMessageCategory, EmailProps } from "./BaseEmail";
 import Body from "./components/Body";
 import Button from "./components/Button";
 import Diff from "./components/Diff";
@@ -37,6 +37,10 @@ export default class DocumentMentionedEmail extends BaseEmail<
   InputProps,
   BeforeSend
 > {
+  protected get category() {
+    return EmailMessageCategory.Notification;
+  }
+
   protected async beforeSend({ documentId, revisionId, userId }: InputProps) {
     const document = await Document.unscoped().findByPk(documentId);
     if (!document) {

--- a/server/emails/templates/DocumentPublishedOrUpdatedEmail.tsx
+++ b/server/emails/templates/DocumentPublishedOrUpdatedEmail.tsx
@@ -6,7 +6,7 @@ import { DocumentHelper } from "@server/models/helpers/DocumentHelper";
 import HTMLHelper from "@server/models/helpers/HTMLHelper";
 import NotificationSettingsHelper from "@server/models/helpers/NotificationSettingsHelper";
 import SubscriptionHelper from "@server/models/helpers/SubscriptionHelper";
-import BaseEmail, { EmailProps } from "./BaseEmail";
+import BaseEmail, { EmailMessageCategory, EmailProps } from "./BaseEmail";
 import Body from "./components/Body";
 import Button from "./components/Button";
 import Diff from "./components/Diff";
@@ -44,6 +44,10 @@ export default class DocumentPublishedOrUpdatedEmail extends BaseEmail<
   InputProps,
   BeforeSend
 > {
+  protected get category() {
+    return EmailMessageCategory.Notification;
+  }
+
   protected async beforeSend(props: InputProps) {
     const { documentId, revisionId } = props;
     const document = await Document.unscoped().findByPk(documentId, {

--- a/server/emails/templates/DocumentSharedEmail.tsx
+++ b/server/emails/templates/DocumentSharedEmail.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { DocumentPermission } from "@shared/types";
 import { Document, UserMembership } from "@server/models";
-import BaseEmail, { EmailProps } from "./BaseEmail";
+import BaseEmail, { EmailMessageCategory, EmailProps } from "./BaseEmail";
 import Body from "./components/Body";
 import Button from "./components/Button";
 import EmailTemplate from "./components/EmailLayout";
@@ -29,6 +29,10 @@ export default class DocumentSharedEmail extends BaseEmail<
   InputProps,
   BeforeSend
 > {
+  protected get category() {
+    return EmailMessageCategory.Notification;
+  }
+
   protected async beforeSend({ documentId, userId }: InputProps) {
     const document = await Document.unscoped().findByPk(documentId);
     if (!document) {

--- a/server/emails/templates/ExportFailureEmail.tsx
+++ b/server/emails/templates/ExportFailureEmail.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { NotificationEventType } from "@shared/types";
 import NotificationSettingsHelper from "@server/models/helpers/NotificationSettingsHelper";
-import BaseEmail, { EmailProps } from "./BaseEmail";
+import BaseEmail, { EmailMessageCategory, EmailProps } from "./BaseEmail";
 import Body from "./components/Body";
 import Button from "./components/Button";
 import EmailTemplate from "./components/EmailLayout";
@@ -29,6 +29,10 @@ export default class ExportFailureEmail extends BaseEmail<
   InputProps,
   BeforeSend
 > {
+  protected get category() {
+    return EmailMessageCategory.Notification;
+  }
+
   protected async beforeSend(props: InputProps) {
     return {
       unsubscribeUrl: this.unsubscribeUrl(props),

--- a/server/emails/templates/ExportSuccessEmail.tsx
+++ b/server/emails/templates/ExportSuccessEmail.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { NotificationEventType } from "@shared/types";
 import env from "@server/env";
 import NotificationSettingsHelper from "@server/models/helpers/NotificationSettingsHelper";
-import BaseEmail, { EmailProps } from "./BaseEmail";
+import BaseEmail, { EmailMessageCategory, EmailProps } from "./BaseEmail";
 import Body from "./components/Body";
 import Button from "./components/Button";
 import EmailTemplate from "./components/EmailLayout";
@@ -32,6 +32,10 @@ export default class ExportSuccessEmail extends BaseEmail<
   InputProps,
   BeforeSend
 > {
+  protected get category() {
+    return EmailMessageCategory.Notification;
+  }
+
   protected async beforeSend(props: InputProps) {
     return {
       unsubscribeUrl: this.unsubscribeUrl(props),

--- a/server/emails/templates/InviteAcceptedEmail.tsx
+++ b/server/emails/templates/InviteAcceptedEmail.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { NotificationEventType } from "@shared/types";
 import env from "@server/env";
 import NotificationSettingsHelper from "@server/models/helpers/NotificationSettingsHelper";
-import BaseEmail, { EmailProps } from "./BaseEmail";
+import BaseEmail, { EmailMessageCategory, EmailProps } from "./BaseEmail";
 import Body from "./components/Body";
 import Button from "./components/Button";
 import EmailTemplate from "./components/EmailLayout";
@@ -30,6 +30,10 @@ export default class InviteAcceptedEmail extends BaseEmail<
   InputProps,
   BeforeSend
 > {
+  protected get category() {
+    return EmailMessageCategory.Notification;
+  }
+
   protected async beforeSend(props: InputProps) {
     return {
       unsubscribeUrl: this.unsubscribeUrl(props),

--- a/server/emails/templates/InviteEmail.tsx
+++ b/server/emails/templates/InviteEmail.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import env from "@server/env";
-import BaseEmail, { EmailProps } from "./BaseEmail";
+import BaseEmail, { EmailMessageCategory, EmailProps } from "./BaseEmail";
 import Body from "./components/Body";
 import Button from "./components/Button";
 import EmailTemplate from "./components/EmailLayout";
@@ -21,6 +21,10 @@ type Props = EmailProps & {
  * Email sent to an external user when an admin sends them an invite.
  */
 export default class InviteEmail extends BaseEmail<Props, Record<string, any>> {
+  protected get category() {
+    return EmailMessageCategory.Invitation;
+  }
+
   protected subject({ actorName, teamName }: Props) {
     return `${actorName} invited you to join ${teamName}’s workspace`;
   }

--- a/server/emails/templates/InviteReminderEmail.tsx
+++ b/server/emails/templates/InviteReminderEmail.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import env from "@server/env";
-import BaseEmail, { EmailProps } from "./BaseEmail";
+import BaseEmail, { EmailMessageCategory, EmailProps } from "./BaseEmail";
 import Body from "./components/Body";
 import Button from "./components/Button";
 import EmailTemplate from "./components/EmailLayout";
@@ -22,6 +22,10 @@ type Props = EmailProps & {
  * haven't signed in after a few days.
  */
 export default class InviteReminderEmail extends BaseEmail<Props> {
+  protected get category() {
+    return EmailMessageCategory.Invitation;
+  }
+
   protected subject({ actorName, teamName }: Props) {
     return `Reminder: ${actorName} invited you to join ${teamName}’s workspace`;
   }

--- a/server/emails/templates/SigninEmail.tsx
+++ b/server/emails/templates/SigninEmail.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Client } from "@shared/types";
 import env from "@server/env";
 import logger from "@server/logging/Logger";
-import BaseEmail, { EmailProps } from "./BaseEmail";
+import BaseEmail, { EmailMessageCategory, EmailProps } from "./BaseEmail";
 import Body from "./components/Body";
 import Button from "./components/Button";
 import EmailTemplate from "./components/EmailLayout";
@@ -21,6 +21,10 @@ type Props = EmailProps & {
  * Email sent to a user when they request a magic sign-in link.
  */
 export default class SigninEmail extends BaseEmail<Props, Record<string, any>> {
+  protected get category() {
+    return EmailMessageCategory.Authentication;
+  }
+
   protected subject() {
     return "Magic signin link";
   }

--- a/server/emails/templates/WebhookDisabledEmail.tsx
+++ b/server/emails/templates/WebhookDisabledEmail.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import BaseEmail, { EmailProps } from "./BaseEmail";
+import BaseEmail, { EmailMessageCategory, EmailProps } from "./BaseEmail";
 import Body from "./components/Body";
 import Button from "./components/Button";
 import EmailTemplate from "./components/EmailLayout";
@@ -18,6 +18,10 @@ type Props = EmailProps & {
  * due to repeated failure.
  */
 export default class WebhookDisabledEmail extends BaseEmail<Props> {
+  protected get category() {
+    return EmailMessageCategory.Notification;
+  }
+
   protected subject() {
     return `Warning: Webhook disabled`;
   }
@@ -28,7 +32,7 @@ export default class WebhookDisabledEmail extends BaseEmail<Props> {
 
   protected renderAsText({ webhookName, teamUrl }: Props): string {
     return `
-Your webhook (${webhookName}) has been automatically disabled as the last 25 
+Your webhook (${webhookName}) has been automatically disabled as the last 25
 delivery attempts have failed. You can re-enable by editing the webhook.
 
 Webhook settings: ${teamUrl}/settings/webhooks

--- a/server/emails/templates/WelcomeEmail.tsx
+++ b/server/emails/templates/WelcomeEmail.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { UserRole } from "@shared/types";
 import env from "@server/env";
-import BaseEmail, { EmailProps } from "./BaseEmail";
+import BaseEmail, { EmailMessageCategory, EmailProps } from "./BaseEmail";
 import Body from "./components/Body";
 import Button from "./components/Button";
 import EmailTemplate from "./components/EmailLayout";
@@ -22,6 +22,10 @@ type BeforeSend = Record<string, never>;
  * in for the first time from an invite.
  */
 export default class WelcomeEmail extends BaseEmail<Props, BeforeSend> {
+  protected get category() {
+    return EmailMessageCategory.Notification;
+  }
+
   protected subject() {
     return `Welcome to ${env.APP_NAME}`;
   }


### PR DESCRIPTION
This is a proactive change to prevent potential attacks in the vein of the recently discovered Zendesk vulnerability here:
https://gist.github.com/hackermondev/68ec8ed145fcee49d2f5e2b9d2cf2e52

By ensuring emails related to login/auth are sent from a unique email address each time we can protect against guessing the email in a third-party system