### PR TITLE
fix: Missing transaction in save causing deadlocks

### DIFF
--- a/server/routes/api/notifications/notifications.ts
+++ b/server/routes/api/notifications/notifications.ts
@@ -53,7 +53,7 @@ const handleUnsubscribe = async (
   });
 
   user.setNotificationEventType(eventType, false);
-  await user.save();
+  await user.save({ transaction });
   ctx.redirect(`${user.team.url}/settings/notifications?success`);
 };
 


### PR DESCRIPTION
This is the cause of a couple of spots of downtime in recent days.