### PR TITLE
fix: Error loading collection

### DIFF
--- a/app/components/Sidebar/components/StarredLink.tsx
+++ b/app/components/Sidebar/components/StarredLink.tsx
@@ -38,10 +38,10 @@ function StarredLink({ star }: Props) {
   const { ui, collections, documents } = useStores();
   const [menuOpen, handleMenuOpen, handleMenuClose] = useBoolean();
   const { documentId, collectionId } = star;
-  const collection = collections.get(collectionId);
+  const collection = collectionId ? collections.get(collectionId) : undefined;
   const locationSidebarContext = useLocationSidebarContext();
   const sidebarContext = starredSidebarContext(
-    star.documentId ?? star.collectionId
+    star.documentId ?? star.collectionId ?? ""
   );
   const [expanded, setExpanded] = useState(
     (star.documentId

--- a/app/models/Star.ts
+++ b/app/models/Star.ts
@@ -22,7 +22,7 @@ class Star extends Model {
   document?: Document;
 
   /** The collection ID that is starred. */
-  collectionId: string;
+  collectionId?: string;
 
   /** The collection that is starred. */
   @Relation(() => Collection, { onDelete: "cascade" })


### PR DESCRIPTION
An error was introduced in https://github.com/outline/outline/pull/9120 due to this type being incorrect, `collectionId` on star is nullable.