### PR TITLE
fix: Commenting unavailable on individually shared documents

### DIFF
--- a/app/actions/definitions/documents.tsx
+++ b/app/actions/definitions/documents.tsx
@@ -1083,17 +1083,13 @@ export const openDocumentComments = createAction({
   analyticsName: "Open comments",
   section: ActiveDocumentSection,
   icon: <CommentIcon />,
-  visible: ({ activeCollectionId, activeDocumentId, stores }) => {
+  visible: ({ activeDocumentId, stores }) => {
     const can = stores.policies.abilities(activeDocumentId ?? "");
-    const collection = activeCollectionId
-      ? stores.collections.get(activeCollectionId)
-      : undefined;
 
     return (
       !!activeDocumentId &&
       can.comment &&
-      (collection?.canCreateComment ??
-        !!stores.auth.team?.getPreference(TeamPreference.Commenting))
+      !!stores.auth.team?.getPreference(TeamPreference.Commenting)
     );
   },
   perform: ({ activeDocumentId, stores }) => {

--- a/app/components/AuthenticatedLayout.tsx
+++ b/app/components/AuthenticatedLayout.tsx
@@ -49,7 +49,7 @@ type Props = {
 };
 
 const AuthenticatedLayout: React.FC = ({ children }: Props) => {
-  const { ui, auth, collections } = useStores();
+  const { ui, auth } = useStores();
   const location = useLocation();
   const layoutRef = React.useRef<HTMLDivElement>(null);
   const can = usePolicy(ui.activeDocumentId);
@@ -108,9 +108,7 @@ const AuthenticatedLayout: React.FC = ({ children }: Props) => {
     can.comment &&
     ui.activeDocumentId &&
     ui.commentsExpanded &&
-    (ui.activeCollectionId
-      ? collections.get(ui.activeCollectionId)?.canCreateComment
-      : !!team.getPreference(TeamPreference.Commenting));
+    !!team.getPreference(TeamPreference.Commenting);
 
   const sidebarRight = (
     <AnimatePresence

--- a/app/models/Collection.ts
+++ b/app/models/Collection.ts
@@ -6,7 +6,6 @@ import {
   type NavigationNode,
   NavigationNodeType,
   type ProsemirrorData,
-  TeamPreference,
 } from "@shared/types";
 import { ProsemirrorHelper } from "@shared/utils/ProsemirrorHelper";
 import { sortNavigationNodes } from "@shared/utils/collections";
@@ -127,21 +126,6 @@ export default class Collection extends ParanoidModel {
    */
   get isPrivate(): boolean {
     return !this.permission;
-  }
-
-  /**
-   * Returns whether comments should be enabled for this collection,
-   *
-   * @returns boolean
-   */
-  @computed
-  get canCreateComment(): boolean {
-    const teamCommentingEnabled =
-      !!this.store.rootStore.auth.team?.getPreference(
-        TeamPreference.Commenting
-      );
-
-    return teamCommentingEnabled && this.commenting !== false;
   }
 
   /** Returns whether the collection description is not empty. */

--- a/app/scenes/Document/components/DocumentMeta.tsx
+++ b/app/scenes/Document/components/DocumentMeta.tsx
@@ -25,7 +25,7 @@ type Props = {
 };
 
 function TitleDocumentMeta({ to, document, revision, ...rest }: Props) {
-  const { collections, views, comments, ui } = useStores();
+  const { views, comments, ui } = useStores();
   const { t } = useTranslation();
   const match = useRouteMatch();
   const sidebarContext = useLocationSidebarContext();
@@ -40,17 +40,11 @@ function TitleDocumentMeta({ to, document, revision, ...rest }: Props) {
 
   const insightsPath = documentInsightsPath(document);
   const commentsCount = comments.unresolvedCommentsInDocumentCount(document.id);
-
-  const collection = document.collectionId
-    ? collections.get(document.collectionId)
-    : undefined;
-  const collectionCommentingEnabled =
-    collection?.canCreateComment ??
-    !!team.getPreference(TeamPreference.Commenting);
+  const commentingEnabled = !!team.getPreference(TeamPreference.Commenting);
 
   return (
     <Meta document={document} revision={revision} to={to} replace {...rest}>
-      {collectionCommentingEnabled && can.comment && (
+      {commentingEnabled && can.comment && (
         <>
           &nbsp;•&nbsp;
           <CommentLink

--- a/app/scenes/Document/components/Editor.tsx
+++ b/app/scenes/Document/components/Editor.tsx
@@ -60,7 +60,7 @@ function DocumentEditor(props: Props, ref: React.RefObject<any>) {
   const { t } = useTranslation();
   const match = useRouteMatch();
   const focusedComment = useFocusedComment();
-  const { ui, comments, collections } = useStores();
+  const { ui, comments } = useStores();
   const user = useCurrentUser({ rejectOnEmpty: false });
   const team = useCurrentTeam({ rejectOnEmpty: false });
   const history = useHistory();
@@ -78,14 +78,7 @@ function DocumentEditor(props: Props, ref: React.RefObject<any>) {
     ...rest
   } = props;
   const can = usePolicy(document);
-
-  // Check collection-level commenting setting
-  const collection = document.collectionId
-    ? collections.get(document.collectionId)
-    : undefined;
-  const collectionCommentingEnabled =
-    collection?.canCreateComment ??
-    !!team?.getPreference(TeamPreference.Commenting);
+  const commentingEnabled = !!team?.getPreference(TeamPreference.Commenting);
 
   const iconColor = document.color ?? (last(colorPalette) as string);
   const childRef = React.useRef<HTMLDivElement>(null);
@@ -266,14 +259,10 @@ function DocumentEditor(props: Props, ref: React.RefObject<any>) {
         focusedCommentId={focusedComment?.id}
         onClickCommentMark={handleClickComment}
         onCreateCommentMark={
-          collectionCommentingEnabled && can.comment
-            ? handleDraftComment
-            : undefined
+          commentingEnabled && can.comment ? handleDraftComment : undefined
         }
         onDeleteCommentMark={
-          collectionCommentingEnabled && can.comment
-            ? handleRemoveComment
-            : undefined
+          commentingEnabled && can.comment ? handleRemoveComment : undefined
         }
         onInit={handleInit}
         onDestroy={handleDestroy}

--- a/server/policies/document.ts
+++ b/server/policies/document.ts
@@ -60,7 +60,8 @@ allow(User, "comment", Document, (actor, document) =>
     ),
     isTeamMutable(actor),
     !!document?.isActive,
-    !document?.template
+    !document?.template,
+    or(!document?.collection, document?.collection?.commenting !== false)
   )
 );
 


### PR DESCRIPTION
Refactor to use policies for comment so the collection is not required to be loaded on the client

closes #9446