### PR TITLE
fix: `dd-trace` upgrade causes errors/high memory consumption

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "crypto-js": "^4.2.0",
     "datadog-metrics": "^0.11.2",
     "date-fns": "^3.6.0",
-    "dd-trace": "^5.41.0",
+    "dd-trace": "^5.40.0",
     "diff": "^5.2.0",
     "dotenv": "^16.4.7",
     "email-providers": "^1.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1677,15 +1677,7 @@
     debug "^4.3.1"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.25.9", "@babel/types@^7.26.9", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
-  version "7.26.9"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.9.tgz#08b43dec79ee8e682c2ac631c010bdcac54a21ce"
-  integrity sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==
-  dependencies:
-    "@babel/helper-string-parser" "^7.25.9"
-    "@babel/helper-validator-identifier" "^7.25.9"
-
-"@babel/types@^7.26.10":
+"@babel/types@^7.0.0", "@babel/types@^7.25.9", "@babel/types@^7.26.10", "@babel/types@^7.26.9", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
   version "7.26.10"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.10.tgz#396382f6335bd4feb65741eacfc808218f859259"
   integrity sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==
@@ -7496,7 +7488,7 @@ dc-polyfill@^0.1.4:
   resolved "https://registry.yarnpkg.com/dc-polyfill/-/dc-polyfill-0.1.4.tgz#4118cec81a8fab9a5729c41c285c715ffa42495a"
   integrity sha512-8iwEduR2jR9wWYggeaYtYZWRiUe3XZPyAQtMTL1otv8X3kfR8xUIVb4l5awHEeyDrH6Je7N324lKzMKlMMN6Yw==
 
-dd-trace@^5.41.0:
+dd-trace@^5.40.0:
   version "5.41.1"
   resolved "https://registry.yarnpkg.com/dd-trace/-/dd-trace-5.41.1.tgz#86c97ba2b0f22b7edb729e7feea32ee95a601ebf"
   integrity sha512-rotpjjUBrqyqWBQMa3YlqeJ0v9Iq95XFdUMGtoTRKtth7OMNZXQ48/GSOi5Cdqi1Ci8+RhYAmusX/GCfZ24R7A==


### PR DESCRIPTION
In a stroke of bad luck this weeks update of dd-trace landed on a new version that has several bugs:

https://github.com/DataDog/dd-trace-js/issues/5389