### PR TITLE
feat: Up arrow in comment input should jump to editing previous comment

### DIFF
--- a/app/editor/extensions/UpArrowAtStart.ts
+++ b/app/editor/extensions/UpArrowAtStart.ts
@@ -1,0 +1,47 @@
+import { Plugin } from "prosemirror-state";
+import { EditorView } from "prosemirror-view";
+import Extension from "@shared/editor/lib/Extension";
+
+export default class UpArrowAtStart extends Extension {
+  get name() {
+    return "upArrowAtStart";
+  }
+
+  get plugins() {
+    return [
+      new Plugin({
+        props: {
+          handleKeyDown: (view: EditorView, event: KeyboardEvent) => {
+            // Only handle up arrow key
+            if (event.key !== "ArrowUp") {
+              return false;
+            }
+
+            const { state } = view;
+            const { selection } = state;
+
+            // Check if cursor is at the very beginning of the document
+            // and it's an empty selection (cursor, not text selection)
+            if (selection.empty && selection.from <= 1) {
+              // Also check if we're at the start of the first text node
+              const $pos = state.doc.resolve(selection.from);
+              const isAtDocStart = $pos.parentOffset === 0 && $pos.depth <= 1;
+
+              if (isAtDocStart) {
+                // Call the onUpArrowAtStart callback if it exists
+                // Cast to any to access the custom prop since it's not in the base Props type
+                const props = this.editor.props as any;
+                if (props.onUpArrowAtStart) {
+                  props.onUpArrowAtStart();
+                  return true;
+                }
+              }
+            }
+
+            return false;
+          },
+        },
+      }),
+    ];
+  }
+}

--- a/app/scenes/Document/components/CommentEditor.tsx
+++ b/app/scenes/Document/components/CommentEditor.tsx
@@ -11,6 +11,7 @@ import MentionMenuExtension from "~/editor/extensions/MentionMenu";
 import PasteHandler from "~/editor/extensions/PasteHandler";
 import PreventTab from "~/editor/extensions/PreventTab";
 import SmartText from "~/editor/extensions/SmartText";
+import UpArrowAtStart from "~/editor/extensions/UpArrowAtStart";
 import useCurrentUser from "~/hooks/useCurrentUser";
 
 const extensions = [
@@ -21,13 +22,19 @@ const extensions = [
   ClipboardTextSerializer,
   EmojiMenuExtension,
   MentionMenuExtension,
+  UpArrowAtStart,
   // Order these default key handlers last
   PreventTab,
   Keys,
 ];
 
+type CommentEditorProps = EditorProps & {
+  /** Callback when user presses up arrow at the start of the editor */
+  onUpArrowAtStart?: () => void;
+};
+
 const CommentEditor = (
-  props: EditorProps,
+  props: CommentEditorProps,
   ref: React.RefObject<SharedEditor>
 ) => {
   const user = useCurrentUser({ rejectOnEmpty: false });

--- a/app/scenes/Document/components/CommentForm.tsx
+++ b/app/scenes/Document/components/CommentForm.tsx
@@ -53,6 +53,8 @@ type Props = {
   onFocus?: () => void;
   /** Callback when the editor is blurred */
   onBlur?: () => void;
+  /** Callback when user presses up arrow at the start of the editor */
+  onUpArrowAtStart?: () => void;
 };
 
 function CommentForm({
@@ -63,6 +65,7 @@ function CommentForm({
   onSaveDraft,
   onFocus,
   onBlur,
+  onUpArrowAtStart,
   autoFocus,
   standalone,
   placeholder,
@@ -227,6 +230,13 @@ function CommentForm({
     file.current?.click();
   };
 
+  const handleUpArrowAtStart = () => {
+    if (onUpArrowAtStart) {
+      onUpArrowAtStart();
+      setInputFocused(false);
+    }
+  };
+
   // Focus the editor when it's a new comment just mounted, after a delay as the
   // editor is mounted within a fade transition.
   React.useEffect(() => {
@@ -296,6 +306,7 @@ function CommentForm({
             onSave={handleSave}
             onFocus={handleFocus}
             onBlur={handleBlur}
+            onUpArrowAtStart={handleUpArrowAtStart}
             maxLength={CommentValidation.maxLength}
             placeholder={
               placeholder ||


### PR DESCRIPTION
Quick improvement to act like other best-in-class chat/commenting apps

closes #9700