### PR TITLE
fix: Skip showing archived docs in shared section

### DIFF
--- a/app/models/Group.ts
+++ b/app/models/Group.ts
@@ -27,7 +27,7 @@ class Group extends Model {
 
   /**
    * Returns the direct memberships that this group has to documents. Documents that the current
-   * user already has access to through a collection and trashed documents are not included.
+   * user already has access to through a collection, archived, and trashed documents are not included.
    *
    * @returns A list of group memberships
    */
@@ -52,7 +52,7 @@ class Group extends Model {
         const policy = document?.collectionId
           ? policies.get(document.collectionId)
           : undefined;
-        return !policy?.abilities?.readDocument && !document?.isDeleted;
+        return !policy?.abilities?.readDocument && !!document?.isActive;
       });
   }
 }

--- a/app/models/User.ts
+++ b/app/models/User.ts
@@ -137,7 +137,7 @@ class User extends ParanoidModel implements Searchable {
 
   /**
    * Returns the direct memberships that this user has to documents. Documents that the
-   * user already has access to through a collection and trashed documents are not included.
+   * user already has access to through a collection, archived, and trashed documents are not included.
    *
    * @returns A list of user memberships
    */
@@ -153,7 +153,7 @@ class User extends ParanoidModel implements Searchable {
         const policy = document?.collectionId
           ? policies.get(document.collectionId)
           : undefined;
-        return !policy?.abilities?.readDocument && !document?.isDeleted;
+        return !policy?.abilities?.readDocument && !!document?.isActive;
       });
   }
 


### PR DESCRIPTION
Tiny bug fix to skip archived docs in shared section.