### PR TITLE
hide share option for templates

### DIFF
--- a/server/policies/document.ts
+++ b/server/policies/document.ts
@@ -119,7 +119,19 @@ allow(User, "publish", Document, (actor, document) =>
   )
 );
 
-allow(User, ["manageUsers", "duplicate"], Document, (actor, document) =>
+allow(User, "manageUsers", Document, (actor, document) =>
+  and(
+    !document?.template,
+    can(actor, "update", document),
+    or(
+      includesMembership(document, [DocumentPermission.Admin]),
+      can(actor, "updateDocument", document?.collection),
+      !!document?.isDraft && actor.id === document?.createdById
+    )
+  )
+);
+
+allow(User, "duplicate", Document, (actor, document) =>
   and(
     can(actor, "update", document),
     or(


### PR DESCRIPTION
Towards #7916.

Split the `manageUser` and `duplicate` policies for documents.
Right now, draft sharing is being allowed; so kept as-is. Not completely sure if this needs to be changed.