### PR TITLE
fix: Inaccessible tooltips after conversion

### DIFF
--- a/app/components/Sharing/Document/AccessControlList.tsx
+++ b/app/components/Sharing/Document/AccessControlList.tsx
@@ -12,6 +12,7 @@ import type Collection from "~/models/Collection";
 import type Document from "~/models/Document";
 import Share from "~/models/Share";
 import Flex from "~/components/Flex";
+import NudeButton from "~/components/NudeButton";
 import Scrollable from "~/components/Scrollable";
 import Text from "~/components/Text";
 import useCurrentTeam from "~/hooks/useCurrentTeam";
@@ -230,7 +231,9 @@ const AccessTooltip = ({
         {children}
       </Text>
       <Tooltip content={content ?? t("Access inherited from collection")}>
-        <QuestionMarkIcon size={18} />
+        <NudeButton size={18}>
+          <QuestionMarkIcon size={18} />
+        </NudeButton>
       </Tooltip>
     </Flex>
   );

--- a/app/components/Sharing/Document/PublicAccess.tsx
+++ b/app/components/Sharing/Document/PublicAccess.tsx
@@ -177,7 +177,9 @@ function PublicAccess({ document, share, sharedParent }: Props) {
                     "Disable this setting to discourage search engines from indexing the page"
                   )}
                 >
-                  <QuestionMarkIcon size={18} />
+                  <NudeButton size={18}>
+                    <QuestionMarkIcon size={18} />
+                  </NudeButton>
                 </Tooltip>
               </Text>
             }


### PR DESCRIPTION
Due to the usage of `asChild` all tooltip children must be accessible