### PR TITLE
chore: Keep classnames in build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -169,6 +169,7 @@ export default () =>
       target: browserslistToEsbuild(),
       reportCompressedSize: false,
       rollupOptions: {
+        keepNames: true,
         onwarn(warning, warn) {
           // Suppress noisy warnings about module-level directives, e.g. "use client"
           if (warning.code === "MODULE_LEVEL_DIRECTIVE") {


### PR DESCRIPTION
Sentry depends on consistency, this will mean a small increase in bundle size again