### PR TITLE
Check flag emoji is supported

### DIFF
--- a/shared/utils/emoji.ts
+++ b/shared/utils/emoji.ts
@@ -5,29 +5,98 @@ import FuzzySearch from "fuzzy-search";
 import capitalize from "lodash/capitalize";
 import sortBy from "lodash/sortBy";
 import { Emoji, EmojiCategory, EmojiSkinTone, EmojiVariants } from "../types";
-import { isMac } from "./browser";
-
-const isMacEnv = isMac();
 
 init({ data: RawData });
 
 // Data has the pre-processed "search" terms.
 const TypedData = Data as EmojiMartData;
 
+// Slightly modified version of https://github.com/koala-interactive/is-emoji-supported/blob/master/src/is-emoji-supported.ts
+const isFlagEmojiSupported = (): boolean => {
+  const emoji = "🇺🇸";
+  let ctx = null;
+  try {
+    ctx = document
+      .createElement("canvas")
+      .getContext("2d", { willReadFrequently: true });
+    // eslint-disable-next-line no-empty
+  } catch {}
+
+  if (!ctx) {
+    return false;
+  }
+
+  const CANVAS_HEIGHT = 25;
+  const CANVAS_WIDTH = 20;
+  const textSize = Math.floor(CANVAS_HEIGHT / 2);
+
+  // Initialize convas context
+  ctx.font = textSize + "px Arial, Sans-Serif";
+  ctx.textBaseline = "top";
+  ctx.canvas.width = CANVAS_WIDTH * 2;
+  ctx.canvas.height = CANVAS_HEIGHT;
+
+  // Draw in red on the left
+  ctx.fillStyle = "#FF0000";
+  ctx.fillText(emoji, 0, 22);
+
+  // Draw in blue on right
+  ctx.fillStyle = "#0000FF";
+  ctx.fillText(emoji, CANVAS_WIDTH, 22);
+
+  const a = ctx.getImageData(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT).data;
+  const count = a.length;
+  let i = 0;
+
+  // Search the first visible pixel
+  // eslint-disable-next-line curly
+  for (; i < count && !a[i + 3]; i += 4);
+
+  // No visible pixel
+  if (i >= count) {
+    return false;
+  }
+
+  // Emoji has immutable color, so we check the color of the emoji in two different colors
+  // the result show be the same.
+  const x = CANVAS_WIDTH + ((i / 4) % CANVAS_WIDTH);
+  const y = Math.floor(i / 4 / CANVAS_WIDTH);
+  const b = ctx.getImageData(x, y, 1, 1).data;
+
+  if (a[i] !== b[0] || a[i + 2] !== b[2]) {
+    return false;
+  }
+
+  // Some emojis are a contraction of different ones, so if it's not
+  // supported, it will show multiple characters
+  if (ctx.measureText(emoji).width >= CANVAS_WIDTH) {
+    return false;
+  }
+
+  // Supported
+  return true;
+};
+
+const allowFlagEmoji = isFlagEmojiSupported();
+
 const flagEmojiIds =
   TypedData.categories
     .filter(({ id }) => id === EmojiCategory.Flags.toLowerCase())
     .map(({ emojis }) => emojis)[0] ?? [];
 
-const Categories = TypedData.categories.filter(
-  ({ id }) => isMacEnv || capitalize(id) !== EmojiCategory.Flags
-);
+const Categories = allowFlagEmoji
+  ? TypedData.categories
+  : TypedData.categories.filter(
+      ({ id }) => capitalize(id) !== EmojiCategory.Flags
+    );
 
-const Emojis = Object.fromEntries(
-  Object.entries(TypedData.emojis).filter(
-    ([id]) => isMacEnv || !flagEmojiIds.includes(id)
-  )
-);
+const Emojis = allowFlagEmoji
+  ? TypedData.emojis
+  : Object.fromEntries(
+      Object.entries(TypedData.emojis).filter(
+        ([id]) => !flagEmojiIds.includes(id)
+      )
+    );
 
 const searcher = new FuzzySearch(Object.values(Emojis), ["search"], {
   caseSensitive: false,


### PR DESCRIPTION
Related #8006 

The logic is ported from [emoji-mart](https://github.com/missive/emoji-mart/blob/16978d04a766eec6455e2e8bb21cd8dc0b3c7436/packages/emoji-mart/src/helpers/native-support.ts#L45).

This has been tested in mac, ubuntu and windows platform. 