### PR TITLE
Add additional CSP protection to `files.get` endpoint

### DIFF
--- a/plugins/storage/server/api/files.ts
+++ b/plugins/storage/server/api/files.ts
@@ -96,6 +96,7 @@ router.get(
     ctx.set("Accept-Ranges", "bytes");
     ctx.set("Cache-Control", cacheHeader);
     ctx.set("Content-Type", contentType);
+    ctx.set("Content-Security-Policy", "sandbox");
     ctx.attachment(fileName, {
       type: forceDownload
         ? "attachment"


### PR DESCRIPTION
An additional protective layer when using the local file storage provider, this doesn't fix any specific known issues.