### PR TITLE
fix: Improve performance of notification queries

### DIFF
--- a/server/models/helpers/NotificationHelper.test.ts
+++ b/server/models/helpers/NotificationHelper.test.ts
@@ -115,29 +115,6 @@ describe("NotificationHelper", () => {
   });
 
   describe("getDocumentNotificationRecipients", () => {
-    it("should return all users who have notification enabled for the event", async () => {
-      const documentAuthor = await buildUser();
-      const document = await buildDocument({
-        userId: documentAuthor.id,
-        teamId: documentAuthor.teamId,
-      });
-      const notificationEnabledUser = await buildUser({
-        teamId: document.teamId,
-        notificationSettings: { [NotificationEventType.UpdateDocument]: true },
-      });
-
-      const recipients =
-        await NotificationHelper.getDocumentNotificationRecipients({
-          document,
-          notificationType: NotificationEventType.UpdateDocument,
-          onlySubscribers: false,
-          actorId: documentAuthor.id,
-        });
-
-      expect(recipients.length).toEqual(1);
-      expect(recipients[0].id).toEqual(notificationEnabledUser.id);
-    });
-
     it("should return users who have subscribed to the document", async () => {
       const documentAuthor = await buildUser();
       const document = await buildDocument({
@@ -154,7 +131,6 @@ describe("NotificationHelper", () => {
         await NotificationHelper.getDocumentNotificationRecipients({
           document,
           notificationType: NotificationEventType.UpdateDocument,
-          onlySubscribers: true,
           actorId: documentAuthor.id,
         });
 
@@ -178,7 +154,6 @@ describe("NotificationHelper", () => {
         await NotificationHelper.getDocumentNotificationRecipients({
           document,
           notificationType: NotificationEventType.UpdateDocument,
-          onlySubscribers: true,
           actorId: documentAuthor.id,
         });
 
@@ -216,7 +191,6 @@ describe("NotificationHelper", () => {
         await NotificationHelper.getDocumentNotificationRecipients({
           document,
           notificationType: NotificationEventType.UpdateDocument,
-          onlySubscribers: true,
           actorId: documentAuthor.id,
         });
 
@@ -235,20 +209,19 @@ describe("NotificationHelper", () => {
       });
       const notificationEnabledUser = await buildUser({
         teamId: document.teamId,
-        notificationSettings: { [NotificationEventType.UpdateDocument]: true },
+        notificationSettings: { [NotificationEventType.PublishDocument]: true },
       });
       // suspended user
       await buildUser({
         suspendedAt: new Date(),
         teamId: document.teamId,
-        notificationSettings: { [NotificationEventType.UpdateDocument]: true },
+        notificationSettings: { [NotificationEventType.PublishDocument]: true },
       });
 
       const recipients =
         await NotificationHelper.getDocumentNotificationRecipients({
           document,
-          notificationType: NotificationEventType.UpdateDocument,
-          onlySubscribers: false,
+          notificationType: NotificationEventType.PublishDocument,
           actorId: documentAuthor.id,
         });
 

--- a/server/models/helpers/NotificationHelper.ts
+++ b/server/models/helpers/NotificationHelper.ts
@@ -60,13 +60,7 @@ export default class NotificationHelper {
     comment: Comment,
     actorId: string
   ): Promise<User[]> => {
-    let recipients = await this.getDocumentNotificationRecipients({
-      document,
-      notificationType: NotificationEventType.CreateComment,
-      actorId,
-      // We will check below, this just prevents duplicate queries
-      disableAccessCheck: true,
-    });
+    let recipients: User[];
 
     // If this is a reply to another comment, we want to notify all users
     // that are involved in the thread of this comment (i.e. the original
@@ -109,6 +103,14 @@ export default class NotificationHelper {
       recipients = recipients.filter((recipient) =>
         recipient.subscribedToEventType(NotificationEventType.CreateComment)
       );
+    } else {
+      recipients = await this.getDocumentNotificationRecipients({
+        document,
+        notificationType: NotificationEventType.CreateComment,
+        actorId,
+        // We will check below, this just prevents duplicate queries
+        disableAccessCheck: true,
+      });
     }
 
     const filtered: User[] = [];

--- a/server/queues/tasks/DocumentPublishedNotificationsTask.ts
+++ b/server/queues/tasks/DocumentPublishedNotificationsTask.ts
@@ -54,7 +54,6 @@ export default class DocumentPublishedNotificationsTask extends BaseTask<Documen
       await NotificationHelper.getDocumentNotificationRecipients({
         document,
         notificationType: NotificationEventType.PublishDocument,
-        onlySubscribers: false,
         actorId: document.lastModifiedById,
       })
     ).filter((recipient) => !userIdsMentioned.includes(recipient.id));

--- a/server/queues/tasks/RevisionCreatedNotificationsTask.ts
+++ b/server/queues/tasks/RevisionCreatedNotificationsTask.ts
@@ -76,7 +76,6 @@ export default class RevisionCreatedNotificationsTask extends BaseTask<RevisionE
       await NotificationHelper.getDocumentNotificationRecipients({
         document,
         notificationType: NotificationEventType.UpdateDocument,
-        onlySubscribers: true,
         actorId: document.lastModifiedById,
       })
     ).filter((recipient) => !userIdsMentioned.includes(recipient.id));


### PR DESCRIPTION
So far I've been unable to reproduce the reported issue of users receiving emails for comments they didn't participate in, but this is a nice refactor that simplifies, improves performance, and removes the dangerous `onlySubscribers` prop

closes #8807