### PR TITLE
fix: Document mentions can be incorrectly attributed during collab session

### DIFF
--- a/server/queues/tasks/DocumentPublishedNotificationsTask.ts
+++ b/server/queues/tasks/DocumentPublishedNotificationsTask.ts
@@ -40,7 +40,7 @@ export default class DocumentPublishedNotificationsTask extends BaseTask<Documen
         await Notification.create({
           event: NotificationEventType.MentionedInDocument,
           userId: recipient.id,
-          actorId: document.updatedBy.id,
+          actorId: mention.actorId,
           teamId: document.teamId,
           documentId: document.id,
         });

--- a/server/queues/tasks/RevisionCreatedNotificationsTask.ts
+++ b/server/queues/tasks/RevisionCreatedNotificationsTask.ts
@@ -60,7 +60,7 @@ export default class RevisionCreatedNotificationsTask extends BaseTask<RevisionE
           event: NotificationEventType.MentionedInDocument,
           userId: recipient.id,
           revisionId: event.modelId,
-          actorId: document.updatedBy.id,
+          actorId: mention.actorId,
           teamId: document.teamId,
           documentId: document.id,
         });


### PR DESCRIPTION
closes #7911 