### PR TITLE
fix: refresh token rotation is broken in OAuth provider implementation

### DIFF
--- a/server/models/oauth/OAuthAuthentication.ts
+++ b/server/models/oauth/OAuthAuthentication.ts
@@ -175,6 +175,10 @@ class OAuthAuthentication extends ParanoidModel<
           association: "user",
           required: true,
         },
+        {
+          association: "oauthClient",
+          required: true,
+        },
       ],
       ...options,
     });

--- a/server/models/oauth/OAuthAuthentication.ts
+++ b/server/models/oauth/OAuthAuthentication.ts
@@ -207,6 +207,10 @@ class OAuthAuthentication extends ParanoidModel<
           association: "user",
           required: true,
         },
+        {
+          association: "oauthClient",
+          required: true,
+        },
       ],
       ...options,
     });

--- a/server/utils/oauth/OAuthInterface.test.ts
+++ b/server/utils/oauth/OAuthInterface.test.ts
@@ -55,6 +55,42 @@ describe("OAuthInterface", () => {
     });
   });
 
+  describe("#getRefreshToken", () => {
+    it("should return correct token details", async () => {
+      const user = await buildUser();
+      const scope = [Scope.Read, Scope.Write];
+      const oAuthClient = await buildOAuthClient({ teamId: user.teamId });
+      const oAuthAuthentication = await buildOAuthAuthentication({
+        user,
+        oauthClientId: oAuthClient.id,
+        scope,
+      });
+
+      const result = await OAuthInterface.getRefreshToken(
+        oAuthAuthentication.refreshToken!
+      );
+
+      expect(result).toEqual({
+        refreshToken: oAuthAuthentication.refreshToken,
+        refreshTokenExpiresAt: oAuthAuthentication.refreshTokenExpiresAt,
+        scope,
+        client: {
+          id: oAuthClient.clientId,
+          grants: OAuthInterface.grants,
+        },
+        user: expect.objectContaining({
+          id: user.id,
+          email: user.email,
+        }),
+      });
+    });
+
+    it("should return false for invalid refresh token", async () => {
+      const result = await OAuthInterface.getRefreshToken("invalid_token");
+      expect(result).toBe(false);
+    });
+  });
+
   describe("#validateRedirectUri", () => {
     it("should return true for valid redirect URI", async () => {
       const redirectUri = "https://example.com/callback";

--- a/server/utils/oauth/OAuthInterface.test.ts
+++ b/server/utils/oauth/OAuthInterface.test.ts
@@ -1,6 +1,13 @@
 import { v4 } from "uuid";
 import { Scope } from "@shared/types";
+import { OAuthAuthentication, OAuthClient, User } from "@server/models";
+import { hash } from "@server/utils/crypto";
 import { OAuthInterface } from "./OAuthInterface";
+import {
+  buildOAuthAuthentication,
+  buildOAuthClient,
+  buildUser,
+} from "@server/test/factories";
 
 describe("OAuthInterface", () => {
   const user = {
@@ -11,6 +18,42 @@ describe("OAuthInterface", () => {
     grants: ["authorization_code", "refresh_token"],
     redirectUris: ["https://example.com/callback"],
   };
+
+  describe("#getAccessToken", () => {
+    it("should return correct token details", async () => {
+      const user = await buildUser();
+      const scope = [Scope.Read, Scope.Write];
+      const oAuthClient = await buildOAuthClient({ teamId: user.teamId });
+      const oAuthAuthentication = await buildOAuthAuthentication({
+        user,
+        oauthClientId: oAuthClient.id,
+        scope,
+      });
+
+      const result = await OAuthInterface.getAccessToken(
+        oAuthAuthentication.accessToken!
+      );
+
+      expect(result).toEqual({
+        accessToken: oAuthAuthentication.accessToken,
+        accessTokenExpiresAt: oAuthAuthentication.accessTokenExpiresAt,
+        scope,
+        client: {
+          id: oAuthClient.clientId,
+          grants: OAuthInterface.grants,
+        },
+        user: expect.objectContaining({
+          id: user.id,
+          email: user.email,
+        }),
+      });
+    });
+
+    it("should return false for invalid access token", async () => {
+      const result = await OAuthInterface.getAccessToken("invalid_token");
+      expect(result).toBe(false);
+    });
+  });
 
   describe("#validateRedirectUri", () => {
     it("should return true for valid redirect URI", async () => {

--- a/server/utils/oauth/OAuthInterface.ts
+++ b/server/utils/oauth/OAuthInterface.ts
@@ -89,7 +89,7 @@ export const OAuthInterface: RefreshTokenModel &
       refreshTokenExpiresAt: authentication.refreshTokenExpiresAt,
       scope: authentication.scope,
       client: {
-        id: authentication.oauthClientId,
+        id: authentication.oauthClient.clientId,
         grants: this.grants,
       },
       user: authentication.user,

--- a/server/utils/oauth/OAuthInterface.ts
+++ b/server/utils/oauth/OAuthInterface.ts
@@ -70,7 +70,7 @@ export const OAuthInterface: RefreshTokenModel &
       accessTokenExpiresAt: authentication.accessTokenExpiresAt,
       scope: authentication.scope,
       client: {
-        id: authentication.oauthClientId,
+        id: authentication.oauthClient.clientId,
         grants: this.grants,
       },
       user: authentication.user,


### PR DESCRIPTION
Due to incorrect id being returned from these interface methods