### PR TITLE
fix: Skip events for sourced group memberships

### DIFF
--- a/server/models/GroupMembership.ts
+++ b/server/models/GroupMembership.ts
@@ -344,6 +344,7 @@ class GroupMembership extends ParanoidModel<
         },
         {
           transaction,
+          hooks: false,
         }
       );
     }


### PR DESCRIPTION
Not a functional impact, however dangling events are created for sourced memberships which fail in the background task.