### PR TITLE
fix: extract domain from user email in Slack authentication

### DIFF
--- a/plugins/slack/server/auth/slack.test.ts
+++ b/plugins/slack/server/auth/slack.test.ts
@@ -1,5 +1,7 @@
 import { buildUser } from "@server/test/factories";
 import { getTestServer } from "@server/test/support";
+import { parseEmail } from "@shared/utils/email";
+import { slugifyDomain } from "@shared/utils/domains";
 
 const server = getTestServer();
 
@@ -29,5 +31,33 @@ describe("#slack.post", () => {
     const body = await res.json();
     expect(res.status).toEqual(400);
     expect(body.message).toEqual("query: one of code or error is required");
+  });
+});
+
+describe("Slack authentication domain extraction", () => {
+  it("should correctly extract domain from user email", () => {
+    const testCases = [
+      { email: "user@gmail.com", expectedDomain: "gmail.com" },
+      { email: "test@company.com", expectedDomain: "company.com" },
+      { email: "admin@subdomain.domain.com", expectedDomain: "subdomain.domain.com" },
+    ];
+
+    testCases.forEach(({ email, expectedDomain }) => {
+      const { domain } = parseEmail(email);
+      expect(domain).toEqual(expectedDomain);
+    });
+  });
+
+  it("should correctly slugify domain for subdomain", () => {
+    const testCases = [
+      { domain: "gmail.com", expectedSubdomain: "gmail" },
+      { domain: "company.com", expectedSubdomain: "company" },
+      { domain: "subdomain.domain.com", expectedSubdomain: "subdomain-domain" },
+    ];
+
+    testCases.forEach(({ domain, expectedSubdomain }) => {
+      const subdomain = slugifyDomain(domain);
+      expect(subdomain).toEqual(expectedSubdomain);
+    });
   });
 });

--- a/plugins/slack/server/auth/slack.test.ts
+++ b/plugins/slack/server/auth/slack.test.ts
@@ -1,7 +1,6 @@
 import { buildUser } from "@server/test/factories";
 import { getTestServer } from "@server/test/support";
 import { parseEmail } from "@shared/utils/email";
-import { slugifyDomain } from "@shared/utils/domains";
 
 const server = getTestServer();
 
@@ -45,19 +44,6 @@ describe("Slack authentication domain extraction", () => {
     testCases.forEach(({ email, expectedDomain }) => {
       const { domain } = parseEmail(email);
       expect(domain).toEqual(expectedDomain);
-    });
-  });
-
-  it("should correctly slugify domain for subdomain", () => {
-    const testCases = [
-      { domain: "gmail.com", expectedSubdomain: "gmail" },
-      { domain: "company.com", expectedSubdomain: "company" },
-      { domain: "subdomain.domain.com", expectedSubdomain: "subdomain-domain" },
-    ];
-
-    testCases.forEach(({ domain, expectedSubdomain }) => {
-      const subdomain = slugifyDomain(domain);
-      expect(subdomain).toEqual(expectedSubdomain);
     });
   });
 });

--- a/plugins/slack/server/auth/slack.ts
+++ b/plugins/slack/server/auth/slack.ts
@@ -25,7 +25,6 @@ import {
   StateStore,
 } from "@server/utils/passport";
 import { parseEmail } from "@shared/utils/email";
-import { slugifyDomain } from "@shared/utils/domains";
 import env from "../env";
 import * as Slack from "../slack";
 import * as T from "./schema";
@@ -64,7 +63,7 @@ if (env.SLACK_CLIENT_ID && env.SLACK_CLIENT_SECRET) {
       clientSecret: env.SLACK_CLIENT_SECRET,
       callbackURL: SlackUtils.callbackUrl(),
       passReqToCallback: true,
-      // @ts-expect-error StateStore
+    
       store: new StateStore(),
       scope: scopes,
     },
@@ -86,7 +85,6 @@ if (env.SLACK_CLIENT_ID && env.SLACK_CLIENT_SECRET) {
 
         
         const { domain } = parseEmail(profile.user.email);
-        const subdomain = slugifyDomain(domain);
 
         const result = await accountProvisioner({
           ip: ctx.ip,
@@ -94,7 +92,7 @@ if (env.SLACK_CLIENT_ID && env.SLACK_CLIENT_SECRET) {
             teamId: team?.id,
             name: profile.team.name,
             domain,
-            subdomain,
+            subdomain: profile.team.domain,
             avatarUrl: profile.team.image_230,
           },
           user: {

--- a/plugins/slack/server/auth/slack.ts
+++ b/plugins/slack/server/auth/slack.ts
@@ -24,6 +24,8 @@ import {
   getTeamFromContext,
   StateStore,
 } from "@server/utils/passport";
+import { parseEmail } from "@shared/utils/email";
+import { slugifyDomain } from "@shared/utils/domains";
 import env from "../env";
 import * as Slack from "../slack";
 import * as T from "./schema";
@@ -82,12 +84,17 @@ if (env.SLACK_CLIENT_ID && env.SLACK_CLIENT_SECRET) {
         const team = await getTeamFromContext(ctx);
         const client = getClientFromContext(ctx);
 
+        
+        const { domain } = parseEmail(profile.user.email);
+        const subdomain = slugifyDomain(domain);
+
         const result = await accountProvisioner({
           ip: ctx.ip,
           team: {
             teamId: team?.id,
             name: profile.team.name,
-            subdomain: profile.team.domain,
+            domain,
+            subdomain,
             avatarUrl: profile.team.image_230,
           },
           user: {

--- a/plugins/slack/server/auth/slack.ts
+++ b/plugins/slack/server/auth/slack.ts
@@ -63,7 +63,7 @@ if (env.SLACK_CLIENT_ID && env.SLACK_CLIENT_SECRET) {
       clientSecret: env.SLACK_CLIENT_SECRET,
       callbackURL: SlackUtils.callbackUrl(),
       passReqToCallback: true,
-    
+      // @ts-expect-error StateStore
       store: new StateStore(),
       scope: scopes,
     },


### PR DESCRIPTION
### I made a PR!

#9641

### Bug Description

- Issue: Slack authentication fails with "Invalid authentication" error when both OIDC and Slack are enabled simultaneously.

- Root Cause: Slack authentication was not extracting the domain from the user's email address, unlike other auth providers (OIDC, Google, Azure, Discord).

- Fix: Added domain extraction from user's email in Slack auth to match the behavior of other authentication providers.

- Impact: Users can now authenticate with Slack even when OIDC is enabled, allowing organizations to use both authentication methods together.
