### PR TITLE
Fix spacing on invite box

### DIFF
--- a/app/scenes/Invite.tsx
+++ b/app/scenes/Invite.tsx
@@ -181,7 +181,7 @@ function Invite({ onSubmit }: Props) {
             {collectionAccessNote}
             {can.update && (
               <Trans>
-                As an admin you can also{" "}
+                {" "}As an admin you can also{" "}
                 <Link to="/settings/security">enable email sign-in</Link>.
               </Trans>
             )}

--- a/app/scenes/Invite.tsx
+++ b/app/scenes/Invite.tsx
@@ -181,7 +181,8 @@ function Invite({ onSubmit }: Props) {
             {collectionAccessNote}
             {can.update && (
               <Trans>
-                {" "}As an admin you can also{" "}
+                {" "}
+                As an admin you can also{" "}
                 <Link to="/settings/security">enable email sign-in</Link>.
               </Trans>
             )}


### PR DESCRIPTION
Fix the spacing just before the "As an admin...":

![image](https://github.com/user-attachments/assets/c84d4ee4-6831-4555-a8a5-f284e8eb9e19)

I didn't test my changes, just made them through the github UI, so not sure if they will work (: 