### PR TITLE
fix: fall back to id_token when OIDC userinfo endpoint is sparse

### DIFF
--- a/plugins/oidc/server/auth/oidc.ts
+++ b/plugins/oidc/server/auth/oidc.ts
@@ -81,12 +81,27 @@ if (
 
           // Some providers, namely ADFS, don't provide anything more than the `sub` claim in the userinfo endpoint
           // So, we'll decode the params.id_token and see if that contains what we need.
-          const id_token = JWT.decode(params.id_token);
-          const token = id_token as {
-            email?: string;
-            preferred_username?: string;
-            sub?: string;
-          };
+          const token = (() => {
+            try {
+              const decoded = JWT.decode(params.id_token);
+
+              if (!decoded || typeof decoded !== "object") {
+                throw AuthenticationError(
+                  `Decoded token is not a valid object.`
+                );
+              }
+
+              return decoded as {
+                email?: string;
+                preferred_username?: string;
+                sub?: string;
+              };
+            } catch (err) {
+              throw AuthenticationError(
+                `Unable to decode id_token from identity provider.`
+              );
+            }
+          })();
 
           const email = profile.email ?? token.email ?? null;
 

--- a/plugins/oidc/server/auth/oidc.ts
+++ b/plugins/oidc/server/auth/oidc.ts
@@ -95,6 +95,7 @@ if (
               `An email field was not returned in the profile or id_token parameter, but is required.`
             );
           }
+
           const team = await getTeamFromContext(ctx);
           const client = getClientFromContext(ctx);
           const { domain } = parseEmail(email);
@@ -130,6 +131,7 @@ if (
 
           // Claim name can be overriden using an env variable.
           // Default is 'preferred_username' as per OIDC spec.
+          // This will default to the profile.preferred_username, but will fall back to preferred_username from the id_token
           const username = get(profile, env.OIDC_USERNAME_CLAIM)
             ? get(profile, env.OIDC_USERNAME_CLAIM)
             : get(token, env.OIDC_USERNAME_CLAIM);

--- a/plugins/oidc/server/auth/oidc.ts
+++ b/plugins/oidc/server/auth/oidc.ts
@@ -147,9 +147,7 @@ if (
           // Claim name can be overriden using an env variable.
           // Default is 'preferred_username' as per OIDC spec.
           // This will default to the profile.preferred_username, but will fall back to preferred_username from the id_token
-          const username = get(profile, env.OIDC_USERNAME_CLAIM)
-            ? get(profile, env.OIDC_USERNAME_CLAIM)
-            : get(token, env.OIDC_USERNAME_CLAIM);
+          const username = get(profile, env.OIDC_USERNAME_CLAIM) ?? get(token, env.OIDC_USERNAME_CLAIM);
           const name = profile.name || username || profile.username;
           const profileId = profile.sub ? profile.sub : profile.id;
 

--- a/plugins/oidc/server/auth/oidc.ts
+++ b/plugins/oidc/server/auth/oidc.ts
@@ -1,4 +1,5 @@
 import passport from "@outlinewiki/koa-passport";
+import JWT from "jsonwebtoken";
 import type { Context } from "koa";
 import Router from "koa-router";
 import get from "lodash/get";
@@ -58,7 +59,7 @@ if (
         ctx: Context,
         accessToken: string,
         refreshToken: string,
-        params: { expires_in: number },
+        params: { expires_in: number; id_token: string },
         _profile: unknown,
         done: (
           err: Error | null,
@@ -78,14 +79,25 @@ if (
             accessToken
           );
 
-          if (!profile.email) {
+          // Some providers, namely ADFS, don't provide anything more than the `sub` claim in the userinfo endpoint
+          // So, we'll decode the params.id_token and see if that contains what we need.
+          const id_token = JWT.decode(params.id_token);
+          const token = id_token as {
+            email?: string;
+            preferred_username?: string;
+            sub?: string;
+          };
+
+          const email = profile.email ?? token.email ?? null;
+
+          if (!email) {
             throw AuthenticationError(
-              `An email field was not returned in the profile parameter, but is required.`
+              `An email field was not returned in the profile or id_token parameter, but is required.`
             );
           }
           const team = await getTeamFromContext(ctx);
           const client = getClientFromContext(ctx);
-          const { domain } = parseEmail(profile.email);
+          const { domain } = parseEmail(email);
 
           // Only a single OIDC provider is supported – find the existing, if any.
           const authenticationProvider = team
@@ -118,13 +130,15 @@ if (
 
           // Claim name can be overriden using an env variable.
           // Default is 'preferred_username' as per OIDC spec.
-          const username = get(profile, env.OIDC_USERNAME_CLAIM);
+          const username = get(profile, env.OIDC_USERNAME_CLAIM)
+            ? get(profile, env.OIDC_USERNAME_CLAIM)
+            : get(token, env.OIDC_USERNAME_CLAIM);
           const name = profile.name || username || profile.username;
           const profileId = profile.sub ? profile.sub : profile.id;
 
           if (!name) {
             throw AuthenticationError(
-              `Neither a name or username was returned in the profile parameter, but at least one is required.`
+              `Neither a ${env.OIDC_USERNAME_CLAIM}, name or username was returned in the profile parameter, but at least one is required.`
             );
           }
 
@@ -138,7 +152,7 @@ if (
             },
             user: {
               name,
-              email: profile.email,
+              email,
               avatarUrl: profile.picture,
             },
             authenticationProvider: {


### PR DESCRIPTION
Supersedes #9169.

ADFS' userinfo endpoint only provides the sub claim, which causes the generic OIDC authentication plugin to fail, as it expects email, preferred_username etc.

This pull request enhances the OIDC authentication plugin by falling back to the OIDC id_token which could contain these claims. 

Regression tested against ADFS and Keycloak -- authentication works with both. 

(Typescript is not my bread and butter -- let me know if I need to rethink any of this!)