### PR TITLE
fix: Flash of 404 page due to timing diff between React & MobX state

### DIFF
--- a/app/scenes/Shared/index.tsx
+++ b/app/scenes/Shared/index.tsx
@@ -31,6 +31,7 @@ import ErrorOffline from "../Errors/ErrorOffline";
 import Login from "../Login";
 import { Collection as CollectionScene } from "./Collection";
 import { Document as DocumentScene } from "./Document";
+import DelayedMount from "~/components/DelayedMount";
 
 // Parse the canonical origin from the SSR HTML, only needs to be done once.
 const canonicalUrl = document
@@ -214,7 +215,11 @@ function SharedScene() {
   }
 
   if (!share) {
-    return <Error404 />;
+    return (
+      <DelayedMount>
+        <Error404 />
+      </DelayedMount>
+    );
   }
 
   return (


### PR DESCRIPTION
`useRequest` updates the local React state while `Shared` scene depends on MobX store.
Intermediate render between the two state updates cause a flash of 404 page.

It's very subtle, doesn't happen all the time.
