### PR TITLE
fix: Potential unsafe `content-type` check

### DIFF
--- a/server/storage/files/BaseStorage.ts
+++ b/server/storage/files/BaseStorage.ts
@@ -1,6 +1,7 @@
 import { Blob } from "buffer";
 import { Readable } from "stream";
 import { PresignedPost } from "@aws-sdk/s3-presigned-post";
+import FileHelper from "@shared/editor/lib/FileHelper";
 import { isBase64Url, isInternalUrl } from "@shared/utils/urls";
 import env from "@server/env";
 import Logger from "@server/logging/Logger";
@@ -239,14 +240,14 @@ export default abstract class BaseStorage {
    * @returns The content disposition
    */
   public getContentDisposition(contentType?: string) {
-    if (contentType && this.safeInlineContentTypes.includes(contentType)) {
-      return "inline";
+    if (!contentType) {
+      return "attachment";
     }
+
     if (
-      contentType &&
-      this.safeInlineContentPrefixes.some((prefix) =>
-        contentType.startsWith(prefix)
-      )
+      FileHelper.isAudio(contentType) ||
+      FileHelper.isVideo(contentType) ||
+      this.safeInlineContentTypes.includes(contentType)
     ) {
       return "inline";
     }
@@ -255,8 +256,8 @@ export default abstract class BaseStorage {
   }
 
   /**
-   * A list of content types considered safe to display inline in the browser. Note that
-   * SVGs are purposefully not included here as they can contain JavaScript.
+   * A list of content types considered safe to display inline in the browser.
+   * Note that SVGs are purposefully not included here as they can contain JS.
    */
   protected safeInlineContentTypes = [
     "application/pdf",
@@ -265,9 +266,4 @@ export default abstract class BaseStorage {
     "image/gif",
     "image/webp",
   ];
-
-  /**
-   * A list of content type prefixes considered safe to display inline in the browser.
-   */
-  protected safeInlineContentPrefixes = ["video/", "audio/"];
 }

--- a/shared/editor/commands/insertFiles.ts
+++ b/shared/editor/commands/insertFiles.ts
@@ -58,11 +58,11 @@ const insertFiles = async function (
   const filesToUpload = await Promise.all(
     files.map(async (file) => {
       const isImage =
-        FileHelper.isImage(file) &&
+        FileHelper.isImage(file.type) &&
         !options.isAttachment &&
         !!schema.nodes.image;
       const isVideo =
-        FileHelper.isVideo(file) &&
+        FileHelper.isVideo(file.type) &&
         !options.isAttachment &&
         !!schema.nodes.video;
       const getDimensions = isImage

--- a/shared/editor/lib/FileHelper.test.ts
+++ b/shared/editor/lib/FileHelper.test.ts
@@ -8,6 +8,8 @@ describe("FileHelper", () => {
     expect(FileHelper.isImage("image/gif")).toBe(true);
     expect(FileHelper.isImage("image/bmp")).toBe(true);
     expect(FileHelper.isImage("image/avif")).toBe(true);
+    expect(FileHelper.isImage("image/heif-sequence")).toBe(true);
+    expect(FileHelper.isImage("image/svg+xml")).toBe(true);
     expect(FileHelper.isImage("text/plain")).toBe(false);
     expect(FileHelper.isImage("application/json")).toBe(false);
   });
@@ -15,7 +17,8 @@ describe("FileHelper", () => {
   it("isVideo", () => {
     expect(FileHelper.isVideo("video/mp4")).toBe(true);
     expect(FileHelper.isVideo("video/webm")).toBe(true);
-    expect(FileHelper.isVideo("video/ogg")).toBe(true);
+    expect(FileHelper.isVideo("video/x-msvideo")).toBe(true);
+    expect(FileHelper.isVideo("video/vnd.dlna.mpeg-tts")).toBe(true);
     expect(FileHelper.isVideo("text/plain")).toBe(false);
     expect(FileHelper.isVideo("application/json")).toBe(false);
   });
@@ -23,6 +26,8 @@ describe("FileHelper", () => {
   it("isAudio", () => {
     expect(FileHelper.isAudio("audio/mpeg")).toBe(true);
     expect(FileHelper.isAudio("audio/wav")).toBe(true);
+    expect(FileHelper.isAudio("audio/vnd.dolby.heaac.1")).toBe(true);
+    expect(FileHelper.isAudio("audio/vnd.lucent.voice")).toBe(true);
     expect(FileHelper.isAudio("text/plain")).toBe(false);
     expect(FileHelper.isAudio("application/json")).toBe(false);
   });

--- a/shared/editor/lib/FileHelper.test.ts
+++ b/shared/editor/lib/FileHelper.test.ts
@@ -1,0 +1,29 @@
+import FileHelper from "./FileHelper";
+
+describe("FileHelper", () => {
+  it("isImage", () => {
+    expect(FileHelper.isImage("image/png")).toBe(true);
+    expect(FileHelper.isImage("image/jpeg")).toBe(true);
+    expect(FileHelper.isImage("image/webp")).toBe(true);
+    expect(FileHelper.isImage("image/gif")).toBe(true);
+    expect(FileHelper.isImage("image/bmp")).toBe(true);
+    expect(FileHelper.isImage("image/avif")).toBe(true);
+    expect(FileHelper.isImage("text/plain")).toBe(false);
+    expect(FileHelper.isImage("application/json")).toBe(false);
+  });
+
+  it("isVideo", () => {
+    expect(FileHelper.isVideo("video/mp4")).toBe(true);
+    expect(FileHelper.isVideo("video/webm")).toBe(true);
+    expect(FileHelper.isVideo("video/ogg")).toBe(true);
+    expect(FileHelper.isVideo("text/plain")).toBe(false);
+    expect(FileHelper.isVideo("application/json")).toBe(false);
+  });
+
+  it("isAudio", () => {
+    expect(FileHelper.isAudio("audio/mpeg")).toBe(true);
+    expect(FileHelper.isAudio("audio/wav")).toBe(true);
+    expect(FileHelper.isAudio("text/plain")).toBe(false);
+    expect(FileHelper.isAudio("application/json")).toBe(false);
+  });
+});

--- a/shared/editor/lib/FileHelper.ts
+++ b/shared/editor/lib/FileHelper.ts
@@ -8,7 +8,7 @@ export default class FileHelper {
    * @returns True if the file is an image
    */
   static isImage(contentType: string) {
-    return /^image\/[a-z0-9_\-\+]+$/i.test(contentType);
+    return /^image\/[!#$%&'*+.^\w`|~-]+$/i.test(contentType);
   }
 
   /**
@@ -18,7 +18,7 @@ export default class FileHelper {
    * @returns True if the file is an video
    */
   static isVideo(contentType: string) {
-    return /^video\/[a-z0-9_\-\+]+$/i.test(contentType);
+    return /^video\/[!#$%&'*+.^\w`|~-]+$/i.test(contentType);
   }
 
   /**
@@ -28,7 +28,7 @@ export default class FileHelper {
    * @returns True if the file is an audio file
    */
   static isAudio(contentType: string) {
-    return /^audio\/[a-z0-9_\-\+]+$/i.test(contentType);
+    return /^audio\/[!#$%&'*+.^\w`|~-]+$/i.test(contentType);
   }
 
   /**

--- a/shared/editor/lib/FileHelper.ts
+++ b/shared/editor/lib/FileHelper.ts
@@ -4,21 +4,31 @@ export default class FileHelper {
   /**
    * Checks if a file is an image.
    *
-   * @param file The file to check
+   * @param contentType The content type of the file
    * @returns True if the file is an image
    */
-  static isImage(file: File) {
-    return file.type.startsWith("image/");
+  static isImage(contentType: string) {
+    return /^image\/[a-z0-9_\-\+]+$/i.test(contentType);
   }
 
   /**
    * Checks if a file is a video.
    *
-   * @param file The file to check
+   * @param contentType The content type of the file
    * @returns True if the file is an video
    */
-  static isVideo(file: File) {
-    return file.type.startsWith("video/");
+  static isVideo(contentType: string) {
+    return /^video\/[a-z0-9_\-\+]+$/i.test(contentType);
+  }
+
+  /**
+   * Checks if a file is an audio file.
+   *
+   * @param contentType The content type of the file
+   * @returns True if the file is an audio file
+   */
+  static isAudio(contentType: string) {
+    return /^audio\/[a-z0-9_\-\+]+$/i.test(contentType);
   }
 
   /**


### PR DESCRIPTION
Using `startsWith` to parse content type is not safe, better to check the entire string.