### PR TITLE
fixed comments

### DIFF
--- a/app/scenes/Document/components/Editor.tsx
+++ b/app/scenes/Document/components/Editor.tsx
@@ -34,8 +34,6 @@ import MultiplayerEditor from "./AsyncMultiplayerEditor";
 import DocumentMeta from "./DocumentMeta";
 import DocumentTitle from "./DocumentTitle";
 
-const extensions = withUIExtensions(withComments(richExtensions));
-
 type Props = Omit<EditorProps, "editorStyle"> & {
   onChangeTitle: (title: string) => void;
   onChangeIcon: (icon: string | null, color: string | null) => void;
@@ -79,6 +77,13 @@ function DocumentEditor(props: Props, ref: React.RefObject<any>) {
   } = props;
   const can = usePolicy(document);
   const commentingEnabled = !!team?.getPreference(TeamPreference.Commenting);
+
+  const extensions = withUIExtensions(
+    commentingEnabled
+      ? withComments(richExtensions)
+      : richExtensions
+  );
+
 
   const iconColor = document.color ?? (last(colorPalette) as string);
   const childRef = React.useRef<HTMLDivElement>(null);
@@ -238,12 +243,12 @@ function DocumentEditor(props: Props, ref: React.RefObject<any>) {
             shareId
               ? undefined
               : {
-                  pathname:
-                    match.path === matchDocumentHistory
-                      ? documentPath(document)
-                      : documentHistoryPath(document),
-                  state: { sidebarContext },
-                }
+                pathname:
+                  match.path === matchDocumentHistory
+                    ? documentPath(document)
+                    : documentHistoryPath(document),
+                state: { sidebarContext },
+              }
           }
           rtl={direction === "rtl"}
         />


### PR DESCRIPTION
issue #9300 

# Hide comment marks when commenting is disabled

## Summary
This change makes the comment plugin in the editor initialize conditionally based on the collection’s **Commenting** setting. When commenting is disabled (`TeamPreference.Commenting = false`), the `withComments` extension is not loaded, so no inline comment markers are ever rendered in the document.

## Changes
- Removed the global `extensions` declaration.
- In `DocumentEditor` (`app/scenes/Document/components/DocumentEditor.tsx`), after reading the `commentingEnabled` flag, compute:
  ```ts
  const extensions = withUIExtensions(
    commentingEnabled
      ? withComments(richExtensions)
      : richExtensions
  );
Only pass onCreateCommentMark and onDeleteCommentMark to <EditorComponent> when commentingEnabled && can.comment.

All other editor extensions and UI behavior remain unchanged.

How to Test
Commenting enabled (Team Preference → Commenting = true):

Inline markers should render as before.

Sidebar comments panel opens and functions normally.

Commenting disabled (Team Preference → Commenting = false):

No comment markers appear in the document (DOM contains no marker decorations).

Sidebar comments panel does not open.

Existing comment data in the database remains intact.