### PR TITLE
chore: Bump rollup-plugin-webpack-stats to v2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -353,7 +353,7 @@
     "prettier": "^2.8.8",
     "react-refresh": "^0.14.2",
     "rimraf": "^2.5.4",
-    "rollup-plugin-webpack-stats": "^0.4.1",
+    "rollup-plugin-webpack-stats": "^2.0.1",
     "terser": "^5.36.0",
     "typescript": "^5.7.2",
     "vite-plugin-static-copy": "^0.17.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import react from "@vitejs/plugin-react";
 import browserslistToEsbuild from "browserslist-to-esbuild";
-import { webpackStats } from "rollup-plugin-webpack-stats";
+import webpackStats from "rollup-plugin-webpack-stats";
 import { CommonServerOptions, defineConfig } from "vite";
 import { VitePWA } from "vite-plugin-pwa";
 import { viteStaticCopy } from "vite-plugin-static-copy";

--- a/yarn.lock
+++ b/yarn.lock
@@ -13803,10 +13803,17 @@ rollup-plugin-node-resolve@^3.0.0:
     is-module "^1.0.0"
     resolve "^1.1.6"
 
-rollup-plugin-webpack-stats@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-webpack-stats/-/rollup-plugin-webpack-stats-0.4.1.tgz#e66f691b7735e9fca39fc0302089632c80b3e03f"
-  integrity sha512-Zi7t0G7FtA55LNcU9B3s2gBo3PODbdo+288Cw2/4sA8+o9H/ahhWZ25UxADeHwriAzW808iDpPbB81C5jGLIbg==
+rollup-plugin-stats@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-stats/-/rollup-plugin-stats-1.3.2.tgz#4dd088465cff3c00688e388787e240dff20aeed8"
+  integrity sha512-VVCNU//OBzroB73gPmGJIm6xkoi25t2MsPoV6LsWUt4BVXbnrKpYAY3CwwnAfiWzM2KL4PN3SeFe/jZ9Ky7WRQ==
+
+rollup-plugin-webpack-stats@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-webpack-stats/-/rollup-plugin-webpack-stats-2.0.1.tgz#0ca7913227fc42db34ae51a74fa6742a6e8f5a1e"
+  integrity sha512-1JALgjz4RDe14SowXJxAsQqJxGnj6JF4TIRo0FistxspFr3TyYIWCpO8B5qaes7vfdKxSNTowJtuQTOlZOobMA==
+  dependencies:
+    rollup-plugin-stats "1.3.2"
 
 rollup@^0.41.4, rollup@^2.43.1, rollup@^4.20.0, rollup@^4.5.1:
   version "4.5.1"


### PR DESCRIPTION
[`rollup-plugin-webpack-stats@v2`](https://github.com/relative-ci/rollup-plugin-webpack-stats/releases) introduces a new way of detecting the correct chunk "initial" flag based on the dependency tree.

According to the report generated on the fork, multiple chunks are affected by the change, but from the tests the initial flag is set correctly (including the index entry): https://bit.ly/40IHFNz.

---

![image](https://github.com/user-attachments/assets/6db6a07f-e73c-4577-98a1-1896a6a9ff30)
