### PR TITLE
Allow middle click

### DIFF
--- a/shared/editor/marks/Link.tsx
+++ b/shared/editor/marks/Link.tsx
@@ -179,7 +179,10 @@ export default class Link extends Mark {
           },
           mousedown: (view: EditorView, event: MouseEvent) => {
             const target = (event.target as HTMLElement)?.closest("a");
-            if (!(target instanceof HTMLAnchorElement) || event.button !== 0) {
+            if (
+              !(target instanceof HTMLAnchorElement) ||
+              (event.button !== 0 && event.button !== 1)
+            ) {
               return false;
             }
 


### PR DESCRIPTION
Allows events to continue if they are clicks _or_ middle clicks.

It doesn't appear to need any further customization, because the underling link handler already opens in a new tab.

Tested:
- Editing middle click
- Reading middle click
- Editing normal click
- Reading normal click