### PR TITLE
fix: Full-width tables now properly span entire editor width

### DIFF
--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -605,11 +605,15 @@ iframe.embed {
 }
 
 .${EditorStyleHelper.tableFullWidth} {
-  transform: translateX(calc(50% + ${
-    EditorStyleHelper.padding
-  }px + var(--container-width) * -0.5));
+  transform: translateX(calc(50% + var(--container-width) * -0.5));
 
-  .${EditorStyleHelper.tableScrollable},
+  .${EditorStyleHelper.tableScrollable} {
+    margin: -1em 0 -0.5em;
+    padding-left: 0;
+    padding-right: 0;
+    width: calc(var(--container-width) - ${EditorStyleHelper.padding * 2}px);
+  }
+
   table {
     width: calc(var(--container-width) - ${EditorStyleHelper.padding * 2}px);
   }


### PR DESCRIPTION
### I made a PR!

FIXES: #9776

### Problem
When users set a table to full-width mode, the table would only move to the left instead of expanding to fill the entire editor width. This was inconsistent with how images behave in full-width mode.

### Root Cause
The CSS transform calculation for table full-width included an extra padding value (`${EditorStyleHelper.padding}px`) that caused incorrect positioning, unlike the working image full-width implementation.

### Solution
- Removed the extra padding from the table full-width transform calculation
- Updated the scrollable area styles to ensure proper full-width behavior
- Tables now use the same positioning logic as images for consistency