### PR TITLE
Include TOC in html export

### DIFF
--- a/server/models/helpers/DocumentHelper.tsx
+++ b/server/models/helpers/DocumentHelper.tsx
@@ -21,6 +21,8 @@ type HTMLOptions = {
   includeStyles?: boolean;
   /** Whether to include the Mermaid script in the generated HTML (defaults to false) */
   includeMermaid?: boolean;
+  /** Whether to include a table of contents in the generated HTML (defaults to false) */
+  includeToc?: boolean;
   /** Whether to include styles to center diff (defaults to true) */
   centered?: boolean;
   /**
@@ -189,6 +191,7 @@ export class DocumentHelper {
       title: options?.includeTitle !== false ? document.title : undefined,
       includeStyles: options?.includeStyles,
       includeMermaid: options?.includeMermaid,
+      includeToc: options?.includeToc,
       centered: options?.centered,
       baseUrl: options?.baseUrl,
     });

--- a/server/models/helpers/ProsemirrorHelper.tsx
+++ b/server/models/helpers/ProsemirrorHelper.tsx
@@ -32,6 +32,8 @@ export type HTMLOptions = {
   includeStyles?: boolean;
   /** Whether to include mermaidjs scripts in the generated HTML (defaults to false) */
   includeMermaid?: boolean;
+  /** Whether to include table of contents (defaults to false) */
+  includeToc?: boolean;
   /** Whether to include styles to center diff (defaults to true) */
   centered?: boolean;
   /** The base URL to use for relative links */
@@ -469,6 +471,22 @@ export class ProsemirrorHelper {
     const children = (
       <>
         {options?.title && <h1 dir={rtl ? "rtl" : "ltr"}>{options.title}</h1>}
+        {options?.includeToc && (
+          <>
+            <details id="toc">
+              <summary
+                style={{
+                  cursor: "pointer",
+                  fontStyle: "italic",
+                  fontWeight: "bold",
+                }}
+              >
+                Contents
+              </summary>
+            </details>
+            <hr />
+          </>
+        )}
         {options?.includeStyles !== false ? (
           <EditorContainer dir={rtl ? "rtl" : "ltr"} rtl={rtl} staticHTML>
             {content}
@@ -530,6 +548,55 @@ export class ProsemirrorHelper {
       for (const el of elements) {
         if ("href" in el && (el.href as string).startsWith("/")) {
           el.href = new URL(el.href as string, options.baseUrl).toString();
+        }
+      }
+    }
+
+    // Inject table-of-contents
+    if (options?.includeToc) {
+      const toc = doc.getElementById("toc");
+      if (toc) {
+        const headings = Array.from(
+          dom.window.document.querySelectorAll("h1, h2, h3, h4")
+        );
+
+        // Discard first h1 which is usually the document title
+        if (
+          headings[0]?.tagName === "H1" &&
+          headings[0].textContent === options.title
+        ) {
+          headings.shift();
+        }
+
+        const minLevel = headings.reduce(
+          (memo, heading) => Math.min(memo, parseInt(heading.tagName.slice(1))),
+          Infinity
+        );
+
+        const generateAnchor = (index: number, text: string) => {
+          const sanitized = text
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, "-")
+            .replace(/(^-|-$)/g, "");
+          return `${index}-${sanitized}`;
+        };
+
+        for (let i = 0; i < headings.length; ++i) {
+          const heading = headings[i];
+          const level = parseInt(heading.tagName.slice(1)) - minLevel;
+          const anchor = generateAnchor(i, heading?.textContent || "");
+
+          // Update original heading with anchor
+          heading.setAttribute("id", anchor);
+
+          // Create a link in the TOC
+          const link = doc.createElement("a");
+          link.textContent = heading.textContent;
+          link.href = `#${anchor}`;
+          const listItem = doc.createElement("li");
+          listItem.setAttribute("style", `margin-left: ${level * 30}px;`);
+          listItem.appendChild(link);
+          toc.appendChild(listItem);
         }
       }
     }

--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -714,6 +714,7 @@ router.post(
       content = await DocumentHelper.toHTML(document, {
         centered: true,
         includeMermaid: true,
+        includeToc: true,
       });
     } else if (accept?.includes("application/pdf")) {
       throw IncorrectEditionError(


### PR DESCRIPTION
Closes #6756 

<img src="https://github.com/user-attachments/assets/b18463e7-96eb-4442-9ea1-be932dc0a466" width="200">     <img src="https://github.com/user-attachments/assets/9ba1d80c-92a7-403a-8b52-96c317f9fb5b" width="200">

Assumptions:
- Markdown exports --> not applicable, right?
- Ctrl + P --> not sure how .. which `@media print`?