### PR TITLE
fix: Update counter cache when a user is deleted (or) suspended

### DIFF
--- a/server/commands/userSuspender.ts
+++ b/server/commands/userSuspender.ts
@@ -38,6 +38,7 @@ export default async function userSuspender({
       userId: user.id,
     },
     transaction,
+    individualHooks: true,
   });
   await Event.create(
     {

--- a/server/queues/processors/UserDeletedProcessor.ts
+++ b/server/queues/processors/UserDeletedProcessor.ts
@@ -20,6 +20,7 @@ export default class UserDeletedProcessor extends BaseProcessor {
           userId: event.userId,
         },
         transaction,
+        individualHooks: true,
       });
       await UserAuthentication.destroy({
         where: {


### PR DESCRIPTION
In `userSuspender` and `UserDeletedProcessor` flows, `GroupUser` deletion triggers an `afterBulkDestroy` hook - however we need the `afterDestroy` hook on each instance to update the group member counter cache.

It's not ideal to listen to `afterBulkDestroy` hook since it won't have the deleted instances data.