### PR TITLE
fix: Viewers unable to connect personal Slack

### DIFF
--- a/app/hooks/useSettingsConfig.ts
+++ b/app/hooks/useSettingsConfig.ts
@@ -16,8 +16,7 @@ import {
   PlusIcon,
   InternetIcon,
 } from "outline-icons";
-import { ComponentProps } from "react";
-import * as React from "react";
+import { ComponentProps, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { integrationSettingsPath } from "@shared/utils/routeHelpers";
 import { Integrations } from "~/scenes/Settings/Integrations";
@@ -65,7 +64,7 @@ const useSettingsConfig = () => {
   const can = usePolicy(team);
   const { t } = useTranslation();
 
-  React.useEffect(() => {
+  useEffect(() => {
     void integrations.fetchAll();
   }, [integrations]);
 
@@ -213,7 +212,7 @@ const useSettingsConfig = () => {
         name: `${t("Install")}…`,
         path: settingsPath("integrations"),
         component: Integrations,
-        enabled: true,
+        enabled: can.update,
         group: t("Integrations"),
         icon: PlusIcon,
       },

--- a/plugins/slack/client/index.tsx
+++ b/plugins/slack/client/index.tsx
@@ -1,4 +1,3 @@
-import { UserRole } from "@shared/types";
 import { createLazyComponent } from "~/components/LazyLoad";
 import { Hook, PluginManager } from "~/utils/PluginManager";
 import config from "../plugin.json";
@@ -14,8 +13,7 @@ PluginManager.add([
       description:
         "Search your knowledge base directly in Slack, get /outline search, rich link previews, and notifications on new or updated docs.",
       component: createLazyComponent(() => import("./Settings")),
-      enabled: (_, user) =>
-        [UserRole.Member, UserRole.Admin].includes(user.role),
+      enabled: () => true,
     },
   },
   {


### PR DESCRIPTION
This actually works well with the recent changes that only show integrations in the sidebar if you have them connected/installed.

closes #9607