### PR TITLE
chore: Remove redis in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
+      config: ${{ steps.filter.outputs.config }}
       server: ${{ steps.filter.outputs.server }}
       app: ${{ steps.filter.outputs.app }}
     steps:


### PR DESCRIPTION
Unused - we mock this, so it was spinning up for no reason