### PR TITLE
fix: Show diff from document when revision has not been created yet

### DIFF
--- a/app/scenes/Document/components/History.tsx
+++ b/app/scenes/Document/components/History.tsx
@@ -136,14 +136,19 @@ function History() {
       "desc"
     );
 
-    const latestEvent = merged[0];
+    const latestRevisionEvent = merged.find(
+      (event) => event.name === "revisions.create"
+    );
 
-    if (latestEvent && document) {
-      const latestRevisionEvent = merged.find(
-        (event) => event.name === "revisions.create"
-      );
+    if (latestRevisionEvent && document) {
+      const latestRevision = revisions.get(latestRevisionEvent.id);
 
-      if (latestEvent.createdAt !== document.updatedAt) {
+      const isDocUpdated =
+        latestRevision?.title !== document.title ||
+        JSON.stringify(latestRevision.data) !== JSON.stringify(document.data);
+
+      if (isDocUpdated) {
+        revisions.remove(RevisionHelper.latestId(document.id));
         merged.unshift({
           id: RevisionHelper.latestId(document.id),
           name: "revisions.create",
@@ -157,7 +162,7 @@ function History() {
     }
 
     return merged;
-  }, [document, revisionEvents, nonRevisionEvents]);
+  }, [revisions, document, revisionEvents, nonRevisionEvents]);
 
   const onCloseHistory = React.useCallback(() => {
     if (document) {

--- a/app/scenes/Document/components/History.tsx
+++ b/app/scenes/Document/components/History.tsx
@@ -1,3 +1,4 @@
+import isEqual from "fast-deep-equal";
 import orderBy from "lodash/orderBy";
 import { observer } from "mobx-react";
 import * as React from "react";
@@ -145,7 +146,7 @@ function History() {
 
       const isDocUpdated =
         latestRevision?.title !== document.title ||
-        JSON.stringify(latestRevision.data) !== JSON.stringify(document.data);
+        !isEqual(latestRevision.data, document.data);
 
       if (isDocUpdated) {
         revisions.remove(RevisionHelper.latestId(document.id));


### PR DESCRIPTION
Closes #8403 

Also fixes the spurious revision shown as the latest when any non-revision events like delete, unpublish happens.