### PR TITLE
adding expandable code block

### DIFF
--- a/app/editor/menus/code.tsx
+++ b/app/editor/menus/code.tsx
@@ -41,6 +41,15 @@ export default function codeMenuItems(
 
   return [
     {
+      name: "expandCodeBlock",
+      icon: <ExpandedIcon />,
+      tooltip: node.attrs.expanded ? "Collapse" : "Expand",
+    },
+    {
+      name: "separator",
+      visible: !readOnly,
+    },
+    {
       name: "copyToClipboard",
       icon: <CopyIcon />,
       label: readOnly ? dictionary.copy : undefined,

--- a/app/editor/menus/code.tsx
+++ b/app/editor/menus/code.tsx
@@ -43,7 +43,7 @@ export default function codeMenuItems(
     {
       name: "expandCodeBlock",
       icon: <ExpandedIcon />,
-      tooltip: node.attrs.expanded ? "Collapse" : "Expand",
+      tooltip: "Expand",
     },
     {
       name: "separator",

--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -1882,9 +1882,9 @@ del[data-operation-index] {
 }
   
 .code-block {
-  max-height: calc(1.4em * 17); /* Default height limit */
-  overflow: hidden; /* Default state: overflow hidden */
   position:relative;
+  max-height: calc(1.4em * 17); /* Default height limit */
+  overflow: hidden; /* Default state: overflow hidden */  
   -webkit-mask-image: linear-gradient(to bottom, black 90%, transparent 100%);
   mask-image: linear-gradient(to bottom, black 90%, transparent 100%);
 }

--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -1331,10 +1331,6 @@ mark {
   height: 16px;
 }
 
-.code-block {
-  position: relative;
-}
-
 .code-block[data-language=mermaidjs] {
   margin: 0.75em 0;
 
@@ -1883,6 +1879,21 @@ del[data-operation-index] {
   img {
     opacity: .5;
   }
+}
+  
+.code-block {
+  max-height: calc(1.4em * 17); /* Default height limit */
+  overflow: hidden; /* Default state: overflow hidden */
+  position:relative;
+  -webkit-mask-image: linear-gradient(to bottom, black 90%, transparent 100%);
+  mask-image: linear-gradient(to bottom, black 90%, transparent 100%);
+}
+
+.code-block.expanded {
+  max-height: none; /* Remove the height limit when expanded */
+  -webkit-mask-image: none;
+  mask-image: none;
+  position:relative;
 }
 
 @media print {

--- a/shared/editor/nodes/CodeFence.ts
+++ b/shared/editor/nodes/CodeFence.ts
@@ -165,6 +165,9 @@ export default class CodeFence extends Node {
           default: DEFAULT_LANGUAGE,
           validate: "string",
         },
+        expanded: {
+          default: false, // default value NOT expanded
+        },
       },
       content: "text*",
       marks: "comment",
@@ -180,6 +183,7 @@ export default class CodeFence extends Node {
             node.querySelector("code") || node,
           getAttrs: (dom: HTMLDivElement) => ({
             language: dom.dataset.language,
+            expanded: dom.classList.contains("expanded"),
           }),
         },
         {
@@ -198,7 +202,7 @@ export default class CodeFence extends Node {
       toDOM: (node) => [
         "div",
         {
-          class: `code-block ${
+          class: `code-block ${node.attrs.expanded ? "expanded" : ""} ${
             this.showLineNumbers ? "with-line-numbers" : ""
           }`,
           "data-language": node.attrs.language,
@@ -218,6 +222,28 @@ export default class CodeFence extends Node {
           language: getRecentCodeLanguage() ?? DEFAULT_LANGUAGE,
           ...attrs,
         });
+      },
+      expandCodeBlock: (): Command => (state, dispatch) => {
+        const { selection } = state;
+        const codeBlock = findParentNode(isCode)(selection);
+
+        if (!codeBlock) return false;
+
+        const { node, pos } = codeBlock;
+        console.log("this is the value of expanded:", node.attrs.expanded);
+
+        const expanded = !(node.attrs.expanded ?? false); // toggle the expanded variable
+
+        if (dispatch) {
+          const newAttrs = {
+            ...node.attrs,
+            expanded,
+          };
+          const tr = state.tr.setNodeMarkup(pos, undefined, newAttrs);
+          dispatch(tr);
+        }
+
+        return true;
       },
       copyToClipboard: (): Command => (state, dispatch) => {
         const codeBlock = findParentNode(isCode)(state.selection);


### PR DESCRIPTION
Heyy , this is to adress the enhancement in #7829 ,I though it was really great so I worked on it .
I kept is pretty simple, I gave code blocks a default max height of 20 lines and added a button to expand and collapse it , all using css, and toggle button that updates a new expanded attribute on the node. Like so :

https://github.com/user-attachments/assets/316838b7-e0e4-4033-bc3d-f5752da7d4ea

Hope this helps