### PR TITLE
fix: Remove # from stored filesystem keys

### DIFF
--- a/server/validation.test.ts
+++ b/server/validation.test.ts
@@ -56,4 +56,12 @@ describe("#ValidateKey.sanitize", () => {
       ValidateKey.sanitize(`public/${uuid1}/${uuid2}/../../malicious_key`)
     ).toEqual(`public/${uuid1}/${uuid2}/malicious_key`);
   });
+
+  it("should remove problematic characters", () => {
+    const uuid1 = uuidv4();
+    const uuid2 = uuidv4();
+    expect(ValidateKey.sanitize(`public/${uuid1}/${uuid2}/test#:*?`)).toEqual(
+      `public/${uuid1}/${uuid2}/test`
+    );
+  });
 });

--- a/server/validation.ts
+++ b/server/validation.ts
@@ -209,7 +209,7 @@ export class ValidateKey {
       .slice(0, -1)
       .filter((part) => part !== "" && part !== ".." && part !== ".")
       .join("/")
-      .concat(`/${sanitize(filename)}`);
+      .concat(`/${sanitize(filename.replace(/#/g, ""))}`);
   };
 
   public static message = "Must be of the form <bucket>/<uuid>/<uuid>/<name>";


### PR DESCRIPTION
I can't reproduce the original issue, but it's straight forward and reasonable to sanitize this character