### PR TITLE
Improvements to history styling

### DIFF
--- a/app/components/EventListItem.tsx
+++ b/app/components/EventListItem.tsx
@@ -7,6 +7,9 @@ import {
   PublishIcon,
   MoveIcon,
   UnpublishIcon,
+  RestoreIcon,
+  UserIcon,
+  CrossIcon,
 } from "outline-icons";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
@@ -18,13 +21,14 @@ import { RevisionHelper } from "@shared/utils/RevisionHelper";
 import Document from "~/models/Document";
 import User from "~/models/User";
 import { Avatar, AvatarSize } from "~/components/Avatar";
-import Item, { Actions, Props as ItemProps } from "~/components/List/Item";
+import Item, { Actions } from "~/components/List/Item";
 import Time from "~/components/Time";
 import { useLocationSidebarContext } from "~/hooks/useLocationSidebarContext";
 import useStores from "~/hooks/useStores";
 import RevisionMenu from "~/menus/RevisionMenu";
 import Logger from "~/utils/Logger";
 import { documentHistoryPath } from "~/utils/routeHelpers";
+import Text from "./Text";
 
 export type RevisionEvent = {
   name: "revisions.create";
@@ -42,7 +46,7 @@ export type DocumentEvent = {
     | "documents.add_user"
     | "documents.remove_user"
     | "documents.move";
-  user?: User;
+  userId: string;
 };
 
 export type Event = { id: string; actor: User; createdAt: string } & (
@@ -57,7 +61,8 @@ type Props = {
 
 const EventListItem = ({ event, document, ...rest }: Props) => {
   const { t } = useTranslation();
-  const { revisions } = useStores();
+  const { revisions, users } = useStores();
+  const user = "userId" in event ? users.get(event.userId) : null;
   const location = useLocation();
   const sidebarContext = useLocationSidebarContext();
   const revisionLoadedRef = React.useRef(false);
@@ -110,47 +115,51 @@ const EventListItem = ({ event, document, ...rest }: Props) => {
       break;
 
     case "documents.archive":
-      icon = <ArchiveIcon size={16} />;
+      icon = <ArchiveIcon />;
       meta = t("{{userName}} archived", opts);
       break;
 
     case "documents.unarchive":
+      icon = <RestoreIcon />;
       meta = t("{{userName}} restored", opts);
       break;
 
     case "documents.delete":
-      icon = <TrashIcon size={16} />;
+      icon = <TrashIcon />;
       meta = t("{{userName}} deleted", opts);
       break;
     case "documents.add_user":
+      icon = <UserIcon />;
       meta = t("{{userName}} added {{addedUserName}}", {
         ...opts,
-        addedUserName: event.user?.name ?? t("a user"),
+        addedUserName: user?.name ?? t("a user"),
       });
       break;
     case "documents.remove_user":
+      icon = <CrossIcon />;
       meta = t("{{userName}} removed {{removedUserName}}", {
         ...opts,
-        removedUserName: event.user?.name ?? t("a user"),
+        removedUserName: user?.name ?? t("a user"),
       });
       break;
 
     case "documents.restore":
+      icon = <RestoreIcon />;
       meta = t("{{userName}} moved from trash", opts);
       break;
 
     case "documents.publish":
-      icon = <PublishIcon size={16} />;
+      icon = <PublishIcon />;
       meta = t("{{userName}} published", opts);
       break;
 
     case "documents.unpublish":
-      icon = <UnpublishIcon size={16} />;
+      icon = <UnpublishIcon />;
       meta = t("{{userName}} unpublished", opts);
       break;
 
     case "documents.move":
-      icon = <MoveIcon size={16} />;
+      icon = <MoveIcon />;
       meta = t("{{userName}} moved", opts);
       break;
 
@@ -171,8 +180,8 @@ const EventListItem = ({ event, document, ...rest }: Props) => {
     to = undefined;
   }
 
-  return (
-    <BaseItem
+  return event.name === "revisions.create" ? (
+    <RevisionItem
       small
       exact
       to={to}
@@ -189,12 +198,7 @@ const EventListItem = ({ event, document, ...rest }: Props) => {
         />
       }
       image={<Avatar model={event.actor} size={AvatarSize.Large} />}
-      subtitle={
-        <Subtitle>
-          {icon}
-          {meta}
-        </Subtitle>
-      }
+      subtitle={meta}
       actions={
         isRevision && isActive && !event.latest ? (
           <StyledEventBoundary>
@@ -206,63 +210,100 @@ const EventListItem = ({ event, document, ...rest }: Props) => {
       ref={ref}
       {...rest}
     />
+  ) : (
+    <EventItem>
+      <IconWrapper size="xsmall" type="secondary">
+        {icon}
+      </IconWrapper>
+      <Text size="xsmall" type="secondary">
+        {meta} &middot;{" "}
+        <Time dateTime={event.createdAt} relative shorten addSuffix />
+      </Text>
+    </EventItem>
   );
 };
 
-const BaseItem = React.forwardRef(function _BaseItem(
-  { to, ...rest }: ItemProps,
-  ref?: React.Ref<HTMLAnchorElement>
-) {
-  return <ListItem to={to} ref={ref} {...rest} />;
-});
+const lineStyle = css`
+  &::before {
+    content: "";
+    display: block;
+    position: absolute;
+    top: -8px;
+    left: 22px;
+    width: 1px;
+    height: calc(50% - 14px + 8px);
+    background: ${s("divider")};
+    mix-blend-mode: multiply;
+    z-index: 1;
+  }
+
+  &:first-child::before {
+    display: none;
+  }
+
+  &:nth-child(2)::before {
+    display: none;
+  }
+
+  &::after {
+    content: "";
+    display: block;
+    position: absolute;
+    top: calc(50% + 14px);
+    left: 22px;
+    width: 1px;
+    height: calc(50% - 14px);
+    background: ${s("divider")};
+    mix-blend-mode: multiply;
+    z-index: 1;
+  }
+
+  &:last-child::after {
+    display: none;
+  }
+
+  h3 + &::before {
+    display: none;
+  }
+`;
+
+const IconWrapper = styled(Text)`
+  height: 24px;
+`;
+
+const EventItem = styled.li`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  list-style: none;
+  margin: 8px 0;
+  padding: 4px 10px;
+  white-space: nowrap;
+  position: relative;
+
+  time {
+    white-space: nowrap;
+  }
+
+  svg {
+    flex-shrink: 0;
+  }
+
+  ${lineStyle}
+`;
 
 const StyledEventBoundary = styled(EventBoundary)`
   height: 24px;
 `;
 
-const Subtitle = styled.span`
-  svg {
-    margin: -3px;
-    margin-right: 2px;
-  }
-`;
-
-const ItemStyle = css`
+const RevisionItem = styled(Item)`
   border: 0;
   position: relative;
   margin: 8px 0;
   padding: 8px;
   border-radius: 8px;
 
-  img {
-    border-color: transparent;
-  }
-
-  &::before {
-    content: "";
-    display: block;
-    position: absolute;
-    top: -4px;
-    left: 23px;
-    width: 2px;
-    height: calc(100% + 8px);
-    background: ${s("textSecondary")};
-    opacity: 0.25;
-  }
-
-  &:nth-child(2)::before {
-    height: 50%;
-    top: auto;
-    bottom: -4px;
-  }
-
-  &:last-child::before {
-    height: 50%;
-  }
-
-  &:first-child:last-child::before {
-    display: none;
-  }
+  ${lineStyle}
 
   ${Actions} {
     opacity: 0.5;
@@ -271,10 +312,6 @@ const ItemStyle = css`
       opacity: 1;
     }
   }
-`;
-
-const ListItem = styled(Item)`
-  ${ItemStyle}
 `;
 
 export default observer(EventListItem);

--- a/app/scenes/Document/components/History.tsx
+++ b/app/scenes/Document/components/History.tsx
@@ -61,7 +61,7 @@ function History() {
         id: data.id,
         name: data.name as DocumentEvent["name"],
         actor: data.actor,
-        user: data.user,
+        userId: data.userId,
         createdAt: data.createdAt,
       } satisfies Event;
     },


### PR DESCRIPTION
Separates the clickable revision history events from the metadata events which cannot be navigated, been meaning to do this for a long time.

| Before | After |
|--------|--------|
|  ![image](https://github.com/user-attachments/assets/e623ae9d-95d0-421a-bbc3-e08b19f78c69) | ![image](https://github.com/user-attachments/assets/0113aaaa-bbd6-4b92-9911-65dd7bcb5412) | 

Blocked by https://github.com/outline/outline/pull/8497