### PR TITLE
Add custom script injection support

### DIFF
--- a/server/env.ts
+++ b/server/env.ts
@@ -649,6 +649,47 @@ export class Environment {
   @Public
   public APP_NAME = "Outline";
 
+  @IsOptional()
+  @IsUrl({ require_tld: false })
+  public CUSTOM_SCRIPT_BASE_URL = this.toOptionalString(
+    environment.CUSTOM_SCRIPT_BASE_URL
+  );
+
+  @IsOptional()
+  public CUSTOM_SCRIPT_PATHS = this.toOptionalCommaList(
+    environment.CUSTOM_SCRIPT_PATHS
+  );
+
+  @IsOptional()
+  public CUSTOM_SCRIPT_JWT_SECRET = this.toOptionalString(
+    environment.CUSTOM_SCRIPT_JWT_SECRET
+  );
+
+  @IsOptional()
+  @IsIn([
+    "HS256",
+    "HS384",
+    "HS512",
+    "RS256",
+    "RS384",
+    "RS512",
+    "ES256",
+    "ES384",
+    "ES512",
+    "PS256",
+    "PS384",
+    "PS512",
+    "none",
+  ])
+  public CUSTOM_SCRIPT_JWT_ALGORITHM = this.toOptionalString(
+    environment.CUSTOM_SCRIPT_JWT_ALGORITHM
+  );
+
+  @IsOptional()
+  public CUSTOM_SCRIPT_JWT_EXPIRATION_SECONDS = this.toOptionalNumber(
+    environment.CUSTOM_SCRIPT_JWT_EXPIRATION_SECONDS
+  );
+
   /**
    * Returns true if the current installation is the cloud hosted version at
    * getoutline.com

--- a/server/services/web.ts
+++ b/server/services/web.ts
@@ -50,6 +50,10 @@ if (env.CDN_URL) {
   defaultSrc.push(env.CDN_URL);
 }
 
+if (env.CUSTOM_SCRIPT_BASE_URL) {
+  scriptSrc.push(env.CUSTOM_SCRIPT_BASE_URL);
+}
+
 export default function init(app: Koa = new Koa(), server?: Server) {
   void initI18n();
 

--- a/server/utils/CustomScript.ts
+++ b/server/utils/CustomScript.ts
@@ -1,0 +1,27 @@
+import * as Cookies from "cookies";
+import jwt, { Algorithm } from "jsonwebtoken";
+import { getUserForJWT } from "@server/utils/jwt";
+
+export default async function createCustomScriptJwt(
+  cookies: Cookies,
+  secret: string,
+  expireationSeconds: number,
+  algorithm: string
+) {
+  const accessToken = cookies.get("accessToken");
+  if (!accessToken || !secret) {
+    return "";
+  }
+  try {
+    const user = await getUserForJWT(accessToken);
+    const toEncode = {
+      identifier: user.email,
+      exp: Math.floor(Date.now() / 1000) + expireationSeconds,
+    };
+    return jwt.sign(toEncode, secret, {
+      algorithm: algorithm as Algorithm,
+    });
+  } catch (e) {
+    return "";
+  }
+}


### PR DESCRIPTION
I've implemented custom JS script injection in Outline.
By adding this feature we were able to add [Chainlit's copilot](https://docs.chainlit.io/deploy/copilot) to Outline:

![image_2025-05-10_130052165(1)](https://github.com/user-attachments/assets/731df571-1005-4008-a519-a1a5cbfd5f3f)

Given [this sample project](https://github.com/mkay1375/chainlit-and-outline) is running, by adding these envs the copilot will show up:
```bash
CUSTOM_SCRIPT_BASE_URL=http://localhost:8000
CUSTOM_SCRIPT_PATHS=/copilot/index.js,/public/copilot/outline.js
```