### PR TITLE
fix: Skip sequelize hooks when creating user membership in collections.update

### DIFF
--- a/server/routes/api/collections/collections.ts
+++ b/server/routes/api/collections/collections.ts
@@ -597,6 +597,7 @@ router.post(
           createdById: user.id,
         },
         transaction,
+        hooks: false,
       });
     }
 


### PR DESCRIPTION
Closes #8840 

I could not reproduce the bug through app - I suppose the bug must've occurred through a direct API invocation.
However, the fix made in this PR is likely the bug source.

On a related note, I'm not sure if the containing block is needed.. maybe it's being used in enterprise edition?
Also, the guard in L587/588 feels out-of-date with comment in L584 🤔 