### PR TITLE
Display breadcrumb instead of collection name when link and mention document

### DIFF
--- a/app/components/DocumentBreadcrumb.tsx
+++ b/app/components/DocumentBreadcrumb.tsx
@@ -98,7 +98,7 @@ function DocumentBreadcrumb(
   const items = React.useMemo(() => {
     const output = [];
 
-    if (category && output.length) {
+    if (category) {
       output.push(category);
     }
     if (collectionNode) {

--- a/app/components/DocumentBreadcrumb.tsx
+++ b/app/components/DocumentBreadcrumb.tsx
@@ -19,6 +19,11 @@ type Props = {
   document: Document;
   onlyText?: boolean;
   reverse?: boolean;
+  /**
+   * Maximum number of items to show in the breadcrumb.
+   * If value is less than or equals to 0, no items will be shown.
+   * If value is undefined, all items will be shown.
+   */
   maxDepth?: number;
 };
 
@@ -67,6 +72,7 @@ function DocumentBreadcrumb(
     ? collections.get(document.collectionId)
     : undefined;
   const can = usePolicy(collection);
+  const depth = maxDepth === undefined ? undefined : Math.max(0, maxDepth);
 
   React.useEffect(() => {
     void document.loadRelations({ withoutPolicies: true });
@@ -96,7 +102,9 @@ function DocumentBreadcrumb(
   const path = document.pathTo.slice(0, -1);
 
   const items = React.useMemo(() => {
-    const output = [];
+    const output: MenuInternalLink[] = [];
+
+    if (depth === 0) return output;
 
     if (category) {
       output.push(category);
@@ -124,8 +132,8 @@ function DocumentBreadcrumb(
     });
 
     return reverse
-      ? output.slice(maxDepth && -maxDepth)
-      : output.slice(0, maxDepth);
+      ? output.slice(depth && -depth)
+      : output.slice(0, depth);
   }, [
     t,
     path,
@@ -141,19 +149,19 @@ function DocumentBreadcrumb(
   }
 
   if (onlyText) {
+    if (depth === 0) return <></>
+
     const slicedPath = reverse
-      ? path.slice((maxDepth && -maxDepth))
-      : path.slice(0, maxDepth);
+      ? path.slice((depth && -depth))
+      : path.slice(0, depth);
 
     const showCollection = collection && (
-      reverse
-        ? !maxDepth || slicedPath.length < maxDepth
-        : maxDepth !== 0
+      !reverse || depth === undefined || slicedPath.length < depth
     );
 
     return (
       <>
-        {showCollection && collection?.name}
+        {showCollection && collection.name}
         {slicedPath.map((node: NavigationNode, index: number) => (
           <React.Fragment key={node.id}>
             {showCollection && <SmallSlash />}

--- a/app/components/DocumentBreadcrumb.tsx
+++ b/app/components/DocumentBreadcrumb.tsx
@@ -133,7 +133,13 @@ function DocumentBreadcrumb(
       });
     });
 
-    return reverse ? output.slice(depth && -depth) : output.slice(0, depth);
+    return reverse
+      ? depth !== undefined
+        ? output.slice(-depth)
+        : output
+      : depth !== undefined
+      ? output.slice(0, depth)
+      : output;
   }, [t, path, category, sidebarContext, collectionNode, reverse, depth]);
 
   if (!collections.isLoaded) {

--- a/app/components/DocumentBreadcrumb.tsx
+++ b/app/components/DocumentBreadcrumb.tsx
@@ -104,7 +104,9 @@ function DocumentBreadcrumb(
   const items = React.useMemo(() => {
     const output: MenuInternalLink[] = [];
 
-    if (depth === 0) return output;
+    if (depth === 0) {
+      return output;
+    }
 
     if (category) {
       output.push(category);
@@ -131,33 +133,25 @@ function DocumentBreadcrumb(
       });
     });
 
-    return reverse
-      ? output.slice(depth && -depth)
-      : output.slice(0, depth);
-  }, [
-    t,
-    path,
-    category,
-    sidebarContext,
-    collectionNode,
-    reverse,
-    maxDepth,
-  ]);
+    return reverse ? output.slice(depth && -depth) : output.slice(0, depth);
+  }, [t, path, category, sidebarContext, collectionNode, reverse, depth]);
 
   if (!collections.isLoaded) {
     return null;
   }
 
   if (onlyText) {
-    if (depth === 0) return <></>
+    if (depth === 0) {
+      return <></>;
+    }
 
     const slicedPath = reverse
-      ? path.slice((depth && -depth))
+      ? path.slice(depth && -depth)
       : path.slice(0, depth);
 
-    const showCollection = collection && (
-      !reverse || depth === undefined || slicedPath.length < depth
-    );
+    const showCollection =
+      collection &&
+      (!reverse || depth === undefined || slicedPath.length < depth);
 
     return (
       <>
@@ -166,7 +160,9 @@ function DocumentBreadcrumb(
           <React.Fragment key={node.id}>
             {showCollection && <SmallSlash />}
             {node.title || t("Untitled")}
-            {!showCollection && index !== slicedPath.length - 1 && <SmallSlash />}
+            {!showCollection && index !== slicedPath.length - 1 && (
+              <SmallSlash />
+            )}
           </React.Fragment>
         ))}
       </>

--- a/app/editor/components/LinkEditor.tsx
+++ b/app/editor/components/LinkEditor.tsx
@@ -255,7 +255,12 @@ const LinkEditor: React.FC<Props> = ({
                   selected={index === selectedIndex}
                   key={doc.id}
                   subtitle={
-                    <DocumentBreadcrumb document={doc} onlyText reverse maxDepth={2} />
+                    <DocumentBreadcrumb
+                      document={doc}
+                      onlyText
+                      reverse
+                      maxDepth={2}
+                    />
                   }
                   title={doc.title}
                   icon={

--- a/app/editor/components/LinkEditor.tsx
+++ b/app/editor/components/LinkEditor.tsx
@@ -255,7 +255,7 @@ const LinkEditor: React.FC<Props> = ({
                   selected={index === selectedIndex}
                   key={doc.id}
                   subtitle={
-                    <DocumentBreadcrumb document={doc} onlyText reverse />
+                    <DocumentBreadcrumb document={doc} onlyText reverse maxDepth={2} />
                   }
                   title={doc.title}
                   icon={
@@ -280,7 +280,7 @@ const Wrapper = styled(Flex)`
   gap: 8px;
 `;
 
-const SearchResults = styled(Scrollable) <{ $hasResults: boolean }>`
+const SearchResults = styled(Scrollable)<{ $hasResults: boolean }>`
   background: ${s("menuBackground")};
   box-shadow: ${(props) => (props.$hasResults ? s("menuShadow") : "none")};
   clip-path: inset(0px -100px -100px -100px);

--- a/app/editor/components/LinkEditor.tsx
+++ b/app/editor/components/LinkEditor.tsx
@@ -10,6 +10,7 @@ import styled from "styled-components";
 import Icon from "@shared/components/Icon";
 import { hideScrollbars, s } from "@shared/styles";
 import { isInternalUrl, sanitizeUrl } from "@shared/utils/urls";
+import DocumentBreadcrumb from "~/components/DocumentBreadcrumb";
 import Flex from "~/components/Flex";
 import { ResizingHeightContainer } from "~/components/ResizingHeightContainer";
 import Scrollable from "~/components/Scrollable";
@@ -69,7 +70,7 @@ const LinkEditor: React.FC<Props> = ({
     React.useCallback(async () => {
       const res = await client.post("/suggestions.mention", { query });
       res.data.documents.map(documents.add);
-    }, [query])
+    }, [query, documents.add])
   );
 
   useEffect(() => {
@@ -253,7 +254,9 @@ const LinkEditor: React.FC<Props> = ({
                   onPointerMove={() => setSelectedIndex(index)}
                   selected={index === selectedIndex}
                   key={doc.id}
-                  subtitle={doc.collection?.name}
+                  subtitle={
+                    <DocumentBreadcrumb document={doc} onlyText reverse />
+                  }
                   title={doc.title}
                   icon={
                     doc.icon ? (
@@ -277,7 +280,7 @@ const Wrapper = styled(Flex)`
   gap: 8px;
 `;
 
-const SearchResults = styled(Scrollable)<{ $hasResults: boolean }>`
+const SearchResults = styled(Scrollable) <{ $hasResults: boolean }>`
   background: ${s("menuBackground")};
   box-shadow: ${(props) => (props.$hasResults ? s("menuShadow") : "none")};
   clip-path: inset(0px -100px -100px -100px);

--- a/app/editor/components/LinkEditor.tsx
+++ b/app/editor/components/LinkEditor.tsx
@@ -70,7 +70,7 @@ const LinkEditor: React.FC<Props> = ({
     React.useCallback(async () => {
       const res = await client.post("/suggestions.mention", { query });
       res.data.documents.map(documents.add);
-    }, [query, documents.add])
+    }, [query])
   );
 
   useEffect(() => {

--- a/app/editor/components/MentionMenu.tsx
+++ b/app/editor/components/MentionMenu.tsx
@@ -11,6 +11,7 @@ import { MenuItem } from "@shared/editor/types";
 import { MentionType } from "@shared/types";
 import parseDocumentSlug from "@shared/utils/parseDocumentSlug";
 import { Avatar, AvatarSize } from "~/components/Avatar";
+import DocumentBreadcrumb from "~/components/DocumentBreadcrumb";
 import Flex from "~/components/Flex";
 import {
   DocumentsSection,
@@ -57,7 +58,7 @@ function MentionMenu({ search, isActive, ...rest }: Props) {
       res.data.documents.map(documents.add);
       res.data.users.map(users.add);
       res.data.collections.map(collections.add);
-    }, [search, documents, users])
+    }, [search, documents, users, collections.add])
   );
 
   React.useEffect(() => {
@@ -68,61 +69,63 @@ function MentionMenu({ search, isActive, ...rest }: Props) {
 
   React.useEffect(() => {
     if (actorId && !loading) {
-      const items = users
+      const items: MentionItem[] = users
         .findByQuery(search, { maxResults: maxResultsInSection })
         .map(
           (user) =>
-            ({
-              name: "mention",
-              icon: (
-                <Flex
-                  align="center"
-                  justify="center"
-                  style={{ width: 24, height: 24 }}
-                >
-                  <Avatar
-                    model={user}
-                    alt={t("Profile picture")}
-                    size={AvatarSize.Small}
-                  />
-                </Flex>
-              ),
-              title: user.name,
-              section: UserSection,
-              appendSpace: true,
-              attrs: {
-                id: v4(),
-                type: MentionType.User,
-                modelId: user.id,
-                actorId,
-                label: user.name,
-              },
-            } as MentionItem)
+          ({
+            name: "mention",
+            icon: (
+              <Flex
+                align="center"
+                justify="center"
+                style={{ width: 24, height: 24 }}
+              >
+                <Avatar
+                  model={user}
+                  alt={t("Profile picture")}
+                  size={AvatarSize.Small}
+                />
+              </Flex>
+            ),
+            title: user.name,
+            section: UserSection,
+            appendSpace: true,
+            attrs: {
+              id: v4(),
+              type: MentionType.User,
+              modelId: user.id,
+              actorId,
+              label: user.name,
+            },
+          } as MentionItem)
         )
         .concat(
           documents
             .findByQuery(search, { maxResults: maxResultsInSection })
             .map(
               (doc) =>
-                ({
-                  name: "mention",
-                  icon: doc.icon ? (
-                    <Icon value={doc.icon} color={doc.color ?? undefined} />
-                  ) : (
-                    <DocumentIcon />
-                  ),
-                  title: doc.title,
-                  subtitle: doc.collection?.name,
-                  section: DocumentsSection,
-                  appendSpace: true,
-                  attrs: {
-                    id: v4(),
-                    type: MentionType.Document,
-                    modelId: doc.id,
-                    actorId,
-                    label: doc.title,
-                  },
-                } as MentionItem)
+              ({
+                name: "mention",
+                icon: doc.icon ? (
+                  <Icon value={doc.icon} color={doc.color ?? undefined} />
+                ) : (
+                  <DocumentIcon />
+                ),
+                title: doc.title,
+                subtitle: (
+                  <DocumentBreadcrumb document={doc} onlyText reverse />
+                ),
+                section: DocumentsSection,
+                appendSpace: true,
+                attrs: {
+                  id: v4(),
+                  type: MentionType.Document,
+                  modelId: doc.id,
+                  actorId,
+                  label: doc.title,
+                },
+              } as MentionItem)
             )
         )
         .concat(
@@ -130,27 +133,27 @@ function MentionMenu({ search, isActive, ...rest }: Props) {
             .findByQuery(search, { maxResults: maxResultsInSection })
             .map(
               (collection) =>
-                ({
-                  name: "mention",
-                  icon: collection.icon ? (
-                    <Icon
-                      value={collection.icon}
-                      color={collection.color ?? undefined}
-                    />
-                  ) : (
-                    <CollectionIcon />
-                  ),
-                  title: collection.name,
-                  section: CollectionsSection,
-                  appendSpace: true,
-                  attrs: {
-                    id: v4(),
-                    type: MentionType.Collection,
-                    modelId: collection.id,
-                    actorId,
-                    label: collection.name,
-                  },
-                } as MentionItem)
+              ({
+                name: "mention",
+                icon: collection.icon ? (
+                  <Icon
+                    value={collection.icon}
+                    color={collection.color ?? undefined}
+                  />
+                ) : (
+                  <CollectionIcon />
+                ),
+                title: collection.name,
+                section: CollectionsSection,
+                appendSpace: true,
+                attrs: {
+                  id: v4(),
+                  type: MentionType.Collection,
+                  modelId: collection.id,
+                  actorId,
+                  label: collection.name,
+                },
+              } as MentionItem)
             )
         )
         .concat([
@@ -176,7 +179,7 @@ function MentionMenu({ search, isActive, ...rest }: Props) {
       setItems(items);
       setLoaded(true);
     }
-  }, [t, actorId, loading, search, users, documents, maxResultsInSection]);
+  }, [t, actorId, loading, search, users, documents, maxResultsInSection, React.useEffect]);
 
   const handleSelect = React.useCallback(
     async (item: MentionItem) => {

--- a/app/editor/components/MentionMenu.tsx
+++ b/app/editor/components/MentionMenu.tsx
@@ -58,7 +58,7 @@ function MentionMenu({ search, isActive, ...rest }: Props) {
       res.data.documents.map(documents.add);
       res.data.users.map(users.add);
       res.data.collections.map(collections.add);
-    }, [search, documents, users, collections.add])
+    }, [search, documents, users, collections])
   );
 
   React.useEffect(() => {
@@ -114,7 +114,7 @@ function MentionMenu({ search, isActive, ...rest }: Props) {
                 ),
                 title: doc.title,
                 subtitle: (
-                  <DocumentBreadcrumb document={doc} onlyText reverse />
+                  <DocumentBreadcrumb document={doc} onlyText reverse maxDepth={2} />
                 ),
                 section: DocumentsSection,
                 appendSpace: true,
@@ -179,7 +179,7 @@ function MentionMenu({ search, isActive, ...rest }: Props) {
       setItems(items);
       setLoaded(true);
     }
-  }, [t, actorId, loading, search, users, documents, maxResultsInSection, React.useEffect]);
+  }, [t, actorId, loading, search, users, documents, maxResultsInSection]);
 
   const handleSelect = React.useCallback(
     async (item: MentionItem) => {

--- a/app/editor/components/MentionMenu.tsx
+++ b/app/editor/components/MentionMenu.tsx
@@ -73,59 +73,64 @@ function MentionMenu({ search, isActive, ...rest }: Props) {
         .findByQuery(search, { maxResults: maxResultsInSection })
         .map(
           (user) =>
-          ({
-            name: "mention",
-            icon: (
-              <Flex
-                align="center"
-                justify="center"
-                style={{ width: 24, height: 24 }}
-              >
-                <Avatar
-                  model={user}
-                  alt={t("Profile picture")}
-                  size={AvatarSize.Small}
-                />
-              </Flex>
-            ),
-            title: user.name,
-            section: UserSection,
-            appendSpace: true,
-            attrs: {
-              id: v4(),
-              type: MentionType.User,
-              modelId: user.id,
-              actorId,
-              label: user.name,
-            },
-          } as MentionItem)
+            ({
+              name: "mention",
+              icon: (
+                <Flex
+                  align="center"
+                  justify="center"
+                  style={{ width: 24, height: 24 }}
+                >
+                  <Avatar
+                    model={user}
+                    alt={t("Profile picture")}
+                    size={AvatarSize.Small}
+                  />
+                </Flex>
+              ),
+              title: user.name,
+              section: UserSection,
+              appendSpace: true,
+              attrs: {
+                id: v4(),
+                type: MentionType.User,
+                modelId: user.id,
+                actorId,
+                label: user.name,
+              },
+            } as MentionItem)
         )
         .concat(
           documents
             .findByQuery(search, { maxResults: maxResultsInSection })
             .map(
               (doc) =>
-              ({
-                name: "mention",
-                icon: doc.icon ? (
-                  <Icon value={doc.icon} color={doc.color ?? undefined} />
-                ) : (
-                  <DocumentIcon />
-                ),
-                title: doc.title,
-                subtitle: (
-                  <DocumentBreadcrumb document={doc} onlyText reverse maxDepth={2} />
-                ),
-                section: DocumentsSection,
-                appendSpace: true,
-                attrs: {
-                  id: v4(),
-                  type: MentionType.Document,
-                  modelId: doc.id,
-                  actorId,
-                  label: doc.title,
-                },
-              } as MentionItem)
+                ({
+                  name: "mention",
+                  icon: doc.icon ? (
+                    <Icon value={doc.icon} color={doc.color ?? undefined} />
+                  ) : (
+                    <DocumentIcon />
+                  ),
+                  title: doc.title,
+                  subtitle: (
+                    <DocumentBreadcrumb
+                      document={doc}
+                      onlyText
+                      reverse
+                      maxDepth={2}
+                    />
+                  ),
+                  section: DocumentsSection,
+                  appendSpace: true,
+                  attrs: {
+                    id: v4(),
+                    type: MentionType.Document,
+                    modelId: doc.id,
+                    actorId,
+                    label: doc.title,
+                  },
+                } as MentionItem)
             )
         )
         .concat(
@@ -133,27 +138,27 @@ function MentionMenu({ search, isActive, ...rest }: Props) {
             .findByQuery(search, { maxResults: maxResultsInSection })
             .map(
               (collection) =>
-              ({
-                name: "mention",
-                icon: collection.icon ? (
-                  <Icon
-                    value={collection.icon}
-                    color={collection.color ?? undefined}
-                  />
-                ) : (
-                  <CollectionIcon />
-                ),
-                title: collection.name,
-                section: CollectionsSection,
-                appendSpace: true,
-                attrs: {
-                  id: v4(),
-                  type: MentionType.Collection,
-                  modelId: collection.id,
-                  actorId,
-                  label: collection.name,
-                },
-              } as MentionItem)
+                ({
+                  name: "mention",
+                  icon: collection.icon ? (
+                    <Icon
+                      value={collection.icon}
+                      color={collection.color ?? undefined}
+                    />
+                  ) : (
+                    <CollectionIcon />
+                  ),
+                  title: collection.name,
+                  section: CollectionsSection,
+                  appendSpace: true,
+                  attrs: {
+                    id: v4(),
+                    type: MentionType.Collection,
+                    modelId: collection.id,
+                    actorId,
+                    label: collection.name,
+                  },
+                } as MentionItem)
             )
         )
         .concat([

--- a/shared/editor/types/index.ts
+++ b/shared/editor/types/index.ts
@@ -24,7 +24,7 @@ export type MenuItem = {
   name?: string;
   title?: string;
   section?: Section;
-  subtitle?: string;
+  subtitle?: React.ReactNode;
   shortcut?: string;
   keywords?: string;
   tooltip?: string;


### PR DESCRIPTION
Attempt to implement the optimization mentioned in #8930 for the display content of the document search box item in the context and link.
![image](https://github.com/user-attachments/assets/2e77c0b9-4d52-4f30-bb37-c48b614cc17c)
![image](https://github.com/user-attachments/assets/a6c2a03d-cf00-4fb3-b381-bf01ac6641d1)
