### PR TITLE
Skip unnecessary update of comment sort preference

### DIFF
--- a/app/scenes/Document/components/CommentSortMenu.tsx
+++ b/app/scenes/Document/components/CommentSortMenu.tsx
@@ -19,19 +19,23 @@ const CommentSortMenu = () => {
   const user = useCurrentUser();
   const params = useQuery();
 
-  const viewingResolved = params.get("resolved") === "";
-  const value = viewingResolved
-    ? "resolved"
-    : user.getPreference(UserPreference.SortCommentsByOrderInDocument)
+  const preferredSortType = user.getPreference(
+    UserPreference.SortCommentsByOrderInDocument
+  )
     ? CommentSortType.OrderInDocument
     : CommentSortType.MostRecent;
 
+  const viewingResolved = params.get("resolved") === "";
+  const value = viewingResolved ? "resolved" : preferredSortType;
+
   const handleSortTypeChange = (type: CommentSortType) => {
-    user.setPreference(
-      UserPreference.SortCommentsByOrderInDocument,
-      type === CommentSortType.OrderInDocument
-    );
-    void user.save();
+    if (type !== preferredSortType) {
+      user.setPreference(
+        UserPreference.SortCommentsByOrderInDocument,
+        type === CommentSortType.OrderInDocument
+      );
+      void user.save();
+    }
   };
 
   const showResolved = () => {


### PR DESCRIPTION
Tiny change to skip invoking `users.update` API when switching from resolved view to existing sort preference view.