### PR TITLE
feat: Allow `allowIndexing` and `showLastUpdated` to be set in `shares.create`

### DIFF
--- a/server/routes/api/shares/schema.ts
+++ b/server/routes/api/shares/schema.ts
@@ -73,6 +73,8 @@ export const SharesCreateSchema = BaseSchema.extend({
         message: "must be uuid or url slug",
       }),
     published: z.boolean().default(false),
+    allowIndexing: z.boolean().optional(),
+    showLastUpdated: z.boolean().optional(),
     urlId: z
       .string()
       .regex(UrlHelper.SHARE_URL_SLUG_REGEX, {

--- a/server/routes/api/shares/shares.test.ts
+++ b/server/routes/api/shares/shares.test.ts
@@ -302,6 +302,29 @@ describe("#shares.create", () => {
     expect(body.data.documentTitle).toBe(document.title);
   });
 
+  it("should accept allowIndexing and showLastUpdated parameters", async () => {
+    const user = await buildUser();
+    const document = await buildDocument({
+      userId: user.id,
+      teamId: user.teamId,
+    });
+    const res = await server.post("/api/shares.create", {
+      body: {
+        token: user.getJwtToken(),
+        documentId: document.id,
+        published: true,
+        allowIndexing: false,
+        showLastUpdated: true,
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.data.published).toBe(true);
+    expect(body.data.allowIndexing).toBe(false);
+    expect(body.data.showLastUpdated).toBe(true);
+    expect(body.data.documentTitle).toBe(document.title);
+  });
+
   it("should fail creating a share record with read-only permissions and publishing", async () => {
     const team = await buildTeam();
     const user = await buildUser({ teamId: team.id });

--- a/server/routes/api/shares/shares.ts
+++ b/server/routes/api/shares/shares.ts
@@ -187,8 +187,14 @@ router.post(
   validate(T.SharesCreateSchema),
   transaction(),
   async (ctx: APIContext<T.SharesCreateReq>) => {
-    const { documentId, published, urlId, includeChildDocuments } =
-      ctx.input.body;
+    const {
+      documentId,
+      published,
+      urlId,
+      includeChildDocuments,
+      allowIndexing,
+      showLastUpdated,
+    } = ctx.input.body;
     const { user } = ctx.state.auth;
     authorize(user, "createShare", user.team);
 
@@ -214,6 +220,8 @@ router.post(
         userId: user.id,
         published,
         includeChildDocuments,
+        allowIndexing,
+        showLastUpdated,
         urlId,
       },
     });


### PR DESCRIPTION
For API users, allow settings this configuration at the point of creation