### PR TITLE
chore: Add API error handler middleware

### DIFF
--- a/server/routes/api/index.ts
+++ b/server/routes/api/index.ts
@@ -22,6 +22,7 @@ import groupMemberships from "./groupMemberships";
 import groups from "./groups";
 import installation from "./installation";
 import integrations from "./integrations";
+import apiErrorHandler from "./middlewares/apiErrorHandler";
 import apiResponse from "./middlewares/apiResponse";
 import apiTracer from "./middlewares/apiTracer";
 import editor from "./middlewares/editor";
@@ -60,6 +61,7 @@ api.use(coalesceBody());
 api.use<BaseContext, UserAgentContext>(userAgent);
 api.use(apiTracer());
 api.use(apiResponse());
+api.use(apiErrorHandler());
 api.use(editor());
 
 // Register plugin API routes before others to allow for overrides

--- a/server/routes/api/middlewares/apiErrorHandler.ts
+++ b/server/routes/api/middlewares/apiErrorHandler.ts
@@ -1,0 +1,47 @@
+import { Context, Next } from "koa";
+import {
+  ValidationError as SequelizeValidationError,
+  EmptyResultError as SequelizeEmptyResultError,
+} from "sequelize";
+import {
+  AuthorizationError,
+  NotFoundError,
+  ValidationError,
+} from "@server/errors";
+
+export default function apiErrorHandler() {
+  return async function apiErrorHandlerMiddleware(ctx: Context, next: Next) {
+    try {
+      await next();
+    } catch (err) {
+      let transformedErr = err;
+
+      if (
+        !(err instanceof AuthorizationError) &&
+        /Authorization error/i.test(err.message)
+      ) {
+        transformedErr = AuthorizationError();
+      }
+
+      if (err instanceof SequelizeValidationError) {
+        if (err.errors && err.errors[0]) {
+          transformedErr = ValidationError(
+            `${err.errors[0].message} (${err.errors[0].path})`
+          );
+        } else {
+          transformedErr = ValidationError();
+        }
+      }
+
+      if (
+        err.code === "ENOENT" ||
+        err instanceof SequelizeEmptyResultError ||
+        /Not found/i.test(err.message)
+      ) {
+        transformedErr = NotFoundError();
+      }
+
+      throw transformedErr;
+    }
+  };
+}


### PR DESCRIPTION
Closes #8565 

koa-logger [logs](https://github.com/koajs/logger/blob/f8edfa00cb5af7e696cf276ddc8b482accd9f7a9/index.js#L55-L61) any uncaught errors before `onerror` callback has a chance to [run](https://github.com/koajs/koa/blob/5054af6e31ffd451a4151a1fe144cef6e5d0d83c/lib/application.js#L193). So, the errors from `/api/` paths are now transformed in an explicit middleware.