### PR TITLE
fix: duplicate highlight shortcut key label

### DIFF
--- a/app/editor/menus/formatting.tsx
+++ b/app/editor/menus/formatting.tsx
@@ -86,7 +86,7 @@ export default function formattingMenuItems(
     },
     {
       tooltip: dictionary.mark,
-      shortcut: `${metaDisplay}+Ctrl+H`,
+      shortcut: `${metaDisplay}+⇧+H`,
       icon: highlight ? (
         <CircleIcon color={highlight.mark.attrs.color || Highlight.colors[0]} />
       ) : (

--- a/app/scenes/KeyboardShortcuts.tsx
+++ b/app/scenes/KeyboardShortcuts.tsx
@@ -206,7 +206,8 @@ function KeyboardShortcuts() {
           {
             shortcut: (
               <>
-                <Key symbol>{metaDisplay}</Key> + <Key>h</Key>
+                <Key symbol>{metaDisplay}</Key> + <Key symbol>⇧</Key> +{" "}
+                <Key>h</Key>
               </>
             ),
             label: t("Highlight"),

--- a/app/scenes/KeyboardShortcuts.tsx
+++ b/app/scenes/KeyboardShortcuts.tsx
@@ -206,7 +206,7 @@ function KeyboardShortcuts() {
           {
             shortcut: (
               <>
-                <Key symbol>{metaDisplay}</Key> + <Key>Ctrl</Key> + <Key>h</Key>
+                <Key symbol>{metaDisplay}</Key> + <Key>h</Key>
               </>
             ),
             label: t("Highlight"),

--- a/shared/editor/marks/Highlight.ts
+++ b/shared/editor/marks/Highlight.ts
@@ -72,7 +72,7 @@ export default class Highlight extends Mark {
 
   keys({ type }: { type: MarkType }) {
     return {
-      "Mod-Ctrl-h": toggleMark(type),
+      "Mod-Shift-h": toggleMark(type),
     };
   }
 


### PR DESCRIPTION
Fixes this bug!

<img width="346" height="229" alt="image" src="https://github.com/user-attachments/assets/aafe1dca-0f5d-47dc-bb38-ed16197d16fe" />
