### PR TITLE
store pin location on mount

### DIFF
--- a/app/components/DocumentCard.tsx
+++ b/app/components/DocumentCard.tsx
@@ -39,6 +39,7 @@ function DocumentCard(props: Props) {
   const { collections } = useStores();
   const theme = useTheme();
   const { document, pin, canUpdatePin, isDraggable } = props;
+  const pinnedToHome = React.useRef(!pin?.collectionId).current;
   const collection = document.collectionId
     ? collections.get(document.collectionId)
     : undefined;
@@ -122,13 +123,13 @@ function DocumentCard(props: Props) {
               <Squircle
                 color={
                   collection?.color ??
-                  (!pin?.collectionId ? theme.slateLight : theme.slateDark)
+                  (pinnedToHome ? theme.slateLight : theme.slateDark)
                 }
               >
                 {collection?.icon &&
                 collection?.icon !== "letter" &&
                 collection?.icon !== "collection" &&
-                !pin?.collectionId ? (
+                pinnedToHome ? (
                   <CollectionIcon collection={collection} color="white" />
                 ) : (
                   <DocumentIcon color="white" />


### PR DESCRIPTION
When a document is unpinned from a collection, sometimes there's an inconsistency with the icon in the card.
This is because the `pin` gets deleted from the store before framer-motion can run the exit animation.

https://github.com/user-attachments/assets/e717b7a6-e61f-494f-b738-b2db29e2719f

