### PR TITLE
fix: Use parent transaction for findOrCreate after-commit hook

### DIFF
--- a/server/typings/sequelize.d.ts
+++ b/server/typings/sequelize.d.ts
@@ -1,0 +1,7 @@
+import "sequelize";
+
+declare module "sequelize" {
+  interface Transaction {
+    parent?: Transaction;
+  }
+}


### PR DESCRIPTION
This PR fixes a bug where events were not published in the `findOrCreateWithCtx` flow.
`findOrCreate` creates a nested transaction and sets the transaction created in the middleware as its parent. This child transaction is passed to all the hooks, including event [afterSave](https://github.com/outline/outline/blob/f448be5830045b886a890d4bf83f9e5bc1314866/server/models/Event.ts#L80). However, we _really_ need to execute the `afterCommit` hook on the parent transaction, since that gets committed by the middleware.

https://github.com/sequelize/sequelize/issues/17452 - This issue provides some more context what's happening under the hood.

Related #7920 