### PR TITLE
Added delay on sidebar exit

### DIFF
--- a/app/components/Sidebar/Sidebar.tsx
+++ b/app/components/Sidebar/Sidebar.tsx
@@ -116,7 +116,7 @@ const Sidebar = React.forwardRef<HTMLDivElement, Props>(function _Sidebar(
 
   const handlePointerActivity = React.useCallback(() => {
     if (ui.sidebarIsClosed) {
-      //clear the timeout when mouse exits
+      // clear the timeout when mouse exits
       if (hoverTimeoutRef.current) {
         clearTimeout(hoverTimeoutRef.current);
       }
@@ -128,12 +128,12 @@ const Sidebar = React.forwardRef<HTMLDivElement, Props>(function _Sidebar(
   const handlePointerLeave = React.useCallback(
     (ev) => {
       if (hasPointerMoved) {
-        //to clear any previous timeOut
+        // clear any previous timeout
         if (hoverTimeoutRef.current) {
           clearTimeout(hoverTimeoutRef.current);
         }
 
-        //add a little bit of a delay when mouse exits the sidebar
+        // add a short delay when mouse exits the sidebar before closing
         hoverTimeoutRef.current = setTimeout(() => {
           setHovering(
             document.hasFocus() &&

--- a/app/components/Sidebar/Sidebar.tsx
+++ b/app/components/Sidebar/Sidebar.tsx
@@ -54,6 +54,8 @@ const Sidebar = React.forwardRef<HTMLDivElement, Props>(function _Sidebar(
   const [hasPointerMoved, setPointerMoved] = React.useState(false);
   const isSmallerThanMinimum = width < minWidth;
 
+  const hoverTimeoutRef = React.useRef<NodeJS.Timeout | null>(null);
+
   const handleDrag = React.useCallback(
     (event: MouseEvent) => {
       // suppresses text selection
@@ -114,6 +116,10 @@ const Sidebar = React.forwardRef<HTMLDivElement, Props>(function _Sidebar(
 
   const handlePointerActivity = React.useCallback(() => {
     if (ui.sidebarIsClosed) {
+      //clear the timeout when mouse exits
+      if (hoverTimeoutRef.current) {
+        clearTimeout(hoverTimeoutRef.current);
+      }
       setHovering(document.hasFocus());
       setPointerMoved(true);
     }
@@ -122,12 +128,20 @@ const Sidebar = React.forwardRef<HTMLDivElement, Props>(function _Sidebar(
   const handlePointerLeave = React.useCallback(
     (ev) => {
       if (hasPointerMoved) {
-        setHovering(
-          document.hasFocus() &&
-            ev.pageX < width &&
-            ev.pageY < window.innerHeight &&
-            ev.pageY > 0
-        );
+        //to clear any previous timeOut
+        if (hoverTimeoutRef.current) {
+          clearTimeout(hoverTimeoutRef.current);
+        }
+
+        //add a little bit of a delay when mouse exits the sidebar
+        hoverTimeoutRef.current = setTimeout(() => {
+          setHovering(
+            document.hasFocus() &&
+              ev.pageX < width &&
+              ev.pageY < window.innerHeight &&
+              ev.pageY > 0
+          );
+        }, 500);
       }
     },
     [width, hasPointerMoved]


### PR DESCRIPTION
Hey, this is adressing this issue #8872  concerning the sidebar closing too fast when hovering off.
I added a half a second delay when the poiter leaves the sidebar to make it a little more convenient.

closes #8872