### PR TITLE
`EventBoundary` wrapper component further down the react tree captures `click` events

### DIFF
--- a/shared/editor/components/Image.tsx
+++ b/shared/editor/components/Image.tsx
@@ -12,8 +12,6 @@ import { ResizeLeft, ResizeRight } from "./ResizeHandle";
 import useDragResize from "./hooks/useDragResize";
 
 type Props = ComponentProps & {
-  /** Callback triggered when the image is clicked */
-  onClick: (event: React.MouseEvent<HTMLDivElement>) => void;
   /** Callback triggered when the download button is clicked */
   onDownload?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   /** Callback triggered when the image is resized */
@@ -72,7 +70,6 @@ const Image = (props: Props) => {
       <ImageWrapper
         isFullWidth={isFullWidth}
         className={isSelected || dragging ? "ProseMirror-selectednode" : ""}
-        onClick={dragging ? undefined : props.onClick}
         style={widthStyle}
       >
         {!dragging && width > 60 && isDownloadable && (

--- a/shared/editor/nodes/Image.tsx
+++ b/shared/editor/nodes/Image.tsx
@@ -298,7 +298,6 @@ export default class Image extends SimpleImage {
   component = (props: ComponentProps) => (
     <ImageComponent
       {...props}
-      onClick={this.handleSelect(props)}
       onDownload={this.handleDownload(props)}
       onChangeSize={this.handleChangeSize(props)}
     >

--- a/shared/editor/nodes/SimpleImage.tsx
+++ b/shared/editor/nodes/SimpleImage.tsx
@@ -76,21 +76,7 @@ export default class SimpleImage extends Node {
     };
   }
 
-  handleSelect =
-    ({ getPos }: { getPos: () => number }) =>
-    (event: React.MouseEvent) => {
-      event.preventDefault();
-
-      const { view } = this.editor;
-      const $pos = view.state.doc.resolve(getPos());
-      const transaction = view.state.tr.setSelection(new NodeSelection($pos));
-      view.dispatch(transaction);
-      view.focus();
-    };
-
-  component = (props: ComponentProps) => (
-    <ImageComponent {...props} onClick={this.handleSelect(props)} />
-  );
+  component = (props: ComponentProps) => <ImageComponent {...props} />;
 
   keys(): Record<string, Command> {
     return {


### PR DESCRIPTION
`EventBoundary` wrapper component further down the react tree captures `click` events, rendering these `onClick` handlers vestigial. Getting rid of these to avoid confusion.