### PR TITLE
fix: Importer truncates newlines in captions

### DIFF
--- a/shared/editor/nodes/Image.tsx
+++ b/shared/editor/nodes/Image.tsx
@@ -351,9 +351,7 @@ export default class Image extends SimpleImage {
       node: "image",
       getAttrs: (token: Token) => ({
         src: token.attrGet("src"),
-        alt:
-          (token?.children && token.children[0] && token.children[0].content) ||
-          null,
+        alt: token.content,
         ...parseTitleAttribute(token?.attrGet("title") || ""),
       }),
     };

--- a/shared/editor/nodes/Image.tsx
+++ b/shared/editor/nodes/Image.tsx
@@ -351,7 +351,7 @@ export default class Image extends SimpleImage {
       node: "image",
       getAttrs: (token: Token) => ({
         src: token.attrGet("src"),
-        alt: token.content,
+        alt: token.content || null,
         ...parseTitleAttribute(token?.attrGet("title") || ""),
       }),
     };

--- a/shared/editor/nodes/SimpleImage.tsx
+++ b/shared/editor/nodes/SimpleImage.tsx
@@ -134,9 +134,7 @@ export default class SimpleImage extends Node {
       node: "image",
       getAttrs: (token: Token) => ({
         src: token.attrGet("src"),
-        alt:
-          (token?.children && token.children[0] && token.children[0].content) ||
-          null,
+        alt: token.content || null,
       }),
     };
   }


### PR DESCRIPTION
Tracked this back to the very original code 5y ago, there doesn't seem to be a solid reason for this other than perhaps a misunderstanding of the `token` internals at the time.

https://github.com/outline/rich-markdown-editor/blame/b0e6a7ee8ea8f70d57a1c91525d828d023a30b8a/src/nodes/Image.tsx#L243

closes #9531 