### PR TITLE
Relax `@typescript-eslint/no-unused-expressions` rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -91,6 +91,12 @@
         "ignoreRestSiblings": true
       }
     ],
+    "@typescript-eslint/no-unused-expressions": [
+      "error",
+      {
+        "allowShortCircuit": true
+      }
+    ],
     "padding-line-between-statements": [
       "error",
       {

--- a/app/utils/download.ts
+++ b/app/utils/download.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-expressions */
 // download.js v3.0, by dandavis; 2008-2014. [CCBY2] see http://danml.com/download.html for tests/usage
 // v1 landed a FF+Chrome compat way of downloading strings to local un-named files, upgraded to use a hidden frame and optional mime
 // v2 added named files via a[download], msSaveBlob, IE (10+) support, and window.URL support for larger+faster saves than dataURLs


### PR DESCRIPTION
Closes #9373 