### PR TITLE
fix: Letter icon incorrect in picker and sidebar

### DIFF
--- a/app/components/Sidebar/components/DocumentLink.tsx
+++ b/app/components/Sidebar/components/DocumentLink.tsx
@@ -182,9 +182,11 @@ function InnerDocumentLink(
   const can = policies.abilities(node.id);
   const icon = document?.icon || node.icon || node.emoji;
   const color = document?.color || node.color;
+  const initial = (document?.title || node.title).slice(0, 1).toUpperCase();
 
   const iconElement = React.useMemo(
-    () => (icon ? <Icon value={icon} color={color} /> : undefined),
+    () =>
+      icon ? <Icon value={icon} color={color} initial={initial} /> : undefined,
     [icon, color]
   );
 

--- a/app/scenes/Document/components/DocumentTitle.tsx
+++ b/app/scenes/Document/components/DocumentTitle.tsx
@@ -230,7 +230,7 @@ const DocumentTitle = React.forwardRef(function _DocumentTitle(
   );
 
   const dir = ref.current?.getComputedDirection();
-
+  const initial = title.slice(0, 1).toUpperCase();
   const fallbackIcon = icon ? (
     <Icon value={icon} color={color} size={40} />
   ) : null;
@@ -258,6 +258,7 @@ const DocumentTitle = React.forwardRef(function _DocumentTitle(
             <StyledIconPicker
               icon={icon ?? null}
               color={color}
+              initial={initial}
               size={40}
               popoverPosition="bottom-start"
               onChange={handleIconChange}


### PR DESCRIPTION
Letter icon is supposed to reflect the first letter in the document or collection, and now it does.