### PR TITLE
Jump to 'workspace' settings section if invoked from Org Menu

### DIFF
--- a/app/actions/definitions/navigation.tsx
+++ b/app/actions/definitions/navigation.tsx
@@ -91,6 +91,15 @@ export const navigateToSettings = createAction({
   perform: () => history.push(settingsPath()),
 });
 
+export const navigateToWorkspaceSettings = createAction({
+  name: ({ t }) => t("Settings"),
+  analyticsName: "Navigate to workspace settings",
+  section: NavigationSection,
+  icon: <SettingsIcon />,
+  visible: () => stores.policies.abilities(stores.auth.team?.id || "").update,
+  perform: () => history.push(settingsPath("details")),
+});
+
 export const navigateToProfileSettings = createAction({
   name: ({ t }) => t("Profile"),
   analyticsName: "Navigate to profile settings",

--- a/app/menus/OrganizationMenu.tsx
+++ b/app/menus/OrganizationMenu.tsx
@@ -4,7 +4,10 @@ import { useTranslation } from "react-i18next";
 import { MenuButton, useMenuState } from "reakit/Menu";
 import ContextMenu from "~/components/ContextMenu";
 import Template from "~/components/ContextMenu/Template";
-import { navigateToSettings, logout } from "~/actions/definitions/navigation";
+import {
+  navigateToWorkspaceSettings,
+  logout,
+} from "~/actions/definitions/navigation";
 import {
   createTeam,
   createTeamsList,
@@ -45,7 +48,7 @@ const OrganizationMenu: React.FC = ({ children }: Props) => {
       createTeam,
       desktopLoginTeam,
       separator(),
-      navigateToSettings,
+      navigateToWorkspaceSettings,
       logout,
     ],
     [context]


### PR DESCRIPTION
> [!NOTE]  
> _Skipped the discussion part given the size; feel free to close directly if disagree :+1:_ 

## Issue
When clicking on the top-left `OrganizationMenu > Settings`, I always get confused why it is showing me the Profiles page, given that the current context is workspace/org.

## Change
Switch the shortcut to point to `Workspace::details` instead. 
For Profile, it's more natural to click the profile button from the bottom-left that's already exist.

## Remarks
Not sure if the new analytics name will cause issues or not.