### PR TITLE
fix: Add prevention of auto-following unsubscribe links in emails

### DIFF
--- a/server/routes/api/notifications/notifications.ts
+++ b/server/routes/api/notifications/notifications.ts
@@ -57,8 +57,19 @@ router.get(
   "notifications.unsubscribe",
   validate(T.NotificationsUnsubscribeSchema),
   transaction(),
-  handleUnsubscribe
+  async (ctx: APIContext<T.NotificationsUnsubscribeReq>) => {
+    const { follow } = ctx.input.query;
+
+    // The link in the email does not include the follow query param, this
+    // is to help prevent anti-virus, and email clients from pre-fetching the link
+    if (!follow) {
+      return ctx.redirectOnClient(ctx.request.href + "&follow=true");
+    }
+
+    return handleUnsubscribe(ctx);
+  }
 );
+
 router.post(
   "notifications.unsubscribe",
   validate(T.NotificationsUnsubscribeSchema),

--- a/server/routes/api/notifications/schema.ts
+++ b/server/routes/api/notifications/schema.ts
@@ -30,6 +30,7 @@ export const NotificationsUnsubscribeSchema = BaseSchema.extend({
     eventType: z.nativeEnum(NotificationEventType).optional(),
   }),
   query: z.object({
+    follow: z.string().default(""),
     userId: z.string().uuid().optional(),
     token: z.string().optional(),
     eventType: z.nativeEnum(NotificationEventType).optional(),

--- a/server/routes/api/subscriptions/schema.ts
+++ b/server/routes/api/subscriptions/schema.ts
@@ -47,6 +47,7 @@ export type SubscriptionsDeleteReq = z.infer<typeof SubscriptionsDeleteSchema>;
 
 export const SubscriptionsDeleteTokenSchema = BaseSchema.extend({
   query: z.object({
+    follow: z.string().default(""),
     userId: z.string().uuid(),
     documentId: z.string().uuid(),
     token: z.string(),

--- a/server/routes/api/subscriptions/subscriptions.ts
+++ b/server/routes/api/subscriptions/subscriptions.ts
@@ -150,7 +150,13 @@ router.get(
   transaction(),
   async (ctx: APIContext<T.SubscriptionsDeleteTokenReq>) => {
     const { transaction } = ctx.state;
-    const { userId, documentId, token } = ctx.input.query;
+    const { follow, userId, documentId, token } = ctx.input.query;
+
+    // The link in the email does not include the follow query param, this
+    // is to help prevent anti-virus, and email clients from pre-fetching the link
+    if (!follow) {
+      return ctx.redirectOnClient(ctx.request.href + "&follow=true");
+    }
 
     const unsubscribeToken = SubscriptionHelper.unsubscribeToken(
       userId,


### PR DESCRIPTION
Add a client-side redirect to prevent anti-virus from loading unsubscribe links and inadvertently unsubbing the user. We have this same protection in place for email signin tokens, and email update tokens.