### PR TITLE
Enable flag emojis on non-mac clients

### DIFF
--- a/shared/utils/emoji.ts
+++ b/shared/utils/emoji.ts
@@ -14,20 +14,11 @@ init({ data: RawData });
 // Data has the pre-processed "search" terms.
 const TypedData = Data as EmojiMartData;
 
-const flagEmojiIds =
-  TypedData.categories
-    .filter(({ id }) => id === EmojiCategory.Flags.toLowerCase())
-    .map(({ emojis }) => emojis)[0] ?? [];
-
 const Categories = TypedData.categories.filter(
   ({ id }) => isMacEnv || capitalize(id) !== EmojiCategory.Flags
 );
 
-const Emojis = Object.fromEntries(
-  Object.entries(TypedData.emojis).filter(
-    ([id]) => isMacEnv || !flagEmojiIds.includes(id)
-  )
-);
+const Emojis = Object.fromEntries(Object.entries(TypedData.emojis));
 
 const searcher = new FuzzySearch(Object.values(Emojis), ["search"], {
   caseSensitive: false,


### PR DESCRIPTION
This small pull request removes a filter that disables searching and selection of flag emojis (🇳🇱) on non-mac platforms. In addition, it removes code that is not required anymore after removing the filter.

Note that I do not understand why the filter was there in the first place. Therefore this patch may break something I am unaware of. Please review carefully. A few versions back, flag emojis worked, but it seems that after [pull request 7038](https://github.com/outline/outline/pull/7038) this functionality was removed. I have tested this change on Firefox on Linux and Firefox on Mac. In both cases I can now select flag emojis. I have not observed any problems during limited testing.