### PR TITLE
fix: Events lacking teamId published for sourced memberships

### DIFF
--- a/server/models/GroupMembership.ts
+++ b/server/models/GroupMembership.ts
@@ -158,7 +158,7 @@ class GroupMembership extends ParanoidModel<
             permission: membership.permission,
             createdById: membership.createdById,
           },
-          { transaction }
+          { transaction, hooks: false }
         )
       )
     );

--- a/server/models/UserMembership.ts
+++ b/server/models/UserMembership.ts
@@ -144,12 +144,12 @@ class UserMembership extends IdModel<
     options: SaveOptions
   ) {
     const { transaction } = options;
-    const groupMemberships = await this.findAll({
+    const userMemberships = await this.findAll({
       where,
       transaction,
     });
     await Promise.all(
-      groupMemberships.map((membership) =>
+      userMemberships.map((membership) =>
         this.create(
           {
             documentId: document.id,
@@ -158,7 +158,7 @@ class UserMembership extends IdModel<
             permission: membership.permission,
             createdById: membership.createdById,
           },
-          { transaction }
+          { transaction, hooks: false }
         )
       )
     );

--- a/shared/editor/nodes/Mention.tsx
+++ b/shared/editor/nodes/Mention.tsx
@@ -30,7 +30,9 @@ export default class Mention extends Node {
   get schema(): NodeSpec {
     return {
       attrs: {
-        type: {},
+        type: {
+          default: MentionType.User,
+        },
         label: {},
         modelId: {},
         actorId: {


### PR DESCRIPTION
Fixes spurious events when publishing document