### PR TITLE
fix: Incorrect parsing of hard breaks from Markdown

### DIFF
--- a/shared/editor/lib/markdown/rules.ts
+++ b/shared/editor/lib/markdown/rules.ts
@@ -16,7 +16,7 @@ export default function makeRules({
   schema,
 }: Options) {
   const markdownIt = markdownit("default", {
-    breaks: false,
+    breaks: true,
     html: false,
     linkify: false,
     ...rules,

--- a/shared/editor/lib/markdown/rules.ts
+++ b/shared/editor/lib/markdown/rules.ts
@@ -16,7 +16,7 @@ export default function makeRules({
   schema,
 }: Options) {
   const markdownIt = markdownit("default", {
-    breaks: true,
+    breaks: false,
     html: false,
     linkify: false,
     ...rules,

--- a/shared/editor/marks/Code.ts
+++ b/shared/editor/marks/Code.ts
@@ -227,6 +227,6 @@ export default class Code extends Mark {
   }
 
   parseMarkdown() {
-    return { mark: "code_inline" };
+    return { mark: "code_inline", noCloseToken: true };
   }
 }

--- a/shared/editor/nodes/CodeFence.ts
+++ b/shared/editor/nodes/CodeFence.ts
@@ -273,6 +273,7 @@ export default class CodeFence extends Node {
     return {
       block: "code_block",
       getAttrs: (tok: Token) => ({ language: tok.info }),
+      noCloseToken: true,
     };
   }
 }

--- a/shared/editor/nodes/HardBreak.ts
+++ b/shared/editor/nodes/HardBreak.ts
@@ -23,6 +23,10 @@ export default class HardBreak extends Node {
     };
   }
 
+  get markdownToken() {
+    return "hardbreak";
+  }
+
   get rulePlugins() {
     return [breakRule];
   }

--- a/shared/editor/nodes/index.ts
+++ b/shared/editor/nodes/index.ts
@@ -65,6 +65,7 @@ export const basicExtensions: Nodes = [
   TrailingNode,
   MaxLength,
   DateTime,
+  HardBreak,
 ];
 
 export const listExtensions: Nodes = [
@@ -91,7 +92,6 @@ export const tableExtensions: Nodes = [
 export const richExtensions: Nodes = [
   ...basicExtensions.filter((n) => n !== SimpleImage),
   Image,
-  HardBreak,
   CodeBlock,
   CodeFence,
   Blockquote,

--- a/shared/editor/rules/breaks.ts
+++ b/shared/editor/rules/breaks.ts
@@ -1,12 +1,10 @@
 import MarkdownIt, { Token } from "markdown-it";
 
-function isHardbreak(token: Token) {
-  return (
-    token.type === "hardbreak" ||
-    (token.type === "text" && token.content === "\\")
-  );
+function isOldHardBreak(token: Token) {
+  return token.type === "text" && token.content === "\\";
 }
 
+/** Markdown plugin to convert old encoded hard breaks to paragraphs */
 export default function markdownBreakToParagraphs(md: MarkdownIt) {
   // insert a new rule after the "inline" rules are parsed
   md.core.ruler.after("inline", "breaks", (state) => {
@@ -15,13 +13,15 @@ export default function markdownBreakToParagraphs(md: MarkdownIt) {
     // work backwards through the tokens and find text that looks like a br
     for (let i = tokens.length - 1; i > 0; i--) {
       const tokenChildren = tokens[i].children || [];
-      const matches = tokenChildren.filter(isHardbreak);
+      const matches = tokenChildren.filter(isOldHardBreak);
 
       if (matches.length) {
         let token;
 
         const nodes: Token[] = [];
-        const children = tokenChildren.filter((child) => !isHardbreak(child));
+        const children = tokenChildren.filter(
+          (child) => !isOldHardBreak(child)
+        );
 
         let count = matches.length;
         if (children.length) {


### PR DESCRIPTION
closes #9532 – Another fun markdown parsing bug that's existed for years