### PR TITLE
fix: TOC unreliable on iOS

### DIFF
--- a/app/menus/TableOfContentsMenu.tsx
+++ b/app/menus/TableOfContentsMenu.tsx
@@ -32,8 +32,13 @@ function TableOfContentsMenu() {
         title: t("Contents"),
       },
       ...headings.map((heading) => ({
-        type: "link",
-        href: `#${heading.id}`,
+        type: "button",
+        onClick: () =>
+          requestAnimationFrame(() =>
+            requestAnimationFrame(
+              () => (window.location.hash = `#${heading.id}`)
+            )
+          ),
         title: <HeadingWrapper>{t(heading.title)}</HeadingWrapper>,
         level: heading.level - minHeading,
       })),


### PR DESCRIPTION
We must wait for the menu to close before navigating, otherwise the page is unscrollable. This menu is only used on mobile

closes #9654