### PR TITLE
fix: Empty placeholder shows up when no text but image in paragraph

### DIFF
--- a/app/editor/extensions/BlockMenu.tsx
+++ b/app/editor/extensions/BlockMenu.tsx
@@ -80,6 +80,7 @@ export default class BlockMenuExtension extends Suggestion {
             $start.depth === 1 &&
             state.selection.$from.pos === $start.pos + node.content.size &&
             !!textContent &&
+            node.childCount === 0 &&
             node.textContent === "",
           text: this.options.dictionary.newLineEmpty,
         },

--- a/shared/editor/nodes/Doc.ts
+++ b/shared/editor/nodes/Doc.ts
@@ -18,11 +18,12 @@ export default class Doc extends Node {
     return [
       new PlaceholderPlugin([
         {
-          condition: ({ $start, parent, state, textContent }) =>
+          condition: ({ $start, parent, node, state, textContent }) =>
             textContent === "" &&
             !isNull(parent) &&
             parent.type === state.doc.type &&
             parent.childCount === 1 &&
+            node.childCount === 0 &&
             $start.index($start.depth - 1) === 0,
           text: this.options.placeholder,
         },


### PR DESCRIPTION
closes #9591