### PR TITLE
fix: API middleware wrapper triggers on JSZip stream

### DIFF
--- a/server/routes/api/middlewares/apiResponse.ts
+++ b/server/routes/api/middlewares/apiResponse.ts
@@ -11,7 +11,10 @@ export default function apiResponse() {
       typeof ctx.body === "object" &&
       !(ctx.body instanceof Readable) &&
       !(ctx.body instanceof stream.Readable) &&
-      !(ctx.body instanceof Buffer)
+      !(ctx.body instanceof Buffer) &&
+      // JSZip returns a wrapped stream instance that is not a true readable stream
+      // and not exported from the module either, so we must identify it like so.
+      !(ctx.body && "_readableState" in ctx.body)
     ) {
       ctx.body = {
         ...ctx.body,


### PR DESCRIPTION
closes #8680