### PR TITLE
fix: Update local storage when creating/deleting pins

### DIFF
--- a/app/hooks/usePinnedDocuments.ts
+++ b/app/hooks/usePinnedDocuments.ts
@@ -2,13 +2,14 @@ import * as React from "react";
 import usePersistedState from "~/hooks/usePersistedState";
 import useStores from "./useStores";
 
-export function usePinnedDocuments(
-  urlId: "home" | string,
-  collectionId?: string
-) {
+type UrlId = "home" | string;
+
+export const pinsCacheKey = (urlId: UrlId) => `pins-${urlId}`;
+
+export function usePinnedDocuments(urlId: UrlId, collectionId?: string) {
   const { pins } = useStores();
   const [pinsCacheCount, setPinsCacheCount] = usePersistedState<number>(
-    `pins-${urlId}`,
+    pinsCacheKey(urlId),
     0
   );
 

--- a/app/models/Document.ts
+++ b/app/models/Document.ts
@@ -27,6 +27,7 @@ import { client } from "~/utils/ApiClient";
 import { settingsPath } from "~/utils/routeHelpers";
 import Collection from "./Collection";
 import Notification from "./Notification";
+import Pin from "./Pin";
 import View from "./View";
 import ArchivableModel from "./base/ArchivableModel";
 import Field from "./decorators/Field";
@@ -465,11 +466,16 @@ export default class Document extends ArchivableModel implements Searchable {
   };
 
   @action
-  pin = (collectionId?: string | null) =>
-    this.store.rootStore.pins.create({
+  pin = async (collectionId?: string | null) => {
+    const pin = new Pin({}, this.store.rootStore.pins);
+
+    await pin.save({
       documentId: this.id,
       ...(collectionId ? { collectionId } : {}),
     });
+
+    return pin;
+  };
 
   @action
   unpin = (collectionId?: string) => {

--- a/app/models/Pin.ts
+++ b/app/models/Pin.ts
@@ -48,9 +48,8 @@ class Pin extends Model {
       return;
     }
 
-    const urlId = collection.path.replace("/collection/", "");
     setPersistedState(
-      pinsCacheKey(urlId),
+      pinsCacheKey(collection.urlId),
       pins.inCollection(collection.id).length
     );
   }

--- a/app/models/Pin.ts
+++ b/app/models/Pin.ts
@@ -43,9 +43,7 @@ class Pin extends Model {
       return;
     }
 
-    const collection = model.store.rootStore.collections.get(
-      model.collectionId
-    );
+    const collection = pins.rootStore.collections.get(model.collectionId);
     if (!collection) {
       return;
     }

--- a/app/models/Pin.ts
+++ b/app/models/Pin.ts
@@ -1,8 +1,12 @@
 import { observable } from "mobx";
+import PinsStore from "~/stores/PinsStore";
+import { setPersistedState } from "~/hooks/usePersistedState";
+import { pinsCacheKey } from "~/hooks/usePinnedDocuments";
 import Collection from "./Collection";
 import Document from "./Document";
 import Model from "./base/Model";
 import Field from "./decorators/Field";
+import { AfterCreate, AfterDelete, AfterRemove } from "./decorators/Lifecycle";
 import Relation from "./decorators/Relation";
 
 class Pin extends Model {
@@ -26,6 +30,32 @@ class Pin extends Model {
   @observable
   @Field
   index: string;
+
+  @AfterCreate
+  @AfterDelete
+  @AfterRemove
+  static updateCache(model: Pin) {
+    const pins = model.store as PinsStore;
+
+    const isHome = !model.collectionId;
+    if (isHome) {
+      setPersistedState(pinsCacheKey("home"), pins.home.length);
+      return;
+    }
+
+    const collection = model.store.rootStore.collections.get(
+      model.collectionId
+    );
+    if (!collection) {
+      return;
+    }
+
+    const urlId = collection.path.replace("/collection/", "");
+    setPersistedState(
+      pinsCacheKey(urlId),
+      pins.inCollection(collection.id).length
+    );
+  }
 }
 
 export default Pin;

--- a/app/scenes/Collection/index.tsx
+++ b/app/scenes/Collection/index.tsx
@@ -73,10 +73,13 @@ const CollectionScene = observer(function _CollectionScene() {
   const sidebarContext = useLocationSidebarContext();
 
   const id = params.id || "";
+  const urlId = id.split("-").pop() ?? "";
+
   const collection: Collection | null | undefined =
     collections.getByUrl(id) || collections.get(id);
   const can = usePolicy(collection);
-  const { pins, count } = usePinnedDocuments(id, collection?.id);
+
+  const { pins, count } = usePinnedDocuments(urlId, collection?.id);
   const [collectionTab, setCollectionTab] = usePersistedState<CollectionPath>(
     `collection-tab:${collection?.id}`,
     collection?.hasDescription


### PR DESCRIPTION
Fixes a bug where the documents list sometimes slides up in the collection scene.

This was because the local cache wasn't updated when a pin is created / deleted. So, when there are no more pins to show, they still take up space until the latest data is retrieved from the server.