### PR TITLE
fix: Add OAuth support to search query source enum

### DIFF
--- a/app/models/SearchQuery.ts
+++ b/app/models/SearchQuery.ts
@@ -12,7 +12,7 @@ class SearchQuery extends Model {
   /**
    * Where the query originated.
    */
-  source: "api" | "app" | "slack";
+  source: "api" | "app" | "slack" | "oauth";
 
   delete = async () => {
     this.isSaving = true;

--- a/server/migrations/20250630100046-add-oauth-to-search-queries-source.js
+++ b/server/migrations/20250630100046-add-oauth-to-search-queries-source.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      "ALTER TYPE enum_search_queries_source ADD VALUE 'oauth'"
+    );
+  },
+
+  async down (queryInterface, Sequelize) {
+    // Note: PostgreSQL doesn't support removing enum values easily
+    // This would require recreating the enum type and updating all references
+    throw new Error('Cannot rollback adding enum value to PostgreSQL');
+  }
+};

--- a/server/models/SearchQuery.ts
+++ b/server/models/SearchQuery.ts
@@ -38,7 +38,7 @@ class SearchQuery extends Model<
   /**
    * Where the query originated.
    */
-  @Column(DataType.ENUM("slack", "app", "api"))
+  @Column(DataType.ENUM("slack", "app", "api", "oauth"))
   source: string;
 
   /**


### PR DESCRIPTION
## Summary
  Fixes search API returning 400 validation error for OAuth-authenticated requests when search parameters are provided.

  ## Problem
  OAuth-authenticated users could perform searches with empty parameters, but received validation errors when providing any search parameters:

  **Working:**
  POST /api/documents.search
  {"query": "", "limit": 10}  // ✅ Success

  Failing:
  POST /api/documents.search
  {"query": "test", "limit": 10}  // ❌ 400 Error

  Error Message:
  "oauth" is not a valid choice in ["slack","app","api"] (source)

  ### Root Cause
  - Empty search queries bypass the search query logging/tracking system (I think)
  - Non-empty search queries trigger the SearchQuery model creation for analytics
  - OAuth requests are internally tagged with source: "oauth"
  - Database enum enum_search_queries_source only included ["slack", "app", "api"]
  - TypeScript models didn't include "oauth" as valid source type

  ### Solution
  - Added "oauth" to enum_search_queries_source database enum via migration
  - Updated TypeScript type definitions in both client and server models
  - Maintains backward compatibility with existing source values

  ### Changes
  - server/models/SearchQuery.ts: Add "oauth" to DataType.ENUM definition
  - app/models/SearchQuery.ts: Add "oauth" to TypeScript type union
  - server/migrations/: New migration to add "oauth" enum value to database

  ### Testing
  - OAuth users can now perform document searches with parameters
  - Empty queries continue to work as before
  - API token and other authentication methods unaffected
  - Database migration applies cleanly
  - 100% reproduction rate resolved

### Impact
  - Enables full search functionality for OAuth-authenticated users
  - Fixes critical limitation affecting OAuth-based integrations
  - Resolves forced workarounds using empty queries or API tokens