### PR TITLE
fix: collection archival post-process parity with deletion

### DIFF
--- a/server/queues/processors/CollectionsProcessor.ts
+++ b/server/queues/processors/CollectionsProcessor.ts
@@ -5,8 +5,11 @@ import { Event as TEvent, CollectionEvent } from "@server/types";
 import DetachDraftsFromCollectionTask from "../tasks/DetachDraftsFromCollectionTask";
 import BaseProcessor from "./BaseProcessor";
 
-export default class CollectionDeletedProcessor extends BaseProcessor {
-  static applicableEvents: TEvent["name"][] = ["collections.delete"];
+export default class CollectionsProcessor extends BaseProcessor {
+  static applicableEvents: TEvent["name"][] = [
+    "collections.delete",
+    "collections.archive",
+  ];
 
   async perform(event: CollectionEvent) {
     await DetachDraftsFromCollectionTask.schedule({

--- a/server/queues/tasks/DetachDraftsFromCollectionTask.test.ts
+++ b/server/queues/tasks/DetachDraftsFromCollectionTask.test.ts
@@ -27,4 +27,28 @@ describe("DetachDraftsFromCollectionTask", () => {
     expect(draft?.deletedAt).toBe(null);
     expect(draft?.collectionId).toBe(null);
   });
+
+  it("should detach drafts from archived collection", async () => {
+    const collection = await buildCollection({ archivedAt: new Date() });
+    const document = await buildDocument({
+      title: "test",
+      collectionId: collection.id,
+      publishedAt: null,
+      createdById: collection.createdById,
+      teamId: collection.teamId,
+    });
+
+    const task = new DetachDraftsFromCollectionTask();
+    await task.perform({
+      collectionId: collection.id,
+      ip,
+      actorId: collection.createdById,
+    });
+
+    const draft = await Document.findByPk(document.id);
+    expect(draft).not.toBe(null);
+    expect(draft?.archivedAt).toBe(null);
+    expect(draft?.deletedAt).toBe(null);
+    expect(draft?.collectionId).toBe(null);
+  });
 });

--- a/server/queues/tasks/DetachDraftsFromCollectionTask.ts
+++ b/server/queues/tasks/DetachDraftsFromCollectionTask.ts
@@ -19,7 +19,11 @@ export default class DetachDraftsFromCollectionTask extends BaseTask<Props> {
       User.findByPk(props.actorId),
     ]);
 
-    if (!actor || !collection || !collection.deletedAt) {
+    if (
+      !actor ||
+      !collection ||
+      !(collection.deletedAt || collection.archivedAt)
+    ) {
       return;
     }
 


### PR DESCRIPTION
Currently, the drafts are not detached when a collection is archived. This allows the user to publish the draft to an archived collection and perform updates later.

This PR ensures archival flow parity with the deletion flow. Specifically,
1. Drafts are now detached when a collection is archived.
2. Team's default view is reset if the archived collection was set as the default one.