### PR TITLE
Default comments to `Order in doc`

### DIFF
--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -32,6 +32,6 @@ export const UserPreferenceDefaults: UserPreferences = {
   [UserPreference.RememberLastPath]: true,
   [UserPreference.UseCursorPointer]: true,
   [UserPreference.CodeBlockLineNumers]: true,
-  [UserPreference.SortCommentsByOrderInDocument]: false,
+  [UserPreference.SortCommentsByOrderInDocument]: true,
   [UserPreference.EnableSmartText]: true,
 };


### PR DESCRIPTION
This has turned out to be more inline with customer expectations based on other tools, so changing the default.