### PR TITLE
fix: Refresh tokens do not work with OIDC discovery

### DIFF
--- a/plugins/oidc/server/auth/oidc.ts
+++ b/plugins/oidc/server/auth/oidc.ts
@@ -40,6 +40,11 @@ if (hasManualConfig) {
 
       const oidcConfig = await fetchOIDCConfiguration(env.OIDC_ISSUER_URL!);
 
+      // Set environment variables for OIDC endpoints so they can be read by OIDC OAuth class
+      env.OIDC_AUTH_URI = oidcConfig.authorization_endpoint;
+      env.OIDC_TOKEN_URI = oidcConfig.token_endpoint;
+      env.OIDC_USERINFO_URI = oidcConfig.userinfo_endpoint;
+
       // Mount endpoints into the existing router
       createOIDCRouter(router, {
         authorizationURL: oidcConfig.authorization_endpoint,


### PR DESCRIPTION
A touch hacky, but I believe this patch is the only way to have this work without another larger refactor