### PR TITLE
fix: If multiple authentication providers match, prioritize enabled one

### DIFF
--- a/app/scenes/Login/components/Notices.tsx
+++ b/app/scenes/Login/components/Notices.tsx
@@ -105,7 +105,7 @@ function Message({ notice }: { notice: string }) {
     case "authentication-provider-disabled":
       return (
         <Trans>
-          Authentication failed – this login method was disabled by a team
+          Authentication failed – this login method was disabled by a workspace
           admin.
         </Trans>
       );

--- a/server/commands/accountProvisioner.test.ts
+++ b/server/commands/accountProvisioner.test.ts
@@ -190,6 +190,56 @@ describe("accountProvisioner", () => {
       expect(error).toBeTruthy();
     });
 
+    it("should prioritize enabled authentication provider", async () => {
+      const existingTeam = await buildTeam();
+      const existingProviders = await existingTeam.$get(
+        "authenticationProviders"
+      );
+
+      const team2 = await buildTeam();
+
+      const providers = await team2.$get("authenticationProviders");
+      const authenticationProvider = providers[0];
+      await authenticationProvider.update({
+        enabled: false,
+        providerId: existingProviders[0].providerId,
+      });
+
+      const existing = await buildUser({
+        teamId: existingTeam.id,
+      });
+      const authentications = await existing.$get("authentications");
+      const authentication = authentications[0];
+      const { isNewUser, isNewTeam } = await accountProvisioner({
+        ip,
+        user: {
+          name: existing.name,
+          email: existing.email!,
+          avatarUrl: existing.avatarUrl,
+        },
+        team: {
+          name: existingTeam.name,
+          avatarUrl: existingTeam.avatarUrl,
+          subdomain: faker.internet.domainWord(),
+        },
+        authenticationProvider: {
+          name: authenticationProvider.name,
+          providerId: authenticationProvider.providerId,
+        },
+        authentication: {
+          providerId: authentication.providerId,
+          accessToken: "123",
+          scopes: ["read"],
+        },
+      });
+      const auth = await UserAuthentication.findByPk(authentication.id);
+      expect(auth?.accessToken).toEqual("123");
+      expect(auth?.scopes.length).toEqual(1);
+      expect(auth?.scopes[0]).toEqual("read");
+      expect(isNewTeam).toEqual(false);
+      expect(isNewUser).toEqual(false);
+    });
+
     it("should throw an error when the domain is not allowed", async () => {
       const existingTeam = await buildTeam();
       const admin = await buildAdmin({ teamId: existingTeam.id });

--- a/server/commands/accountProvisioner.ts
+++ b/server/commands/accountProvisioner.ts
@@ -102,7 +102,7 @@ async function accountProvisioner({
     if (err.id === "invalid_authentication") {
       const authenticationProvider = await AuthenticationProvider.findOne({
         where: {
-          name: authenticationProviderParams.name, // example: "google"
+          name: authenticationProviderParams.name,
           teamId: teamParams.teamId,
         },
         include: [
@@ -112,6 +112,7 @@ async function accountProvisioner({
             required: true,
           },
         ],
+        order: [["enabled", "DESC"]],
       });
 
       if (authenticationProvider) {

--- a/server/commands/teamProvisioner.ts
+++ b/server/commands/teamProvisioner.ts
@@ -61,6 +61,7 @@ async function teamProvisioner({
         paranoid: false,
       },
     ],
+    order: [["enabled", "DESC"]],
   });
 
   // This authentication provider already exists which means we have a team and

--- a/server/commands/userProvisioner.ts
+++ b/server/commands/userProvisioner.ts
@@ -63,7 +63,7 @@ export default async function userProvisioner({
   const auth = authentication
     ? await UserAuthentication.findOne({
         where: {
-          providerId: "" + authentication.providerId,
+          providerId: String(authentication.providerId),
         },
         include: [
           {

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -794,7 +794,7 @@
   "Sorry, it looks like that sign-in link is no longer valid, please try requesting another.": "Sorry, it looks like that sign-in link is no longer valid, please try requesting another.",
   "Your account has been suspended. To re-activate your account, please contact a workspace admin.": "Your account has been suspended. To re-activate your account, please contact a workspace admin.",
   "This workspace has been suspended. Please contact support to restore access.": "This workspace has been suspended. Please contact support to restore access.",
-  "Authentication failed – this login method was disabled by a team admin.": "Authentication failed – this login method was disabled by a team admin.",
+  "Authentication failed – this login method was disabled by a workspace admin.": "Authentication failed – this login method was disabled by a workspace admin.",
   "The workspace you are trying to join requires an invite before you can create an account.<1></1>Please request an invite from your workspace admin and try again.": "The workspace you are trying to join requires an invite before you can create an account.<1></1>Please request an invite from your workspace admin and try again.",
   "Sorry, an unknown error occurred.": "Sorry, an unknown error occurred.",
   "Login": "Login",


### PR DESCRIPTION
Sometimes there can be multiple workspaces with the same SSO provider, in this circumstance usually one is deleted/disabled.

If a user logs in from the homepage without a team subdomain we should always prioritize the enabled one.