### PR TITLE
Copy to clipboard as Markdown

### DIFF
--- a/app/editor/extensions/ClipboardTextSerializer.ts
+++ b/app/editor/extensions/ClipboardTextSerializer.ts
@@ -1,7 +1,5 @@
 import { Plugin, PluginKey } from "prosemirror-state";
 import Extension from "@shared/editor/lib/Extension";
-import textBetween from "@shared/editor/lib/textBetween";
-import { getTextSerializers } from "@shared/editor/lib/textSerializers";
 
 /**
  * A plugin that allows overriding the default behavior of the editor to allow
@@ -14,19 +12,15 @@ export default class ClipboardTextSerializer extends Extension {
   }
 
   get plugins() {
-    const textSerializers = getTextSerializers(this.editor.schema);
-
     return [
       new Plugin({
         key: new PluginKey("clipboardTextSerializer"),
         props: {
-          clipboardTextSerializer: () => {
-            const { doc, selection } = this.editor.view.state;
-            const { ranges } = selection;
-            const from = Math.min(...ranges.map((range) => range.$from.pos));
-            const to = Math.max(...ranges.map((range) => range.$to.pos));
-
-            return textBetween(doc, from, to, textSerializers);
+          clipboardTextSerializer: (slice) => {
+            const serializer = this.editor.extensions.serializer();
+            return serializer.serialize(slice.content, {
+              softBreak: true,
+            });
           },
         },
       }),

--- a/app/editor/extensions/ClipboardTextSerializer.ts
+++ b/app/editor/extensions/ClipboardTextSerializer.ts
@@ -3,8 +3,7 @@ import Extension from "@shared/editor/lib/Extension";
 
 /**
  * A plugin that allows overriding the default behavior of the editor to allow
- * copying text for nodes that do not inherently have text children by defining
- * a `toPlainText` method in the node spec.
+ * copying text including the markdown formatting.
  */
 export default class ClipboardTextSerializer extends Extension {
   get name() {
@@ -12,16 +11,16 @@ export default class ClipboardTextSerializer extends Extension {
   }
 
   get plugins() {
+    const serializer = this.editor.extensions.serializer();
+
     return [
       new Plugin({
         key: new PluginKey("clipboardTextSerializer"),
         props: {
-          clipboardTextSerializer: (slice) => {
-            const serializer = this.editor.extensions.serializer();
-            return serializer.serialize(slice.content, {
+          clipboardTextSerializer: (slice) =>
+            serializer.serialize(slice.content, {
               softBreak: true,
-            });
-          },
+            }),
         },
       }),
     ];


### PR DESCRIPTION
Editor content copied to the clipboard will now include markdown formatting. Less code, more functionality 👌 

closes #8292