### PR TITLE
fix: null `collectionId` received in websocket payload for unpublished drafts

### DIFF
--- a/server/queues/processors/WebsocketsProcessor.ts
+++ b/server/queues/processors/WebsocketsProcessor.ts
@@ -69,11 +69,13 @@ export default class WebsocketsProcessor {
               updatedAt: document.updatedAt,
             },
           ],
-          collectionIds: [
-            {
-              id: document.collectionId,
-            },
-          ],
+          collectionIds: document.collectionId
+            ? [
+                {
+                  id: document.collectionId,
+                },
+              ]
+            : [],
         });
       }
 


### PR DESCRIPTION
closes #9275