### PR TITLE
fix: Notifications received for draft with access but no subscription

### DIFF
--- a/server/models/helpers/NotificationHelper.ts
+++ b/server/models/helpers/NotificationHelper.ts
@@ -193,10 +193,16 @@ export default class NotificationHelper {
             [Op.ne]: actorId,
           },
           event: SubscriptionType.Document,
-          [Op.or]: [
-            { collectionId: document.collectionId },
-            { documentId: document.id },
-          ],
+          ...(document.collectionId
+            ? {
+                [Op.or]: [
+                  { collectionId: document.collectionId },
+                  { documentId: document.id },
+                ],
+              }
+            : {
+                documentId: document.id,
+              }),
         },
         include: [
           {


### PR DESCRIPTION
Finally solves this issue, it required the following to be true:

- There must be a draft without a collection
- Someone should comment on the draft
- Other users must have access to the draft through a user or group membership
- Other users must have document subscriptions to at least one other document
- If all the above is true they will be notified, when they should not have been

Prior to the [fix here](https://github.com/outline/outline/pull/8997/files#diff-0a9c587545d94867afe9683cdeb90d01295f6dd2f07b7a0b5f4470c7a93c7cb3R209-R212) they would be sent a notification for _every other document subscription_ in the db. In the worst case scenario with a large Outline instance and a large group given access to the draft document this could result in thousands of spurious notifications.

closes #8807