### PR TITLE
fix: CMD+F with in-app find interface open should open native find

### DIFF
--- a/app/editor/components/FindAndReplace.tsx
+++ b/app/editor/components/FindAndReplace.tsx
@@ -41,6 +41,7 @@ function useKeyboardShortcuts({
   useKeyDown(
     (ev) =>
       isModKey(ev) &&
+      !popover.visible &&
       ev.code === "KeyF" &&
       // Keyboard handler is through the AppMenu on Desktop v1.2.0+
       !(Desktop.bridge && "onFindInPage" in Desktop.bridge),


### PR DESCRIPTION
CMD+F twice should open native browser find

Regressed in https://github.com/outline/outline/pull/8560