### PR TITLE
fix: Embeds not enabled on collection overview

### DIFF
--- a/app/components/CollectionDescription.tsx
+++ b/app/components/CollectionDescription.tsx
@@ -69,7 +69,6 @@ function CollectionDescription({ collection }: Props) {
             readOnly={!can.update}
             userId={user.id}
             editorStyle={editorStyle}
-            embedsDisabled
           />
           <div ref={childRef} />
         </React.Suspense>

--- a/shared/editor/components/Embed.tsx
+++ b/shared/editor/components/Embed.tsx
@@ -17,10 +17,10 @@ type Props = ComponentProps & {
 
 const Embed = (props: Props) => {
   const ref = React.useRef<HTMLIFrameElement>(null);
-  const { node, isEditable, onChangeSize } = props;
+  const { node, isEditable, embedsDisabled, onChangeSize } = props;
   const naturalWidth = 0;
   const naturalHeight = 400;
-  const isResizable = !!onChangeSize;
+  const isResizable = !!onChangeSize && !embedsDisabled;
 
   const { width, height, setSize, handlePointerDown, dragging } = useDragResize(
     {


### PR DESCRIPTION
fix: Disabled embeds show unusable resize handle

closes #8950