### PR TITLE
Fix header key for react-table v7

### DIFF
--- a/app/components/Table.tsx
+++ b/app/components/Table.tsx
@@ -120,30 +120,33 @@ function Table({
       <Anchor ref={topRef} />
       <InnerTable {...getTableProps()}>
         <thead>
-          {headerGroups.map((headerGroup) => (
-            <tr {...headerGroup.getHeaderGroupProps()} key={headerGroup.id}>
-              {headerGroup.headers.map((column) => (
-                <Head
-                  {...column.getHeaderProps(column.getSortByToggleProps())}
-                  key={column.id}
-                >
-                  <SortWrapper
-                    align="center"
-                    $sortable={!column.disableSortBy}
-                    gap={4}
+          {headerGroups.map((headerGroup) => {
+            const groupProps = headerGroup.getHeaderGroupProps();
+            return (
+              <tr {...groupProps} key={groupProps.key}>
+                {headerGroup.headers.map((column) => (
+                  <Head
+                    {...column.getHeaderProps(column.getSortByToggleProps())}
+                    key={column.id}
                   >
-                    {column.render("Header")}
-                    {column.isSorted &&
-                      (column.isSortedDesc ? (
-                        <DescSortIcon />
-                      ) : (
-                        <AscSortIcon />
-                      ))}
-                  </SortWrapper>
-                </Head>
-              ))}
-            </tr>
-          ))}
+                    <SortWrapper
+                      align="center"
+                      $sortable={!column.disableSortBy}
+                      gap={4}
+                    >
+                      {column.render("Header")}
+                      {column.isSorted &&
+                        (column.isSortedDesc ? (
+                          <DescSortIcon />
+                        ) : (
+                          <AscSortIcon />
+                        ))}
+                    </SortWrapper>
+                  </Head>
+                ))}
+              </tr>
+            );
+          })}
         </thead>
         <tbody {...getTableBodyProps()}>
           {rows.map((row) => {


### PR DESCRIPTION
Removes annoying warning + technically more correct.

<img src="https://github.com/user-attachments/assets/7c45d2eb-46df-4002-be60-de9db6d41f67" width="200">
(when opening `settings/shares`)

---

`header.id` does not exist in v7 (it does in v8). `@types/react-table` lied.

Stashed v7 documentation:
https://github.com/TanStack/table/blob/v7/docs/src/pages/docs/api/useTable.md#headergroup-properties