### PR TITLE
security-ish: disable search engine indexing for shared documents by default

### DIFF
--- a/server/models/Share.ts
+++ b/server/models/Share.ts
@@ -114,7 +114,7 @@ class Share extends IdModel<
   @Column
   domain: string | null;
 
-  @Default(true)
+  @Default(false)
   @Column
   allowIndexing: boolean;
 


### PR DESCRIPTION
This PR fixes an issue where publicly shared documents could unintentionally be indexed by search engines due to their inclusion in sitemaps.

By default, when a user shares a document via a public link, they typically intend to share it with specific people — not to have it discoverable via Google or other search engines. Now that sitemaps are in use, there is a higher risk that these public shares will be crawled and indexed, which can expose content more broadly than intended.

This change ensures that public shares are not indexed by default, unless the user explicitly opts in.

Closes #9538 