### PR TITLE
Improve table operations accessibility

### DIFF
--- a/app/editor/menus/tableCol.tsx
+++ b/app/editor/menus/tableCol.tsx
@@ -6,7 +6,6 @@ import {
   InsertLeftIcon,
   InsertRightIcon,
   ArrowIcon,
-  MoreIcon,
   TableHeaderColumnIcon,
 } from "outline-icons";
 import { EditorState } from "prosemirror-state";
@@ -77,33 +76,28 @@ export default function tableColMenuItems(
       name: "separator",
     },
     {
-      icon: <MoreIcon />,
-      children: [
-        {
-          name: "toggleHeaderColumn",
-          label: dictionary.toggleHeader,
-          icon: <TableHeaderColumnIcon />,
-          visible: index === 0,
-        },
-        {
-          name: rtl ? "addColumnAfter" : "addColumnBefore",
-          label: rtl ? dictionary.addColumnAfter : dictionary.addColumnBefore,
-          icon: <InsertLeftIcon />,
-          attrs: { index },
-        },
-        {
-          name: rtl ? "addColumnBefore" : "addColumnAfter",
-          label: rtl ? dictionary.addColumnBefore : dictionary.addColumnAfter,
-          icon: <InsertRightIcon />,
-          attrs: { index },
-        },
-        {
-          name: "deleteColumn",
-          dangerous: true,
-          label: dictionary.deleteColumn,
-          icon: <TrashIcon />,
-        },
-      ],
+      name: "toggleHeaderColumn",
+      tooltip: dictionary.toggleHeader,
+      icon: <TableHeaderColumnIcon />,
+      visible: index === 0,
+    },
+    {
+      name: rtl ? "addColumnAfter" : "addColumnBefore",
+      tooltip: rtl ? dictionary.addColumnAfter : dictionary.addColumnBefore,
+      icon: <InsertLeftIcon />,
+      attrs: { index },
+    },
+    {
+      name: rtl ? "addColumnBefore" : "addColumnAfter",
+      tooltip: rtl ? dictionary.addColumnBefore : dictionary.addColumnAfter,
+      icon: <InsertRightIcon />,
+      attrs: { index },
+    },
+    {
+      name: "deleteColumn",
+      tooltip: dictionary.deleteColumn,
+      icon: <TrashIcon />,
+      dangerous: true,
     },
   ];
 }

--- a/app/editor/menus/tableRow.tsx
+++ b/app/editor/menus/tableRow.tsx
@@ -2,7 +2,6 @@ import {
   TrashIcon,
   InsertAboveIcon,
   InsertBelowIcon,
-  MoreIcon,
   TableHeaderRowIcon,
 } from "outline-icons";
 import { EditorState } from "prosemirror-state";
@@ -17,33 +16,28 @@ export default function tableRowMenuItems(
 ): MenuItem[] {
   return [
     {
-      icon: <MoreIcon />,
-      children: [
-        {
-          name: "toggleHeaderRow",
-          label: dictionary.toggleHeader,
-          icon: <TableHeaderRowIcon />,
-          visible: index === 0,
-        },
-        {
-          name: "addRowBefore",
-          label: dictionary.addRowBefore,
-          icon: <InsertAboveIcon />,
-          attrs: { index },
-        },
-        {
-          name: "addRowAfter",
-          label: dictionary.addRowAfter,
-          icon: <InsertBelowIcon />,
-          attrs: { index },
-        },
-        {
-          name: "deleteRow",
-          label: dictionary.deleteRow,
-          dangerous: true,
-          icon: <TrashIcon />,
-        },
-      ],
+      name: "toggleHeaderRow",
+      tooltip: dictionary.toggleHeader,
+      icon: <TableHeaderRowIcon />,
+      visible: index === 0,
+    },
+    {
+      name: "addRowBefore",
+      tooltip: dictionary.addRowBefore,
+      icon: <InsertAboveIcon />,
+      attrs: { index },
+    },
+    {
+      name: "addRowAfter",
+      tooltip: dictionary.addRowAfter,
+      icon: <InsertBelowIcon />,
+      attrs: { index },
+    },
+    {
+      name: "deleteRow",
+      tooltip: dictionary.deleteRow,
+      icon: <TrashIcon />,
+      dangerous: true,
     },
   ];
 }


### PR DESCRIPTION
refactor: simplify table column and row menu items by removing MoreIcon and restructuring items

Removed the MoreIcon from both table column and row menu items. Restructured the menu items to directly include actions like toggling header, adding, and deleting rows/columns with tooltips for better clarity.

Table column select now looks like this - 
<img width="357" alt="image" src="https://github.com/user-attachments/assets/b87218d3-0b46-4fda-b944-5e0f5e734b3c" />

Table row select now looks like this - 
<img width="156" alt="image" src="https://github.com/user-attachments/assets/799c508e-f253-4758-8a66-ced8170ff06c" />
