### PR TITLE
fix: Map hardbreaks to breaks

### DIFF
--- a/shared/editor/nodes/HardBreak.ts
+++ b/shared/editor/nodes/HardBreak.ts
@@ -23,10 +23,6 @@ export default class HardBreak extends Node {
     };
   }
 
-  get markdownToken() {
-    return "hardbreak";
-  }
-
   get rulePlugins() {
     return [breakRule];
   }

--- a/shared/editor/rules/breaks.ts
+++ b/shared/editor/rules/breaks.ts
@@ -6,6 +6,30 @@ function isOldHardBreak(token: Token) {
 
 /** Markdown plugin to convert old encoded hard breaks to paragraphs */
 export default function markdownBreakToParagraphs(md: MarkdownIt) {
+  md.core.ruler.after("inline", "hardbreaks", (state) => {
+    const tokens = state.tokens;
+
+    // iterate through tokens and convert hardbreak tokens to br tokens
+    for (let i = 0; i < tokens.length; i++) {
+      const token = tokens[i];
+
+      if (token.children) {
+        for (let j = 0; j < token.children.length; j++) {
+          const child = token.children[j];
+
+          if (child.type === "hardbreak") {
+            // convert hardbreak token to br token, we don't care about the difference
+            child.type = "br";
+            child.tag = "br";
+            child.nesting = 0;
+          }
+        }
+      }
+    }
+
+    return false;
+  });
+
   // insert a new rule after the "inline" rules are parsed
   md.core.ruler.after("inline", "breaks", (state) => {
     const tokens = state.tokens;


### PR DESCRIPTION
On markdown import we do not care about the semantics of these two things.