### PR TITLE
fix: Sporadic rate limiting errors from Notion

### DIFF
--- a/plugins/notion/server/tasks/NotionAPIImportTask.ts
+++ b/plugins/notion/server/tasks/NotionAPIImportTask.ts
@@ -149,6 +149,17 @@ export default class NotionAPIImportTask extends APIImportTask<IntegrationServic
           );
           return null;
         }
+
+        // Rate limit errors should be handled by the fetchWithRetry method in NotionClient
+        // If we still get here, it means the maximum retries were exceeded
+        if (error.code === APIErrorCode.RateLimited) {
+          Logger.error(
+            `Rate limit exceeded for Notion API when processing ${
+              item.type === PageType.Database ? "database" : "page"
+            } ${item.externalId}. Maximum retries reached.`,
+            error
+          );
+        }
       }
       // Re-throw other errors to be handled by the parent try/catch
       throw error;


### PR DESCRIPTION
I can't find a logical error that would result in going past the 3req/min that's defined in the limiter. For reliability's sake I'd like to include this retry mechanism as well.