### PR TITLE
Ensure iframely fallback is not executed for connected unfurl integration

### DIFF
--- a/plugins/github/server/github.ts
+++ b/plugins/github/server/github.ts
@@ -206,12 +206,12 @@ export class GitHub {
       );
       const { data } = await client.requestResource(resource);
       if (!data) {
-        return;
+        return { error: "Resource not found" };
       }
       return { ...data, type: resource.type };
     } catch (err) {
       Logger.warn("Failed to fetch resource from GitHub", err);
-      return;
+      return { error: err.message || "Unknown error" };
     }
   };
 }

--- a/server/routes/api/urls/urls.test.ts
+++ b/server/routes/api/urls/urls.test.ts
@@ -20,7 +20,7 @@ jest.mock("dns", () => ({
 
 jest
   .spyOn(Iframely, "requestResource")
-  .mockImplementation(() => Promise.resolve(undefined));
+  .mockImplementation(() => Promise.resolve({}));
 
 const server = getTestServer();
 

--- a/server/routes/api/urls/urls.ts
+++ b/server/routes/api/urls/urls.ts
@@ -98,11 +98,12 @@ router.post(
     }
 
     for (const plugin of plugins) {
-      const data = await plugin.value.unfurl(url, actor);
-      if (data) {
-        if ("error" in data) {
+      const unfurl = await plugin.value.unfurl(url, actor);
+      if (unfurl) {
+        if (unfurl.error) {
           return (ctx.response.status = 204);
         } else {
+          const data = unfurl as Unfurl;
           await CacheHelper.setData(
             CacheHelper.getUnfurlKey(actor.teamId, url),
             data,

--- a/server/types.ts
+++ b/server/types.ts
@@ -578,10 +578,12 @@ export type CollectionJSONExport = {
 
 export type Unfurl = { [x: string]: JSONValue; type: UnfurlResourceType };
 
+export type UnfurlError = { error: string };
+
 export type UnfurlSignature = (
   url: string,
   actor?: User
-) => Promise<Unfurl | void>;
+) => Promise<Unfurl | UnfurlError | undefined>;
 
 export type UninstallSignature = (integration: Integration) => Promise<void>;
 


### PR DESCRIPTION
With the introduction of GitHub mentions (and more in the pipeline), we need to ensure iframely fallback is not used for such connected integrations.
This ends up causing issues due to data format mismatch between iframely and GitHub for e.g.