### PR TITLE
Fix: Prevent password managers from suggesting user's own email 

### DIFF
--- a/app/scenes/Invite.tsx
+++ b/app/scenes/Invite.tsx
@@ -209,11 +209,11 @@ function Invite({ onSubmit }: Props) {
                   placeholder={`name@${predictedDomain}`}
                   value={invite.email}
                   required={index === 0}
+                  autoFocus
                   autoComplete="new-email"
                   data-1p-ignore
                   flex
                 />
-
                 <StyledInput
                   type="text"
                   name="name"

--- a/app/scenes/Invite.tsx
+++ b/app/scenes/Invite.tsx
@@ -209,11 +209,11 @@ function Invite({ onSubmit }: Props) {
                   placeholder={`name@${predictedDomain}`}
                   value={invite.email}
                   required={index === 0}
-                  autoComplete="off"
-                  autoFocus
+                  autoComplete="new-email"
                   data-1p-ignore
                   flex
                 />
+
                 <StyledInput
                   type="text"
                   name="name"


### PR DESCRIPTION
This PR prevents password managers from suggesting the current user's email address in the invite form.
Replaced autoComplete="off" with autoComplete="new-email" to better handle browser autofill behavior
Removed autoFocus.
I've removed unnecessary modifications to keep the implementation clean and focused. Thank you for the opportunity to make my first contribution.