### PR TITLE
Require collection manage permissions to export

### DIFF
--- a/server/policies/collection.ts
+++ b/server/policies/collection.ts
@@ -2,7 +2,7 @@ import invariant from "invariant";
 import filter from "lodash/filter";
 import { CollectionPermission } from "@shared/types";
 import { Collection, User, Team } from "@server/models";
-import { allow, can } from "./cancan";
+import { allow } from "./cancan";
 import { and, isTeamAdmin, isTeamModel, isTeamMutable, or } from "./utils";
 
 allow(User, "createCollection", Team, (actor, team) =>
@@ -65,15 +65,6 @@ allow(
 
     return true;
   }
-);
-
-allow(User, "export", Collection, (actor, collection) =>
-  and(
-    //
-    can(actor, "read", collection),
-    !actor.isViewer,
-    !actor.isGuest
-  )
 );
 
 allow(User, "share", Collection, (user, collection) => {
@@ -161,7 +152,7 @@ allow(
   }
 );
 
-allow(User, ["update", "archive"], Collection, (user, collection) =>
+allow(User, ["update", "export", "archive"], Collection, (user, collection) =>
   and(
     !!collection,
     !!collection?.isActive,


### PR DESCRIPTION
Changing this to match workspace export, to bulk export data of any form should require admin permissions