### PR TITLE
multiple reactions comments

### DIFF
--- a/server/models/Notification.ts
+++ b/server/models/Notification.ts
@@ -124,6 +124,18 @@ class Notification extends Model<
   @Column(DataType.STRING)
   event: NotificationEventType;
 
+  @AllowNull
+  @Column(DataType.STRING)
+  emoji: string;
+
+  @AllowNull
+  @Column(DataType.ARRAY(DataType.UUID))
+  actorIds: string[];
+
+  @AllowNull
+  @Column(DataType.TEXT)
+  message: string;
+
   // associations
 
   @BelongsTo(() => User, "userId")

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -348,6 +348,7 @@ export enum NotificationEventType {
   Onboarding = "emails.onboarding",
   Features = "emails.features",
   ExportCompleted = "emails.export_completed",
+  ReactionToComment = "comments.reaction",
 }
 
 export enum NotificationChannelType {
@@ -380,6 +381,7 @@ export const NotificationEventDefaults: Record<NotificationEventType, boolean> =
     [NotificationEventType.ExportCompleted]: true,
     [NotificationEventType.AddUserToDocument]: true,
     [NotificationEventType.AddUserToCollection]: true,
+    [NotificationEventType.ReactionToComment]: true,
   };
 
 export enum UnfurlResourceType {


### PR DESCRIPTION
issue #7878
## feat(notifications): upsert reaction notifications on comment reactions

### Summary

This PR adds support for updating an existing unread notification when multiple users react with the same emoji on a comment.  
Instead of creating a new notification each time, we now display messages like:

> `Tom and 5 others reacted 👍 to your comment`

### Changes

- **Notification model**
  - Added new columns:
    - `emoji: STRING`
    - `actorIds: UUID[]`
    - `message: TEXT`
  - Updated `server/models/Notification.ts` accordingly.

- **NotificationEventType**
  - Added new event type:
    ```ts
    ReactionToComment = "comments.reaction"
    ```
  - Registered it in `NotificationEventDefaults`.

- **comments.add_reaction handler**
  - After `Reaction.findOrCreate(...)`:
    - If an unread notification with same `commentId + emoji` exists:
      - Append actor to `actorIds`
      - Update `message`
    - Otherwise, create a new notification
  - Added necessary imports (`Notification`, `NotificationEventType`, `Op`)

---

### Problem

The project does **not compile** due to a type error:

TS1360: Type 'NotificationEventType.ReactionToComment' does not satisfy the expected type 'never'.

This likely means:
- the `NotificationEventType.ReactionToComment` enum is not recognized correctly in the `Notification` model
- or the shared enum types were not correctly linked at build time