### PR TITLE
Migrate share popovers to Radix

### DIFF
--- a/app/components/Collaborators.tsx
+++ b/app/components/Collaborators.tsx
@@ -1,4 +1,3 @@
-import * as Popover from "@radix-ui/react-popover";
 import filter from "lodash/filter";
 import isEqual from "lodash/isEqual";
 import orderBy from "lodash/orderBy";
@@ -6,16 +5,18 @@ import uniq from "lodash/uniq";
 import { observer } from "mobx-react";
 import { useState, useMemo, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import styled from "styled-components";
-import { depths, s } from "@shared/styles";
 import Document from "~/models/Document";
 import { AvatarSize, AvatarWithPresence } from "~/components/Avatar";
 import DocumentViews from "~/components/DocumentViews";
 import Facepile from "~/components/Facepile";
 import NudeButton from "~/components/NudeButton";
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "~/components/primitives/Popover";
 import useCurrentUser from "~/hooks/useCurrentUser";
 import useStores from "~/hooks/useStores";
-import { fadeAndScaleIn } from "~/styles/animations";
 
 type Props = {
   /** The document to display live collaborators for */
@@ -23,21 +24,6 @@ type Props = {
   /** The maximum number of collaborators to display, defaults to 6 */
   limit?: number;
 };
-
-// Styled components to match the original Popover styling
-const StyledPopoverContent = styled(Popover.Content)`
-  animation: ${fadeAndScaleIn} 200ms ease;
-  transform-origin: 75% 0;
-  background: ${s("menuBackground")};
-  border-radius: 6px;
-  padding: 12px 24px;
-  max-height: 75vh;
-  box-shadow: ${s("menuShadow")};
-  z-index: ${depths.modal};
-  overflow-x: hidden;
-  overflow-y: auto;
-  outline: none;
-`;
 
 /**
  * Displays a list of live collaborators for a document, including their avatars
@@ -49,7 +35,6 @@ function Collaborators(props: Props) {
   const user = useCurrentUser();
   const currentUserId = user?.id;
   const [requestedUserIds, setRequestedUserIds] = useState<string[]>([]);
-  const [popoverOpen, setPopoverOpen] = useState(false);
   const { users, presence, ui } = useStores();
   const { document } = props;
   const { observingUserId } = ui;
@@ -164,8 +149,8 @@ function Collaborators(props: Props) {
   );
 
   return (
-    <Popover.Root open={popoverOpen} onOpenChange={setPopoverOpen}>
-      <Popover.Trigger asChild>
+    <Popover>
+      <PopoverTrigger>
         <NudeButton
           width={Math.min(collaborators.length, limit) * AvatarSize.Large}
           height={AvatarSize.Large}
@@ -178,19 +163,11 @@ function Collaborators(props: Props) {
             renderAvatar={renderAvatar}
           />
         </NudeButton>
-      </Popover.Trigger>
-      <Popover.Portal>
-        <StyledPopoverContent
-          side="bottom"
-          align="end"
-          sideOffset={0}
-          aria-label={t("Viewers")}
-          style={{ width: 300 }}
-        >
-          <DocumentViews document={document} />
-        </StyledPopoverContent>
-      </Popover.Portal>
-    </Popover.Root>
+      </PopoverTrigger>
+      <PopoverContent aria-label={t("Viewers")} side="bottom" align="end">
+        <DocumentViews document={document} />
+      </PopoverContent>
+    </Popover>
   );
 }
 

--- a/app/components/IconPicker/index.tsx
+++ b/app/components/IconPicker/index.tsx
@@ -1,19 +1,22 @@
-import * as Popover from "@radix-ui/react-popover";
 import * as Tabs from "@radix-ui/react-tabs";
 import { SmileyIcon } from "outline-icons";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import styled, { css } from "styled-components";
 import Icon from "@shared/components/Icon";
-import { s, hover, depths } from "@shared/styles";
+import { s, hover } from "@shared/styles";
 import theme from "@shared/styles/theme";
 import { IconType } from "@shared/types";
 import { determineIconType } from "@shared/utils/icon";
 import Flex from "~/components/Flex";
 import NudeButton from "~/components/NudeButton";
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "~/components/primitives/Popover";
 import useMobile from "~/hooks/useMobile";
 import useWindowSize from "~/hooks/useWindowSize";
-import { fadeAndScaleIn } from "~/styles/animations";
 import { Drawer, DrawerContent, DrawerTrigger } from "../primitives/Drawer";
 import EmojiPanel from "./components/EmojiPanel";
 import IconPanel from "./components/IconPanel";
@@ -126,7 +129,24 @@ const IconPicker = ({
     onChange(null, null);
   }, [setOpen, onChange]);
 
-  const PickerContent = (
+  const pickerTrigger = (
+    <PopoverButton
+      aria-label={t("Show menu")}
+      className={className}
+      size={size}
+      $borderOnHover={borderOnHover}
+    >
+      {children ? (
+        children
+      ) : iconType && icon ? (
+        <Icon value={icon} color={color} size={size} initial={initial} />
+      ) : (
+        <StyledSmileyIcon color={theme.placeholder} size={size} />
+      )}
+    </PopoverButton>
+  );
+
+  const pickerContent = (
     <Content
       open={open}
       activeTab={activeTab}
@@ -151,60 +171,28 @@ const IconPicker = ({
   if (isMobile) {
     return (
       <Drawer open={open} onOpenChange={setOpen}>
-        <DrawerTrigger asChild>
-          <PopoverButton
-            aria-label={t("Show menu")}
-            className={className}
-            size={size}
-            $borderOnHover={borderOnHover}
-          >
-            {children ? (
-              children
-            ) : iconType && icon ? (
-              <Icon value={icon} color={color} size={size} initial={initial} />
-            ) : (
-              <StyledSmileyIcon color={theme.placeholder} size={size} />
-            )}
-          </PopoverButton>
-        </DrawerTrigger>
+        <DrawerTrigger asChild>{pickerTrigger}</DrawerTrigger>
         <DrawerContent aria-label={t("Icon Picker")}>
-          {PickerContent}
+          {pickerContent}
         </DrawerContent>
       </Drawer>
     );
   }
 
   return (
-    <Popover.Root open={open} onOpenChange={handleOpenChange} modal={true}>
-      <Popover.Trigger asChild>
-        <PopoverButton
-          aria-label={t("Show menu")}
-          className={className}
-          size={size}
-          $borderOnHover={borderOnHover}
-        >
-          {children ? (
-            children
-          ) : iconType && icon ? (
-            <Icon value={icon} color={color} size={size} initial={initial} />
-          ) : (
-            <StyledSmileyIcon color={theme.placeholder} size={size} />
-          )}
-        </PopoverButton>
-      </Popover.Trigger>
-      <Popover.Portal>
-        <StyledPopoverContent
-          side={popoverPosition === "right" ? "right" : "bottom"}
-          align={popoverPosition === "bottom-start" ? "start" : "center"}
-          sideOffset={0}
-          width={popoverWidth}
-          aria-label={t("Icon Picker")}
-          onClick={(e) => e.stopPropagation()}
-        >
-          {PickerContent}
-        </StyledPopoverContent>
-      </Popover.Portal>
-    </Popover.Root>
+    <Popover open={open} onOpenChange={handleOpenChange} modal={true}>
+      <PopoverTrigger>{pickerTrigger}</PopoverTrigger>
+      <PopoverContent
+        aria-label={t("Icon Picker")}
+        width={popoverWidth}
+        side={popoverPosition === "right" ? "right" : "bottom"}
+        align={popoverPosition === "bottom-start" ? "start" : "center"}
+        scrollable={false}
+        shrink
+      >
+        {pickerContent}
+      </PopoverContent>
+    </Popover>
   );
 };
 
@@ -346,29 +334,6 @@ const StyledTab = styled(Tabs.Trigger)<{ $active: boolean }>`
 const StyledTabContent = styled(Tabs.Content)`
   height: 410px;
   overflow-y: auto;
-`;
-
-const StyledPopoverContent = styled(Popover.Content)<{ width: number }>`
-  animation: ${fadeAndScaleIn} 200ms ease;
-  transform-origin: var(--radix-popover-content-transform-origin);
-  background: ${s("menuBackground")};
-  border-radius: 6px;
-  padding: 6px 0;
-  max-height: 75vh;
-  box-shadow: ${s("menuShadow")};
-  z-index: ${depths.modal};
-  width: ${(props) => props.width}px;
-  overflow: hidden;
-  outline: none;
-
-  @media (max-width: 768px) {
-    position: fixed;
-    z-index: ${depths.menu};
-    top: 50px;
-    left: 8px;
-    right: 8px;
-    width: auto;
-  }
 `;
 
 export default React.memo(IconPicker);

--- a/app/components/Notifications/NotificationsPopover.tsx
+++ b/app/components/Notifications/NotificationsPopover.tsx
@@ -1,11 +1,11 @@
-import * as Popover from "@radix-ui/react-popover";
-import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { observer } from "mobx-react";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import styled from "styled-components";
-import { depths, s } from "@shared/styles";
-import { fadeAndSlideUp } from "~/styles/animations";
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "~/components/primitives/Popover";
 import Notifications from "./Notifications";
 
 type Props = {
@@ -14,13 +14,11 @@ type Props = {
 
 const NotificationsPopover: React.FC = ({ children }: Props) => {
   const { t } = useTranslation();
+  const [open, setOpen] = React.useState(false);
   const scrollableRef = React.useRef<HTMLDivElement>(null);
-  const closeRef = React.useRef<HTMLButtonElement>(null);
 
   const handleRequestClose = React.useCallback(() => {
-    if (closeRef.current) {
-      closeRef.current.click();
-    }
+    setOpen(false);
   }, []);
 
   const handleAutoFocus = React.useCallback((event: Event) => {
@@ -35,51 +33,22 @@ const NotificationsPopover: React.FC = ({ children }: Props) => {
   }, []);
 
   return (
-    <Popover.Root>
-      <Popover.Trigger asChild>{children}</Popover.Trigger>
-      <Popover.Portal>
-        <StyledContent
-          side="top"
-          align="start"
-          sideOffset={0}
-          avoidCollisions={true}
-          aria-label={t("Notifications")}
-          onOpenAutoFocus={handleAutoFocus}
-        >
-          <Notifications
-            onRequestClose={handleRequestClose}
-            ref={scrollableRef}
-          />
-          <VisuallyHidden>
-            <Popover.Close ref={closeRef} />
-          </VisuallyHidden>
-        </StyledContent>
-      </Popover.Portal>
-    </Popover.Root>
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger>{children}</PopoverTrigger>
+      <PopoverContent
+        aria-label={t("Notifications")}
+        side="top"
+        align="start"
+        onOpenAutoFocus={handleAutoFocus}
+        shrink
+      >
+        <Notifications
+          onRequestClose={handleRequestClose}
+          ref={scrollableRef}
+        />
+      </PopoverContent>
+    </Popover>
   );
 };
-
-const StyledContent = styled(Popover.Content)`
-  z-index: ${depths.menu};
-  display: flex;
-  animation: ${fadeAndSlideUp} 200ms ease;
-  transform-origin: 75% 0;
-  background: ${s("menuBackground")};
-  border-radius: 6px;
-  padding: 6px 0;
-  max-height: 75vh;
-  box-shadow: ${s("menuShadow")};
-  width: 380px;
-  overflow: hidden;
-
-  @media (max-width: 768px) {
-    position: fixed;
-    z-index: ${depths.menu};
-    top: 50px;
-    left: 8px;
-    right: 8px;
-    width: auto;
-  }
-`;
 
 export default observer(NotificationsPopover);

--- a/app/components/primitives/Popover.tsx
+++ b/app/components/primitives/Popover.tsx
@@ -1,0 +1,123 @@
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+import * as React from "react";
+import { mergeRefs } from "react-merge-refs";
+import styled from "styled-components";
+import { depths, s } from "@shared/styles";
+import { fadeAndScaleIn, fadeOutAndScale } from "~/styles/animations";
+
+const Popover = PopoverPrimitive.Root;
+
+const PopoverTrigger = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Trigger>
+>((props, ref) => {
+  const { children, ...rest } = props;
+  return (
+    <PopoverPrimitive.Trigger ref={ref} {...rest} asChild>
+      {children}
+    </PopoverPrimitive.Trigger>
+  );
+});
+PopoverTrigger.displayName = PopoverPrimitive.Trigger.displayName;
+
+type ContentProps = {
+  /** The width of the popover, defaults to 380px. */
+  width?: number;
+  /** The minimum width of the popover, use instead of width if contents adjusts size. */
+  minWidth?: number;
+  /** Whether the popover should be scrollable, defaults to true. */
+  scrollable?: boolean;
+  /** Shrink the padding of the popover */
+  shrink?: boolean;
+} & React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>;
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  ContentProps
+>((props, forwardedRef) => {
+  const ref = React.useRef<React.ElementRef<typeof PopoverPrimitive.Content>>();
+
+  const {
+    width = 380,
+    minWidth,
+    scrollable = true,
+    shrink = false,
+    sideOffset = 4,
+    children,
+    ...rest
+  } = props;
+
+  const enablePointerEvents = React.useCallback(() => {
+    if (ref.current) {
+      ref.current.style.pointerEvents = "auto";
+    }
+  }, []);
+
+  const disablePointerEvents = React.useCallback(() => {
+    if (ref.current) {
+      ref.current.style.pointerEvents = "none";
+    }
+  }, []);
+
+  return (
+    <PopoverPrimitive.Portal>
+      <StyledContent
+        ref={mergeRefs([ref, forwardedRef])}
+        sideOffset={sideOffset}
+        $width={width}
+        $minWidth={minWidth}
+        $scrollable={scrollable}
+        $shrink={shrink}
+        onAnimationStart={disablePointerEvents}
+        onAnimationEnd={enablePointerEvents}
+        {...rest}
+      >
+        {children}
+      </StyledContent>
+    </PopoverPrimitive.Portal>
+  );
+});
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+type StyledContentProps = {
+  $width?: number;
+  $minWidth?: number;
+  $scrollable: boolean;
+  $shrink: boolean;
+};
+
+const StyledContent = styled(PopoverPrimitive.Content)<StyledContentProps>`
+  z-index: ${depths.modal};
+  max-height: var(--radix-popover-content-available-height);
+  transform-origin: var(--radix-popover-content-transform-origin);
+
+  background: ${s("menuBackground")};
+  box-shadow: ${s("menuShadow")};
+  border-radius: 6px;
+  outline: none;
+
+  padding: ${({ $shrink }) => ($shrink ? "6px 0" : "12px 24px")};
+
+  ${({ $width }) => $width && `width: ${$width}px`};
+  ${({ $minWidth }) => $minWidth && `min-width: ${$minWidth}px`};
+
+  ${({ $scrollable }) =>
+    $scrollable
+      ? `
+      		overflow-x: hidden;
+      		overflow-y: auto;
+    		`
+      : `
+      		overflow: hidden;
+    		`}
+
+  &[data-state="open"] {
+    animation: ${fadeAndScaleIn} 150ms cubic-bezier(0.22, 0.61, 0.36, 1); // ease-out-cubic
+  }
+
+  &[data-state="closed"] {
+    animation: ${fadeOutAndScale} 150ms cubic-bezier(0.22, 0.61, 0.36, 1); // ease-out-cubic
+  }
+`;
+
+export { Popover, PopoverTrigger, PopoverContent };

--- a/app/components/primitives/Popover.tsx
+++ b/app/components/primitives/Popover.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { mergeRefs } from "react-merge-refs";
 import styled from "styled-components";
 import { depths, s } from "@shared/styles";
-import { fadeAndScaleIn, fadeOutAndScale } from "~/styles/animations";
+import { fadeAndScaleIn } from "~/styles/animations";
 
 const Popover = PopoverPrimitive.Root;
 
@@ -112,11 +112,7 @@ const StyledContent = styled(PopoverPrimitive.Content)<StyledContentProps>`
     		`}
 
   &[data-state="open"] {
-    animation: ${fadeAndScaleIn} 150ms cubic-bezier(0.22, 0.61, 0.36, 1); // ease-out-cubic
-  }
-
-  &[data-state="closed"] {
-    animation: ${fadeOutAndScale} 150ms cubic-bezier(0.22, 0.61, 0.36, 1); // ease-out-cubic
+    animation: ${fadeAndScaleIn} 150ms cubic-bezier(0.08, 0.82, 0.17, 1); // ease-out-circ
   }
 `;
 

--- a/app/scenes/Collection/components/ShareButton.tsx
+++ b/app/scenes/Collection/components/ShareButton.tsx
@@ -1,11 +1,15 @@
 import { observer } from "mobx-react";
 import { GlobeIcon, PadlockIcon } from "outline-icons";
+import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { usePopoverState, PopoverDisclosure } from "reakit/Popover";
 import Collection from "~/models/Collection";
 import Button from "~/components/Button";
-import Popover from "~/components/Popover";
 import SharePopover from "~/components/Sharing/Collection/SharePopover";
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "~/components/primitives/Popover";
 import useCurrentTeam from "~/hooks/useCurrentTeam";
 import useMobile from "~/hooks/useMobile";
 import useStores from "~/hooks/useStores";
@@ -17,18 +21,18 @@ type Props = {
 
 function ShareButton({ collection }: Props) {
   const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
   const { shares } = useStores();
+  const isMobile = useMobile();
   const team = useCurrentTeam();
   const share = shares.getByCollectionId(collection.id);
   const isPubliclyShared =
     team.sharing !== false && collection?.sharing !== false && share?.published;
 
-  const popover = usePopoverState({
-    gutter: 0,
-    placement: "bottom-end",
-    unstable_fixed: true,
-  });
-  const isMobile = useMobile();
+  const closePopover = useCallback(() => {
+    setOpen(false);
+  }, []);
+
   if (isMobile) {
     return null;
   }
@@ -40,28 +44,25 @@ function ShareButton({ collection }: Props) {
   );
 
   return (
-    <>
-      <PopoverDisclosure {...popover}>
-        {(props) => (
-          <Button icon={icon} neutral {...props}>
-            {t("Share")}
-          </Button>
-        )}
-      </PopoverDisclosure>
-
-      <Popover
-        {...popover}
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger>
+        <Button icon={icon} neutral>
+          {t("Share")}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
         aria-label={t("Share")}
         width={400}
-        scrollable={false}
+        side="bottom"
+        align="end"
       >
         <SharePopover
           collection={collection}
-          onRequestClose={popover.hide}
-          visible={popover.visible}
+          onRequestClose={closePopover}
+          visible={open}
         />
-      </Popover>
-    </>
+      </PopoverContent>
+    </Popover>
   );
 }
 

--- a/app/scenes/Document/components/ShareButton.tsx
+++ b/app/scenes/Document/components/ShareButton.tsx
@@ -1,11 +1,15 @@
 import { observer } from "mobx-react";
 import { GlobeIcon } from "outline-icons";
+import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { usePopoverState, PopoverDisclosure } from "reakit/Popover";
 import Document from "~/models/Document";
 import Button from "~/components/Button";
-import Popover from "~/components/Popover";
 import SharePopover from "~/components/Sharing/Document";
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "~/components/primitives/Popover";
 import useMobile from "~/hooks/useMobile";
 import useStores from "~/hooks/useStores";
 
@@ -16,18 +20,17 @@ type Props = {
 
 function ShareButton({ document }: Props) {
   const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
   const { shares } = useStores();
+  const isMobile = useMobile();
   const share = shares.getByDocumentId(document.id);
   const sharedParent = shares.getByDocumentParents(document.id);
   const domain = share?.domain || sharedParent?.domain;
 
-  const popover = usePopoverState({
-    gutter: 0,
-    placement: "bottom-end",
-    unstable_fixed: true,
-  });
+  const closePopover = useCallback(() => {
+    setOpen(false);
+  }, []);
 
-  const isMobile = useMobile();
   if (isMobile) {
     return null;
   }
@@ -35,28 +38,25 @@ function ShareButton({ document }: Props) {
   const icon = document.isPubliclyShared ? <GlobeIcon /> : undefined;
 
   return (
-    <>
-      <PopoverDisclosure {...popover}>
-        {(props) => (
-          <Button icon={icon} neutral {...props}>
-            {t("Share")} {domain && <>&middot; {domain}</>}
-          </Button>
-        )}
-      </PopoverDisclosure>
-
-      <Popover
-        {...popover}
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger>
+        <Button icon={icon} neutral>
+          {t("Share")} {domain && <>&middot; {domain}</>}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
         aria-label={t("Share")}
         width={400}
-        scrollable={false}
+        side="bottom"
+        align="end"
       >
         <SharePopover
           document={document}
-          onRequestClose={popover.hide}
-          visible={popover.visible}
+          onRequestClose={closePopover}
+          visible={open}
         />
-      </Popover>
-    </>
+      </PopoverContent>
+    </Popover>
   );
 }
 

--- a/app/styles/animations.ts
+++ b/app/styles/animations.ts
@@ -23,18 +23,6 @@ export const fadeAndScaleIn = keyframes`
   }
 `;
 
-export const fadeOutAndScale = keyframes`
-  from {
-    opacity: 1;
-    transform: scale(1);
-  }
-
-  to {
-    opacity: 0;
-    transform: scale(0.98);
-  }
-`;
-
 export const fadeAndSlideDown = keyframes`
   from {
     opacity: 0;

--- a/app/styles/animations.ts
+++ b/app/styles/animations.ts
@@ -23,6 +23,18 @@ export const fadeAndScaleIn = keyframes`
   }
 `;
 
+export const fadeOutAndScale = keyframes`
+  from {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  to {
+    opacity: 0;
+    transform: scale(0.98);
+  }
+`;
+
 export const fadeAndSlideDown = keyframes`
   from {
     opacity: 0;


### PR DESCRIPTION
- Added a `Popover` primitive that has base styles with entry/exit animations.
- `Collaborators`, `IconPicker`, and `Notifications` were already ported to Radix. They now use the new primitive.
- Ported document and collection share popovers in this PR.

Towards #6456 