### PR TITLE
fix: Flash of styles when printing dark mode

### DIFF
--- a/app/components/Actions.ts
+++ b/app/components/Actions.ts
@@ -31,7 +31,6 @@ const Actions = styled(Flex)`
   left: 0;
   border-radius: 3px;
   background: ${s("background")};
-  transition: ${s("backgroundTransition")};
   padding: 12px;
   backdrop-filter: blur(20px);
 

--- a/app/components/CollectionDescription.tsx
+++ b/app/components/CollectionDescription.tsx
@@ -201,7 +201,6 @@ const Input = styled.div`
   margin: -8px;
   padding: 8px;
   border-radius: 8px;
-  transition: ${s("backgroundTransition")};
 
   &:after {
     content: "";

--- a/app/components/ContentEditable.tsx
+++ b/app/components/ContentEditable.tsx
@@ -182,7 +182,6 @@ function placeCaret(element: HTMLElement, atStart: boolean) {
 
 const Content = styled.span`
   background: ${s("background")};
-  transition: ${s("backgroundTransition")};
   color: ${s("text")};
   -webkit-text-fill-color: ${s("text")};
   outline: none;

--- a/app/components/Guide.tsx
+++ b/app/components/Guide.tsx
@@ -94,7 +94,6 @@ const Scene = styled.div`
   align-items: flex-start;
   width: 350px;
   background: ${s("background")};
-  transition: ${s("backgroundTransition")};
   border-radius: 8px;
   outline: none;
   opacity: 0;

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -130,7 +130,6 @@ const Wrapper = styled(Flex)<WrapperProps>`
       `};
 
   padding: 12px;
-  transition: all 100ms ease-out;
   transform: translate3d(0, 0, 0);
   min-height: ${HEADER_HEIGHT}px;
   justify-content: flex-start;

--- a/app/components/Layout.tsx
+++ b/app/components/Layout.tsx
@@ -76,7 +76,6 @@ const Layout = React.forwardRef(function Layout_(
 
 const Container = styled(Flex)`
   background: ${s("background")};
-  transition: ${s("backgroundTransition")};
   position: relative;
   width: 100%;
   min-height: 100%;

--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -174,7 +174,6 @@ const Fullscreen = styled.div<FullscreenProps>`
   justify-content: center;
   align-items: flex-start;
   background: ${s("background")};
-  transition: ${s("backgroundTransition")};
   outline: none;
 
   ${breakpoint("tablet")`
@@ -265,7 +264,6 @@ const Small = styled.div`
   justify-content: center;
   align-items: flex-start;
   background: ${s("modalBackground")};
-  transition: ${s("backgroundTransition")};
   box-shadow: ${s("modalShadow")};
   border-radius: 8px;
   outline: none;

--- a/app/components/Reactions/Reaction.tsx
+++ b/app/components/Reactions/Reaction.tsx
@@ -144,7 +144,6 @@ const EmojiButton = styled(NudeButton)<{
   height: 28px;
   padding: 6px;
   border-radius: 12px;
-  transition: ${s("backgroundTransition")};
   background: ${s("backgroundTertiary")};
   pointer-events: ${({ disabled }) => disabled && "none"};
 

--- a/app/components/Sidebar/Sidebar.tsx
+++ b/app/components/Sidebar/Sidebar.tsx
@@ -298,9 +298,8 @@ const Container = styled(Flex)<ContainerProps>`
   width: 100%;
   background: ${s("sidebarBackground")};
   transition: box-shadow 150ms ease-in-out, transform 150ms ease-out,
-    ${s("backgroundTransition")}
-      ${(props: ContainerProps) =>
-        props.$isAnimating ? `,width ${ANIMATION_MS}ms ease-out` : ""};
+    ${(props: ContainerProps) =>
+      props.$isAnimating ? `,width ${ANIMATION_MS}ms ease-out` : ""};
   transform: translateX(
     ${(props) => (props.$mobileSidebarVisible ? 0 : "-100%")}
   );

--- a/app/components/Sidebar/components/SidebarButton.tsx
+++ b/app/components/Sidebar/components/SidebarButton.tsx
@@ -105,7 +105,6 @@ const Button = styled(Flex)<{
   &:hover,
   &[aria-expanded="true"] {
     color: ${s("sidebarText")};
-    transition: background 100ms ease-in-out;
     background: ${s("sidebarActiveBackground")};
   }
 

--- a/app/components/Sidebar/components/SidebarLink.tsx
+++ b/app/components/Sidebar/components/SidebarLink.tsx
@@ -78,7 +78,6 @@ function SidebarLink(
 
   const activeStyle = React.useMemo(
     () => ({
-      fontWeight: 600,
       color: theme.text,
       background: theme.sidebarActiveBackground,
       ...style,
@@ -202,10 +201,10 @@ const Link = styled(NavLink)<{
   display: flex;
   position: relative;
   text-overflow: ellipsis;
+  font-weight: 475;
   padding: 6px 16px;
   border-radius: 4px;
   min-height: 32px;
-  transition: background 50ms, color 50ms;
   user-select: none;
   background: ${(props) =>
     props.$isActiveDrop ? props.theme.slateDark : "inherit"};

--- a/app/components/Subheading.tsx
+++ b/app/components/Subheading.tsx
@@ -31,7 +31,6 @@ const Background = styled.div<{ sticky?: boolean }>`
   margin: 0 -8px;
   padding: 0 8px;
   background: ${s("background")};
-  transition: ${s("backgroundTransition")};
   z-index: 1;
 `;
 

--- a/app/components/Table.tsx
+++ b/app/components/Table.tsx
@@ -312,7 +312,6 @@ const Head = styled.th`
   padding: 6px 6px 0;
   border-bottom: 1px solid ${s("divider")};
   background: ${s("background")};
-  transition: ${s("backgroundTransition")};
   font-size: 14px;
   color: ${s("textSecondary")};
   font-weight: 500;

--- a/app/components/Tabs.tsx
+++ b/app/components/Tabs.tsx
@@ -45,7 +45,6 @@ const Sticky = styled.div`
   margin: 0 -8px;
   padding: 0 8px;
   background: ${s("background")};
-  transition: ${s("backgroundTransition")};
   z-index: 1;
 `;
 

--- a/app/scenes/Document/components/CommentThreadItem.tsx
+++ b/app/scenes/Document/components/CommentThreadItem.tsx
@@ -419,7 +419,7 @@ export const Bubble = styled(Flex)<{
   min-width: 2em;
   margin-bottom: 1px;
   padding: 8px 12px;
-  transition: color 100ms ease-out, ${s("backgroundTransition")};
+  transition: color 100ms ease-out, background 100ms ease-out;
 
   ${({ $lastOfThread, $canReply }) =>
     $lastOfThread &&

--- a/app/scenes/Document/components/Contents.tsx
+++ b/app/scenes/Document/components/Contents.tsx
@@ -87,7 +87,6 @@ const StickyWrapper = styled.div`
   border-radius: 8px;
 
   background: ${s("background")};
-  transition: ${s("backgroundTransition")};
 
   @supports (backdrop-filter: blur(20px)) {
     backdrop-filter: blur(20px);

--- a/app/scenes/Document/components/Document.tsx
+++ b/app/scenes/Document/components/Document.tsx
@@ -695,7 +695,6 @@ const Footer = styled.div`
 const Background = styled(Container)`
   position: relative;
   background: ${s("background")};
-  transition: ${s("backgroundTransition")};
 `;
 
 const ReferencesWrapper = styled.div`

--- a/app/scenes/Home.tsx
+++ b/app/scenes/Home.tsx
@@ -118,7 +118,6 @@ function Home() {
 const Documents = styled.div`
   position: relative;
   background: ${s("background")};
-  transition: ${s("backgroundTransition")};
 `;
 
 export default observer(Home);

--- a/app/scenes/Search/components/SearchInput.tsx
+++ b/app/scenes/Search/components/SearchInput.tsx
@@ -59,7 +59,6 @@ const StyledInput = styled.input`
   outline: none;
   border: 0;
   background: ${s("sidebarBackground")};
-  transition: ${s("backgroundTransition")};
   border-radius: 4px;
 
   color: ${s("text")};

--- a/app/scenes/Settings/components/ActionRow.tsx
+++ b/app/scenes/Settings/components/ActionRow.tsx
@@ -12,7 +12,6 @@ export const ActionRow = styled.div`
   margin: 0 -50vw;
 
   background: ${s("background")};
-  transition: ${s("backgroundTransition")};
 
   @supports (backdrop-filter: blur(20px)) {
     backdrop-filter: blur(20px);

--- a/app/typings/styled-components.d.ts
+++ b/app/typings/styled-components.d.ts
@@ -124,7 +124,6 @@ declare module "styled-components" {
     backgroundSecondary: string;
     backgroundTertiary: string;
     backgroundQuaternary: string;
-    backgroundTransition: string;
     accent: string;
     accentText: string;
     link: string;

--- a/shared/styles/globals.ts
+++ b/shared/styles/globals.ts
@@ -21,9 +21,12 @@ export default createGlobalStyle<Props>`
     margin: 0;
     padding: 0;
     print-color-adjust: exact;
-    -webkit-print-color-adjust: exact;
     --pointer: ${(props) => (props.useCursorPointer ? "pointer" : "default")};
     overscroll-behavior-x: none;
+
+    @media print {
+      background: none !important;
+    }
   }
 
   body,

--- a/shared/styles/theme.ts
+++ b/shared/styles/theme.ts
@@ -67,7 +67,6 @@ const buildBaseTheme = (input: Partial<Colors>) => {
     fontWeightRegular: 400,
     fontWeightMedium: 500,
     fontWeightBold: 600,
-    backgroundTransition: "background 100ms ease-in-out",
     accentText: colors.white,
     selected: colors.accent,
     textHighlight: "#FDEA9B",


### PR DESCRIPTION
The background transitions are no longer needed since we're now using the `startTransition` API to switch between themes. Note: This does not fix the page becoming white when using `window.print` from the contenxt menu, that seems like a browser issue as we don't have any control beyond calling print.

closes #8005