### PR TITLE
fix: Skip fetching children for unsupported Notion blocks

### DIFF
--- a/plugins/notion/server/notion.ts
+++ b/plugins/notion/server/notion.ts
@@ -57,6 +57,11 @@ export class NotionClient {
   private client: Client;
   private limiter: ReturnType<typeof RateLimit>;
   private pageSize = 25;
+  private unsupportedBlockTypes = [
+    "unsupported",
+    "child_page",
+    "child_database",
+  ];
 
   constructor(
     accessToken: string,
@@ -178,8 +183,7 @@ export class NotionClient {
       blocks.map(async (block) => {
         if (
           block.has_children &&
-          block.type !== "child_page" &&
-          block.type !== "child_database"
+          !this.unsupportedBlockTypes.includes(block.type)
         ) {
           block.children = await this.fetchBlockChildren(block.id);
         }

--- a/plugins/notion/server/notion.ts
+++ b/plugins/notion/server/notion.ts
@@ -57,7 +57,7 @@ export class NotionClient {
   private client: Client;
   private limiter: ReturnType<typeof RateLimit>;
   private pageSize = 25;
-  private unsupportedBlockTypes = [
+  private skipChildrenForBlock = [
     "unsupported",
     "child_page",
     "child_database",
@@ -183,7 +183,7 @@ export class NotionClient {
       blocks.map(async (block) => {
         if (
           block.has_children &&
-          !this.unsupportedBlockTypes.includes(block.type)
+          !this.skipChildrenForBlock.includes(block.type)
         ) {
           block.children = await this.fetchBlockChildren(block.id);
         }


### PR DESCRIPTION
Closes #9287 

Probably the only "unsupported" block with children right now, which might be why this wasn't faced before.