### PR TITLE
fix: Handle nested collapsed headings in findCollapsedNodes

### DIFF
--- a/shared/editor/queries/findCollapsedNodes.ts
+++ b/shared/editor/queries/findCollapsedNodes.ts
@@ -5,27 +5,26 @@ export function findCollapsedNodes(doc: Node): NodeWithPos[] {
   const blocks = findBlockNodes(doc);
   const nodes: NodeWithPos[] = [];
 
-  let withinCollapsedHeading;
-
+  const collapsedStack: number[] = [];
   for (const block of blocks) {
-    if (block.node.type.name === "heading") {
-      if (
-        !withinCollapsedHeading ||
-        block.node.attrs.level <= withinCollapsedHeading
-      ) {
-        if (block.node.attrs.collapsed) {
-          if (!withinCollapsedHeading) {
-            withinCollapsedHeading = block.node.attrs.level;
-          }
-        } else {
-          withinCollapsedHeading = undefined;
-        }
-        continue;
-      }
-    }
+    if (collapsedStack.length) {
+      const top = collapsedStack[collapsedStack.length - 1];
+      // if the block encountered same or higher level heading, pop the stack
+      if (block.node.type.name === "heading" && block.node.attrs.level <= top) {
+        collapsedStack.pop();
 
-    if (withinCollapsedHeading) {
-      nodes.push(block);
+        // if the block is a heading and it is collapsed, push it to the stack
+        if (block.node.attrs.collapsed) {
+          collapsedStack.push(block.node.attrs.level);
+        }
+      } else {
+        // the deepest level or non-heading block should be added to the nodes
+        nodes.push(block);
+      }
+    } else {
+      if (block.node.type.name === "heading" && block.node.attrs.collapsed) {
+        collapsedStack.push(block.node.attrs.level);
+      }
     }
   }
 


### PR DESCRIPTION
This PR fixes #8221 by addressing the issue in `shared/editor/queries/findCollapsedNodes.ts` where nested collapsible headings were not handled properly. The problem stemmed from using a single `withinCollapsedHeading` variable, which failed to manage multiple collapsing levels accurately.

**Changes**  
- Replaced `withinCollapsedHeading` with a stack (`collapsedStack`) to track multiple collapsing levels.
- Ensured nested headings are correctly hidden under their collapsed parent headings.

**Expected Behavior**  
Collapsing higher-level headings (e.g., `##`) will now consistently hide all nested content, regardless of the state of lower-level headings.