### PR TITLE
Require collection admin permission to update template

### DIFF
--- a/app/actions/definitions/documents.tsx
+++ b/app/actions/definitions/documents.tsx
@@ -771,7 +771,7 @@ export const createTemplateFromDocument = createAction({
     }
     return !!(
       !!activeCollectionId &&
-      stores.policies.abilities(activeCollectionId).updateDocument
+      stores.policies.abilities(activeCollectionId).createTemplate
     );
   },
   perform: ({ activeDocumentId, stores, t, event }) => {

--- a/app/components/TeamLogo.ts
+++ b/app/components/TeamLogo.ts
@@ -4,8 +4,20 @@ import { Avatar } from "./Avatar";
 
 const TeamLogo = styled(Avatar)`
   border-radius: 4px;
-  box-shadow: inset 0 0 0 1px ${s("divider")};
   border: 0;
+  position: relative;
+
+  &::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: 4px;
+    box-shadow: inset 0 0 0 1px ${s("divider")};
+    z-index: -1;
+  }
 `;
 
 export default TeamLogo;

--- a/app/components/TemplatizeDialog/SelectLocation.tsx
+++ b/app/components/TemplatizeDialog/SelectLocation.tsx
@@ -52,7 +52,7 @@ const SelectLocation = ({ defaultCollectionId, onSelect }: Props) => {
       collections.orderedData.reduce<Option[]>((memo, collection) => {
         const canCollection = policies.abilities(collection.id);
 
-        if (canCollection.createDocument) {
+        if (canCollection.createTemplate) {
           memo.push({
             label: (
               <Label

--- a/app/menus/NewTemplateMenu.tsx
+++ b/app/menus/NewTemplateMenu.tsx
@@ -42,7 +42,7 @@ function NewTemplateMenu() {
       collections.orderedData.reduce<MenuItem[]>((filtered, collection) => {
         const can = policies.abilities(collection.id);
 
-        if (can.createDocument) {
+        if (can.createTemplate) {
           filtered.push({
             type: "route",
             to: newTemplatePath(collection.id),

--- a/server/policies/collection.ts
+++ b/server/policies/collection.ts
@@ -132,6 +132,18 @@ allow(
   User,
   ["createDocument", "deleteDocument"],
   Collection,
+  (user, collection) =>
+    and(
+      //
+      !!collection?.isActive,
+      can(user, "updateDocument", collection)
+    )
+);
+
+allow(
+  User,
+  ["createTemplate", "updateTemplate"],
+  Collection,
   (user, collection) => {
     if (
       !collection ||
@@ -147,14 +159,11 @@ allow(
     }
 
     if (
-      collection.permission !== CollectionPermission.ReadWrite ||
+      collection.permission !== CollectionPermission.Admin ||
       user.isViewer ||
       user.isGuest
     ) {
-      return includesMembership(collection, [
-        CollectionPermission.ReadWrite,
-        CollectionPermission.Admin,
-      ]);
+      return includesMembership(collection, [CollectionPermission.Admin]);
     }
 
     return true;

--- a/server/policies/document.test.ts
+++ b/server/policies/document.test.ts
@@ -407,14 +407,20 @@ describe("template", () => {
         collectionId: collection.id,
         template: true,
       });
+      await UserMembership.create({
+        userId: user.id,
+        documentId: doc.id,
+        permission: DocumentPermission.ReadWrite,
+        createdById: user.id,
+      });
 
       // reload to get membership
       const document = await Document.findByPk(doc.id, { userId: user.id });
       const abilities = serialize(user, document);
       expect(abilities.read).toBeTruthy();
       expect(abilities.download).toBeTruthy();
-      expect(abilities.update).toEqual(false);
-      expect(abilities.createChildDocument).toEqual(false);
+      expect(abilities.update).toBeFalsy();
+      expect(abilities.createChildDocument).toBeFalsy();
       expect(abilities.manageUsers).toEqual(false);
       expect(abilities.archive).toEqual(false);
       expect(abilities.delete).toEqual(false);

--- a/server/policies/document.ts
+++ b/server/policies/document.ts
@@ -97,7 +97,11 @@ allow(User, "update", Document, (actor, document) =>
         DocumentPermission.Admin,
       ]),
       or(
-        can(actor, "updateDocument", document?.collection),
+        and(
+          !document?.template &&
+            can(actor, "updateDocument", document?.collection)
+        ),
+        and(!!document?.template && can(actor, "update", document?.collection)),
         and(!!document?.isDraft && actor.id === document?.createdById),
         and(
           !!document?.isWorkspaceTemplate,

--- a/server/policies/document.ts
+++ b/server/policies/document.ts
@@ -92,16 +92,22 @@ allow(User, "update", Document, (actor, document) =>
     isTeamMutable(actor),
     !!document?.isActive,
     or(
-      includesMembership(document, [
-        DocumentPermission.ReadWrite,
-        DocumentPermission.Admin,
-      ]),
+      and(
+        !document?.template,
+        includesMembership(document, [
+          DocumentPermission.ReadWrite,
+          DocumentPermission.Admin,
+        ])
+      ),
       or(
         and(
           !document?.template &&
             can(actor, "updateDocument", document?.collection)
         ),
-        and(!!document?.template && can(actor, "update", document?.collection)),
+        and(
+          !!document?.template &&
+            can(actor, "updateTemplate", document?.collection)
+        ),
         and(!!document?.isDraft && actor.id === document?.createdById),
         and(
           !!document?.isWorkspaceTemplate,

--- a/server/policies/index.test.ts
+++ b/server/policies/index.test.ts
@@ -14,6 +14,6 @@ it("should serialize domain policies on Team", async () => {
     teamId: team.id,
   });
   const response = serialize(user, team);
-  expect(response.createTemplate).toBeTruthy();
+  expect(response.createDocument).toBeTruthy();
   expect(response.inviteUser).toBeTruthy();
 });

--- a/server/policies/team.test.ts
+++ b/server/policies/team.test.ts
@@ -16,7 +16,7 @@ describe("policies/team", () => {
     expect(abilities.createTeam).toEqual(false);
     expect(abilities.createAttachment).toBeTruthy();
     expect(abilities.createCollection).toBeTruthy();
-    expect(abilities.createTemplate).toBeTruthy();
+    expect(abilities.createTemplate).toEqual(false);
     expect(abilities.createGroup).toEqual(false);
     expect(abilities.createIntegration).toEqual(false);
   });
@@ -77,7 +77,7 @@ describe("policies/team", () => {
   describe("create template", () => {
     const permissions = new Map<UserRole, boolean>([
       [UserRole.Admin, true],
-      [UserRole.Member, true],
+      [UserRole.Member, false],
       [UserRole.Viewer, false],
       [UserRole.Guest, false],
     ]);

--- a/server/policies/team.ts
+++ b/server/policies/team.ts
@@ -40,11 +40,10 @@ allow(User, ["delete", "audit"], Team, (actor, team) =>
   )
 );
 
-allow(User, "createTemplate", Team, (actor, team) =>
+allow(User, ["createTemplate", "updateTemplate"], Team, (actor, team) =>
   and(
     //
-    !actor.isGuest,
-    !actor.isViewer,
+    actor.isAdmin,
     isTeamModel(actor, team),
     isTeamMutable(actor)
   )
@@ -52,13 +51,4 @@ allow(User, "createTemplate", Team, (actor, team) =>
 
 allow(User, "readTemplate", Team, (actor, team) =>
   and(!actor.isViewer, isTeamModel(actor, team))
-);
-
-allow(User, "updateTemplate", Team, (actor, team) =>
-  and(
-    //
-    actor.isAdmin,
-    isTeamModel(actor, team),
-    isTeamMutable(actor)
-  )
 );

--- a/server/routes/api/documents/documents.test.ts
+++ b/server/routes/api/documents/documents.test.ts
@@ -2041,7 +2041,7 @@ describe("#documents.templatize", () => {
     expect(body.data.collectionId).toEqual(collection.id);
   });
   it("should create a published workspace template", async () => {
-    const user = await buildUser();
+    const user = await buildAdmin();
     const collection = await buildCollection({
       createdById: user.id,
       teamId: user.teamId,
@@ -2063,8 +2063,9 @@ describe("#documents.templatize", () => {
     expect(body.data.publishedAt).toBeTruthy();
     expect(body.data.collectionId).toBeNull();
   });
+
   it("should create a draft non-workspace template", async () => {
-    const user = await buildUser();
+    const user = await buildAdmin();
     const collection = await buildCollection({
       createdById: user.id,
       teamId: user.teamId,
@@ -2087,8 +2088,9 @@ describe("#documents.templatize", () => {
     expect(body.data.publishedAt).toBeNull();
     expect(body.data.collectionId).toEqual(collection.id);
   });
+
   it("should create a draft workspace template", async () => {
-    const user = await buildUser();
+    const user = await buildAdmin();
     const collection = await buildCollection({
       createdById: user.id,
       teamId: user.teamId,
@@ -2110,6 +2112,7 @@ describe("#documents.templatize", () => {
     expect(body.data.publishedAt).toBeNull();
     expect(body.data.collectionId).toBeNull();
   });
+
   it("should create a template in a different collection", async () => {
     const user = await buildUser();
     const collection = await buildCollection({
@@ -3394,7 +3397,7 @@ describe("#documents.create", () => {
   });
 
   it("should retain template variables when a template is created from another template", async () => {
-    const user = await buildUser();
+    const user = await buildAdmin();
     const template = await buildDocument({
       userId: user.id,
       teamId: user.teamId,
@@ -3416,7 +3419,7 @@ describe("#documents.create", () => {
   });
 
   it("should create a document with empty title if no title is explicitly passed", async () => {
-    const user = await buildUser();
+    const user = await buildAdmin();
     const res = await server.post("/api/documents.create", {
       body: {
         token: user.getJwtToken(),
@@ -3429,7 +3432,7 @@ describe("#documents.create", () => {
   });
 
   it("should use template title when doc is supposed to be created using the template and title is not explicitly passed", async () => {
-    const user = await buildUser();
+    const user = await buildAdmin();
     const template = await buildDocument({
       userId: user.id,
       teamId: user.teamId,
@@ -3450,7 +3453,7 @@ describe("#documents.create", () => {
   });
 
   it("should override template title when doc title is explicitly passed", async () => {
-    const user = await buildUser();
+    const user = await buildAdmin();
     const template = await buildDocument({
       userId: user.id,
       teamId: user.teamId,
@@ -3470,7 +3473,7 @@ describe("#documents.create", () => {
   });
 
   it("should override template text when doc text is explicitly passed", async () => {
-    const user = await buildUser();
+    const user = await buildAdmin();
     const template = await buildDocument({
       userId: user.id,
       teamId: user.teamId,
@@ -3611,7 +3614,7 @@ describe("#documents.create", () => {
 
   it("should allow creating a draft template without a collection", async () => {
     const team = await buildTeam();
-    const user = await buildUser({ teamId: team.id });
+    const user = await buildAdmin({ teamId: team.id });
     const res = await server.post("/api/documents.create", {
       body: {
         template: true,
@@ -3630,7 +3633,7 @@ describe("#documents.create", () => {
 
   it("should not allow publishing without specifying the collection", async () => {
     const team = await buildTeam();
-    const user = await buildUser({ teamId: team.id });
+    const user = await buildAdmin({ teamId: team.id });
     const res = await server.post("/api/documents.create", {
       body: {
         token: user.getJwtToken(),
@@ -3849,7 +3852,7 @@ describe("#documents.update", () => {
 
   it("should successfully publish a draft template without collection", async () => {
     const team = await buildTeam();
-    const user = await buildUser({ teamId: team.id });
+    const user = await buildAdmin({ teamId: team.id });
     const collection = await buildCollection({
       userId: user.id,
       teamId: team.id,

--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -1627,7 +1627,11 @@ router.post(
         },
         transaction,
       });
-      authorize(user, "createDocument", collection);
+      authorize(
+        user,
+        template ? "createTemplate" : "createDocument",
+        collection
+      );
     } else if (!!template && !collectionId) {
       authorize(user, "createTemplate", user.team);
     }


### PR DESCRIPTION
Changes behavior so that:

- Admin permission is required to create and update workspace templates
- Collection admin permission is required to create and update collection templates

closes #8692