### PR TITLE
fix: Public share search offset is incorrect

### DIFF
--- a/app/components/PaginatedList.tsx
+++ b/app/components/PaginatedList.tsx
@@ -150,12 +150,15 @@ const PaginatedList = <T extends PaginatedItem>({
         offset,
         ...options,
       });
+      if (!results) {
+        return;
+      }
 
       if (offset !== 0) {
         setRenderCount((prevCount) => prevCount + limit);
       }
 
-      if (results && (results.length === 0 || results.length < limit)) {
+      if (results.length === 0 || results.length < limit) {
         setAllowLoadMore(false);
       } else {
         setOffset((prevOffset) => prevOffset + limit);


### PR DESCRIPTION
`offset` incorrectly moves forward when no search is made.

closes #9463 