### PR TITLE
fix: Release redis lock only when it hasn't expired

### DIFF
--- a/server/utils/CacheHelper.ts
+++ b/server/utils/CacheHelper.ts
@@ -54,7 +54,12 @@ export class CacheHelper {
       }
       return value;
     } finally {
-      await lock?.release();
+      try {
+        await lock?.release();
+      } catch (err) {
+        // This is fine - a concurrent process (or) redlock itself would have released the lock upon expiry.
+        Logger.error(`Failed to release lock for ${key}`, err);
+      }
     }
   }
 

--- a/server/utils/CacheHelper.ts
+++ b/server/utils/CacheHelper.ts
@@ -54,11 +54,8 @@ export class CacheHelper {
       }
       return value;
     } finally {
-      try {
-        await lock?.release();
-      } catch (err) {
-        // This is fine - a concurrent process (or) redlock itself would have released the lock upon expiry.
-        Logger.error(`Failed to release lock for ${key}`, err);
+      if (lock && lock.expiration > new Date().getTime()) {
+        await lock.release();
       }
     }
   }


### PR DESCRIPTION
This PR suppresses any exceptions that could arise during redlock flow. It's fine to suppress as sometimes the operation could fail when the lock has already expired (or) some other process has active lock on it.
More on this here - https://github.com/mike-marcacci/node-redlock/issues/168

This exception ends up failing the document update emails - noticed it in #8763 