### PR TITLE
Allow specifying exact pixel width for images

### DIFF
--- a/app/editor/components/MediaDimension.tsx
+++ b/app/editor/components/MediaDimension.tsx
@@ -1,0 +1,147 @@
+import { NodeSelection } from "prosemirror-state";
+import { useCallback, useEffect, useRef, useState } from "react";
+import styled from "styled-components";
+import Flex from "@shared/components/Flex";
+import Text from "@shared/components/Text";
+import { EditorStyleHelper } from "@shared/editor/styles/EditorStyleHelper";
+import { extraArea } from "@shared/styles";
+import Input, { NativeInput, Outline } from "~/components/Input";
+import useBoolean from "~/hooks/useBoolean";
+import { useEditor } from "./EditorContext";
+
+const MinWidth = 50;
+
+export function MediaDimension() {
+  const ref = useRef<HTMLDivElement>(null);
+  const maxWidthRef = useRef<number>();
+  const { view, commands } = useEditor();
+  const { state } = view;
+  const { selection } = state;
+
+  if (!maxWidthRef.current && ref.current) {
+    const docWidth = parseInt(
+      getComputedStyle(ref.current).getPropertyValue("--document-width")
+    );
+    maxWidthRef.current = docWidth - EditorStyleHelper.padding * 2;
+  }
+
+  // This component will be rendered only when the selection is image or video (NodeSelection types).
+  const node = (selection as NodeSelection).node;
+  const nodeType = node.type.name,
+    width = node.attrs.width as number,
+    height = node.attrs.height as number;
+
+  const [localWidth, setLocalWidth] = useState<string>(String(width));
+  const [errored, setErrored, resetErrored] = useBoolean();
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const { value } = e.target;
+      const isNumber = /^\d+$/.test(value);
+
+      if (value && (!isNumber || value === "0")) {
+        return;
+      }
+
+      const valueAsNumber = Number(value);
+
+      if (valueAsNumber < MinWidth || valueAsNumber > maxWidthRef.current!) {
+        setErrored();
+      } else {
+        resetErrored();
+      }
+
+      setLocalWidth(value);
+    },
+    [setErrored, resetErrored]
+  );
+
+  const handleBlur = useCallback(() => {
+    if (!localWidth) {
+      resetErrored();
+      setLocalWidth(String(width)); // Reset to original width if empty
+      return;
+    }
+
+    const localWidthValue = parseInt(localWidth, 10);
+    if (localWidthValue === width) {
+      resetErrored();
+      return;
+    }
+
+    if (localWidthValue < MinWidth || localWidthValue > maxWidthRef.current!) {
+      resetErrored();
+      setLocalWidth(String(width)); // Reset to original width if out of bounds
+      return;
+    }
+
+    const aspectRatio = height / width;
+
+    if (nodeType === "image") {
+      commands["resizeImage"]({
+        width: localWidthValue,
+        height: localWidthValue * aspectRatio,
+      });
+    }
+  }, [commands, localWidth, width, height, nodeType, resetErrored]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        handleBlur();
+      } else if (e.key === "Escape") {
+        resetErrored();
+        setLocalWidth(String(width)); // Reset to original width on escape
+      }
+    },
+    [width, handleBlur, resetErrored]
+  );
+
+  useEffect(() => {
+    if (width !== Number(localWidth)) {
+      setLocalWidth(String(width)); // Sync drag resize updates
+    }
+  }, [width]);
+
+  return (
+    <StyledFlex ref={ref} align="center">
+      <StyledInput
+        value={localWidth}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+        margin={0}
+        $error={errored}
+      />
+      <Text size="xsmall" type="tertiary">
+        x
+      </Text>
+      <StyledInput value={height} margin={0} readOnly />
+    </StyledFlex>
+  );
+}
+
+const StyledFlex = styled(Flex)`
+  pointer-events: all;
+  position: relative;
+
+  ${extraArea(4)}
+`;
+
+const StyledInput = styled(Input)<{ $error?: boolean }>`
+  width: 50px;
+  z-index: 1;
+
+  ${Outline} {
+    background: transparent;
+    border-color: transparent;
+  }
+
+  ${NativeInput} {
+    height: 24px;
+    padding: 0;
+    text-align: center;
+
+    ${(props) => props.$error && `color: ${props.theme.danger}`};
+  }
+`;

--- a/app/editor/components/SelectionToolbar.tsx
+++ b/app/editor/components/SelectionToolbar.tsx
@@ -221,6 +221,9 @@ export default function SelectionToolbar(props: Props) {
     if (item.name === "separator") {
       return true;
     }
+    if (item.name === "dimensions") {
+      return item.visible ?? false;
+    }
     if (item.name && !commands[item.name]) {
       return false;
     }

--- a/app/editor/components/ToolbarMenu.tsx
+++ b/app/editor/components/ToolbarMenu.tsx
@@ -11,6 +11,7 @@ import Template from "~/components/ContextMenu/Template";
 import { TooltipProvider } from "~/components/TooltipContext";
 import { MenuItem as TMenuItem } from "~/types";
 import { useEditor } from "./EditorContext";
+import { MediaDimension } from "./MediaDimension";
 import ToolbarButton from "./ToolbarButton";
 import ToolbarSeparator from "./ToolbarSeparator";
 import Tooltip from "./Tooltip";
@@ -101,7 +102,7 @@ function ToolbarMenu(props: Props) {
           if (item.name === "separator" && item.visible !== false) {
             return <ToolbarSeparator key={index} />;
           }
-          if (item.visible === false || !item.icon) {
+          if (item.visible === false || (!item.skipIcon && !item.icon)) {
             return null;
           }
           const isActive = item.active ? item.active(state) : false;
@@ -112,7 +113,9 @@ function ToolbarMenu(props: Props) {
               shortcut={item.shortcut}
               content={item.label === item.tooltip ? undefined : item.tooltip}
             >
-              {item.children ? (
+              {item.name === "dimensions" ? (
+                <MediaDimension key={index} />
+              ) : item.children ? (
                 <ToolbarDropdown active={isActive && !item.label} item={item} />
               ) : (
                 <ToolbarButton

--- a/app/editor/menus/image.tsx
+++ b/app/editor/menus/image.tsx
@@ -60,6 +60,15 @@ export default function imageMenuItems(
       name: "separator",
     },
     {
+      name: "dimensions",
+      tooltip: dictionary.dimensions,
+      visible: !isFullWidthAligned(state),
+      skipIcon: true,
+    },
+    {
+      name: "separator",
+    },
+    {
       name: "downloadImage",
       tooltip: dictionary.downloadImage,
       icon: <DownloadIcon />,

--- a/app/hooks/useDictionary.ts
+++ b/app/hooks/useDictionary.ts
@@ -35,6 +35,7 @@ export default function useDictionary() {
       deleteRow: t("Delete"),
       deleteTable: t("Delete table"),
       deleteAttachment: t("Delete file"),
+      dimensions: t("Width x Height"),
       download: t("Download"),
       downloadAttachment: t("Download file"),
       replaceAttachment: t("Replace file"),

--- a/shared/editor/types/index.ts
+++ b/shared/editor/types/index.ts
@@ -40,6 +40,7 @@ export type MenuItem = {
   visible?: boolean;
   active?: (state: EditorState) => boolean;
   appendSpace?: boolean;
+  skipIcon?: boolean;
 };
 
 export type ComponentProps = {

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -447,6 +447,7 @@
   "Create a new child doc": "Create a new child doc",
   "Delete table": "Delete table",
   "Delete file": "Delete file",
+  "Width x Height": "Width x Height",
   "Download file": "Download file",
   "Replace file": "Replace file",
   "Delete image": "Delete image",


### PR DESCRIPTION
Closes #8347 

We don't have a way to resize image height for now, so the PR focuses on providing pixel width only.

Per my investigation, supporting height resizing would need a sizable effort to maintain aspect-ratio and related stuff (mainly driven by width now). It didn't seem like a good idea to combine it with this PR.


https://github.com/user-attachments/assets/5576f816-8144-451d-badc-b94ccc3f2a43

