### PR TITLE
Send editor version down websocket and force reload

### DIFF
--- a/app/components/WebsocketProvider.tsx
+++ b/app/components/WebsocketProvider.tsx
@@ -1,11 +1,14 @@
 import invariant from "invariant";
 import find from "lodash/find";
+import isObject from "lodash/isObject";
 import { action, observable } from "mobx";
 import { observer } from "mobx-react";
 import * as React from "react";
 import { withTranslation, WithTranslation } from "react-i18next";
+import semver from "semver";
 import { io, Socket } from "socket.io-client";
 import { toast } from "sonner";
+import EDITOR_VERSION from "@shared/editor/version";
 import { FileOperationState, FileOperationType } from "@shared/types";
 import RootStore from "~/stores/RootStore";
 import Collection from "~/models/Collection";
@@ -114,9 +117,22 @@ class WebsocketProvider extends React.Component<Props> {
       }
     });
 
-    this.socket.on("authenticated", () => {
+    this.socket.on("authenticated", (data) => {
       if (this.socket) {
         this.socket.authenticated = true;
+      }
+      if (isObject(data) && "editorVersion" in data) {
+        const parsedClientVersion = semver.parse(EDITOR_VERSION);
+        const parsedCurrentVersion = semver.parse(String(data.editorVersion));
+
+        if (
+          parsedClientVersion &&
+          parsedCurrentVersion &&
+          (parsedClientVersion.major < parsedCurrentVersion.major ||
+            parsedClientVersion.minor < parsedCurrentVersion.minor)
+        ) {
+          window.location.reload();
+        }
       }
     });
 

--- a/server/services/websockets.ts
+++ b/server/services/websockets.ts
@@ -4,6 +4,7 @@ import cookie from "cookie";
 import Koa from "koa";
 import IO from "socket.io";
 import { createAdapter } from "socket.io-redis";
+import EDITOR_VERSION from "@shared/editor/version";
 import { AuthenticationError } from "@server/errors";
 import Logger from "@server/logging/Logger";
 import Metrics from "@server/logging/Metrics";
@@ -116,7 +117,7 @@ export default function init(
       await authenticate(socket);
       Logger.debug("websockets", `Authenticated socket ${socket.id}`);
 
-      socket.emit("authenticated", true);
+      socket.emit("authenticated", { editorVersion: EDITOR_VERSION });
       void authenticated(io, socket);
     } catch (err) {
       Logger.debug("websockets", `Authentication error socket ${socket.id}`, {


### PR DESCRIPTION
The previous breaking editor change left some clients hanging out in tabs, while there is already a reload mechanism using API requests it seems as though this is not reliable enough.