### PR TITLE
chore: Move `Revision` event writing to model layer

### DIFF
--- a/server/commands/revisionCreator.test.ts
+++ b/server/commands/revisionCreator.test.ts
@@ -26,7 +26,6 @@ describe("revisionCreator", () => {
     expect(revision.createdAt).toEqual(document.updatedAt);
     expect(event!.name).toEqual("revisions.create");
     expect(event!.modelId).toEqual(revision.id);
-    expect(event!.createdAt).toEqual(document.updatedAt);
     expect(event!.authType).toEqual(AuthenticationType.APP);
   });
 });

--- a/server/models/Revision.test.ts
+++ b/server/models/Revision.test.ts
@@ -1,19 +1,23 @@
-import { buildDocument } from "@server/test/factories";
+import { createContext } from "@server/context";
+import { buildDocument, buildUser } from "@server/test/factories";
 import Revision from "./Revision";
 
 describe("#findLatest", () => {
   test("should return latest revision", async () => {
+    const user = await buildUser();
     const document = await buildDocument({
       title: "Title",
       text: "Content",
+      userId: user.id,
     });
-    await Revision.createFromDocument(document);
+    const ctx = createContext({ user });
+    await Revision.createFromDocument(ctx, document);
     document.title = "Changed 1";
     await document.save();
-    await Revision.createFromDocument(document);
+    await Revision.createFromDocument(ctx, document);
     document.title = "Changed 2";
     await document.save();
-    await Revision.createFromDocument(document);
+    await Revision.createFromDocument(ctx, document);
     const revision = await Revision.findLatest(document.id);
     expect(revision?.title).toBe("Changed 2");
   });

--- a/server/models/Revision.ts
+++ b/server/models/Revision.ts
@@ -1,9 +1,4 @@
-import {
-  InferAttributes,
-  InferCreationAttributes,
-  Op,
-  SaveOptions,
-} from "sequelize";
+import { InferAttributes, InferCreationAttributes, Op } from "sequelize";
 import {
   DataType,
   BelongsTo,
@@ -17,6 +12,7 @@ import {
 } from "sequelize-typescript";
 import type { ProsemirrorData } from "@shared/types";
 import { DocumentValidation, RevisionValidation } from "@shared/validations";
+import { APIContext } from "@server/types";
 import Document from "./Document";
 import User from "./User";
 import ParanoidModel from "./base/ParanoidModel";
@@ -187,15 +183,15 @@ class Revision extends ParanoidModel<
   /**
    * Create a Revision model from a Document model and save it to the database
    *
+   * @param ctx context to use for DB operations
    * @param document The document to create from
    * @param collaboratorIds Optional array of user IDs who authored this revision
-   * @param options Options passed to the save method
    * @returns A Promise that resolves when saved
    */
   static createFromDocument(
+    ctx: APIContext,
     document: Document,
-    collaboratorIds?: string[],
-    options?: SaveOptions<InferAttributes<Revision>>
+    collaboratorIds?: string[]
   ) {
     const revision = this.buildFromDocument(document);
 
@@ -203,7 +199,7 @@ class Revision extends ParanoidModel<
       revision.collaboratorIds = collaboratorIds;
     }
 
-    return revision.save(options);
+    return revision.saveWithCtx(ctx);
   }
 
   // instance methods

--- a/server/queues/processors/RevisionsProcessor.test.ts
+++ b/server/queues/processors/RevisionsProcessor.test.ts
@@ -1,5 +1,6 @@
+import { createContext } from "@server/context";
 import { Revision } from "@server/models";
-import { buildDocument } from "@server/test/factories";
+import { buildDocument, buildUser } from "@server/test/factories";
 import RevisionsProcessor from "./RevisionsProcessor";
 
 const ip = "127.0.0.1";
@@ -28,8 +29,12 @@ describe("documents.update.debounced", () => {
   });
 
   test("should not create a revision if identical to previous", async () => {
-    const document = await buildDocument();
-    await Revision.createFromDocument(document);
+    const user = await buildUser();
+    const document = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    await Revision.createFromDocument(createContext({ user }), document);
 
     const processor = new RevisionsProcessor();
     await processor.perform({

--- a/server/routes/api/documents/documents.test.ts
+++ b/server/routes/api/documents/documents.test.ts
@@ -3286,7 +3286,10 @@ describe("#documents.restore", () => {
       userId: user.id,
       teamId: user.teamId,
     });
-    const revision = await Revision.createFromDocument(document);
+    const revision = await Revision.createFromDocument(
+      createContext({ user }),
+      document
+    );
     const previous = revision.content;
     const revisionId = revision.id;
 
@@ -3316,7 +3319,10 @@ describe("#documents.restore", () => {
       teamId: user.teamId,
     });
     const anotherDoc = await buildDocument();
-    const revision = await Revision.createFromDocument(anotherDoc);
+    const revision = await Revision.createFromDocument(
+      createContext({ user }),
+      anotherDoc
+    );
     const revisionId = revision.id;
     const res = await server.post("/api/documents.restore", {
       body: {
@@ -3347,8 +3353,15 @@ describe("#documents.restore", () => {
   });
 
   it("should require authorization", async () => {
-    const document = await buildDocument();
-    const revision = await Revision.createFromDocument(document);
+    const admin = await buildAdmin();
+    const document = await buildDocument({
+      teamId: admin.teamId,
+      userId: admin.id,
+    });
+    const revision = await Revision.createFromDocument(
+      createContext({ user: admin }),
+      document
+    );
     const revisionId = revision.id;
     const user = await buildUser();
     const res = await server.post("/api/documents.restore", {

--- a/server/routes/api/revisions/revisions.test.ts
+++ b/server/routes/api/revisions/revisions.test.ts
@@ -1,3 +1,4 @@
+import { createContext } from "@server/context";
 import { UserMembership, Revision } from "@server/models";
 import {
   buildAdmin,
@@ -16,7 +17,10 @@ describe("#revisions.info", () => {
       userId: user.id,
       teamId: user.teamId,
     });
-    const revision = await Revision.createFromDocument(document);
+    const revision = await Revision.createFromDocument(
+      createContext({ user }),
+      document
+    );
     const res = await server.post("/api/revisions.info", {
       body: {
         token: user.getJwtToken(),
@@ -30,8 +34,15 @@ describe("#revisions.info", () => {
   });
 
   it("should require authorization", async () => {
-    const document = await buildDocument();
-    const revision = await Revision.createFromDocument(document);
+    const admin = await buildAdmin();
+    const document = await buildDocument({
+      teamId: admin.teamId,
+      userId: admin.id,
+    });
+    const revision = await Revision.createFromDocument(
+      createContext({ user: admin }),
+      document
+    );
     const user = await buildUser();
     const res = await server.post("/api/revisions.info", {
       body: {
@@ -50,7 +61,10 @@ describe("#revisions.update", () => {
       userId: user.id,
       teamId: user.teamId,
     });
-    const revision = await Revision.createFromDocument(document);
+    const revision = await Revision.createFromDocument(
+      createContext({ user }),
+      document
+    );
 
     const res = await server.post("/api/revisions.update", {
       body: {
@@ -70,7 +84,10 @@ describe("#revisions.update", () => {
       userId: user.id,
       teamId: user.teamId,
     });
-    const revision = await Revision.createFromDocument(document);
+    const revision = await Revision.createFromDocument(
+      createContext({ user }),
+      document
+    );
 
     const res = await server.post("/api/revisions.update", {
       body: {
@@ -90,7 +107,10 @@ describe("#revisions.update", () => {
       userId: user.id,
       teamId: user.teamId,
     });
-    const revision = await Revision.createFromDocument(document);
+    const revision = await Revision.createFromDocument(
+      createContext({ user }),
+      document
+    );
 
     const res = await server.post("/api/revisions.update", {
       body: {
@@ -107,7 +127,10 @@ describe("#revisions.update", () => {
     const document = await buildDocument({
       teamId: admin.teamId,
     });
-    const revision = await Revision.createFromDocument(document);
+    const revision = await Revision.createFromDocument(
+      createContext({ user: admin }),
+      document
+    );
 
     const res = await server.post("/api/revisions.update", {
       body: {
@@ -122,8 +145,15 @@ describe("#revisions.update", () => {
   });
 
   it("should require authorization", async () => {
-    const document = await buildDocument();
-    const revision = await Revision.createFromDocument(document);
+    const admin = await buildAdmin();
+    const document = await buildDocument({
+      teamId: admin.teamId,
+      userId: admin.id,
+    });
+    const revision = await Revision.createFromDocument(
+      createContext({ user: admin }),
+      document
+    );
     const user = await buildUser();
     const res = await server.post("/api/revisions.update", {
       body: {
@@ -143,7 +173,10 @@ describe("#revisions.diff", () => {
       userId: user.id,
       teamId: user.teamId,
     });
-    const revision = await Revision.createFromDocument(document);
+    const revision = await Revision.createFromDocument(
+      createContext({ user }),
+      document
+    );
     const res = await server.post("/api/revisions.diff", {
       body: {
         token: user.getJwtToken(),
@@ -168,7 +201,10 @@ describe("#revisions.diff", () => {
       userId: user.id,
       teamId: user.teamId,
     });
-    const revision = await Revision.createFromDocument(document);
+    const revision = await Revision.createFromDocument(
+      createContext({ user }),
+      document
+    );
 
     const res = await server.post("/api/revisions.diff", {
       body: {
@@ -197,7 +233,7 @@ describe("#revisions.diff", () => {
       userId: user.id,
       teamId: user.teamId,
     });
-    await Revision.createFromDocument(document);
+    await Revision.createFromDocument(createContext({ user }), document);
 
     await document.update({
       content: {
@@ -216,7 +252,10 @@ describe("#revisions.diff", () => {
         ],
       },
     });
-    const revision1 = await Revision.createFromDocument(document);
+    const revision1 = await Revision.createFromDocument(
+      createContext({ user }),
+      document
+    );
 
     const res = await server.post("/api/revisions.diff", {
       body: {
@@ -237,8 +276,15 @@ describe("#revisions.diff", () => {
   });
 
   it("should require authorization", async () => {
-    const document = await buildDocument();
-    const revision = await Revision.createFromDocument(document);
+    const admin = await buildAdmin();
+    const document = await buildDocument({
+      teamId: admin.teamId,
+      userId: admin.id,
+    });
+    const revision = await Revision.createFromDocument(
+      createContext({ user: admin }),
+      document
+    );
     const user = await buildUser();
     const res = await server.post("/api/revisions.diff", {
       body: {
@@ -257,7 +303,7 @@ describe("#revisions.list", () => {
       userId: user.id,
       teamId: user.teamId,
     });
-    await Revision.createFromDocument(document);
+    await Revision.createFromDocument(createContext({ user }), document);
     const res = await server.post("/api/revisions.list", {
       body: {
         token: user.getJwtToken(),
@@ -282,7 +328,7 @@ describe("#revisions.list", () => {
       collectionId: collection.id,
       teamId: user.teamId,
     });
-    await Revision.createFromDocument(document);
+    await Revision.createFromDocument(createContext({ user }), document);
     collection.permission = null;
     await collection.save();
     await UserMembership.destroy({

--- a/server/types.ts
+++ b/server/types.ts
@@ -258,7 +258,6 @@ export type EmptyTrashEvent = {
 export type RevisionEvent = BaseEvent<Revision> & {
   name: "revisions.create";
   documentId: string;
-  collectionId: string;
   modelId: string;
 };
 


### PR DESCRIPTION
Closes #9609 
Towards #7920 