### PR TITLE
fix: Set name and id in `Switch` events

### DIFF
--- a/app/components/Switch.tsx
+++ b/app/components/Switch.tsx
@@ -51,13 +51,13 @@ function Switch(
       if (onChange) {
         // Create a synthetic event to maintain compatibility with existing code
         const syntheticEvent = {
-          target: { checked: checkedState },
+          target: { id: props.id, name: props.name, checked: checkedState },
           currentTarget: { checked: checkedState },
         } as React.ChangeEvent<HTMLInputElement>;
         onChange(syntheticEvent);
       }
     },
-    [onChange]
+    [onChange, props.id, props.name]
   );
 
   const component = (


### PR DESCRIPTION
We need to set the target `name` and `id` in the Switch event since some pages use them in handlers, eg. [Preferences](https://github.com/outline/outline/blob/main/app/scenes/Settings/Preferences.tsx#L56), [Security](https://github.com/outline/outline/blob/main/app/scenes/Settings/Security.tsx#L93) page..

Ideally, Switch's `onChange` handler should be changed to `(checked: boolean) => void`, but that'd mean a lot of changes throughout the app.

Regressed in #9358 