### PR TITLE
fix: restore documents from a deleted collection

### DIFF
--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -819,7 +819,7 @@ router.post(
     const srcCollection = sourceCollectionId
       ? await Collection.scope({
           method: ["withMembership", user.id],
-        }).findByPk(sourceCollectionId)
+        }).findByPk(sourceCollectionId, { paranoid: false })
       : undefined;
 
     const destCollection = destCollectionId
@@ -834,7 +834,8 @@ router.post(
       );
     }
 
-    if (sourceCollectionId !== destCollectionId) {
+    // Skip this for drafts of a deleted collection as they won't have sourceCollectionId
+    if (sourceCollectionId && sourceCollectionId !== destCollectionId) {
       authorize(user, "updateDocument", srcCollection);
       await srcCollection?.removeDocumentInStructure(document, {
         save: true,


### PR DESCRIPTION
This PR fixes a bug wherein documents of a deleted collection cannot be restored from trash.