### PR TITLE
feat: Improve inline rule matching

### DIFF
--- a/shared/editor/lib/markInputRule.ts
+++ b/shared/editor/lib/markInputRule.ts
@@ -5,7 +5,7 @@ import { EditorState } from "prosemirror-state";
 import { getMarksBetween } from "../queries/getMarksBetween";
 
 /**
- * A factory function for creating Prosemirror plugins that automatically apply a mark to text
+ * A factory function for creating a Prosemirror InputRule that automatically apply a mark to text
  * that matches a given regular expression.
  *
  * Assumes the mark is not already applied, and that the regex includes two named capture groups:
@@ -69,8 +69,8 @@ export default function markInputRule(
 }
 
 /**
- * A factory function for creating Prosemirror plugins that automatically apply a mark to text
- * is surrounded by a given pattern.
+ * A factory function for creating a Prosemirror InputRule that automatically applies a mark to
+ * text that is surrounded by a given pattern.
  *
  * @param pattern The pattern to match.
  * @param markType The mark type to apply.

--- a/shared/editor/marks/Bold.ts
+++ b/shared/editor/marks/Bold.ts
@@ -1,7 +1,7 @@
 import { toggleMark } from "prosemirror-commands";
 import { InputRule } from "prosemirror-inputrules";
 import { MarkSpec, MarkType } from "prosemirror-model";
-import markInputRule from "../lib/markInputRule";
+import { markInputRuleForPattern } from "../lib/markInputRule";
 import Mark from "./Mark";
 
 const heavyWeightRegex = /^(bold(er)?|[5-9]\d{2,})$/;
@@ -33,7 +33,7 @@ export default class Bold extends Mark {
   }
 
   inputRules({ type }: { type: MarkType }): InputRule[] {
-    return [markInputRule(/(?:\*\*)([^*]+)(?:\*\*)$/, type)];
+    return [markInputRuleForPattern("**", type)];
   }
 
   keys({ type }: { type: MarkType }) {

--- a/shared/editor/marks/Code.ts
+++ b/shared/editor/marks/Code.ts
@@ -9,7 +9,7 @@ import {
 } from "prosemirror-model";
 import { Plugin, TextSelection } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
-import { markInputRuleForCharacter } from "../lib/markInputRule";
+import { markInputRuleForPattern } from "../lib/markInputRule";
 import { MarkdownSerializerState } from "../lib/markdown/serializer";
 import { isInCode } from "../queries/isInCode";
 import Mark from "./Mark";
@@ -28,7 +28,7 @@ export default class Code extends Mark {
   }
 
   inputRules({ type }: { type: MarkType }) {
-    return [markInputRuleForCharacter("`", type)];
+    return [markInputRuleForPattern("`", type)];
   }
 
   keys({ type }: { type: MarkType }) {

--- a/shared/editor/marks/Code.ts
+++ b/shared/editor/marks/Code.ts
@@ -9,7 +9,7 @@ import {
 } from "prosemirror-model";
 import { Plugin, TextSelection } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
-import markInputRule from "../lib/markInputRule";
+import { markInputRuleForCharacter } from "../lib/markInputRule";
 import { MarkdownSerializerState } from "../lib/markdown/serializer";
 import { isInCode } from "../queries/isInCode";
 import Mark from "./Mark";
@@ -28,7 +28,7 @@ export default class Code extends Mark {
   }
 
   inputRules({ type }: { type: MarkType }) {
-    return [markInputRule(/(?:^|\s)((?:`)((?:[^`]+))(?:`))$/, type)];
+    return [markInputRuleForCharacter("`", type)];
   }
 
   keys({ type }: { type: MarkType }) {

--- a/shared/editor/marks/Highlight.ts
+++ b/shared/editor/marks/Highlight.ts
@@ -1,7 +1,7 @@
 import { rgba } from "polished";
 import { toggleMark } from "prosemirror-commands";
 import { MarkSpec, MarkType } from "prosemirror-model";
-import markInputRule from "../lib/markInputRule";
+import { markInputRuleForPattern } from "../lib/markInputRule";
 import markRule from "../rules/mark";
 import Mark from "./Mark";
 
@@ -53,7 +53,7 @@ export default class Highlight extends Mark {
   }
 
   inputRules({ type }: { type: MarkType }) {
-    return [markInputRule(/(?:==)([^=]+)(?:==)$/, type)];
+    return [markInputRuleForPattern("==", type)];
   }
 
   keys({ type }: { type: MarkType }) {

--- a/shared/editor/marks/Italic.ts
+++ b/shared/editor/marks/Italic.ts
@@ -2,7 +2,7 @@ import { toggleMark } from "prosemirror-commands";
 import { InputRule } from "prosemirror-inputrules";
 import { MarkSpec, MarkType } from "prosemirror-model";
 import { Command } from "prosemirror-state";
-import markInputRule from "../lib/markInputRule";
+import { markInputRuleForPattern } from "../lib/markInputRule";
 import Mark from "./Mark";
 
 export default class Italic extends Mark {
@@ -25,29 +25,9 @@ export default class Italic extends Mark {
   }
 
   inputRules({ type }: { type: MarkType }): InputRule[] {
-    /**
-     * Due to use of snake_case strings common in docs the matching conditions
-     * are a bit more strict than e.g. the ** bold syntax to help prevent
-     * false positives.
-     *
-     * Matches:
-     * _1_
-     * _123_
-     * (_one_
-     * [_one_
-     *
-     * No match:
-     * __
-     * __123_
-     * __123__
-     * _123
-     * one_123_
-     * ONE_123_
-     * 1_123_
-     */
     return [
-      markInputRule(/(?:^|[^_a-zA-Z0-9])(_([^_]+)_)$/, type),
-      markInputRule(/(?:^|[^*a-zA-Z0-9])(\*([^*]+)\*)$/, type),
+      markInputRuleForPattern("_", type),
+      markInputRuleForPattern("*", type),
     ];
   }
 

--- a/shared/editor/marks/Strikethrough.ts
+++ b/shared/editor/marks/Strikethrough.ts
@@ -1,6 +1,6 @@
 import { toggleMark } from "prosemirror-commands";
 import { MarkSpec, MarkType } from "prosemirror-model";
-import markInputRule from "../lib/markInputRule";
+import { markInputRuleForPattern } from "../lib/markInputRule";
 import Mark from "./Mark";
 
 export default class Strikethrough extends Mark {
@@ -36,7 +36,7 @@ export default class Strikethrough extends Mark {
   }
 
   inputRules({ type }: { type: MarkType }) {
-    return [markInputRule(/~([^~]+)~$/, type)];
+    return [markInputRuleForPattern("~", type)];
   }
 
   toMarkdown() {

--- a/shared/editor/marks/Underline.ts
+++ b/shared/editor/marks/Underline.ts
@@ -1,6 +1,6 @@
 import { toggleMark } from "prosemirror-commands";
 import { MarkSpec, MarkType } from "prosemirror-model";
-import markInputRule from "../lib/markInputRule";
+import { markInputRuleForPattern } from "../lib/markInputRule";
 import underlinesRule from "../rules/underlines";
 import Mark from "./Mark";
 
@@ -32,7 +32,7 @@ export default class Underline extends Mark {
   }
 
   inputRules({ type }: { type: MarkType }) {
-    return [markInputRule(/(?:__)([^_]+)(?:__)$/, type)];
+    return [markInputRuleForPattern("__", type)];
   }
 
   keys({ type }: { type: MarkType }) {


### PR DESCRIPTION
Refactors inline mark matching to use a single consistent rule, adds ability to match when preceded by "(" "[" "{" characters.

closes #8083