### PR TITLE
fix: Check pasted text is url before creating an URL object

### DIFF
--- a/app/editor/components/PasteMenu.tsx
+++ b/app/editor/components/PasteMenu.tsx
@@ -6,6 +6,7 @@ import { v4 } from "uuid";
 import { EmbedDescriptor } from "@shared/editor/embeds";
 import { MenuItem } from "@shared/editor/types";
 import { MentionType } from "@shared/types";
+import { isUrl } from "@shared/utils/urls";
 import Integration from "~/models/Integration";
 import useCurrentUser from "~/hooks/useCurrentUser";
 import useStores from "~/hooks/useStores";
@@ -29,9 +30,9 @@ export const PasteMenu = observer(({ pastedText, embeds, ...props }: Props) => {
   const user = useCurrentUser({ rejectOnEmpty: false });
 
   let mentionType: MentionType | undefined;
-  const url = pastedText ? new URL(pastedText) : undefined;
 
-  if (url) {
+  if (pastedText && isUrl(pastedText)) {
+    const url = new URL(pastedText);
     const integration = integrations.find((intg: Integration) =>
       isURLMentionable({ url, integration: intg })
     );


### PR DESCRIPTION
Closes #9081 

Anchored links of [collections](https://github.com/outline/outline/blob/main/app/editor/extensions/PasteHandler.tsx#L206) and [documents](https://github.com/outline/outline/blob/main/app/editor/extensions/PasteHandler.tsx#L161) were the root cause.