### PR TITLE
fix: Check user has enabled create-comment notification in email flow

### DIFF
--- a/server/models/helpers/NotificationHelper.ts
+++ b/server/models/helpers/NotificationHelper.ts
@@ -62,7 +62,7 @@ export default class NotificationHelper {
   ): Promise<User[]> => {
     let recipients = await this.getDocumentNotificationRecipients({
       document,
-      notificationType: NotificationEventType.UpdateDocument,
+      notificationType: NotificationEventType.CreateComment,
       onlySubscribers: !comment.parentCommentId,
       actorId,
     });


### PR DESCRIPTION
Fixes a bug where comment creation notifications incorrectly check for "document updates" type.