### PR TITLE
fix: Collaboration server inaccurately counts connections

### DIFF
--- a/server/collaboration/ConnectionLimitExtension.test.ts
+++ b/server/collaboration/ConnectionLimitExtension.test.ts
@@ -1,0 +1,109 @@
+import { Server } from "@hocuspocus/server";
+import WebSocket from "ws";
+import EDITOR_VERSION from "@shared/editor/version";
+import { sleep } from "@server/utils/timers";
+import { ConnectionLimitExtension } from "./ConnectionLimitExtension";
+import { EditorVersionExtension } from "./EditorVersionExtension";
+
+jest.mock("@server/env", () => ({
+  COLLABORATION_MAX_CLIENTS_PER_DOCUMENT: 2,
+}));
+
+describe("ConnectionLimitExtension", () => {
+  let server: typeof Server;
+  let extension: ConnectionLimitExtension;
+  const port = 12345;
+  const url = `ws://localhost:${port}`;
+  const documentName = "test";
+
+  beforeEach(async () => {
+    extension = new ConnectionLimitExtension();
+    server = Server.configure({
+      port,
+      extensions: [extension, new EditorVersionExtension()],
+    });
+    await server.listen();
+  });
+
+  afterEach(async () => {
+    await server.destroy();
+  });
+
+  const getConnections = () =>
+    extension.connectionsByDocument.get(documentName)?.size ?? 0;
+
+  const createWebSocket = (editorVersion = EDITOR_VERSION) =>
+    new Promise<WebSocket>((resolve, reject) => {
+      const ws = new WebSocket(
+        `${url}/${documentName}?editorVersion=${editorVersion}`
+      );
+      ws.on("open", () => resolve(ws));
+      ws.on("error", reject);
+    });
+
+  it("should allow connections within limit", async () => {
+    const ws1 = await createWebSocket();
+    const ws2 = await createWebSocket();
+
+    expect(ws1.readyState).toBe(WebSocket.OPEN);
+    expect(ws2.readyState).toBe(WebSocket.OPEN);
+    expect(getConnections()).toBe(2);
+
+    ws1.close();
+    ws2.close();
+
+    await sleep(250);
+    expect(getConnections()).toBe(0);
+  });
+
+  it("should close connections exceeding limit", async () => {
+    const ws1 = await createWebSocket();
+    const ws2 = await createWebSocket();
+
+    const ws3 = await createWebSocket();
+    await sleep(250);
+
+    expect(ws3.readyState).toBe(WebSocket.CLOSED);
+    expect(ws2.readyState).toBe(WebSocket.OPEN);
+    expect(ws1.readyState).toBe(WebSocket.OPEN);
+    expect(getConnections()).toBe(2);
+
+    ws1.close();
+    ws2.close();
+
+    await sleep(250);
+    expect(getConnections()).toBe(0);
+  });
+
+  it("should handle connections closed by other extensions", async () => {
+    const ws1 = await createWebSocket();
+
+    // Create a connection that will be closed by the EditorVersionExtension
+    const ws2 = await createWebSocket("1.0.0");
+
+    ws1.close();
+    ws2.close();
+
+    await sleep(250);
+    expect(getConnections()).toBe(0);
+  });
+
+  it("should allow new connection after disconnect", async () => {
+    const ws1 = await createWebSocket();
+    const ws2 = await createWebSocket();
+
+    ws1.close();
+    await sleep(250);
+    expect(getConnections()).toBe(1);
+
+    const ws3 = await createWebSocket();
+    expect(ws3.readyState).toBe(WebSocket.OPEN);
+    expect(getConnections()).toBe(2);
+
+    ws2.close();
+    ws3.close();
+
+    await sleep(250);
+    expect(getConnections()).toBe(0);
+  });
+});

--- a/server/collaboration/ConnectionLimitExtension.ts
+++ b/server/collaboration/ConnectionLimitExtension.ts
@@ -49,7 +49,7 @@ export class ConnectionLimitExtension implements Extension {
   }
 
   /**
-   * Connected hook is called when a new connection has been established.
+   * onConnect hook is called when a new connection has been established.
    * This is where we can check if the document has reached the maximum number of
    * connections and reject the connection if it has.
    *
@@ -74,8 +74,8 @@ export class ConnectionLimitExtension implements Extension {
   }
 
   /**
-   * Connected hook is called when a new connection has been established.
-   * This is where we can update the connection count for the document.
+   * Connected hook is called after a new connection has been established.
+   * We can safely update the connection count for the document.
    *
    * @param data The onConnect payload
    * @returns Promise


### PR DESCRIPTION
Fixes a regression in [#8751](https://github.com/outline/outline/pull/8751/files#diff-074611e897564d35bc1cb7e548e081e800f80f11604c09cebf020a916c87f560) where the connection count would be increased before a connection is successfully established, resulting in an incorrect count if another extension rejects the connection.