### PR TITLE
Add teamId index on attachments table

### DIFF
--- a/server/migrations/20241231045203-add-attachments-teamId-index.js
+++ b/server/migrations/20241231045203-add-attachments-teamId-index.js
@@ -1,0 +1,12 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addIndex("attachments", ["teamId"]);
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeIndex("attachments", ["teamId"]);
+  },
+};


### PR DESCRIPTION
Closes #7507 

There are quite a few use-cases of "id/teamId", "documentId/teamId", and "teamId" based queries.
It's better to create a simple index on `teamId` so that the query planner can combine multiple simple indexes (which we already have on `id` and `documentId`) when necessary.