### PR TITLE
Assorted fixes/improvs in FindAndReplace popover

### DIFF
--- a/app/components/Input.tsx
+++ b/app/components/Input.tsx
@@ -234,7 +234,7 @@ function Input(
               hasIcon={!!icon}
               hasPrefix={!!prefix}
               {...rest}
-              // set it after "rest" to allow "handleKeyDown" to override "onKeyDown" from prop.
+              // set it after "rest" to override "onKeyDown" from prop.
               onKeyDown={handleKeyDown}
             />
           ) : (
@@ -249,7 +249,7 @@ function Input(
               hasPrefix={!!prefix}
               type={type}
               {...rest}
-              // set it after "rest" to "handleKeyDown" to override "onKeyDown" from prop.
+              // set it after "rest" to override "onKeyDown" from prop.
               onKeyDown={handleKeyDown}
             />
           )}

--- a/app/components/Input.tsx
+++ b/app/components/Input.tsx
@@ -176,6 +176,7 @@ function Input(
     if (ev.key === "Enter" && ev.metaKey) {
       if (props.onRequestSubmit) {
         props.onRequestSubmit(ev);
+        return;
       }
     }
 
@@ -230,10 +231,11 @@ function Input(
               ])}
               onBlur={handleBlur}
               onFocus={handleFocus}
-              onKeyDown={handleKeyDown}
               hasIcon={!!icon}
               hasPrefix={!!prefix}
               {...rest}
+              // set it after "rest" to allow "handleKeyDown" to override "onKeyDown" from prop.
+              onKeyDown={handleKeyDown}
             />
           ) : (
             <NativeInput
@@ -243,11 +245,12 @@ function Input(
               ])}
               onBlur={handleBlur}
               onFocus={handleFocus}
-              onKeyDown={handleKeyDown}
               hasIcon={!!icon}
               hasPrefix={!!prefix}
               type={type}
               {...rest}
+              // set it after "rest" to "handleKeyDown" to override "onKeyDown" from prop.
+              onKeyDown={handleKeyDown}
             />
           )}
           {children}

--- a/app/editor/components/FindAndReplace.tsx
+++ b/app/editor/components/FindAndReplace.tsx
@@ -399,12 +399,28 @@ export default function FindAndReplace({
                   onRequestSubmit={handleReplaceAll}
                   onChange={(ev) => setReplaceTerm(ev.currentTarget.value)}
                 />
-                <Button onClick={handleReplace} disabled={disabled} neutral>
-                  {t("Replace")}
-                </Button>
-                <Button onClick={handleReplaceAll} disabled={disabled} neutral>
-                  {t("Replace all")}
-                </Button>
+                <Tooltip
+                  content={t("Replace")}
+                  shortcut="enter"
+                  placement="bottom"
+                >
+                  <Button onClick={handleReplace} disabled={disabled} neutral>
+                    {t("Replace")}
+                  </Button>
+                </Tooltip>
+                <Tooltip
+                  content={t("Replace all")}
+                  shortcut={`${metaDisplay}+enter`}
+                  placement="bottom"
+                >
+                  <Button
+                    onClick={handleReplaceAll}
+                    disabled={disabled}
+                    neutral
+                  >
+                    {t("Replace all")}
+                  </Button>
+                </Tooltip>
               </Flex>
             )}
           </ResizingHeightContainer>

--- a/app/editor/components/FindAndReplace.tsx
+++ b/app/editor/components/FindAndReplace.tsx
@@ -143,25 +143,40 @@ export default function FindAndReplace({
     inputRef.current?.setSelectionRange(0, inputRef.current?.value.length);
   }, []);
 
+  const selectInputReplaceText = React.useCallback(() => {
+    setTimeout(() => {
+      inputReplaceRef.current?.focus();
+      inputReplaceRef.current?.setSelectionRange(
+        0,
+        inputReplaceRef.current?.value.length
+      );
+    }, 100);
+  }, []);
+
   const handleOpen = React.useCallback(
     ({ withReplace }: { withReplace: boolean }) => {
-      const includeReplace = () => {
-        if (!readOnly && withReplace) {
-          setShowReplace(true);
-        }
-      };
+      const shouldShowReplace = !readOnly && withReplace;
 
+      // If already open, switch focus to corresponding input text.
       if (popover.visible) {
-        selectInputText();
-        includeReplace();
+        if (shouldShowReplace) {
+          setShowReplace(true);
+          selectInputReplaceText();
+        } else {
+          selectInputText();
+        }
+
         return;
       }
 
       selectionRef.current = window.getSelection()?.toString();
       popover.show();
-      includeReplace();
+
+      if (shouldShowReplace) {
+        setShowReplace(true);
+      }
     },
-    [popover, selectInputText, readOnly]
+    [popover, readOnly, selectInputText, selectInputReplaceText]
   );
 
   const handleMore = React.useCallback(() => {

--- a/app/editor/components/FindAndReplace.tsx
+++ b/app/editor/components/FindAndReplace.tsx
@@ -308,7 +308,7 @@ export default function FindAndReplace({
     <>
       <Tooltip
         content={t("Previous match")}
-        shortcut="shift+enter"
+        shortcut="Shift+Enter"
         placement="bottom"
       >
         <ButtonLarge
@@ -318,7 +318,7 @@ export default function FindAndReplace({
           <CaretUpIcon />
         </ButtonLarge>
       </Tooltip>
-      <Tooltip content={t("Next match")} shortcut="enter" placement="bottom">
+      <Tooltip content={t("Next match")} shortcut="Enter" placement="bottom">
         <ButtonLarge
           disabled={disabled}
           onClick={() => editor.commands.nextSearchMatch()}
@@ -401,7 +401,7 @@ export default function FindAndReplace({
                 />
                 <Tooltip
                   content={t("Replace")}
-                  shortcut="enter"
+                  shortcut="Enter"
                   placement="bottom"
                 >
                   <Button onClick={handleReplace} disabled={disabled} neutral>
@@ -410,7 +410,7 @@ export default function FindAndReplace({
                 </Tooltip>
                 <Tooltip
                   content={t("Replace all")}
-                  shortcut={`${metaDisplay}+enter`}
+                  shortcut={`${metaDisplay}+Enter`}
                   placement="bottom"
                 >
                   <Button


### PR DESCRIPTION
This started as a bug fix to re-search the document when case sensitivity and regex are toggled through keyboard shortcut. Along the way, I noticed a couple of small improvs - individual commits have info about them. Please let me know if something needs to be changed/removed.

Included keyboard navigation is inspired by VSCode.
Also, I find the "Match word" variant very useful in VSCode - perhaps we can include it in Outline?