### PR TITLE
fix: Allow team admin to manage permissions on any document they have access to 

### DIFF
--- a/server/policies/document.ts
+++ b/server/policies/document.ts
@@ -125,6 +125,7 @@ allow(User, "manageUsers", Document, (actor, document) =>
     can(actor, "update", document),
     or(
       includesMembership(document, [DocumentPermission.Admin]),
+      and(isTeamAdmin(actor, document), can(actor, "read", document)),
       can(actor, "updateDocument", document?.collection),
       !!document?.isDraft && actor.id === document?.createdById
     )
@@ -136,6 +137,7 @@ allow(User, "duplicate", Document, (actor, document) =>
     can(actor, "update", document),
     or(
       includesMembership(document, [DocumentPermission.Admin]),
+      and(isTeamAdmin(actor, document), can(actor, "read", document)),
       can(actor, "updateDocument", document?.collection),
       !!document?.isDraft && actor.id === document?.createdById,
       and(
@@ -233,6 +235,7 @@ allow(User, "archive", Document, (actor, document) =>
     can(actor, "update", document),
     or(
       includesMembership(document, [DocumentPermission.Admin]),
+      and(isTeamAdmin(actor, document), can(actor, "read", document)),
       can(actor, "updateDocument", document?.collection)
     )
   )


### PR DESCRIPTION
closes #8740