### PR TITLE
Migrate `SearchPopover` to Radix

### DIFF
--- a/app/components/primitives/Popover.tsx
+++ b/app/components/primitives/Popover.tsx
@@ -7,6 +7,8 @@ import { fadeAndScaleIn } from "~/styles/animations";
 
 const Popover = PopoverPrimitive.Root;
 
+const PopoverAnchor = PopoverPrimitive.Anchor;
+
 const PopoverTrigger = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Trigger>
@@ -116,4 +118,4 @@ const StyledContent = styled(PopoverPrimitive.Content)<StyledContentProps>`
   }
 `;
 
-export { Popover, PopoverTrigger, PopoverContent };
+export { Popover, PopoverAnchor, PopoverTrigger, PopoverContent };


### PR DESCRIPTION
Turns out `PopoverAnchor` can be used in place of a trigger, rather than build a combobox.

Supersedes #9751 