### PR TITLE
fix: JS error when no integrations are connected

### DIFF
--- a/app/scenes/Settings/Integrations.tsx
+++ b/app/scenes/Settings/Integrations.tsx
@@ -55,10 +55,10 @@ export function Integrations() {
       </StickyFilters>
 
       <Cards gap={30} wrap>
-        {groupedItems.connected.map((item) => (
+        {groupedItems.connected?.map((item) => (
           <IntegrationCard key={item.path} integration={item} isConnected />
         ))}
-        {groupedItems.available.map((item) => (
+        {groupedItems.available?.map((item) => (
           <IntegrationCard key={item.path} integration={item} />
         ))}
       </Cards>


### PR DESCRIPTION
Annoyingly group by does not produce an empty array, but undefined in this situation