### PR TITLE
fix: `collectionIndexing` results in `teamId` undefined error

### DIFF
--- a/server/utils/indexing.test.ts
+++ b/server/utils/indexing.test.ts
@@ -1,0 +1,87 @@
+import {
+  buildCollection,
+  buildDocument,
+  buildStar,
+  buildTeam,
+  buildUser,
+} from "@server/test/factories";
+import { collectionIndexing, starIndexing } from "./indexing";
+
+describe("collectionIndexing", () => {
+  it("should generate index for collections without index", async () => {
+    const team = await buildTeam();
+    const collections = await Promise.all([
+      buildCollection({
+        teamId: team.id,
+      }),
+      buildCollection({
+        teamId: team.id,
+      }),
+    ]);
+
+    // Set index to null to simulate no index
+    collections[0].index = null;
+    collections[1].index = null;
+    await collections[0].save({ hooks: false });
+    await collections[1].save({ hooks: false });
+
+    const result = await collectionIndexing(team.id, {});
+    expect(Object.keys(result).length).toBe(2);
+    expect(result[collections[0].id]).toBeTruthy();
+    expect(result[collections[1].id]).toBeTruthy();
+  });
+
+  it("should maintain existing indices", async () => {
+    const team = await buildTeam();
+    const collection = await buildCollection({
+      teamId: team.id,
+      index: "a1",
+    });
+
+    const result = await collectionIndexing(team.id, {});
+    expect(result[collection.id]).toBe("a1");
+  });
+});
+
+describe("starIndexing", () => {
+  it("should generate index for stars without index", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const document = await buildDocument();
+    const stars = await Promise.all([
+      buildStar({
+        userId: user.id,
+        documentId: document.id,
+      }),
+      buildStar({
+        userId: user.id,
+        documentId: document.id,
+      }),
+    ]);
+
+    // Set index to null to simulate no index
+    stars[0].index = null;
+    stars[1].index = null;
+    await stars[0].save({ hooks: false });
+    await stars[1].save({ hooks: false });
+
+    const result = await starIndexing(user.id);
+    expect(Object.keys(result).length).toBe(2);
+    expect(result[stars[0].id]).toBeTruthy();
+    expect(result[stars[1].id]).toBeTruthy();
+  });
+
+  it("should maintain existing indices", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const document = await buildDocument();
+    const star = await buildStar({
+      userId: user.id,
+      documentId: document.id,
+      index: "a1",
+    });
+
+    const result = await starIndexing(user.id);
+    expect(result[star.id]).toBe("a1");
+  });
+});

--- a/server/utils/indexing.ts
+++ b/server/utils/indexing.ts
@@ -10,10 +10,8 @@ export async function collectionIndexing(
   const collections = await Collection.findAll({
     where: {
       teamId,
-      // no point in maintaining index of deleted collections.
-      deletedAt: null,
     },
-    attributes: ["id", "index", "name"],
+    attributes: ["id", "index", "name", "teamId"],
     transaction,
   });
 
@@ -26,7 +24,9 @@ export async function collectionIndexing(
   for (const collection of sortable) {
     if (collection.index === null) {
       collection.index = fractionalIndex(previousIndex, null);
-      promises.push(collection.save({ fields: ["index"], transaction })); // save only index to prevent overwriting other unfetched fields.
+      promises.push(
+        collection.save({ fields: ["index"], silent: true, transaction })
+      );
     }
 
     previousIndex = collection.index;
@@ -67,7 +67,7 @@ export async function starIndexing(userId: string) {
   for (const star of sortable) {
     if (star.index === null) {
       star.index = fractionalIndex(previousIndex, null);
-      promises.push(star.save());
+      promises.push(star.save({ silent: true }));
     }
 
     previousIndex = star.index;


### PR DESCRIPTION
This seems to be due to a bug in Sequelize when selecting fields to query. The bug can be reproduced by removing the changes in `indexing.ts` and running the included tests