### PR TITLE
Fix flash of previous value after editing title in sidebar for documents

### DIFF
--- a/app/components/EditableTitle.tsx
+++ b/app/components/EditableTitle.tsx
@@ -69,7 +69,6 @@ function EditableTitle(
 
       if (trimmedValue === originalValue || trimmedValue.length === 0) {
         setValue(originalValue);
-        setIsEditing(false);
         onCancel?.();
         return;
       }
@@ -77,12 +76,12 @@ function EditableTitle(
       try {
         await onSubmit(trimmedValue);
         setOriginalValue(trimmedValue);
-        setIsEditing(false);
       } catch (error) {
         setValue(originalValue);
-        setIsEditing(false);
         toast.error(error.message);
         throw error;
+      } finally {
+        setIsEditing(false);
       }
     },
     [originalValue, value, onCancel, onSubmit]

--- a/app/components/EditableTitle.tsx
+++ b/app/components/EditableTitle.tsx
@@ -64,11 +64,12 @@ function EditableTitle(
     async (ev) => {
       ev.preventDefault();
       ev.stopPropagation();
-      setIsEditing(false);
+
       const trimmedValue = value.trim();
 
       if (trimmedValue === originalValue || trimmedValue.length === 0) {
         setValue(originalValue);
+        setIsEditing(false);
         onCancel?.();
         return;
       }
@@ -76,8 +77,10 @@ function EditableTitle(
       try {
         await onSubmit(trimmedValue);
         setOriginalValue(trimmedValue);
+        setIsEditing(false);
       } catch (error) {
         setValue(originalValue);
+        setIsEditing(false);
         toast.error(error.message);
         throw error;
       }


### PR DESCRIPTION
In this PR, I addressed an issue where editing the title in the sidebar and hitting "Enter" would cause a flash of the previous value, specifically for documents. issue #9195

Moved setIsEditing(false) after successful onSubmit to prevent premature UI updates.

Now properly exits edit mode on both success and error cases.

Eliminates the flash of old values when submitting with Enter.

https://github.com/user-attachments/assets/28058917-1210-46b7-9fc0-33d92a64bcbb

