### PR TITLE
fix: Introduce more guards against empty text nodes in `NotionConverter`

### DIFF
--- a/plugins/notion/server/utils/NotionConverter.ts
+++ b/plugins/notion/server/utils/NotionConverter.ts
@@ -288,7 +288,7 @@ export class NotionConverter {
       if (item.mention.type === "link_mention") {
         return {
           type: "text",
-          text: item.plain_text,
+          text: item.plain_text || item.mention.link_mention.href,
           marks: [
             {
               type: "link",
@@ -302,7 +302,7 @@ export class NotionConverter {
       if (item.mention.type === "link_preview") {
         return {
           type: "text",
-          text: item.plain_text,
+          text: item.plain_text || item.mention.link_preview.url,
           marks: [
             {
               type: "link",
@@ -314,14 +314,14 @@ export class NotionConverter {
         };
       }
 
-      if (!item.plain_text) {
-        return undefined;
+      if (item.plain_text) {
+        return {
+          type: "text",
+          text: item.plain_text,
+        };
       }
 
-      return {
-        type: "text",
-        text: item.plain_text,
-      };
+      return undefined;
     }
 
     if (item.type === "equation") {
@@ -336,20 +336,20 @@ export class NotionConverter {
       };
     }
 
-    if (!item.text.content) {
-      return undefined;
+    if (item.text.content) {
+      return {
+        type: "text",
+        text: item.text.content,
+        marks: [
+          ...mapAttrs(),
+          ...(item.text.link
+            ? [{ type: "link", attrs: { href: item.text.link.url } }]
+            : []),
+        ].filter(Boolean),
+      };
     }
 
-    return {
-      type: "text",
-      text: item.text.content,
-      marks: [
-        ...mapAttrs(),
-        ...(item.text.link
-          ? [{ type: "link", attrs: { href: item.text.link.url } }]
-          : []),
-      ].filter(Boolean),
-    };
+    return undefined;
   }
 
   private static rich_text_to_plaintext(item: RichTextItemResponse) {

--- a/server/test/fixtures/notion-page-with-empty-text-nodes.json
+++ b/server/test/fixtures/notion-page-with-empty-text-nodes.json
@@ -191,7 +191,7 @@
             "code": false,
             "color": "default"
           },
-          "plain_text": "http://github.com/outline/",
+          "plain_text": "",
           "href": "http://github.com/outline/"
         }
       ],


### PR DESCRIPTION
closes #9035