### PR TITLE
fix: Invariant violation with `addToArchive` called with non-model

### DIFF
--- a/app/components/WebsocketProvider.tsx
+++ b/app/components/WebsocketProvider.tsx
@@ -285,7 +285,8 @@ class WebsocketProvider extends Component<Props> {
     this.socket.on(
       "documents.archive",
       action((event: PartialExcept<Document, "id">) => {
-        documents.addToArchive(event as Document);
+        const model = documents.add(event);
+        documents.addToArchive(model);
 
         if (event.collectionId) {
           const collection = collections.get(event.collectionId);


### PR DESCRIPTION
This is one of those "How did this ever work?" bugs, as far as I can tell a POJO has always been passed to this method that expects a model instead with `modelName` attribute.

closes #9667