### PR TITLE
fix: Blank page is rendered when link to draft without collection is shared

### DIFF
--- a/server/commands/documentLoader.ts
+++ b/server/commands/documentLoader.ts
@@ -142,10 +142,10 @@ export default async function loadDocument({
         includeDocumentStructure: true,
         rejectOnEmpty: true,
       });
-    }
 
-    if (!collection?.sharing) {
-      throw AuthorizationError();
+      if (!collection.sharing) {
+        throw AuthorizationError();
+      }
     }
 
     // If we're attempting to load a document that isn't the document originally

--- a/server/routes/api/documents/documents.test.ts
+++ b/server/routes/api/documents/documents.test.ts
@@ -385,6 +385,33 @@ describe("#documents.info", () => {
       });
       expect(res.status).toEqual(200);
     });
+
+    it("should return sharedTree as null for shared draft without collection", async () => {
+      const user = await buildUser();
+      const document = await buildDraftDocument({
+        userId: user.id,
+        teamId: user.teamId,
+        collectionId: null,
+      });
+      const share = await buildShare({
+        documentId: document.id,
+        teamId: document.teamId,
+        userId: user.id,
+        includeChildDocuments: true,
+      });
+      const res = await server.post("/api/documents.info", {
+        body: {
+          shareId: share.id,
+          apiVersion: 2,
+        },
+      });
+      const body = await res.json();
+      expect(res.status).toEqual(200);
+      expect(body.data.document.id).toEqual(document.id);
+      expect(body.data.document.createdBy).toEqual(undefined);
+      expect(body.data.document.updatedBy).toEqual(undefined);
+      expect(body.data.sharedTree).toEqual(null);
+    });
   });
 
   it("should not return document from shareId if sharing is disabled for collection", async () => {

--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -597,8 +597,8 @@ router.post(
                 )
               : undefined,
             sharedTree:
-              share && share.includeChildDocuments
-                ? collection?.getDocumentTree(share.documentId)
+              share && share.includeChildDocuments && collection
+                ? collection.getDocumentTree(share.documentId)
                 : null,
           }
         : serializedDocument;


### PR DESCRIPTION
closes #9603