### PR TITLE
Improve useTableRequest for better reactivity

### DIFF
--- a/app/scenes/Settings/Members.tsx
+++ b/app/scenes/Settings/Members.tsx
@@ -44,7 +44,7 @@ function Members() {
   const reqParams = React.useMemo(
     () => ({
       query: params.get("query") || undefined,
-      filter: params.get("filter") || undefined,
+      filter: params.get("filter") || "active",
       role: params.get("role") || undefined,
       sort: params.get("sort") || "name",
       direction: (params.get("direction") || "asc").toUpperCase() as

--- a/app/scenes/Settings/Members.tsx
+++ b/app/scenes/Settings/Members.tsx
@@ -7,7 +7,7 @@ import { useHistory, useLocation } from "react-router-dom";
 import { toast } from "sonner";
 import styled from "styled-components";
 import { depths, s } from "@shared/styles";
-import UsersStore from "~/stores/UsersStore";
+import UsersStore, { queriedUsers } from "~/stores/UsersStore";
 import { Action } from "~/components/Actions";
 import Button from "~/components/Button";
 import Fade from "~/components/Fade";
@@ -65,9 +65,11 @@ function Members() {
   const { data, error, loading, next } = useTableRequest({
     data: getFilteredUsers({
       users,
+      query: reqParams.query,
       filter: reqParams.filter,
       role: reqParams.role,
     }),
+    sort,
     reqFn: users.fetchPage,
     reqParams,
   });
@@ -181,10 +183,12 @@ function Members() {
 
 function getFilteredUsers({
   users,
+  query,
   filter,
   role,
 }: {
   users: UsersStore;
+  query?: string;
   filter?: string;
   role?: string;
 }) {
@@ -204,9 +208,15 @@ function getFilteredUsers({
       filteredUsers = users.active;
   }
 
-  return role
-    ? filteredUsers.filter((user) => user.role === role)
-    : filteredUsers;
+  if (role) {
+    filteredUsers = filteredUsers.filter((user) => user.role === role);
+  }
+
+  if (query) {
+    filteredUsers = queriedUsers(filteredUsers, query);
+  }
+
+  return filteredUsers;
 }
 
 const StickyFilters = styled(Flex)`

--- a/app/scenes/Settings/Shares.tsx
+++ b/app/scenes/Settings/Shares.tsx
@@ -45,6 +45,7 @@ function Shares() {
 
   const { data, error, loading, next } = useTableRequest({
     data: shares.orderedData,
+    sort,
     reqFn: shares.fetchPage,
     reqParams,
   });

--- a/app/stores/UsersStore.ts
+++ b/app/stores/UsersStore.ts
@@ -208,7 +208,7 @@ export default class UsersStore extends Store<User> {
   };
 }
 
-function queriedUsers(users: User[], query?: string) {
+export function queriedUsers(users: User[], query?: string) {
   const normalizedQuery = deburr((query || "").toLocaleLowerCase());
 
   return normalizedQuery

--- a/server/routes/api/users/users.ts
+++ b/server/routes/api/users/users.ts
@@ -545,6 +545,7 @@ router.post(
   validate(T.UsersInviteSchema),
   async (ctx: APIContext<T.UsersInviteReq>) => {
     const { invites } = ctx.input.body;
+    const actor = ctx.state.auth.user;
 
     if (invites.length > UserValidation.maxInvitesPerRequest) {
       throw ValidationError(
@@ -565,7 +566,9 @@ router.post(
     ctx.body = {
       data: {
         sent: response.sent,
-        users: response.users.map((user) => presentUser(user)),
+        users: response.users.map((user) =>
+          presentUser(user, { includeEmail: !!can(actor, "readEmail", user) })
+        ),
       },
     };
   }


### PR DESCRIPTION
Towards #7484 

This PR removes the intermediate `dataIds` state used in `useTableRequest`. This was causing issues in reactive updates from other places such as when inviting a user, adding new group. In hindsight, using `dataIds` was unnecessary - should have completely depended on the store data.

Along the way, two bugs that have been present for some time have been fixed.
1. When no filter is set, load the `active` users only (previously, we were loading all users).
2. Return invited user's email in `users.invite` response. This allows us to display the email in the members table without needing a refresh.