### PR TITLE
fix: Reset editing state when collection/document title is unmodified

### DIFF
--- a/app/components/EditableTitle.tsx
+++ b/app/components/EditableTitle.tsx
@@ -69,6 +69,7 @@ function EditableTitle(
 
       if (trimmedValue === originalValue || trimmedValue.length === 0) {
         setValue(originalValue);
+        setIsEditing(false);
         onCancel?.();
         return;
       }


### PR DESCRIPTION
Regressed in #9197 