### PR TITLE
fix: Handle empty text blocks from Notion response

### DIFF
--- a/plugins/notion/server/utils/NotionConverter.test.ts
+++ b/plugins/notion/server/utils/NotionConverter.test.ts
@@ -1,12 +1,22 @@
 import { Node } from "prosemirror-model";
 import { ProsemirrorHelper } from "@server/models/helpers/ProsemirrorHelper";
-import data from "@server/test/fixtures/notion-page.json";
+import nodesWithEmptyTextNode from "@server/test/fixtures/notion-page-with-empty-text-nodes.json";
+import allNodes from "@server/test/fixtures/notion-page.json";
 import { NotionConverter, NotionPage } from "./NotionConverter";
 
 describe("NotionConverter", () => {
   it("converts a page", () => {
     const response = NotionConverter.page({
-      children: data,
+      children: allNodes,
+    } as NotionPage);
+
+    expect(response).toMatchSnapshot();
+    expect(ProsemirrorHelper.toProsemirror(response)).toBeInstanceOf(Node);
+  });
+
+  it("converts a page with empty text nodes", () => {
+    const response = NotionConverter.page({
+      children: nodesWithEmptyTextNode,
     } as NotionPage);
 
     expect(response).toMatchSnapshot();

--- a/plugins/notion/server/utils/NotionConverter.ts
+++ b/plugins/notion/server/utils/NotionConverter.ts
@@ -179,11 +179,15 @@ export class NotionConverter {
   }
 
   private static bookmark(item: BookmarkBlockObjectResponse) {
+    const caption = item.bookmark.caption
+      .map(this.rich_text_to_plaintext)
+      .join("");
+
     return {
       type: "paragraph",
       content: [
         {
-          text: item.bookmark.caption.map(this.rich_text_to_plaintext).join(""),
+          text: caption || item.bookmark.url,
           type: "text",
           marks: [
             {
@@ -221,17 +225,14 @@ export class NotionConverter {
   }
 
   private static code(item: CodeBlockObjectResponse) {
+    const text = item.code.rich_text.map(this.rich_text_to_plaintext).join("");
+
     return {
       type: "code_fence",
       attrs: {
         language: item.code.language,
       },
-      content: [
-        {
-          type: "text",
-          text: item.code.rich_text.map(this.rich_text_to_plaintext).join(""),
-        },
-      ],
+      content: text ? [{ type: "text", text }] : undefined,
     };
   }
 
@@ -364,12 +365,14 @@ export class NotionConverter {
   private static equation(item: EquationBlockObjectResponse) {
     return {
       type: "math_block",
-      content: [
-        {
-          type: "text",
-          text: item.equation.expression,
-        },
-      ],
+      content: item.equation.expression
+        ? [
+            {
+              type: "text",
+              text: item.equation.expression,
+            },
+          ]
+        : undefined,
     };
   }
 

--- a/plugins/notion/server/utils/__snapshots__/NotionConverter.test.ts.snap
+++ b/plugins/notion/server/utils/__snapshots__/NotionConverter.test.ts.snap
@@ -1983,3 +1983,148 @@ exports[`NotionConverter converts a page 1`] = `
   "type": "doc",
 }
 `;
+
+exports[`NotionConverter converts a page with empty text nodes 1`] = `
+{
+  "content": [
+    {
+      "content": [],
+      "type": "paragraph",
+    },
+    {
+      "attrs": {
+        "language": "javascript",
+      },
+      "content": undefined,
+      "type": "code_fence",
+    },
+    {
+      "content": [],
+      "type": "paragraph",
+    },
+    {
+      "content": [
+        {
+          "content": [
+            {
+              "text": "E",
+              "type": "text",
+            },
+          ],
+          "type": "math_inline",
+        },
+      ],
+      "type": "paragraph",
+    },
+    {
+      "content": [],
+      "type": "paragraph",
+    },
+    {
+      "content": [
+        {
+          "marks": [
+            {
+              "attrs": {
+                "href": "http://github.com/outline/",
+              },
+              "type": "link",
+            },
+          ],
+          "text": "http://github.com/outline/",
+          "type": "text",
+        },
+      ],
+      "type": "paragraph",
+    },
+    {
+      "content": [],
+      "type": "paragraph",
+    },
+    {
+      "content": [
+        {
+          "marks": [
+            {
+              "attrs": {
+                "href": "https://github.com/outline/outline",
+              },
+              "type": "link",
+            },
+          ],
+          "text": "https://github.com/outline/outline",
+          "type": "text",
+        },
+      ],
+      "type": "paragraph",
+    },
+    {
+      "content": [],
+      "type": "paragraph",
+    },
+    {
+      "content": undefined,
+      "type": "math_block",
+    },
+    {
+      "content": [],
+      "type": "paragraph",
+    },
+    {
+      "content": [
+        {
+          "marks": [
+            {
+              "attrs": {
+                "href": "https://google.com",
+                "title": null,
+              },
+              "type": "link",
+            },
+          ],
+          "text": "https://google.com",
+          "type": "text",
+        },
+      ],
+      "type": "paragraph",
+    },
+    {
+      "content": [],
+      "type": "paragraph",
+    },
+    {
+      "content": [
+        {
+          "marks": [
+            {
+              "attrs": {
+                "href": "https://github.com/outline/outline",
+              },
+              "type": "link",
+            },
+          ],
+          "text": "https://github.com/outline/outline",
+          "type": "text",
+        },
+      ],
+      "type": "paragraph",
+    },
+    {
+      "content": [],
+      "type": "paragraph",
+    },
+    {
+      "attrs": {
+        "href": "https://prod-files-secure.s3.us-west-2.amazonaws.com/2f3fcad6-fc32-434b-b6b2-a03ca7893c4d/49bfa851-95c1-458b-abb0-88ed591f7712/Empty_pdf.pdf",
+        "title": "",
+      },
+      "type": "attachment",
+    },
+    {
+      "content": [],
+      "type": "paragraph",
+    },
+  ],
+  "type": "doc",
+}
+`;

--- a/server/test/fixtures/notion-page-with-empty-text-nodes.json
+++ b/server/test/fixtures/notion-page-with-empty-text-nodes.json
@@ -1,0 +1,509 @@
+[
+  {
+    "object": "block",
+    "id": "1c12c2bb-bca8-803b-a8dc-d10fdf86fd60",
+    "parent": {
+      "type": "page_id",
+      "page_id": "1c12c2bb-bca8-8023-ba9a-f8fafab74e48"
+    },
+    "created_time": "2025-03-25T07:49:00.000Z",
+    "last_edited_time": "2025-03-25T07:49:00.000Z",
+    "created_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "last_edited_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "has_children": false,
+    "archived": false,
+    "in_trash": false,
+    "type": "paragraph",
+    "paragraph": {
+      "rich_text": [],
+      "color": "default"
+    }
+  },
+  {
+    "object": "block",
+    "id": "1c12c2bb-bca8-809a-a9e5-f33faf274c5f",
+    "parent": {
+      "type": "page_id",
+      "page_id": "1c12c2bb-bca8-8023-ba9a-f8fafab74e48"
+    },
+    "created_time": "2025-03-25T07:56:00.000Z",
+    "last_edited_time": "2025-03-25T08:09:00.000Z",
+    "created_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "last_edited_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "has_children": false,
+    "archived": false,
+    "in_trash": false,
+    "type": "code",
+    "code": {
+      "caption": [],
+      "rich_text": [],
+      "language": "javascript"
+    }
+  },
+  {
+    "object": "block",
+    "id": "1c12c2bb-bca8-80c2-986a-ef8ae792a0f9",
+    "parent": {
+      "type": "page_id",
+      "page_id": "1c12c2bb-bca8-8023-ba9a-f8fafab74e48"
+    },
+    "created_time": "2025-03-25T08:04:00.000Z",
+    "last_edited_time": "2025-03-25T08:04:00.000Z",
+    "created_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "last_edited_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "has_children": false,
+    "archived": false,
+    "in_trash": false,
+    "type": "paragraph",
+    "paragraph": {
+      "rich_text": [],
+      "color": "default"
+    }
+  },
+  {
+    "object": "block",
+    "id": "1c12c2bb-bca8-80b3-9180-c6bc089c00fc",
+    "parent": {
+      "type": "page_id",
+      "page_id": "1c12c2bb-bca8-8023-ba9a-f8fafab74e48"
+    },
+    "created_time": "2025-03-25T07:56:00.000Z",
+    "last_edited_time": "2025-03-25T08:05:00.000Z",
+    "created_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "last_edited_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "has_children": false,
+    "archived": false,
+    "in_trash": false,
+    "type": "paragraph",
+    "paragraph": {
+      "rich_text": [
+        {
+          "type": "equation",
+          "equation": {
+            "expression": "E"
+          },
+          "annotations": {
+            "bold": false,
+            "italic": false,
+            "strikethrough": false,
+            "underline": false,
+            "code": false,
+            "color": "default"
+          },
+          "plain_text": "E",
+          "href": null
+        }
+      ],
+      "color": "default"
+    }
+  },
+  {
+    "object": "block",
+    "id": "1c12c2bb-bca8-80ca-974e-c226a1a1ae76",
+    "parent": {
+      "type": "page_id",
+      "page_id": "1c12c2bb-bca8-8023-ba9a-f8fafab74e48"
+    },
+    "created_time": "2025-03-25T08:10:00.000Z",
+    "last_edited_time": "2025-03-25T08:10:00.000Z",
+    "created_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "last_edited_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "has_children": false,
+    "archived": false,
+    "in_trash": false,
+    "type": "paragraph",
+    "paragraph": {
+      "rich_text": [],
+      "color": "default"
+    }
+  },
+  {
+    "object": "block",
+    "id": "1c12c2bb-bca8-8028-944b-e2593f20e09a",
+    "parent": {
+      "type": "page_id",
+      "page_id": "1c12c2bb-bca8-8023-ba9a-f8fafab74e48"
+    },
+    "created_time": "2025-03-25T08:09:00.000Z",
+    "last_edited_time": "2025-03-25T08:10:00.000Z",
+    "created_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "last_edited_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "has_children": false,
+    "archived": false,
+    "in_trash": false,
+    "type": "paragraph",
+    "paragraph": {
+      "rich_text": [
+        {
+          "type": "mention",
+          "mention": {
+            "type": "link_mention",
+            "link_mention": {
+              "href": "http://github.com/outline/",
+              "title": "Outline",
+              "icon_url": "https://github.com/fluidicon.png",
+              "description": "We're building an open source collaborative knowledge base for modern teams - Outline",
+              "link_provider": "GitHub",
+              "thumbnail_url": "https://avatars.githubusercontent.com/u/1765001?s=280&v=4"
+            }
+          },
+          "annotations": {
+            "bold": false,
+            "italic": false,
+            "strikethrough": false,
+            "underline": false,
+            "code": false,
+            "color": "default"
+          },
+          "plain_text": "http://github.com/outline/",
+          "href": "http://github.com/outline/"
+        }
+      ],
+      "color": "default"
+    }
+  },
+  {
+    "object": "block",
+    "id": "1c12c2bb-bca8-80f8-a272-c519ce56de27",
+    "parent": {
+      "type": "page_id",
+      "page_id": "1c12c2bb-bca8-8023-ba9a-f8fafab74e48"
+    },
+    "created_time": "2025-03-25T08:12:00.000Z",
+    "last_edited_time": "2025-03-25T08:12:00.000Z",
+    "created_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "last_edited_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "has_children": false,
+    "archived": false,
+    "in_trash": false,
+    "type": "paragraph",
+    "paragraph": {
+      "rich_text": [],
+      "color": "default"
+    }
+  },
+  {
+    "object": "block",
+    "id": "1c12c2bb-bca8-8096-8a94-e44b32127e73",
+    "parent": {
+      "type": "page_id",
+      "page_id": "1c12c2bb-bca8-8023-ba9a-f8fafab74e48"
+    },
+    "created_time": "2025-03-25T08:12:00.000Z",
+    "last_edited_time": "2025-03-25T08:12:00.000Z",
+    "created_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "last_edited_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "has_children": false,
+    "archived": false,
+    "in_trash": false,
+    "type": "paragraph",
+    "paragraph": {
+      "rich_text": [
+        {
+          "type": "mention",
+          "mention": {
+            "type": "link_preview",
+            "link_preview": {
+              "url": "https://github.com/outline/outline"
+            }
+          },
+          "annotations": {
+            "bold": false,
+            "italic": false,
+            "strikethrough": false,
+            "underline": false,
+            "code": false,
+            "color": "default"
+          },
+          "plain_text": "https://github.com/outline/outline",
+          "href": "https://github.com/outline/outline"
+        }
+      ],
+      "color": "default"
+    }
+  },
+  {
+    "object": "block",
+    "id": "1c12c2bb-bca8-807b-98de-ff2c1d0080f2",
+    "parent": {
+      "type": "page_id",
+      "page_id": "1c12c2bb-bca8-8023-ba9a-f8fafab74e48"
+    },
+    "created_time": "2025-03-25T08:13:00.000Z",
+    "last_edited_time": "2025-03-25T08:13:00.000Z",
+    "created_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "last_edited_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "has_children": false,
+    "archived": false,
+    "in_trash": false,
+    "type": "paragraph",
+    "paragraph": {
+      "rich_text": [],
+      "color": "default"
+    }
+  },
+  {
+    "object": "block",
+    "id": "1c12c2bb-bca8-80dd-b816-cb4dd04d4f46",
+    "parent": {
+      "type": "page_id",
+      "page_id": "1c12c2bb-bca8-8023-ba9a-f8fafab74e48"
+    },
+    "created_time": "2025-03-25T08:13:00.000Z",
+    "last_edited_time": "2025-03-25T08:13:00.000Z",
+    "created_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "last_edited_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "has_children": false,
+    "archived": false,
+    "in_trash": false,
+    "type": "equation",
+    "equation": {
+      "expression": ""
+    }
+  },
+  {
+    "object": "block",
+    "id": "1c12c2bb-bca8-8074-a5e0-f0ba30bd0510",
+    "parent": {
+      "type": "page_id",
+      "page_id": "1c12c2bb-bca8-8023-ba9a-f8fafab74e48"
+    },
+    "created_time": "2025-03-25T08:18:00.000Z",
+    "last_edited_time": "2025-03-25T08:18:00.000Z",
+    "created_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "last_edited_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "has_children": false,
+    "archived": false,
+    "in_trash": false,
+    "type": "paragraph",
+    "paragraph": {
+      "rich_text": [],
+      "color": "default"
+    }
+  },
+  {
+    "object": "block",
+    "id": "1c12c2bb-bca8-80dc-8a14-db8b714450f6",
+    "parent": {
+      "type": "page_id",
+      "page_id": "1c12c2bb-bca8-8023-ba9a-f8fafab74e48"
+    },
+    "created_time": "2025-03-25T08:18:00.000Z",
+    "last_edited_time": "2025-03-25T08:30:00.000Z",
+    "created_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "last_edited_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "has_children": false,
+    "archived": false,
+    "in_trash": false,
+    "type": "bookmark",
+    "bookmark": {
+      "caption": [],
+      "url": "https://google.com"
+    }
+  },
+  {
+    "object": "block",
+    "id": "1c12c2bb-bca8-80f2-94b4-df422d9cd18e",
+    "parent": {
+      "type": "page_id",
+      "page_id": "1c12c2bb-bca8-8023-ba9a-f8fafab74e48"
+    },
+    "created_time": "2025-03-25T08:24:00.000Z",
+    "last_edited_time": "2025-03-25T08:24:00.000Z",
+    "created_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "last_edited_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "has_children": false,
+    "archived": false,
+    "in_trash": false,
+    "type": "paragraph",
+    "paragraph": {
+      "rich_text": [],
+      "color": "default"
+    }
+  },
+  {
+    "object": "block",
+    "id": "1c12c2bb-bca8-8046-946c-d89c2bc7827c",
+    "parent": {
+      "type": "page_id",
+      "page_id": "1c12c2bb-bca8-8023-ba9a-f8fafab74e48"
+    },
+    "created_time": "2025-03-25T08:24:00.000Z",
+    "last_edited_time": "2025-03-25T08:24:00.000Z",
+    "created_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "last_edited_by": {
+      "object": "user",
+      "id": "1b32c2bb-bca8-816a-99c0-0027ab5c4cb0"
+    },
+    "has_children": false,
+    "archived": false,
+    "in_trash": false,
+    "type": "link_preview",
+    "link_preview": {
+      "url": "https://github.com/outline/outline"
+    }
+  },
+  {
+    "object": "block",
+    "id": "1c12c2bb-bca8-80e6-80d3-f9501fc1a6fb",
+    "parent": {
+      "type": "page_id",
+      "page_id": "1c12c2bb-bca8-8023-ba9a-f8fafab74e48"
+    },
+    "created_time": "2025-03-25T08:24:00.000Z",
+    "last_edited_time": "2025-03-25T08:24:00.000Z",
+    "created_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "last_edited_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "has_children": false,
+    "archived": false,
+    "in_trash": false,
+    "type": "paragraph",
+    "paragraph": {
+      "rich_text": [],
+      "color": "default"
+    }
+  },
+  {
+    "object": "block",
+    "id": "1c12c2bb-bca8-8070-9c41-ca4c3aa1a419",
+    "parent": {
+      "type": "page_id",
+      "page_id": "1c12c2bb-bca8-8023-ba9a-f8fafab74e48"
+    },
+    "created_time": "2025-03-25T08:24:00.000Z",
+    "last_edited_time": "2025-03-25T08:30:00.000Z",
+    "created_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "last_edited_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "has_children": false,
+    "archived": false,
+    "in_trash": false,
+    "type": "pdf",
+    "pdf": {
+      "caption": [],
+      "type": "file",
+      "file": {
+        "url": "https://prod-files-secure.s3.us-west-2.amazonaws.com/2f3fcad6-fc32-434b-b6b2-a03ca7893c4d/49bfa851-95c1-458b-abb0-88ed591f7712/Empty_pdf.pdf",
+        "expiry_time": "2025-03-25T09:32:41.690Z"
+      }
+    }
+  },
+  {
+    "object": "block",
+    "id": "1c12c2bb-bca8-800c-8857-eca03207279f",
+    "parent": {
+      "type": "page_id",
+      "page_id": "1c12c2bb-bca8-8023-ba9a-f8fafab74e48"
+    },
+    "created_time": "2025-03-25T08:26:00.000Z",
+    "last_edited_time": "2025-03-25T08:26:00.000Z",
+    "created_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "last_edited_by": {
+      "object": "user",
+      "id": "b69e71d0-c6c2-428c-ae38-5c020343b36b"
+    },
+    "has_children": false,
+    "archived": false,
+    "in_trash": false,
+    "type": "paragraph",
+    "paragraph": {
+      "rich_text": [],
+      "color": "default"
+    }
+  }
+]


### PR DESCRIPTION
Closes #8782 

Empty content in bookmark caption, code block and math block from Notion causes the "empty text node" error in Prosemirror. Other cases of converting to "text" node works fine.