### PR TITLE
Revert "Move document history to `revisions.list` API"

### DIFF
--- a/app/components/PaginatedEventList.tsx
+++ b/app/components/PaginatedEventList.tsx
@@ -1,13 +1,16 @@
 import * as React from "react";
 import styled from "styled-components";
 import Document from "~/models/Document";
+import Event from "~/models/Event";
 import PaginatedList from "~/components/PaginatedList";
-import EventListItem, { type Event } from "./EventListItem";
+import EventListItem from "./EventListItem";
 
 type Props = {
-  events: Event[];
+  events: Event<Document>[];
   document: Document;
-  fetch: (options: Record<string, any> | undefined) => Promise<Event[]>;
+  fetch: (
+    options: Record<string, any> | undefined
+  ) => Promise<Event<Document>[]>;
   options?: Record<string, any>;
   heading?: React.ReactNode;
   empty?: React.ReactNode;
@@ -29,8 +32,13 @@ const PaginatedEventList = React.memo<Props>(function PaginatedEventList({
       heading={heading}
       fetch={fetch}
       options={options}
-      renderItem={(item: Event) => (
-        <EventListItem key={item.id} event={item} document={document} />
+      renderItem={(item: Event<Document>, index) => (
+        <EventListItem
+          key={item.id}
+          event={item}
+          document={document}
+          latest={index === 0}
+        />
       )}
       renderHeading={(name) => <Heading>{name}</Heading>}
       {...rest}

--- a/app/components/PaginatedList.tsx
+++ b/app/components/PaginatedList.tsx
@@ -60,7 +60,7 @@ class PaginatedList<T extends PaginatedItem> extends React.PureComponent<
   fetchCounter = 0;
 
   @observable
-  renderCount = Pagination.defaultLimit;
+  renderCount = 15;
 
   @observable
   offset = 0;
@@ -108,16 +108,13 @@ class PaginatedList<T extends PaginatedItem> extends React.PureComponent<
         ...this.props.options,
       });
 
-      if (this.offset !== 0) {
-        this.renderCount += limit;
-      }
-
       if (results && (results.length === 0 || results.length < limit)) {
         this.allowLoadMore = false;
       } else {
         this.offset += limit;
       }
 
+      this.renderCount += limit;
       this.isFetchingInitial = false;
     } catch (err) {
       this.error = err;
@@ -251,9 +248,7 @@ class PaginatedList<T extends PaginatedItem> extends React.PureComponent<
           }}
         </ArrowKeyNavigation>
         {this.allowLoadMore && (
-          <div style={{ height: "1px" }}>
-            <Waypoint key={this.renderCount} onEnter={this.loadMoreResults} />
-          </div>
+          <Waypoint key={this.renderCount} onEnter={this.loadMoreResults} />
         )}
       </>
     );

--- a/app/scenes/Document/components/History.tsx
+++ b/app/scenes/Document/components/History.tsx
@@ -1,20 +1,12 @@
-import orderBy from "lodash/orderBy";
 import { observer } from "mobx-react";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { useHistory, useRouteMatch } from "react-router-dom";
 import styled from "styled-components";
-import { Pagination } from "@shared/constants";
 import { RevisionHelper } from "@shared/utils/RevisionHelper";
 import Document from "~/models/Document";
-import EventModel from "~/models/Event";
-import Revision from "~/models/Revision";
+import Event from "~/models/Event";
 import Empty from "~/components/Empty";
-import {
-  DocumentEvent,
-  RevisionEvent,
-  type Event,
-} from "~/components/EventListItem";
 import PaginatedEventList from "~/components/PaginatedEventList";
 import useKeyDown from "~/hooks/useKeyDown";
 import { useLocationSidebarContext } from "~/hooks/useLocationSidebarContext";
@@ -22,133 +14,21 @@ import useStores from "~/hooks/useStores";
 import { documentPath } from "~/utils/routeHelpers";
 import Sidebar from "./SidebarLayout";
 
-const DocumentEvents = [
-  "documents.publish",
-  "documents.unpublish",
-  "documents.archive",
-  "documents.unarchive",
-  "documents.delete",
-  "documents.restore",
-  "documents.add_user",
-  "documents.remove_user",
-  "documents.move",
-];
+const EMPTY_ARRAY: Event<Document>[] = [];
 
 function History() {
-  const { events, documents, revisions } = useStores();
+  const { events, documents } = useStores();
   const { t } = useTranslation();
   const match = useRouteMatch<{ documentSlug: string }>();
   const history = useHistory();
   const sidebarContext = useLocationSidebarContext();
   const document = documents.getByUrl(match.params.documentSlug);
 
-  const [, setForceRender] = React.useState(0);
-  const offset = React.useMemo(() => ({ revisions: 0, events: 0 }), []);
+  const eventsInDocument = document
+    ? events.filter({ documentId: document.id })
+    : EMPTY_ARRAY;
 
-  const toEvent = React.useCallback(
-    (data: Revision | EventModel<Document>): Event => {
-      if (data instanceof Revision) {
-        return {
-          id: data.id,
-          name: "revisions.create",
-          actor: data.createdBy,
-          createdAt: data.createdAt,
-          latest: false,
-        } satisfies Event;
-      }
-
-      return {
-        id: data.id,
-        name: data.name as DocumentEvent["name"],
-        actor: data.actor,
-        user: data.user,
-        createdAt: data.createdAt,
-      } satisfies Event;
-    },
-    []
-  );
-
-  const fetchHistory = React.useCallback(async () => {
-    if (!document) {
-      return [];
-    }
-
-    const [revisionsArr, eventsArr] = await Promise.all([
-      revisions.fetchPage({
-        documentId: document.id,
-        offset: offset.revisions,
-        limit: Pagination.defaultLimit,
-      }),
-      events.fetchPage({
-        events: DocumentEvents,
-        documentId: document.id,
-        offset: offset.events,
-        limit: Pagination.defaultLimit,
-      }),
-    ]);
-
-    const pageEvents = orderBy(
-      [...revisionsArr, ...eventsArr].map(toEvent),
-      "createdAt",
-      "desc"
-    ).slice(0, Pagination.defaultLimit);
-
-    const revisionsCount = pageEvents.filter(
-      (event) => event.name === "revisions.create"
-    ).length;
-
-    offset.revisions += revisionsCount;
-    offset.events += pageEvents.length - revisionsCount;
-
-    // needed to re-render after mobx store and offset is updated
-    setForceRender((s) => ++s);
-
-    return pageEvents;
-  }, [document, revisions, events, toEvent, offset]);
-
-  const revisionEvents = React.useMemo(
-    () =>
-      document
-        ? revisions
-            .filter({ documentId: document.id })
-            .slice(0, offset.revisions + 1) // take one extra to account for realtime edits
-            .map(toEvent)
-        : [],
-    [document, revisions, offset.revisions, toEvent]
-  );
-  const otherEvents = React.useMemo(
-    () =>
-      document
-        ? events
-            .filter({ documentId: document.id })
-            .slice(0, offset.events)
-            .map(toEvent)
-        : [],
-    [document, events, offset.events, toEvent]
-  );
-
-  const latestRevision = revisionEvents[0];
-
-  if (latestRevision && document) {
-    if (latestRevision.createdAt !== document.updatedAt) {
-      revisionEvents.unshift({
-        id: RevisionHelper.latestId(document.id),
-        name: "revisions.create",
-        createdAt: document.updatedAt,
-        actor: document.updatedBy!,
-        latest: true,
-      });
-    } else {
-      (latestRevision as RevisionEvent).latest = true;
-    }
-  }
-
-  const mergedEvents = React.useMemo(
-    () => orderBy([...revisionEvents, ...otherEvents], "createdAt", "desc"),
-    [revisionEvents, otherEvents]
-  );
-
-  const onCloseHistory = React.useCallback(() => {
+  const onCloseHistory = () => {
     if (document) {
       history.push({
         pathname: documentPath(document),
@@ -157,7 +37,30 @@ function History() {
     } else {
       history.goBack();
     }
-  }, [history, document, sidebarContext]);
+  };
+
+  const items = React.useMemo(() => {
+    if (
+      eventsInDocument[0] &&
+      document &&
+      eventsInDocument[0].createdAt !== document.updatedAt
+    ) {
+      eventsInDocument.unshift(
+        new Event(
+          {
+            id: RevisionHelper.latestId(document.id),
+            name: "revisions.create",
+            documentId: document.id,
+            createdAt: document.updatedAt,
+            actor: document.updatedBy,
+          },
+          events
+        )
+      );
+    }
+
+    return eventsInDocument;
+  }, [eventsInDocument, events, document]);
 
   useKeyDown("Escape", onCloseHistory);
 
@@ -166,8 +69,11 @@ function History() {
       {document ? (
         <PaginatedEventList
           aria-label={t("History")}
-          fetch={fetchHistory}
-          events={mergedEvents}
+          fetch={events.fetchPage}
+          events={items}
+          options={{
+            documentId: document.id,
+          }}
           document={document}
           empty={<EmptyHistory>{t("No history yet")}</EmptyHistory>}
         />

--- a/app/stores/RevisionsStore.ts
+++ b/app/stores/RevisionsStore.ts
@@ -58,7 +58,7 @@ export default class RevisionsStore extends Store<Revision> {
 
   @action
   fetchPage = async (
-    options: { documentId: string } & (PaginationParams | undefined)
+    options: PaginationParams | undefined
   ): Promise<Revision[]> => {
     this.isFetching = true;
 

--- a/server/routes/api/events/events.test.ts
+++ b/server/routes/api/events/events.test.ts
@@ -228,45 +228,6 @@ describe("#events.list", () => {
     expect(body.data[0].id).toEqual(event.id);
   });
 
-  it("should allow filtering by events param", async () => {
-    const user = await buildUser();
-    const admin = await buildAdmin({ teamId: user.teamId });
-    const collection = await buildCollection({
-      userId: user.id,
-      teamId: user.teamId,
-    });
-    const document = await buildDocument({
-      userId: user.id,
-      collectionId: collection.id,
-      teamId: user.teamId,
-    });
-    // audit event
-    await buildEvent({
-      name: "users.promote",
-      teamId: user.teamId,
-      actorId: admin.id,
-      userId: user.id,
-    });
-    // event viewable in activity stream
-    const event = await buildEvent({
-      name: "documents.publish",
-      collectionId: collection.id,
-      documentId: document.id,
-      teamId: user.teamId,
-      actorId: user.id,
-    });
-    const res = await server.post("/api/events.list", {
-      body: {
-        token: user.getJwtToken(),
-        events: ["documents.publish"],
-      },
-    });
-    const body = await res.json();
-    expect(res.status).toEqual(200);
-    expect(body.data.length).toEqual(1);
-    expect(body.data[0].id).toEqual(event.id);
-  });
-
   it("should return events with deleted actors", async () => {
     const user = await buildUser();
     const admin = await buildAdmin({ teamId: user.teamId });

--- a/server/routes/api/events/schema.ts
+++ b/server/routes/api/events/schema.ts
@@ -1,19 +1,8 @@
 import { z } from "zod";
-import { EventHelper } from "@shared/utils/EventHelper";
 import { BaseSchema } from "@server/routes/api/schema";
 
 export const EventsListSchema = BaseSchema.extend({
   body: z.object({
-    /** Events to retrieve */
-    events: z
-      .array(
-        z.union([
-          z.enum(EventHelper.ACTIVITY_EVENTS),
-          z.enum(EventHelper.AUDIT_EVENTS),
-        ])
-      )
-      .optional(),
-
     /** Id of the user who performed the action */
     actorId: z.string().uuid().optional(),
 
@@ -26,9 +15,7 @@ export const EventsListSchema = BaseSchema.extend({
     /** Whether to include audit events */
     auditLog: z.boolean().default(false),
 
-    /** @deprecated, use 'events' parameter instead
-     * Name of the event to retrieve
-     */
+    /** Name of the event to retrieve */
     name: z.string().optional(),
 
     /** The attribute to sort the events by */

--- a/shared/utils/EventHelper.ts
+++ b/shared/utils/EventHelper.ts
@@ -1,5 +1,5 @@
 export class EventHelper {
-  public static ACTIVITY_EVENTS = [
+  public static readonly ACTIVITY_EVENTS = [
     "collections.create",
     "collections.delete",
     "collections.move",
@@ -20,9 +20,9 @@ export class EventHelper {
     "users.create",
     "users.demote",
     "userMemberships.update",
-  ] as const;
+  ];
 
-  public static AUDIT_EVENTS = [
+  public static readonly AUDIT_EVENTS = [
     "api_keys.create",
     "api_keys.delete",
     "authenticationProviders.update",
@@ -73,5 +73,5 @@ export class EventHelper {
     "fileOperations.delete",
     "webhookSubscriptions.create",
     "webhookSubscriptions.delete",
-  ] as const;
+  ];
 }


### PR DESCRIPTION
Reverts outline/outline#8458 – some bugs here created duplicate headings in sidebar, and duplicate "latest" entries