### PR TITLE
fix: Tidying mention hover cards

### DIFF
--- a/app/components/HoverPreview/Components.tsx
+++ b/app/components/HoverPreview/Components.tsx
@@ -33,7 +33,7 @@ export const Title = styled(Text).attrs({ as: "h2", size: "large" })`
   display: flex;
   align-items: flex-start;
   justify-content: flex-start;
-  gap: 4px;
+  gap: 6px;
 `;
 
 export const Info = styled(StyledText).attrs(() => ({

--- a/app/components/HoverPreview/Components.tsx
+++ b/app/components/HoverPreview/Components.tsx
@@ -2,7 +2,6 @@ import { transparentize } from "polished";
 import { Link } from "react-router-dom";
 import styled, { css } from "styled-components";
 import { s } from "@shared/styles";
-import { getTextColor } from "@shared/utils/color";
 import Text from "~/components/Text";
 
 export const CARD_MARGIN = 10;
@@ -60,15 +59,27 @@ export const Thumbnail = styled.img`
 export const Label = styled(Text).attrs({ size: "xsmall", weight: "bold" })<{
   color?: string;
 }>`
-  background-color: ${(props) =>
-    props.color ?? props.theme.backgroundSecondary};
-  color: ${(props) =>
-    props.color ? getTextColor(props.color) : props.theme.text};
+  border: 1px solid ${(props) => props.theme.divider};
   width: fit-content;
   border-radius: 2em;
-  padding: 0 8px;
+  padding: 1px 8px 1px 20px;
   margin-right: 0.5em;
   margin-top: 0.5em;
+  position: relative;
+  flex-shrink: 0;
+
+  &::after {
+    content: "";
+    position: absolute;
+    left: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background-color: ${(props) =>
+      props.color || props.theme.backgroundSecondary};
+  }
 `;
 
 export const CardContent = styled.div`

--- a/app/components/HoverPreview/HoverPreviewIssue.tsx
+++ b/app/components/HoverPreview/HoverPreviewIssue.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 import { Trans } from "react-i18next";
+import styled from "styled-components";
+import { Backticks } from "@shared/components/Backticks";
 import { IssueStatusIcon } from "@shared/components/IssueStatusIcon";
 import {
   IntegrationService,
@@ -40,9 +42,14 @@ const HoverPreviewIssue = React.forwardRef(function _HoverPreviewIssue(
           <CardContent>
             <Flex gap={2} column>
               <Title>
-                <IssueStatusIcon service={service} state={state} size={18} />
+                <StyledIssueStatusIcon
+                  service={service}
+                  state={state}
+                  size={18}
+                />
                 <span>
-                  {title}&nbsp;<Text type="tertiary">{id}</Text>
+                  <Backticks content={title} />
+                  &nbsp;<Text type="tertiary">{id}</Text>
                 </span>
               </Title>
               <Flex align="center" gap={6}>
@@ -70,5 +77,9 @@ const HoverPreviewIssue = React.forwardRef(function _HoverPreviewIssue(
     </Preview>
   );
 });
+
+const StyledIssueStatusIcon = styled(IssueStatusIcon)`
+  margin-top: 2px;
+`;
 
 export default HoverPreviewIssue;

--- a/app/components/HoverPreview/HoverPreviewIssue.tsx
+++ b/app/components/HoverPreview/HoverPreviewIssue.tsx
@@ -40,13 +40,13 @@ const HoverPreviewIssue = React.forwardRef(function _HoverPreviewIssue(
           <CardContent>
             <Flex gap={2} column>
               <Title>
-                <IssueStatusIcon service={service} state={state} />
+                <IssueStatusIcon service={service} state={state} size={18} />
                 <span>
                   {title}&nbsp;<Text type="tertiary">{id}</Text>
                 </span>
               </Title>
-              <Flex align="center" gap={4}>
-                <Avatar src={author.avatarUrl} />
+              <Flex align="center" gap={6}>
+                <Avatar src={author.avatarUrl} size={18} />
                 <Info>
                   <Trans>
                     {{ authorName }} created{" "}

--- a/app/components/HoverPreview/HoverPreviewPullRequest.tsx
+++ b/app/components/HoverPreview/HoverPreviewPullRequest.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 import { Trans } from "react-i18next";
+import styled from "styled-components";
+import { Backticks } from "@shared/components/Backticks";
 import { PullRequestIcon } from "@shared/components/PullRequestIcon";
 import { UnfurlResourceType, UnfurlResponse } from "@shared/types";
 import { Avatar } from "~/components/Avatar";
@@ -31,13 +33,14 @@ const HoverPreviewPullRequest = React.forwardRef(
             <CardContent>
               <Flex gap={2} column>
                 <Title>
-                  <PullRequestIcon
+                  <StyledPullRequestIcon
                     status={state.name}
                     color={state.color}
                     size={18}
                   />
                   <span>
-                    {title}&nbsp;<Text type="tertiary">{id}</Text>
+                    <Backticks content={title} />
+                    &nbsp;<Text type="tertiary">{id}</Text>
                   </span>
                 </Title>
                 <Flex align="center" gap={6}>
@@ -58,5 +61,9 @@ const HoverPreviewPullRequest = React.forwardRef(
     );
   }
 );
+
+const StyledPullRequestIcon = styled(PullRequestIcon)`
+  margin-top: 2px;
+`;
 
 export default HoverPreviewPullRequest;

--- a/app/components/HoverPreview/HoverPreviewPullRequest.tsx
+++ b/app/components/HoverPreview/HoverPreviewPullRequest.tsx
@@ -31,13 +31,17 @@ const HoverPreviewPullRequest = React.forwardRef(
             <CardContent>
               <Flex gap={2} column>
                 <Title>
-                  <PullRequestIcon status={state.name} color={state.color} />
+                  <PullRequestIcon
+                    status={state.name}
+                    color={state.color}
+                    size={18}
+                  />
                   <span>
                     {title}&nbsp;<Text type="tertiary">{id}</Text>
                   </span>
                 </Title>
-                <Flex align="center" gap={4}>
-                  <Avatar src={author.avatarUrl} />
+                <Flex align="center" gap={6}>
+                  <Avatar src={author.avatarUrl} size={18} />
                   <Info>
                     <Trans>
                       {{ authorName }} opened{" "}

--- a/shared/components/Backticks.tsx
+++ b/shared/components/Backticks.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import styled from "styled-components";
+import { s } from "../styles";
+
+const BacktickSpan = styled.span`
+  font-family: ${s("fontFamilyMono")};
+  background: ${s("codeBackground")};
+  border-radius: 3px;
+  padding: 2px 4px;
+  font-size: 90%;
+`;
+
+interface Props {
+  /** The content to be rendered that may contain backticks. */
+  content: string;
+}
+
+/**
+ * Component to render backticked content with styling.
+ * @param props - Props object containing the content to be rendered.
+ * @returns JSX.Element - The rendered component.
+ */
+export const Backticks: React.FC<Props> = ({ content }) => {
+  // Regex to match text between backticks
+  const regex = /`([^`]+)`/g;
+  const parts = content.split(regex);
+
+  return (
+    <>
+      {parts.map((part, i) => {
+        // Even indices are normal text, odd indices are backticked content
+        if (i % 2 === 0) {
+          return part;
+        }
+        return <BacktickSpan key={i}>{part}</BacktickSpan>;
+      })}
+    </>
+  );
+};

--- a/shared/components/IssueStatusIcon/GitHubIssueStatusIcon.tsx
+++ b/shared/components/IssueStatusIcon/GitHubIssueStatusIcon.tsx
@@ -2,15 +2,15 @@ import React from "react";
 import { BaseIconProps } from ".";
 
 export function GitHubIssueStatusIcon(props: BaseIconProps) {
-  const { state, className } = props;
+  const { state, className, size = 16 } = props;
 
   switch (state.name) {
     case "open":
       return (
         <svg
           viewBox="0 0 16 16"
-          width="16"
-          height="16"
+          width={size}
+          height={size}
           fill={state.color}
           className={className}
         >
@@ -22,8 +22,8 @@ export function GitHubIssueStatusIcon(props: BaseIconProps) {
       return (
         <svg
           viewBox="0 0 16 16"
-          width="16"
-          height="16"
+          width={size}
+          height={size}
           fill={state.color}
           className={className}
         >
@@ -35,8 +35,8 @@ export function GitHubIssueStatusIcon(props: BaseIconProps) {
       return (
         <svg
           viewBox="0 0 16 16"
-          width="16"
-          height="16"
+          width={size}
+          height={size}
           fill={state.color}
           className={className}
         >

--- a/shared/components/IssueStatusIcon/LinearIssueStatusIcon.tsx
+++ b/shared/components/IssueStatusIcon/LinearIssueStatusIcon.tsx
@@ -14,7 +14,7 @@ enum StateType {
 
 export function LinearIssueStatusIcon(props: BaseIconProps) {
   const theme = useTheme();
-  const { state } = props;
+  const { state, size = 16 } = props;
   const percentage =
     state.type === StateType.Triage ||
     state.type === StateType.Backlog ||
@@ -31,7 +31,7 @@ export function LinearIssueStatusIcon(props: BaseIconProps) {
   const magicFour = isSafari() ? 3.895 : 3.98;
 
   return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+    <svg width={size} height={size} viewBox="0 0 14 14" fill="none">
       <circle
         cx={7}
         cy={7}

--- a/shared/components/IssueStatusIcon/index.tsx
+++ b/shared/components/IssueStatusIcon/index.tsx
@@ -12,10 +12,10 @@ import { LinearIssueStatusIcon } from "./LinearIssueStatusIcon";
 export type BaseIconProps = {
   state: UnfurlResponse[UnfurlResourceType.Issue]["state"];
   className?: string;
+  size?: number;
 };
 
 type Props = BaseIconProps & {
-  size?: number;
   service: IssueTrackerIntegrationService;
 };
 
@@ -23,12 +23,12 @@ export function IssueStatusIcon(props: Props) {
   return <Icon size={props.size}>{getIcon(props)}</Icon>;
 }
 
-function getIcon({ service, ...rest }: Props) {
-  switch (service) {
+function getIcon(props: Props) {
+  switch (props.service) {
     case IntegrationService.GitHub:
-      return <GitHubIssueStatusIcon {...rest} />;
+      return <GitHubIssueStatusIcon {...props} />;
     case IntegrationService.Linear:
-      return <LinearIssueStatusIcon {...rest} />;
+      return <LinearIssueStatusIcon {...props} />;
   }
 }
 

--- a/shared/components/IssueStatusIcon/index.tsx
+++ b/shared/components/IssueStatusIcon/index.tsx
@@ -20,7 +20,11 @@ type Props = BaseIconProps & {
 };
 
 export function IssueStatusIcon(props: Props) {
-  return <Icon size={props.size}>{getIcon(props)}</Icon>;
+  return (
+    <Icon size={props.size} className={props.className}>
+      {getIcon(props)}
+    </Icon>
+  );
 }
 
 function getIcon(props: Props) {

--- a/shared/components/PullRequestIcon.tsx
+++ b/shared/components/PullRequestIcon.tsx
@@ -11,9 +11,9 @@ type Props = {
 /**
  * Issue status icon based on GitHub pull requests, but can be used for any git-style integration.
  */
-export function PullRequestIcon({ size, ...rest }: Props) {
+export function PullRequestIcon({ size, className, ...rest }: Props) {
   return (
-    <Icon size={size}>
+    <Icon size={size} className={className}>
       <BaseIcon {...rest} />
     </Icon>
   );

--- a/shared/components/PullRequestIcon.tsx
+++ b/shared/components/PullRequestIcon.tsx
@@ -28,16 +28,16 @@ const Icon = styled.span<{ size?: number }>`
   justify-content: center;
 `;
 
-function BaseIcon(props: Props) {
-  switch (props.status) {
+function BaseIcon({ status, size, color, className }: Props) {
+  switch (status) {
     case "open":
       return (
         <svg
           viewBox="0 0 16 16"
-          width="16"
-          height="16"
-          fill={props.color}
-          className={props.className}
+          width={size}
+          height={size}
+          fill={color}
+          className={className}
         >
           <path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z" />
         </svg>
@@ -46,10 +46,10 @@ function BaseIcon(props: Props) {
       return (
         <svg
           viewBox="0 0 16 16"
-          width="16"
-          height="16"
-          fill={props.color}
-          className={props.className}
+          width={size}
+          height={size}
+          fill={color}
+          className={className}
         >
           <path d="M5.45 5.154A4.25 4.25 0 0 0 9.25 7.5h1.378a2.251 2.251 0 1 1 0 1.5H9.25A5.734 5.734 0 0 1 5 7.123v3.505a2.25 2.25 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.95-.218ZM4.25 13.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm8.5-4.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5ZM5 3.25a.75.75 0 1 0 0 .005V3.25Z" />
         </svg>
@@ -58,10 +58,10 @@ function BaseIcon(props: Props) {
       return (
         <svg
           viewBox="0 0 16 16"
-          width="16"
-          height="16"
-          fill={props.color}
-          className={props.className}
+          width={size}
+          height={size}
+          fill={color}
+          className={className}
         >
           <path d="M3.25 1A2.25 2.25 0 0 1 4 5.372v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.251 2.251 0 0 1 3.25 1Zm9.5 5.5a.75.75 0 0 1 .75.75v3.378a2.251 2.251 0 1 1-1.5 0V7.25a.75.75 0 0 1 .75-.75Zm-2.03-5.273a.75.75 0 0 1 1.06 0l.97.97.97-.97a.748.748 0 0 1 1.265.332.75.75 0 0 1-.205.729l-.97.97.97.97a.751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018l-.97-.97-.97.97a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734l.97-.97-.97-.97a.75.75 0 0 1 0-1.06ZM2.5 3.25a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0ZM3.25 12a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm9.5 0a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Z" />
         </svg>

--- a/shared/editor/components/Mentions.tsx
+++ b/shared/editor/components/Mentions.tsx
@@ -10,6 +10,7 @@ import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
+import { Backticks } from "../../components/Backticks";
 import Flex from "../../components/Flex";
 import Icon from "../../components/Icon";
 import { IssueStatusIcon } from "../../components/IssueStatusIcon";
@@ -207,7 +208,9 @@ export const MentionIssue = observer((props: IssuePrProps) => {
       <Flex align="center" gap={6}>
         <IssueStatusIcon size={14} service={service} state={issue.state} />
         <Flex align="center" gap={4}>
-          <Text>{issue.title}</Text>
+          <Text>
+            <Backticks content={issue.title} />
+          </Text>
           <Text type="tertiary">{issue.id}</Text>
         </Flex>
       </Flex>
@@ -282,7 +285,9 @@ export const MentionPullRequest = observer((props: IssuePrProps) => {
           color={pullRequest.state.color}
         />
         <Flex align="center" gap={4}>
-          <Text>{pullRequest.title}</Text>
+          <Text>
+            <Backticks content={pullRequest.title} />
+          </Text>
           <Text type="tertiary">{pullRequest.id}</Text>
         </Flex>
       </Flex>


### PR DESCRIPTION
Various fixes to the styling of issue/PR hovercards and iconography

### Before
<img width="418" alt="image" src="https://github.com/user-attachments/assets/f36d991b-6dce-4ab5-bc21-0c8cb41c71ac" />


### After
<img width="415" alt="image" src="https://github.com/user-attachments/assets/2657d494-e1ec-4b19-ac31-570c320e96f4" />
