### PR TITLE
Add missing space to invite modal

### DIFF
--- a/app/scenes/Invite.tsx
+++ b/app/scenes/Invite.tsx
@@ -180,10 +180,13 @@ function Invite({ onSubmit }: Props) {
             />{" "}
             {collectionAccessNote}
             {can.update && (
-              <Trans>
-                As an admin you can also{" "}
-                <Link to="/settings/security">enable email sign-in</Link>.
-              </Trans>
+              <>
+                {" "}
+                <Trans>
+                  As an admin you can also{" "}
+                  <Link to="/settings/security">enable email sign-in</Link>.
+                </Trans>{" "}
+              </>
             )}
           </Text>
         )}


### PR DESCRIPTION
This PR adds a space between `Invited members will receive access to N collections.` and `As an admin you can also enable email sign-in.` in the _Invite to workspace_ modal.

**Before**

<img width="437" alt="Screenshot 2024-12-13 at 2 23 01 am" src="https://github.com/user-attachments/assets/2e862c73-1e56-4328-8aac-2c99beabc4a2" />
