### PR TITLE
fix: `EditorUpdateError` code outside valid range

### DIFF
--- a/shared/collaboration/CloseEvents.ts
+++ b/shared/collaboration/CloseEvents.ts
@@ -19,6 +19,6 @@ export const TooManyConnections = {
 };
 
 export const EditorUpdateError = {
-  code: 5000,
+  code: 4999,
   reason: "Editor Update Required",
 };

--- a/shared/editor/version.ts
+++ b/shared/editor/version.ts
@@ -1,3 +1,3 @@
-const EDITOR_VERSION = "14.0.0";
+const EDITOR_VERSION = "15.0.0";
 
 export default EDITOR_VERSION;


### PR DESCRIPTION
By change 4999 is the highest valid number, using 5000 caused the server to crash rather than issue the error code when this codepath is hit