### PR TITLE
fix: Frontend errors not properly filtered when source is minified

### DIFF
--- a/app/utils/sentry.ts
+++ b/app/utils/sentry.ts
@@ -2,8 +2,22 @@ import { BrowserTracing } from "@sentry/browser";
 import * as Sentry from "@sentry/react";
 import { History } from "history";
 import env from "~/env";
+import {
+  AuthorizationError,
+  BadRequestError,
+  NetworkError,
+  NotFoundError,
+  OfflineError,
+  RateLimitExceededError,
+  ServiceUnavailableError,
+  UpdateRequiredError,
+} from "./errors";
 
 export function initSentry(history: History) {
+  function filterFromClass(error: new (...args: any[]) => Error) {
+    return new RegExp(`/^${error.name}:.*$/`);
+  }
+
   Sentry.init({
     dsn: env.SENTRY_DSN,
     environment: env.ENVIRONMENT,
@@ -20,16 +34,16 @@ export function initSentry(history: History) {
       "Failed to fetch dynamically imported module",
       "ResizeObserver loop completed with undelivered notifications",
       "ResizeObserver loop limit exceeded",
-      "AuthorizationError",
-      "BadRequestError",
-      "NetworkError",
-      "NotFoundError",
-      "OfflineError",
-      "RateLimitExceededError",
-      "ServiceUnavailableError",
-      "UpdateRequiredError",
       "file://",
       "chrome-extension://",
+      filterFromClass(AuthorizationError),
+      filterFromClass(BadRequestError),
+      filterFromClass(NetworkError),
+      filterFromClass(NotFoundError),
+      filterFromClass(OfflineError),
+      filterFromClass(RateLimitExceededError),
+      filterFromClass(ServiceUnavailableError),
+      filterFromClass(UpdateRequiredError),
     ],
   });
 }


### PR DESCRIPTION
This regressed as part of #9523 – however, relying on this string comparison was bad practice to begin with, a further enhancement here might be to inherit all of these errors from a single ignored type?