### PR TITLE
fix: Allow setting revision name to `null`

### DIFF
--- a/server/routes/api/revisions/revisions.test.ts
+++ b/server/routes/api/revisions/revisions.test.ts
@@ -64,6 +64,44 @@ describe("#revisions.update", () => {
     expect(body.data.name).toEqual("new name");
   });
 
+  it("should allow setting name to null", async () => {
+    const user = await buildUser();
+    const document = await buildDocument({
+      userId: user.id,
+      teamId: user.teamId,
+    });
+    const revision = await Revision.createFromDocument(document);
+
+    const res = await server.post("/api/revisions.update", {
+      body: {
+        token: user.getJwtToken(),
+        id: revision.id,
+        name: null,
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.data.name).toBeNull();
+  });
+
+  it("should not allow setting name to empty string", async () => {
+    const user = await buildUser();
+    const document = await buildDocument({
+      userId: user.id,
+      teamId: user.teamId,
+    });
+    const revision = await Revision.createFromDocument(document);
+
+    const res = await server.post("/api/revisions.update", {
+      body: {
+        token: user.getJwtToken(),
+        id: revision.id,
+        name: "",
+      },
+    });
+    expect(res.status).toEqual(400);
+  });
+
   it("should allow an admin to update a document revision", async () => {
     const admin = await buildAdmin();
     const document = await buildDocument({

--- a/server/routes/api/revisions/schema.ts
+++ b/server/routes/api/revisions/schema.ts
@@ -33,7 +33,8 @@ export const RevisionsUpdateSchema = BaseSchema.extend({
     name: z
       .string()
       .min(RevisionValidation.minNameLength)
-      .max(RevisionValidation.maxNameLength),
+      .max(RevisionValidation.maxNameLength)
+      .or(z.null()),
   }),
 });
 


### PR DESCRIPTION
Allow removing custom name through API