### PR TITLE
fix: Allow viewers to read templates

### DIFF
--- a/server/policies/team.test.ts
+++ b/server/policies/team.test.ts
@@ -57,7 +57,7 @@ describe("policies/team", () => {
     const permissions = new Map<UserRole, boolean>([
       [UserRole.Admin, true],
       [UserRole.Member, true],
-      [UserRole.Viewer, false],
+      [UserRole.Viewer, true],
       [UserRole.Guest, true],
     ]);
     for (const [role, permission] of permissions.entries()) {

--- a/server/policies/team.ts
+++ b/server/policies/team.ts
@@ -9,7 +9,7 @@ import {
   or,
 } from "./utils";
 
-allow(User, "read", Team, isTeamModel);
+allow(User, ["read", "readTemplate"], Team, isTeamModel);
 
 allow(User, "share", Team, (actor, team) =>
   and(
@@ -48,10 +48,6 @@ allow(User, "createTemplate", Team, (actor, team) =>
     isTeamModel(actor, team),
     isTeamMutable(actor)
   )
-);
-
-allow(User, "readTemplate", Team, (actor, team) =>
-  and(!actor.isViewer, isTeamModel(actor, team))
 );
 
 allow(User, "updateTemplate", Team, (actor, team) =>


### PR DESCRIPTION
There is no real harm to loosening this permission. Viewers can currently be upgraded to edit rights in specific collections and documents, but in these cases they do not have access to templates.

closes #8736