### PR TITLE
chore: Cleanup deprecated task schedule method

### DIFF
--- a/server/queues/tasks/BaseTask.ts
+++ b/server/queues/tasks/BaseTask.ts
@@ -24,25 +24,6 @@ export default abstract class BaseTask<T extends Record<string, any>> {
    * Schedule this task type to be processed asynchronously by a worker.
    *
    * @param props Properties to be used by the task
-   * @returns A promise that resolves once the job is placed on the task queue
-   */
-  public static schedule<T>(props?: T, options?: JobOptions): Promise<Job> {
-    // @ts-expect-error cannot create an instance of an abstract class, we wont
-    const task = new this();
-
-    return taskQueue.add(
-      {
-        name: this.name,
-        props,
-      },
-      { ...options, ...task.options }
-    );
-  }
-
-  /**
-   * Schedule this task type to be processed asynchronously by a worker.
-   *
-   * @param props Properties to be used by the task
    * @param options Job options such as priority and retry strategy, as defined by Bull.
    * @returns A promise that resolves once the job is placed on the task queue
    */


### PR DESCRIPTION
Removes deprecated non-typesafe schedule method which was superseded in #9079 