### PR TITLE
Switch Linear to `actor=app` method

### DIFF
--- a/plugins/linear/shared/LinearUtils.ts
+++ b/plugins/linear/shared/LinearUtils.ts
@@ -46,7 +46,7 @@ export class LinearUtils {
       scope: this.oauthScopes,
       response_type: "code",
       prompt: "consent",
-      actor: "application",
+      actor: "app",
     };
     return `${this.authBaseUrl}?${queryString.stringify(params)}`;
   }


### PR DESCRIPTION
Prevents multiple installations and an improved permission management experience.