### PR TITLE
Move document history to `revisions.list` API

### DIFF
--- a/app/components/EventListItem.tsx
+++ b/app/components/EventListItem.tsx
@@ -14,8 +14,9 @@ import { useLocation } from "react-router-dom";
 import styled, { css } from "styled-components";
 import EventBoundary from "@shared/components/EventBoundary";
 import { s, hover } from "@shared/styles";
+import { RevisionHelper } from "@shared/utils/RevisionHelper";
 import Document from "~/models/Document";
-import Event from "~/models/Event";
+import User from "~/models/User";
 import { Avatar, AvatarSize } from "~/components/Avatar";
 import Item, { Actions, Props as ItemProps } from "~/components/List/Item";
 import Time from "~/components/Time";
@@ -25,21 +26,47 @@ import RevisionMenu from "~/menus/RevisionMenu";
 import Logger from "~/utils/Logger";
 import { documentHistoryPath } from "~/utils/routeHelpers";
 
-type Props = {
-  document: Document;
-  event: Event<Document>;
-  latest?: boolean;
+export type RevisionEvent = {
+  name: "revisions.create";
+  latest: boolean;
 };
 
-const EventListItem = ({ event, latest, document, ...rest }: Props) => {
+export type DocumentEvent = {
+  name:
+    | "documents.publish"
+    | "documents.unpublish"
+    | "documents.archive"
+    | "documents.unarchive"
+    | "documents.delete"
+    | "documents.restore"
+    | "documents.add_user"
+    | "documents.remove_user"
+    | "documents.move";
+  user?: User;
+};
+
+export type Event = { id: string; actor: User; createdAt: string } & (
+  | RevisionEvent
+  | DocumentEvent
+);
+
+type Props = {
+  document: Document;
+  event: Event;
+};
+
+const EventListItem = ({ event, document, ...rest }: Props) => {
   const { t } = useTranslation();
   const { revisions } = useStores();
   const location = useLocation();
   const sidebarContext = useLocationSidebarContext();
+  const revisionLoadedRef = React.useRef(false);
   const opts = {
     userName: event.actor.name,
   };
   const isRevision = event.name === "revisions.create";
+  const isDerivedFromDocument =
+    event.id === RevisionHelper.latestId(document.id);
   let meta, icon, to: LocationDescriptor | undefined;
 
   const ref = React.useRef<HTMLAnchorElement>(null);
@@ -50,15 +77,20 @@ const EventListItem = ({ event, latest, document, ...rest }: Props) => {
   };
 
   const prefetchRevision = async () => {
-    if (event.name === "revisions.create" && event.modelId) {
-      await revisions.fetch(event.modelId);
+    if (
+      event.name === "revisions.create" &&
+      !isDerivedFromDocument &&
+      !revisionLoadedRef.current
+    ) {
+      await revisions.fetch(event.id, { force: true });
+      revisionLoadedRef.current = true;
     }
   };
 
   switch (event.name) {
     case "revisions.create":
       icon = <EditIcon size={16} />;
-      meta = latest ? (
+      meta = event.latest ? (
         <>
           {t("Current version")} &middot; {event.actor.name}
         </>
@@ -66,7 +98,10 @@ const EventListItem = ({ event, latest, document, ...rest }: Props) => {
         t("{{userName}} edited", opts)
       );
       to = {
-        pathname: documentHistoryPath(document, event.modelId || "latest"),
+        pathname: documentHistoryPath(
+          document,
+          isDerivedFromDocument ? "latest" : event.id
+        ),
         state: {
           sidebarContext,
           retainScrollPosition: true,
@@ -161,9 +196,9 @@ const EventListItem = ({ event, latest, document, ...rest }: Props) => {
         </Subtitle>
       }
       actions={
-        isRevision && isActive && event.modelId && !latest ? (
+        isRevision && isActive && !event.latest ? (
           <StyledEventBoundary>
-            <RevisionMenu document={document} revisionId={event.modelId} />
+            <RevisionMenu document={document} revisionId={event.id} />
           </StyledEventBoundary>
         ) : undefined
       }

--- a/app/components/PaginatedEventList.tsx
+++ b/app/components/PaginatedEventList.tsx
@@ -1,16 +1,13 @@
 import * as React from "react";
 import styled from "styled-components";
 import Document from "~/models/Document";
-import Event from "~/models/Event";
 import PaginatedList from "~/components/PaginatedList";
-import EventListItem from "./EventListItem";
+import EventListItem, { type Event } from "./EventListItem";
 
 type Props = {
-  events: Event<Document>[];
+  events: Event[];
   document: Document;
-  fetch: (
-    options: Record<string, any> | undefined
-  ) => Promise<Event<Document>[]>;
+  fetch: (options: Record<string, any> | undefined) => Promise<Event[]>;
   options?: Record<string, any>;
   heading?: React.ReactNode;
   empty?: React.ReactNode;
@@ -32,13 +29,8 @@ const PaginatedEventList = React.memo<Props>(function PaginatedEventList({
       heading={heading}
       fetch={fetch}
       options={options}
-      renderItem={(item: Event<Document>, index) => (
-        <EventListItem
-          key={item.id}
-          event={item}
-          document={document}
-          latest={index === 0}
-        />
+      renderItem={(item: Event) => (
+        <EventListItem key={item.id} event={item} document={document} />
       )}
       renderHeading={(name) => <Heading>{name}</Heading>}
       {...rest}

--- a/app/components/PaginatedList.tsx
+++ b/app/components/PaginatedList.tsx
@@ -60,7 +60,7 @@ class PaginatedList<T extends PaginatedItem> extends React.PureComponent<
   fetchCounter = 0;
 
   @observable
-  renderCount = 15;
+  renderCount = Pagination.defaultLimit;
 
   @observable
   offset = 0;
@@ -108,13 +108,16 @@ class PaginatedList<T extends PaginatedItem> extends React.PureComponent<
         ...this.props.options,
       });
 
+      if (this.offset !== 0) {
+        this.renderCount += limit;
+      }
+
       if (results && (results.length === 0 || results.length < limit)) {
         this.allowLoadMore = false;
       } else {
         this.offset += limit;
       }
 
-      this.renderCount += limit;
       this.isFetchingInitial = false;
     } catch (err) {
       this.error = err;
@@ -248,7 +251,9 @@ class PaginatedList<T extends PaginatedItem> extends React.PureComponent<
           }}
         </ArrowKeyNavigation>
         {this.allowLoadMore && (
-          <Waypoint key={this.renderCount} onEnter={this.loadMoreResults} />
+          <div style={{ height: "1px" }}>
+            <Waypoint key={this.renderCount} onEnter={this.loadMoreResults} />
+          </div>
         )}
       </>
     );

--- a/app/scenes/Document/components/History.tsx
+++ b/app/scenes/Document/components/History.tsx
@@ -106,18 +106,26 @@ function History() {
     return pageEvents;
   }, [document, revisions, events, toEvent, offset]);
 
-  const revisionEvents = document
-    ? revisions
-        .filter({ documentId: document.id })
-        .slice(0, offset.revisions + 1) // take one extra to account for realtime edits
-        .map(toEvent)
-    : [];
-  const otherEvents = document
-    ? events
-        .filter({ documentId: document.id })
-        .slice(0, offset.events)
-        .map(toEvent)
-    : [];
+  const revisionEvents = React.useMemo(
+    () =>
+      document
+        ? revisions
+            .filter({ documentId: document.id })
+            .slice(0, offset.revisions + 1) // take one extra to account for realtime edits
+            .map(toEvent)
+        : [],
+    [document, revisions, offset.revisions, toEvent]
+  );
+  const otherEvents = React.useMemo(
+    () =>
+      document
+        ? events
+            .filter({ documentId: document.id })
+            .slice(0, offset.events)
+            .map(toEvent)
+        : [],
+    [document, events, offset.events, toEvent]
+  );
 
   const latestRevision = revisionEvents[0];
 
@@ -135,10 +143,9 @@ function History() {
     }
   }
 
-  const mergedEvents = orderBy(
-    [...revisionEvents, ...otherEvents],
-    "createdAt",
-    "desc"
+  const mergedEvents = React.useMemo(
+    () => orderBy([...revisionEvents, ...otherEvents], "createdAt", "desc"),
+    [revisionEvents, otherEvents]
   );
 
   const onCloseHistory = React.useCallback(() => {

--- a/app/scenes/Document/components/History.tsx
+++ b/app/scenes/Document/components/History.tsx
@@ -1,12 +1,20 @@
+import orderBy from "lodash/orderBy";
 import { observer } from "mobx-react";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { useHistory, useRouteMatch } from "react-router-dom";
 import styled from "styled-components";
+import { Pagination } from "@shared/constants";
 import { RevisionHelper } from "@shared/utils/RevisionHelper";
 import Document from "~/models/Document";
-import Event from "~/models/Event";
+import EventModel from "~/models/Event";
+import Revision from "~/models/Revision";
 import Empty from "~/components/Empty";
+import {
+  DocumentEvent,
+  RevisionEvent,
+  type Event,
+} from "~/components/EventListItem";
 import PaginatedEventList from "~/components/PaginatedEventList";
 import useKeyDown from "~/hooks/useKeyDown";
 import { useLocationSidebarContext } from "~/hooks/useLocationSidebarContext";
@@ -14,21 +22,126 @@ import useStores from "~/hooks/useStores";
 import { documentPath } from "~/utils/routeHelpers";
 import Sidebar from "./SidebarLayout";
 
-const EMPTY_ARRAY: Event<Document>[] = [];
+const DocumentEvents = [
+  "documents.publish",
+  "documents.unpublish",
+  "documents.archive",
+  "documents.unarchive",
+  "documents.delete",
+  "documents.restore",
+  "documents.add_user",
+  "documents.remove_user",
+  "documents.move",
+];
 
 function History() {
-  const { events, documents } = useStores();
+  const { events, documents, revisions } = useStores();
   const { t } = useTranslation();
   const match = useRouteMatch<{ documentSlug: string }>();
   const history = useHistory();
   const sidebarContext = useLocationSidebarContext();
   const document = documents.getByUrl(match.params.documentSlug);
 
-  const eventsInDocument = document
-    ? events.filter({ documentId: document.id })
-    : EMPTY_ARRAY;
+  const [, setForceRender] = React.useState(0);
+  const offset = React.useMemo(() => ({ revisions: 0, events: 0 }), []);
 
-  const onCloseHistory = () => {
+  const toEvent = React.useCallback(
+    (data: Revision | EventModel<Document>): Event => {
+      if (data instanceof Revision) {
+        return {
+          id: data.id,
+          name: "revisions.create",
+          actor: data.createdBy,
+          createdAt: data.createdAt,
+          latest: false,
+        } satisfies Event;
+      }
+
+      return {
+        id: data.id,
+        name: data.name as DocumentEvent["name"],
+        actor: data.actor,
+        user: data.user,
+        createdAt: data.createdAt,
+      } satisfies Event;
+    },
+    []
+  );
+
+  const fetchHistory = React.useCallback(async () => {
+    if (!document) {
+      return [];
+    }
+
+    const [revisionsArr, eventsArr] = await Promise.all([
+      revisions.fetchPage({
+        documentId: document.id,
+        offset: offset.revisions,
+        limit: Pagination.defaultLimit,
+      }),
+      events.fetchPage({
+        events: DocumentEvents,
+        documentId: document.id,
+        offset: offset.events,
+        limit: Pagination.defaultLimit,
+      }),
+    ]);
+
+    const pageEvents = orderBy(
+      [...revisionsArr, ...eventsArr].map(toEvent),
+      "createdAt",
+      "desc"
+    ).slice(0, Pagination.defaultLimit);
+
+    const revisionsCount = pageEvents.filter(
+      (event) => event.name === "revisions.create"
+    ).length;
+
+    offset.revisions += revisionsCount;
+    offset.events += pageEvents.length - revisionsCount;
+
+    // needed to re-render after mobx store and offset is updated
+    setForceRender((s) => ++s);
+
+    return pageEvents;
+  }, [document, revisions, events, toEvent, offset]);
+
+  const revisionEvents = document
+    ? revisions
+        .filter({ documentId: document.id })
+        .slice(0, offset.revisions + 1) // take one extra to account for realtime edits
+        .map(toEvent)
+    : [];
+  const otherEvents = document
+    ? events
+        .filter({ documentId: document.id })
+        .slice(0, offset.events)
+        .map(toEvent)
+    : [];
+
+  const latestRevision = revisionEvents[0];
+
+  if (latestRevision && document) {
+    if (latestRevision.createdAt !== document.updatedAt) {
+      revisionEvents.unshift({
+        id: RevisionHelper.latestId(document.id),
+        name: "revisions.create",
+        createdAt: document.updatedAt,
+        actor: document.updatedBy!,
+        latest: true,
+      });
+    } else {
+      (latestRevision as RevisionEvent).latest = true;
+    }
+  }
+
+  const mergedEvents = orderBy(
+    [...revisionEvents, ...otherEvents],
+    "createdAt",
+    "desc"
+  );
+
+  const onCloseHistory = React.useCallback(() => {
     if (document) {
       history.push({
         pathname: documentPath(document),
@@ -37,30 +150,7 @@ function History() {
     } else {
       history.goBack();
     }
-  };
-
-  const items = React.useMemo(() => {
-    if (
-      eventsInDocument[0] &&
-      document &&
-      eventsInDocument[0].createdAt !== document.updatedAt
-    ) {
-      eventsInDocument.unshift(
-        new Event(
-          {
-            id: RevisionHelper.latestId(document.id),
-            name: "revisions.create",
-            documentId: document.id,
-            createdAt: document.updatedAt,
-            actor: document.updatedBy,
-          },
-          events
-        )
-      );
-    }
-
-    return eventsInDocument;
-  }, [eventsInDocument, events, document]);
+  }, [history, document, sidebarContext]);
 
   useKeyDown("Escape", onCloseHistory);
 
@@ -69,11 +159,8 @@ function History() {
       {document ? (
         <PaginatedEventList
           aria-label={t("History")}
-          fetch={events.fetchPage}
-          events={items}
-          options={{
-            documentId: document.id,
-          }}
+          fetch={fetchHistory}
+          events={mergedEvents}
           document={document}
           empty={<EmptyHistory>{t("No history yet")}</EmptyHistory>}
         />

--- a/app/stores/RevisionsStore.ts
+++ b/app/stores/RevisionsStore.ts
@@ -58,7 +58,7 @@ export default class RevisionsStore extends Store<Revision> {
 
   @action
   fetchPage = async (
-    options: PaginationParams | undefined
+    options: { documentId: string } & (PaginationParams | undefined)
   ): Promise<Revision[]> => {
     this.isFetching = true;
 

--- a/server/routes/api/events/events.ts
+++ b/server/routes/api/events/events.ts
@@ -1,4 +1,5 @@
 import Router from "koa-router";
+import intersection from "lodash/intersection";
 import { Op, WhereOptions } from "sequelize";
 import { EventHelper } from "@shared/utils/EventHelper";
 import auth from "@server/middlewares/authentication";
@@ -34,13 +35,15 @@ router.post(
       teamId: user.teamId,
     };
 
-    if (events?.length) {
-      where.name = events;
-    } else if (auditLog) {
+    if (auditLog) {
       authorize(user, "audit", user.team);
-      where.name = EventHelper.AUDIT_EVENTS;
+      where.name = events
+        ? intersection(EventHelper.AUDIT_EVENTS, events)
+        : EventHelper.AUDIT_EVENTS;
     } else {
-      where.name = EventHelper.ACTIVITY_EVENTS;
+      where.name = events
+        ? intersection(EventHelper.ACTIVITY_EVENTS, events)
+        : EventHelper.ACTIVITY_EVENTS;
     }
 
     if (name && (where.name as string[]).includes(name)) {

--- a/server/routes/api/events/events.ts
+++ b/server/routes/api/events/events.ts
@@ -20,6 +20,7 @@ router.post(
   async (ctx: APIContext<T.EventsListReq>) => {
     const { user } = ctx.state.auth;
     const {
+      name,
       events,
       auditLog,
       actorId,
@@ -32,6 +33,10 @@ router.post(
     let where: WhereOptions<Event> = {
       teamId: user.teamId,
     };
+
+    if (name && (where.name as string[]).includes(name)) {
+      where.name = name;
+    }
 
     if (events?.length) {
       where.name = events;

--- a/server/routes/api/events/events.ts
+++ b/server/routes/api/events/events.ts
@@ -34,22 +34,17 @@ router.post(
       teamId: user.teamId,
     };
 
-    if (name && (where.name as string[]).includes(name)) {
-      where.name = name;
-    }
-
     if (events?.length) {
       where.name = events;
+    } else if (auditLog) {
+      authorize(user, "audit", user.team);
+      where.name = EventHelper.AUDIT_EVENTS;
     } else {
       where.name = EventHelper.ACTIVITY_EVENTS;
     }
 
-    if (auditLog) {
-      authorize(user, "audit", user.team);
-
-      if (!where.name) {
-        where.name = EventHelper.AUDIT_EVENTS;
-      }
+    if (name && (where.name as string[]).includes(name)) {
+      where.name = name;
     }
 
     if (actorId) {

--- a/server/routes/api/events/schema.ts
+++ b/server/routes/api/events/schema.ts
@@ -1,8 +1,19 @@
 import { z } from "zod";
+import { EventHelper } from "@shared/utils/EventHelper";
 import { BaseSchema } from "@server/routes/api/schema";
 
 export const EventsListSchema = BaseSchema.extend({
   body: z.object({
+    /** Events to retrieve */
+    events: z
+      .array(
+        z.union([
+          z.enum(EventHelper.ACTIVITY_EVENTS),
+          z.enum(EventHelper.AUDIT_EVENTS),
+        ])
+      )
+      .optional(),
+
     /** Id of the user who performed the action */
     actorId: z.string().uuid().optional(),
 
@@ -14,9 +25,6 @@ export const EventsListSchema = BaseSchema.extend({
 
     /** Whether to include audit events */
     auditLog: z.boolean().default(false),
-
-    /** Name of the event to retrieve */
-    name: z.string().optional(),
 
     /** The attribute to sort the events by */
     sort: z

--- a/server/routes/api/events/schema.ts
+++ b/server/routes/api/events/schema.ts
@@ -26,7 +26,7 @@ export const EventsListSchema = BaseSchema.extend({
     /** Whether to include audit events */
     auditLog: z.boolean().default(false),
 
-    /** @deprecated, use 'events' instead
+    /** @deprecated, use 'events' parameter instead
      * Name of the event to retrieve
      */
     name: z.string().optional(),

--- a/server/routes/api/events/schema.ts
+++ b/server/routes/api/events/schema.ts
@@ -26,6 +26,11 @@ export const EventsListSchema = BaseSchema.extend({
     /** Whether to include audit events */
     auditLog: z.boolean().default(false),
 
+    /** @deprecated, use 'events' instead
+     * Name of the event to retrieve
+     */
+    name: z.string().optional(),
+
     /** The attribute to sort the events by */
     sort: z
       .string()

--- a/shared/utils/EventHelper.ts
+++ b/shared/utils/EventHelper.ts
@@ -1,5 +1,5 @@
 export class EventHelper {
-  public static readonly ACTIVITY_EVENTS = [
+  public static ACTIVITY_EVENTS = [
     "collections.create",
     "collections.delete",
     "collections.move",
@@ -20,9 +20,9 @@ export class EventHelper {
     "users.create",
     "users.demote",
     "userMemberships.update",
-  ];
+  ] as const;
 
-  public static readonly AUDIT_EVENTS = [
+  public static AUDIT_EVENTS = [
     "api_keys.create",
     "api_keys.delete",
     "authenticationProviders.update",
@@ -73,5 +73,5 @@ export class EventHelper {
     "fileOperations.delete",
     "webhookSubscriptions.create",
     "webhookSubscriptions.delete",
-  ];
+  ] as const;
 }


### PR DESCRIPTION
Closes #8424 

This doesn't fix #8403 - it needs a bit more work to consolidate local document state.

I also noticed that document restore doesn't create a `documents.restore` event which sometimes messes up the history - will create a separate PR.