### PR TITLE
fix: `ExportDocumentTreeTask` needs `documentStructure`

### DIFF
--- a/server/queues/tasks/ExportDocumentTreeTask.ts
+++ b/server/queues/tasks/ExportDocumentTreeTask.ts
@@ -171,7 +171,8 @@ export default abstract class ExportDocumentTreeTask extends ExportTask {
   /**
    * Generates a map of document urls to their path in the zip file.
    *
-   * @param collections
+   * @param collections The collections to generate the path map for.
+   * @param format The format of the exported documents.
    */
   private createPathMap(
     collections: Collection[],

--- a/server/queues/tasks/ExportTask.ts
+++ b/server/queues/tasks/ExportTask.ts
@@ -44,11 +44,13 @@ export default abstract class ExportTask extends BaseTask<Props> {
       ? [fileOperation.collectionId]
       : await user.collectionIds();
 
-    const collections = await Collection.findAll({
-      where: {
-        id: collectionIds,
-      },
-    });
+    const collections = await Collection.scope("withDocumentStructure").findAll(
+      {
+        where: {
+          id: collectionIds,
+        },
+      }
+    );
 
     let filePath: string | undefined;
 


### PR DESCRIPTION
Regression from https://github.com/outline/outline/pull/9141