### PR TITLE
perf: Move recalculation of memberships to async job

### DIFF
--- a/server/queues/processors/DocumentMovedProcessor.ts
+++ b/server/queues/processors/DocumentMovedProcessor.ts
@@ -1,0 +1,87 @@
+import { Transaction } from "sequelize";
+import { Document, GroupMembership, UserMembership } from "@server/models";
+import { sequelize } from "@server/storage/database";
+import { DocumentMovedEvent, Event } from "@server/types";
+import BaseProcessor from "./BaseProcessor";
+
+export default class DocumentMovedProcessor extends BaseProcessor {
+  static applicableEvents: Event["name"][] = ["documents.move"];
+
+  async perform(event: DocumentMovedEvent) {
+    await sequelize.transaction(async (transaction) => {
+      const document = await Document.findByPk(event.documentId, {
+        transaction,
+      });
+      if (!document) {
+        return;
+      }
+
+      // If there are any sourced memberships for this document, we need to go to the source
+      // memberships and recalculate the membership for the user or group.
+      const [
+        userMemberships,
+        parentDocumentUserMemberships,
+        groupMemberships,
+        parentDocumentGroupMemberships,
+      ] = await Promise.all([
+        UserMembership.findRootMembershipsForDocument(document.id, undefined, {
+          transaction,
+        }),
+        document.parentDocumentId
+          ? UserMembership.findRootMembershipsForDocument(
+              document.parentDocumentId,
+              undefined,
+              { transaction }
+            )
+          : [],
+        GroupMembership.findRootMembershipsForDocument(document.id, undefined, {
+          transaction,
+        }),
+        document.parentDocumentId
+          ? GroupMembership.findRootMembershipsForDocument(
+              document.parentDocumentId,
+              undefined,
+              { transaction }
+            )
+          : [],
+      ]);
+
+      await this.recalculateUserMemberships(userMemberships, transaction);
+      await this.recalculateUserMemberships(
+        parentDocumentUserMemberships,
+        transaction
+      );
+      await this.recalculateGroupMemberships(groupMemberships, transaction);
+      await this.recalculateGroupMemberships(
+        parentDocumentGroupMemberships,
+        transaction
+      );
+    });
+  }
+
+  private async recalculateUserMemberships(
+    memberships: UserMembership[],
+    transaction?: Transaction
+  ) {
+    await Promise.all(
+      memberships.map((membership) =>
+        UserMembership.createSourcedMemberships(membership, {
+          transaction,
+        })
+      )
+    );
+  }
+
+  private async recalculateGroupMemberships(
+    memberships: GroupMembership[],
+    transaction?: Transaction
+  ) {
+    await Promise.all(
+      memberships.map((membership) =>
+        GroupMembership.createSourcedMemberships(membership, {
+          transaction,
+        })
+      )
+    );
+  }
+}

--- a/server/types.ts
+++ b/server/types.ts
@@ -213,15 +213,6 @@ export type DocumentEvent = BaseEvent<Document> &
         };
       }
     | {
-        name: "documents.move";
-        documentId: string;
-        collectionId: string;
-        data: {
-          collectionIds: string[];
-          documentIds: string[];
-        };
-      }
-    | {
         name:
           | "documents.update"
           | "documents.update.delayed"
@@ -246,6 +237,16 @@ export type DocumentEvent = BaseEvent<Document> &
         };
       }
   );
+
+export type DocumentMovedEvent = {
+  name: "documents.move";
+  documentId: string;
+  collectionId: string;
+  data: {
+    collectionIds: string[];
+    documentIds: string[];
+  };
+};
 
 export type EmptyTrashEvent = {
   name: "documents.empty_trash";
@@ -492,6 +493,7 @@ export type Event =
   | AuthenticationProviderEvent
   | DocumentEvent
   | DocumentUserEvent
+  | DocumentMovedEvent
   | DocumentGroupEvent
   | PinEvent
   | CommentEvent


### PR DESCRIPTION
Endpoint is a latency outlier as so many database operations happen within the request itself, we can move all of the relationship recalculations to an async task