### PR TITLE
Updates new tables to start with fixed column widths

### DIFF
--- a/app/editor/components/BlockMenu.tsx
+++ b/app/editor/components/BlockMenu.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import useDictionary from "~/hooks/useDictionary";
 import getMenuItems from "../menus/block";
+import { useEditor } from "./EditorContext";
 import SuggestionsMenu, {
   Props as SuggestionsMenuProps,
 } from "./SuggestionsMenu";
@@ -11,6 +12,7 @@ type Props = Omit<SuggestionsMenuProps, "renderMenuItem" | "items"> &
 
 function BlockMenu(props: Props) {
   const dictionary = useDictionary();
+  const { elementRef } = useEditor();
 
   return (
     <SuggestionsMenu
@@ -26,7 +28,7 @@ function BlockMenu(props: Props) {
           shortcut={item.shortcut}
         />
       )}
-      items={getMenuItems(dictionary)}
+      items={getMenuItems(dictionary, elementRef)}
     />
   );
 }

--- a/app/editor/menus/block.tsx
+++ b/app/editor/menus/block.tsx
@@ -127,7 +127,7 @@ export default function blockMenuItems(
       attrs: {
         rowsCount: 3,
         colsCount: 3,
-        columnWidths: [documentWidth / 3, documentWidth / 3],
+        colWidth: documentWidth / 3,
       },
     },
     {

--- a/app/editor/menus/block.tsx
+++ b/app/editor/menus/block.tsx
@@ -38,7 +38,12 @@ const Img = styled(Image)`
   height: 18px;
 `;
 
-export default function blockMenuItems(dictionary: Dictionary): MenuItem[] {
+export default function blockMenuItems(
+  dictionary: Dictionary,
+  documentRef: React.RefObject<HTMLDivElement>
+): MenuItem[] {
+  const documentWidth = documentRef.current?.clientWidth ?? 0;
+
   return [
     {
       name: "heading",
@@ -119,7 +124,11 @@ export default function blockMenuItems(dictionary: Dictionary): MenuItem[] {
       name: "table",
       title: dictionary.table,
       icon: <TableIcon />,
-      attrs: { rowsCount: 3, colsCount: 3 },
+      attrs: {
+        rowsCount: 3,
+        colsCount: 3,
+        columnWidths: [documentWidth / 3, documentWidth / 3],
+      },
     },
     {
       name: "blockquote",

--- a/shared/editor/commands/table.ts
+++ b/shared/editor/commands/table.ts
@@ -20,19 +20,19 @@ import { collapseSelection } from "./collapseSelection";
 export function createTable({
   rowsCount,
   colsCount,
-  columnWidths = [],
+  colWidth,
 }: {
   /** The number of rows in the table. */
   rowsCount: number;
   /** The number of columns in the table. */
   colsCount: number;
   /** The widths of each column in the table. */
-  columnWidths: number[];
+  colWidth: number;
 }): Command {
   return (state, dispatch) => {
     if (dispatch) {
       const offset = state.tr.selection.anchor + 1;
-      const nodes = createTableInner(state, rowsCount, colsCount, columnWidths);
+      const nodes = createTableInner(state, rowsCount, colsCount, colWidth);
       const tr = state.tr.replaceSelectionWith(nodes).scrollIntoView();
       const resolvedPos = tr.doc.resolve(offset);
       tr.setSelection(TextSelection.near(resolvedPos));
@@ -46,7 +46,7 @@ function createTableInner(
   state: EditorState,
   rowsCount: number,
   colsCount: number,
-  columnWidths: number[],
+  colWidth: number,
   withHeaderRow = true,
   cellContent?: Node
 ) {
@@ -61,9 +61,9 @@ function createTableInner(
       : cellType.createAndFill(attrs);
 
   for (let index = 0; index < colsCount; index += 1) {
-    const attrs = columnWidths[index]
+    const attrs = colWidth
       ? {
-          colwidth: [columnWidths[index]],
+          colwidth: [colWidth],
           colspan: 1,
           rowspan: 1,
         }

--- a/shared/editor/commands/table.ts
+++ b/shared/editor/commands/table.ts
@@ -1,4 +1,4 @@
-import { Fragment, Node, NodeType } from "prosemirror-model";
+import { Node, NodeType } from "prosemirror-model";
 import { Command, EditorState, TextSelection } from "prosemirror-state";
 import {
   CellSelection,
@@ -20,14 +20,19 @@ import { collapseSelection } from "./collapseSelection";
 export function createTable({
   rowsCount,
   colsCount,
+  columnWidths = [],
 }: {
+  /** The number of rows in the table. */
   rowsCount: number;
+  /** The number of columns in the table. */
   colsCount: number;
+  /** The widths of each column in the table. */
+  columnWidths: number[];
 }): Command {
   return (state, dispatch) => {
     if (dispatch) {
       const offset = state.tr.selection.anchor + 1;
-      const nodes = createTableInner(state, rowsCount, colsCount);
+      const nodes = createTableInner(state, rowsCount, colsCount, columnWidths);
       const tr = state.tr.replaceSelectionWith(nodes).scrollIntoView();
       const resolvedPos = tr.doc.resolve(offset);
       tr.setSelection(TextSelection.near(resolvedPos));
@@ -41,6 +46,7 @@ function createTableInner(
   state: EditorState,
   rowsCount: number,
   colsCount: number,
+  columnWidths: number[],
   withHeaderRow = true,
   cellContent?: Node
 ) {
@@ -49,23 +55,27 @@ function createTableInner(
   const cells: Node[] = [];
   const rows: Node[] = [];
 
-  const createCell = (
-    cellType: NodeType,
-    cellContent: Fragment | Node | readonly Node[] | null | undefined
-  ) =>
+  const createCell = (cellType: NodeType, attrs: Record<string, any> | null) =>
     cellContent
-      ? cellType.createChecked(null, cellContent)
-      : cellType.createAndFill();
+      ? cellType.createChecked(attrs, cellContent)
+      : cellType.createAndFill(attrs);
 
   for (let index = 0; index < colsCount; index += 1) {
-    const cell = createCell(types.cell, cellContent);
+    const attrs = columnWidths[index]
+      ? {
+          colwidth: [columnWidths[index]],
+          colspan: 1,
+          rowspan: 1,
+        }
+      : null;
+    const cell = createCell(types.cell, attrs);
 
     if (cell) {
       cells.push(cell);
     }
 
     if (withHeaderRow) {
-      const headerCell = createCell(types.header_cell, cellContent);
+      const headerCell = createCell(types.header_cell, attrs);
 
       if (headerCell) {
         headerCells.push(headerCell);

--- a/shared/editor/types/index.ts
+++ b/shared/editor/types/index.ts
@@ -35,8 +35,8 @@ export type MenuItem = {
   children?: MenuItem[];
   defaultHidden?: boolean;
   attrs?:
-    | Record<string, Primitive | Primitive[] | null>
-    | ((state: EditorState) => Record<string, Primitive | Primitive[] | null>);
+    | Record<string, Primitive | null>
+    | ((state: EditorState) => Record<string, Primitive | null>);
   visible?: boolean;
   active?: (state: EditorState) => boolean;
   appendSpace?: boolean;

--- a/shared/editor/types/index.ts
+++ b/shared/editor/types/index.ts
@@ -35,8 +35,8 @@ export type MenuItem = {
   children?: MenuItem[];
   defaultHidden?: boolean;
   attrs?:
-    | Record<string, Primitive>
-    | ((state: EditorState) => Record<string, Primitive>);
+    | Record<string, Primitive | Primitive[] | null>
+    | ((state: EditorState) => Record<string, Primitive | Primitive[] | null>);
   visible?: boolean;
   active?: (state: EditorState) => boolean;
   appendSpace?: boolean;


### PR DESCRIPTION
Flexible columns are frustrating when it comes to collaborative editing, moving this inline with other products by starting with a default width that can be resized.