### PR TITLE
perf: Move text serialization to task runner

### DIFF
--- a/server/commands/documentCollaborativeUpdater.ts
+++ b/server/commands/documentCollaborativeUpdater.ts
@@ -1,10 +1,8 @@
 import isEqual from "fast-deep-equal";
 import uniq from "lodash/uniq";
-import { Node } from "prosemirror-model";
 import { yDocToProsemirrorJSON } from "y-prosemirror";
 import * as Y from "yjs";
 import { ProsemirrorData } from "@shared/types";
-import { schema, serializer } from "@server/editor";
 import Logger from "@server/logging/Logger";
 import { Document, Event } from "@server/models";
 import { sequelize } from "@server/storage/database";
@@ -45,8 +43,6 @@ export default async function documentCollaborativeUpdater({
 
     const state = Y.encodeStateAsUpdate(ydoc);
     const content = yDocToProsemirrorJSON(ydoc, "default") as ProsemirrorData;
-    const node = Node.fromJSON(schema, content);
-    const text = serializer.serialize(node, undefined);
     const isUnchanged = isEqual(document.content, content);
     const lastModifiedById =
       sessionCollaboratorIds[sessionCollaboratorIds.length - 1] ??
@@ -72,7 +68,6 @@ export default async function documentCollaborativeUpdater({
 
     await document.update(
       {
-        text,
         content,
         state: Buffer.from(state),
         lastModifiedById,

--- a/server/commands/documentCreator.ts
+++ b/server/commands/documentCreator.ts
@@ -1,9 +1,9 @@
 import { Optional } from "utility-types";
-import { ProsemirrorHelper } from "@shared/utils/ProsemirrorHelper";
+import { ProsemirrorHelper as SharedProsemirrorHelper } from "@shared/utils/ProsemirrorHelper";
 import { TextHelper } from "@shared/utils/TextHelper";
 import { Document, Event, User } from "@server/models";
 import { DocumentHelper } from "@server/models/helpers/DocumentHelper";
-import { ProsemirrorHelper as ProsemirrorHelper2 } from "@server/models/helpers/ProsemirrorHelper";
+import { ProsemirrorHelper } from "@server/models/helpers/ProsemirrorHelper";
 import { APIContext } from "@server/types";
 
 type Props = Optional<
@@ -91,11 +91,11 @@ export default async function documentCreator({
       : "");
 
   const contentWithReplacements = text
-    ? ProsemirrorHelper2.toProsemirror(text).toJSON()
+    ? ProsemirrorHelper.toProsemirror(text).toJSON()
     : templateDocument
     ? template
       ? templateDocument.content
-      : ProsemirrorHelper.replaceTemplateVariables(
+      : SharedProsemirrorHelper.replaceTemplateVariables(
           await DocumentHelper.toJSON(templateDocument),
           user
         )
@@ -125,7 +125,9 @@ export default async function documentCreator({
     state,
   });
 
-  document.text = DocumentHelper.toMarkdown(document);
+  document.text = DocumentHelper.toMarkdown(document, {
+    includeTitle: false,
+  });
 
   await document.save({
     silent: !!createdAt,

--- a/server/commands/documentDuplicator.ts
+++ b/server/commands/documentDuplicator.ts
@@ -52,7 +52,6 @@ export default async function documentDuplicator({
       DocumentHelper.toProsemirror(document),
       ["comment"]
     ),
-    text: document.text,
     ...sharedProperties,
   });
 
@@ -86,7 +85,6 @@ export default async function documentDuplicator({
           DocumentHelper.toProsemirror(childDocument),
           ["comment"]
         ),
-        text: childDocument.text,
         ...sharedProperties,
       });
 

--- a/server/models/Document.ts
+++ b/server/models/Document.ts
@@ -830,7 +830,9 @@ class Document extends ArchivableModel<
     }
 
     this.content = revision.content;
-    this.text = revision.text;
+    this.text = DocumentHelper.toMarkdown(revision, {
+      includeTitle: false,
+    });
     this.title = revision.title;
     this.icon = revision.icon;
     this.color = revision.color;

--- a/server/models/Revision.test.ts
+++ b/server/models/Revision.test.ts
@@ -16,6 +16,5 @@ describe("#findLatest", () => {
     await Revision.createFromDocument(document);
     const revision = await Revision.findLatest(document.id);
     expect(revision?.title).toBe("Changed 2");
-    expect(revision?.text).toBe("Content");
   });
 });

--- a/server/models/Revision.ts
+++ b/server/models/Revision.ts
@@ -69,8 +69,9 @@ class Revision extends IdModel<
   /**
    * The content of the revision as Markdown.
    *
-   * @deprecated Use `content` instead, or `DocumentHelper.toMarkdown` if exporting lossy markdown.
-   * This column will be removed in a future migration.
+   * @deprecated Use `content` instead, or `DocumentHelper.toMarkdown` if
+   * exporting lossy markdown. This column will be removed in a future migration
+   * and is no longer being written.
    */
   @Column(DataType.TEXT)
   text: string;
@@ -134,7 +135,6 @@ class Revision extends IdModel<
   static buildFromDocument(document: Document) {
     return this.build({
       title: document.title,
-      text: document.text,
       icon: document.icon,
       color: document.color,
       content: document.content,

--- a/server/models/helpers/DocumentHelper.tsx
+++ b/server/models/helpers/DocumentHelper.tsx
@@ -147,10 +147,12 @@ export class DocumentHelper {
    * Returns the document as Markdown. This is a lossy conversion and should only be used for export.
    *
    * @param document The document or revision to convert
+   * @param options Options for the conversion
    * @returns The document title and content as a Markdown string
    */
   static toMarkdown(
-    document: Document | Revision | Collection | ProsemirrorData
+    document: Document | Revision | Collection | ProsemirrorData,
+    options?: { includeTitle?: boolean }
   ) {
     const text = serializer
       .serialize(DocumentHelper.toProsemirror(document))
@@ -165,7 +167,10 @@ export class DocumentHelper {
       return text;
     }
 
-    if (document instanceof Document || document instanceof Revision) {
+    if (
+      options?.includeTitle &&
+      (document instanceof Document || document instanceof Revision)
+    ) {
       const iconType = determineIconType(document.icon);
 
       const title = `${iconType === IconType.Emoji ? document.icon + " " : ""}${

--- a/server/models/helpers/DocumentHelper.tsx
+++ b/server/models/helpers/DocumentHelper.tsx
@@ -152,7 +152,10 @@ export class DocumentHelper {
    */
   static toMarkdown(
     document: Document | Revision | Collection | ProsemirrorData,
-    options?: { includeTitle?: boolean }
+    options?: {
+      /** Whether to include the document title (default: true) */
+      includeTitle?: boolean;
+    }
   ) {
     const text = serializer
       .serialize(DocumentHelper.toProsemirror(document))
@@ -168,8 +171,8 @@ export class DocumentHelper {
     }
 
     if (
-      options?.includeTitle &&
-      (document instanceof Document || document instanceof Revision)
+      (document instanceof Document || document instanceof Revision) &&
+      options?.includeTitle !== false
     ) {
       const iconType = determineIconType(document.icon);
 

--- a/server/models/helpers/ProseMirrorHelper.test.ts
+++ b/server/models/helpers/ProseMirrorHelper.test.ts
@@ -3,7 +3,7 @@ import { MentionType, ProsemirrorData } from "@shared/types";
 import { buildProseMirrorDoc } from "@server/test/factories";
 import { MentionAttrs, ProsemirrorHelper } from "./ProsemirrorHelper";
 
-describe("ProseMirrorHelper", () => {
+describe("ProsemirrorHelper", () => {
   describe("getNodeForMentionEmail", () => {
     it("should return the paragraph node", () => {
       const mentionAttrs: MentionAttrs = {

--- a/server/models/helpers/ProsemirrorHelper.tsx
+++ b/server/models/helpers/ProsemirrorHelper.tsx
@@ -118,10 +118,13 @@ export class ProsemirrorHelper {
   /**
    * Converts a plain object into a Prosemirror Node.
    *
-   * @param data The object to parse
+   * @param data The ProsemirrorData object or string to parse.
    * @returns The content as a Prosemirror Node
    */
-  static toProsemirror(data: ProsemirrorData) {
+  static toProsemirror(data: ProsemirrorData | string) {
+    if (typeof data === "string") {
+      return parser.parse(data);
+    }
     return Node.fromJSON(schema, data);
   }
 

--- a/server/presenters/document.ts
+++ b/server/presenters/document.ts
@@ -42,7 +42,7 @@ async function presentDocument(
 
   const text =
     !asData || options?.includeText
-      ? document.text || DocumentHelper.toMarkdown(data)
+      ? DocumentHelper.toMarkdown(data)
       : undefined;
 
   const res: Record<string, any> = {

--- a/server/presenters/document.ts
+++ b/server/presenters/document.ts
@@ -42,7 +42,7 @@ async function presentDocument(
 
   const text =
     !asData || options?.includeText
-      ? DocumentHelper.toMarkdown(data)
+      ? DocumentHelper.toMarkdown(data, { includeTitle: false })
       : undefined;
 
   const res: Record<string, any> = {

--- a/server/queues/processors/RevisionsProcessor.ts
+++ b/server/queues/processors/RevisionsProcessor.ts
@@ -2,6 +2,7 @@ import isEqual from "fast-deep-equal";
 import revisionCreator from "@server/commands/revisionCreator";
 import { Revision, Document, User } from "@server/models";
 import { DocumentEvent, RevisionEvent, Event } from "@server/types";
+import DocumentUpdateTextTask from "../tasks/DocumentUpdateTextTask";
 import BaseProcessor from "./BaseProcessor";
 
 export default class RevisionsProcessor extends BaseProcessor {
@@ -35,6 +36,8 @@ export default class RevisionsProcessor extends BaseProcessor {
         ) {
           return;
         }
+
+        await DocumentUpdateTextTask.schedule(event);
 
         const user = await User.findByPk(event.actorId, {
           paranoid: false,

--- a/server/queues/tasks/DocumentUpdateTextTask.ts
+++ b/server/queues/tasks/DocumentUpdateTextTask.ts
@@ -1,0 +1,18 @@
+import { Node } from "prosemirror-model";
+import { schema, serializer } from "@server/editor";
+import { Document } from "@server/models";
+import { DocumentUserEvent } from "@server/types";
+import BaseTask from "./BaseTask";
+
+export default class DocumentUpdateTextTask extends BaseTask<DocumentUserEvent> {
+  public async perform(event: DocumentUserEvent) {
+    const document = await Document.findByPk(event.documentId);
+    if (!document?.content) {
+      return;
+    }
+
+    const node = Node.fromJSON(schema, document.content);
+    document.text = serializer.serialize(node);
+    await document.save({ silent: true });
+  }
+}

--- a/server/queues/tasks/DocumentUpdateTextTask.ts
+++ b/server/queues/tasks/DocumentUpdateTextTask.ts
@@ -1,11 +1,11 @@
 import { Node } from "prosemirror-model";
 import { schema, serializer } from "@server/editor";
 import { Document } from "@server/models";
-import { DocumentUserEvent } from "@server/types";
+import { DocumentEvent } from "@server/types";
 import BaseTask from "./BaseTask";
 
-export default class DocumentUpdateTextTask extends BaseTask<DocumentUserEvent> {
-  public async perform(event: DocumentUserEvent) {
+export default class DocumentUpdateTextTask extends BaseTask<DocumentEvent> {
+  public async perform(event: DocumentEvent) {
     const document = await Document.findByPk(event.documentId);
     if (!document?.content) {
       return;


### PR DESCRIPTION
The core of this PR is to move the potentially expensive serialization from every collaborative persistence into a delayed task runner.

Because of this change we can no longer rely on `text` being up to date, which is where the other changes come in – removing reliance on `text`. At this point the column is used essentially only for search indexing content.