### PR TITLE
Improvements around templates

### DIFF
--- a/app/actions/definitions/documents.tsx
+++ b/app/actions/definitions/documents.tsx
@@ -131,11 +131,30 @@ export const createDocumentFromTemplate = createAction({
   section: DocumentSection,
   icon: <NewDocumentIcon />,
   keywords: "create",
-  visible: ({ currentTeamId, activeDocumentId, stores }) =>
-    !!currentTeamId &&
-    !!activeDocumentId &&
-    !!stores.documents.get(activeDocumentId)?.template &&
-    stores.policies.abilities(currentTeamId).createDocument,
+  visible: ({
+    currentTeamId,
+    activeCollectionId,
+    activeDocumentId,
+    stores,
+  }) => {
+    const document = activeDocumentId
+      ? stores.documents.get(activeDocumentId)
+      : undefined;
+
+    if (
+      !currentTeamId ||
+      !document?.isTemplate ||
+      !!document?.isDraft ||
+      !!document?.isDeleted
+    ) {
+      return false;
+    }
+
+    if (activeCollectionId) {
+      return stores.policies.abilities(activeCollectionId).createDocument;
+    }
+    return stores.policies.abilities(currentTeamId).createDocument;
+  },
   perform: ({ activeCollectionId, activeDocumentId, sidebarContext }) =>
     history.push(
       newDocumentPath(activeCollectionId, { templateId: activeDocumentId }),

--- a/app/components/CommandBar/useTemplatesAction.tsx
+++ b/app/components/CommandBar/useTemplatesAction.tsx
@@ -2,7 +2,11 @@ import { NewDocumentIcon, ShapesIcon } from "outline-icons";
 import * as React from "react";
 import Icon from "~/components/Icon";
 import { createAction } from "~/actions";
-import { DocumentSection } from "~/actions/sections";
+import {
+  ActiveCollectionSection,
+  DocumentSection,
+  TeamSection,
+} from "~/actions/sections";
 import useStores from "~/hooks/useStores";
 import history from "~/utils/history";
 import { newDocumentPath } from "~/utils/routeHelpers";
@@ -16,21 +20,37 @@ const useTemplatesAction = () => {
 
   const actions = React.useMemo(
     () =>
-      documents.templatesAlphabetical.map((item) =>
+      documents.templatesAlphabetical.map((template) =>
         createAction({
-          name: item.titleWithDefault,
+          name: template.titleWithDefault,
           analyticsName: "New document",
-          section: DocumentSection,
-          icon: item.icon ? (
-            <Icon value={item.icon} color={item.color ?? undefined} />
+          section: template.isWorkspaceTemplate
+            ? TeamSection
+            : ActiveCollectionSection,
+          icon: template.icon ? (
+            <Icon value={template.icon} color={template.color ?? undefined} />
           ) : (
             <NewDocumentIcon />
           ),
           keywords: "create",
+          visible: ({ currentTeamId, activeCollectionId, stores }) => {
+            if (activeCollectionId) {
+              return (
+                stores.policies.abilities(activeCollectionId).createDocument &&
+                (template.collectionId === activeCollectionId ||
+                  template.isWorkspaceTemplate)
+              );
+            }
+            return (
+              !!currentTeamId &&
+              stores.policies.abilities(currentTeamId).createDocument &&
+              template.isWorkspaceTemplate
+            );
+          },
           perform: ({ activeCollectionId, sidebarContext }) =>
             history.push(
-              newDocumentPath(item.collectionId ?? activeCollectionId, {
-                templateId: item.id,
+              newDocumentPath(template.collectionId ?? activeCollectionId, {
+                templateId: template.id,
               }),
               {
                 sidebarContext,
@@ -49,9 +69,15 @@ const useTemplatesAction = () => {
         placeholder: ({ t }) => t("Choose a template"),
         section: DocumentSection,
         icon: <ShapesIcon />,
-        visible: ({ currentTeamId, stores }) =>
-          !!currentTeamId &&
-          stores.policies.abilities(currentTeamId).createDocument,
+        visible: ({ currentTeamId, activeCollectionId, stores }) => {
+          if (activeCollectionId) {
+            return stores.policies.abilities(activeCollectionId).createDocument;
+          }
+          return (
+            !!currentTeamId &&
+            stores.policies.abilities(currentTeamId).createDocument
+          );
+        },
         children: () => actions,
       }),
     [actions]

--- a/app/models/Document.ts
+++ b/app/models/Document.ts
@@ -254,7 +254,8 @@ export default class Document extends ArchivableModel {
 
   @computed
   get path(): string {
-    const prefix = this.template ? settingsPath("templates") : "/doc";
+    const prefix =
+      this.template && !this.isDeleted ? settingsPath("templates") : "/doc";
 
     if (!this.title) {
       return `${prefix}/untitled-${this.urlId}`;


### PR DESCRIPTION
This PR provides the following improvements around templates.

- Hide "New from template" menu item for the following cases.
  - User does not have access to create document in a collection (An user with view permission to a collection).
  - Template is deleted.
  - Template is a draft.
- Conditionally show "New from template" action in the command bar.
  - When user does not have create document permission in a collection, the action is hidden.
  - When a collection is active, the templates in this collection + workspace templates are listed.
  - When no collection is active, only the workspace templates are listed.
- Viewing a deleted template will now stay in the "Trash" page itself. Earlier, it was navigating to the templates page.