### PR TITLE
fix: Move search term to `q` query string

### DIFF
--- a/app/actions/definitions/collections.tsx
+++ b/app/actions/definitions/collections.tsx
@@ -149,7 +149,7 @@ export const searchInCollection = createAction({
   },
 
   perform: ({ activeCollectionId }) => {
-    history.push(searchPath(undefined, { collectionId: activeCollectionId }));
+    history.push(searchPath({ collectionId: activeCollectionId }));
   },
 });
 

--- a/app/actions/definitions/documents.tsx
+++ b/app/actions/definitions/documents.tsx
@@ -693,7 +693,7 @@ export const searchInDocument = createAction({
     return !!document?.isActive;
   },
   perform: ({ activeDocumentId }) => {
-    history.push(searchPath(undefined, { documentId: activeDocumentId }));
+    history.push(searchPath({ documentId: activeDocumentId }));
   },
 });
 
@@ -806,15 +806,15 @@ export const openRandomDocument = createAction({
   },
 });
 
-export const searchDocumentsForQuery = (searchQuery: string) =>
+export const searchDocumentsForQuery = (query: string) =>
   createAction({
     id: "search",
     name: ({ t }) =>
-      t(`Search documents for "{{searchQuery}}"`, { searchQuery }),
+      t(`Search documents for "{{searchQuery}}"`, { searchQuery: query }),
     analyticsName: "Search documents",
     section: DocumentSection,
     icon: <SearchIcon />,
-    perform: () => history.push(searchPath(searchQuery)),
+    perform: () => history.push(searchPath({ query })),
     visible: ({ location }) => location.pathname !== searchPath(),
   });
 

--- a/app/actions/definitions/navigation.tsx
+++ b/app/actions/definitions/navigation.tsx
@@ -50,7 +50,7 @@ export const navigateToRecentSearchQuery = (searchQuery: SearchQuery) =>
     name: searchQuery.query,
     analyticsName: "Navigate to recent search query",
     icon: <SearchIcon />,
-    perform: () => history.push(searchPath(searchQuery.query)),
+    perform: () => history.push(searchPath({ query: searchQuery.query })),
   });
 
 export const navigateToDrafts = createAction({

--- a/app/components/InputSearchPage.tsx
+++ b/app/components/InputSearchPage.tsx
@@ -60,7 +60,8 @@ function InputSearchPage({
       if (ev.key === "Enter") {
         ev.preventDefault();
         history.push(
-          searchPath(ev.currentTarget.value, {
+          searchPath({
+            query: ev.currentTarget.value,
             collectionId,
             ref: source,
           })

--- a/app/routes/authenticated.tsx
+++ b/app/routes/authenticated.tsx
@@ -83,7 +83,7 @@ function AuthenticatedRoutes() {
             <Route exact path={`/doc/${slug}/insights`} component={Document} />
             <Route exact path={`/doc/${slug}/edit`} component={Document} />
             <Route path={`/doc/${slug}`} component={Document} />
-            <Route exact path={`${searchPath()}/:term?`} component={Search} />
+            <Route exact path={`${searchPath()}/:query?`} component={Search} />
             <Route path="/404" component={Error404} />
             <SettingsRoutes />
             <Route component={Error404} />

--- a/app/scenes/Search/Search.tsx
+++ b/app/scenes/Search/Search.tsx
@@ -48,7 +48,7 @@ function Search(props: Props) {
   const params = useQuery();
   const location = useLocation();
   const history = useHistory();
-  const routeMatch = useRouteMatch<{ term: string }>();
+  const routeMatch = useRouteMatch<{ query: string }>();
 
   // refs
   const searchInputRef = React.useRef<HTMLInputElement | null>(null);
@@ -57,7 +57,7 @@ function Search(props: Props) {
 
   // filters
   const decodedQuery = decodeURIComponentSafe(
-    routeMatch.params.term ?? params.get("query") ?? ""
+    routeMatch.params.query ?? params.get("q") ?? params.get("query") ?? ""
   ).trim();
   const query = decodedQuery !== "" ? decodedQuery : undefined;
   const collectionId = params.get("collectionId") ?? "";
@@ -130,9 +130,9 @@ function Search(props: Props) {
 
   const updateLocation = (query: string) => {
     history.replace({
-      pathname: searchPath(query),
+      pathname: location.pathname,
       search: queryString.stringify(
-        { ...queryString.parse(location.search), query: undefined },
+        { ...queryString.parse(location.search), q: query },
         {
           skipEmptyString: true,
         }
@@ -153,7 +153,7 @@ function Search(props: Props) {
     history.replace({
       pathname: location.pathname,
       search: queryString.stringify(
-        { ...queryString.parse(location.search), query: undefined, ...search },
+        { ...queryString.parse(location.search), ...search },
         {
           skipEmptyString: true,
         }

--- a/app/scenes/Search/components/RecentSearchListItem.tsx
+++ b/app/scenes/Search/components/RecentSearchListItem.tsx
@@ -27,7 +27,7 @@ function RecentSearchListItem({ searchQuery }: Props) {
 
   return (
     <RecentSearch
-      to={searchPath(searchQuery.query)}
+      to={searchPath({ query: searchQuery.query })}
       ref={ref}
       {...rovingTabIndex}
     >

--- a/app/utils/routeHelpers.ts
+++ b/app/utils/routeHelpers.ts
@@ -111,23 +111,26 @@ export function newNestedDocumentPath(parentDocumentId?: string): string {
   return `/doc/new?${queryString.stringify({ parentDocumentId })}`;
 }
 
-export function searchPath(
-  query?: string,
-  params: {
-    collectionId?: string;
-    documentId?: string;
-    ref?: string;
-  } = {}
-): string {
-  let search = queryString.stringify(params);
-  let route = "/search";
-
-  if (query) {
-    route += `/${encodeURIComponent(query.replace(/%/g, "%25"))}`;
-  }
+export function searchPath({
+  query,
+  collectionId,
+  documentId,
+  ref,
+}: {
+  query?: string;
+  collectionId?: string;
+  documentId?: string;
+  ref?: string;
+} = {}): string {
+  let search = queryString.stringify({
+    q: query,
+    collectionId,
+    documentId,
+    ref,
+  });
 
   search = search ? `?${search}` : "";
-  return `${route}${search}`;
+  return `/search${search}`;
 }
 
 export function sharedDocumentPath(shareId: string, docPath?: string) {


### PR DESCRIPTION
Browsers mess with the path when it includes slashes – automatically changing back to forward slash. Even better than that, it doesn't matter if it's encoded – they'll _still_ mess with it. Moving the search term to query string, with the path variant as a fallback for backwards compat.

closes #8644 