### PR TITLE
feat: add optional public URL for serving uploaded files from S3

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -96,6 +96,10 @@ AWS_REGION=xx-xxxx-x
 AWS_S3_ACCELERATE_URL=
 AWS_S3_UPLOAD_BUCKET_URL=http://s3:4569
 AWS_S3_UPLOAD_BUCKET_NAME=bucket_name_here
+# Optional: Public URL for serving uploaded files if different from AWS_S3_UPLOAD_BUCKET_URL.
+# Use this when your S3 endpoint is not publicly accessible or when serving files through a CDN.
+# If not provided, defaults to AWS_S3_UPLOAD_BUCKET_URL.
+AWS_S3_PUBLIC_URL=
 AWS_S3_FORCE_PATH_STYLE=true
 AWS_S3_ACL=private
 

--- a/server/env.ts
+++ b/server/env.ts
@@ -604,6 +604,14 @@ export class Environment {
   public AWS_S3_UPLOAD_BUCKET_URL = environment.AWS_S3_UPLOAD_BUCKET_URL ?? "";
 
   /**
+   * Optional public URL for serving uploaded files. If not provided, defaults to AWS_S3_UPLOAD_BUCKET_URL.
+   * Use this when your S3 endpoint is not publicly accessible or when serving files through a CDN.
+   */
+  @Public
+  @IsOptional()
+  public AWS_S3_PUBLIC_URL = environment.AWS_S3_PUBLIC_URL ?? "";
+
+  /**
    * The bucket name to store file attachments in.
    */
   @IsOptional()


### PR DESCRIPTION
Our S3 endpoint is not publicly accessible. This is not a problem for attachments as they are requested by the VM outline is running on. But the avatars require the /public folder of the S3 endpoint to be accessible as the avatars are not handled the same way as attachments. This introduces a new env variable named `AWS_S3_PUBLIC_URL` to manually configure these URLs. If unset nothing changes for existing users. Also nothing changes for attachments as the new variable is only used for `^/public/` paths.