### PR TITLE
fix(Grist): Improve integration of Grist links

### DIFF
--- a/shared/editor/embeds/index.tsx
+++ b/shared/editor/embeds/index.tsx
@@ -404,11 +404,11 @@ const embeds: EmbedDescriptor[] = [
     transformMatch: (matches: RegExpMatchArray) => {
       const input = matches.input ?? matches[0];
 
-      if (input.includes("style=singlePage")) {
+      if (input.includes("style=singlePage") || input.includes("embed=true")) {
         return input;
       }
 
-      return input.replace(/(\?embed=true)?$/, "?embed=true");
+      return `${input}${input.includes("?")?"&embed=true":"?embed=true"}`
     },
     icon: <Img src="/images/grist.png" alt="Grist" />,
   }),


### PR DESCRIPTION
When I publicly share a Grist spreadsheet the link is:
```
https://{{ grist_url }}/o/docs/{{ doc_id }}/{{ doc_name }}?utm_id=share-doc
```

The `utm_id` is create [here](https://github.com/gristlabs/grist-core/blob/efefc961e0c98d54bf22f0bafab629b6f534c0f6/app/client/ui/ShareMenu.ts#L331)

If I paste the link on Outline the link is transform by 
```
https://{{ grist_url }}/o/docs/{{ doc_id }}/{{ doc_name }}?utm_id=share-doc?embed=true
```

The code which add this is [here](https://github.com/outline/outline/blob/6c1e4a5b4041caa0c9ee1b429bc7a2beaea19b1d/shared/editor/embeds/index.tsx#L411).

The rendering is therefore not done correctly.