### PR TITLE
fix: Use team name on link metadata if public branding enabled

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -171,6 +171,10 @@ router.get("*", shareDomains(), async (ctx, next) => {
     : [];
 
   return renderApp(ctx, next, {
+    title:
+      team?.getPreference(TeamPreference.PublicBranding) && team.name
+        ? team.name
+        : undefined,
     analytics,
     shortcutIcon:
       team?.getPreference(TeamPreference.PublicBranding) && team.avatarUrl


### PR DESCRIPTION
closes #9269