### PR TITLE
fix: `/auth/` and `/s/` url paths should not be allowed as post-login redirect

### DIFF
--- a/app/utils/urls.test.ts
+++ b/app/utils/urls.test.ts
@@ -1,4 +1,4 @@
-import { decodeURIComponentSafe } from "./urls";
+import { decodeURIComponentSafe, isAllowedLoginRedirect } from "./urls";
 
 describe("decodeURIComponentSafe", () => {
   test("to handle % symbols", () => {
@@ -59,5 +59,69 @@ describe("decodeURIComponentSafe", () => {
 
     // Already encoded %25 should decode to %
     expect(decodeURIComponentSafe("%25%25")).toBe("%%");
+  });
+
+  describe("isAllowedLoginRedirect", () => {
+    test("should block disallowed paths", () => {
+      expect(isAllowedLoginRedirect("/")).toBe(false);
+      expect(isAllowedLoginRedirect("/create")).toBe(false);
+      expect(isAllowedLoginRedirect("/home")).toBe(false);
+      expect(isAllowedLoginRedirect("/logout")).toBe(false);
+    });
+
+    test("should block paths starting with /auth/", () => {
+      expect(isAllowedLoginRedirect("/auth/")).toBe(false);
+      expect(isAllowedLoginRedirect("/auth/login")).toBe(false);
+      expect(isAllowedLoginRedirect("/auth/signup")).toBe(false);
+      expect(isAllowedLoginRedirect("/auth/callback")).toBe(false);
+      expect(isAllowedLoginRedirect("/auth/google")).toBe(false);
+      expect(isAllowedLoginRedirect("/auth/slack/callback")).toBe(false);
+    });
+
+    test("should block paths starting with /s/", () => {
+      expect(isAllowedLoginRedirect("/s/")).toBe(false);
+      expect(isAllowedLoginRedirect("/s/share")).toBe(false);
+      expect(isAllowedLoginRedirect("/s/public")).toBe(false);
+      expect(isAllowedLoginRedirect("/s/document/123")).toBe(false);
+      expect(isAllowedLoginRedirect("/s/collection/456")).toBe(false);
+    });
+
+    test("should allow valid redirect paths", () => {
+      expect(isAllowedLoginRedirect("/documents")).toBe(true);
+      expect(isAllowedLoginRedirect("/settings")).toBe(true);
+      expect(isAllowedLoginRedirect("/team")).toBe(true);
+      expect(isAllowedLoginRedirect("/profile")).toBe(true);
+      expect(isAllowedLoginRedirect("/document/123")).toBe(true);
+      expect(isAllowedLoginRedirect("/collection/456")).toBe(true);
+    });
+
+    test("should strip query strings before checking", () => {
+      expect(isAllowedLoginRedirect("/?foo=bar")).toBe(false);
+      expect(isAllowedLoginRedirect("/create?id=123")).toBe(false);
+      expect(isAllowedLoginRedirect("/home?tab=recent")).toBe(false);
+      expect(isAllowedLoginRedirect("/logout?redirect=true")).toBe(false);
+      expect(isAllowedLoginRedirect("/auth/login?next=/docs")).toBe(false);
+      expect(isAllowedLoginRedirect("/s/share?token=abc")).toBe(false);
+      expect(isAllowedLoginRedirect("/documents?search=test")).toBe(true);
+      expect(isAllowedLoginRedirect("/settings?tab=profile")).toBe(true);
+    });
+
+    test("should handle edge cases", () => {
+      expect(isAllowedLoginRedirect("")).toBe(true);
+      expect(isAllowedLoginRedirect("/authenticate")).toBe(true); // doesn't start with /auth/
+      expect(isAllowedLoginRedirect("/authorization")).toBe(true); // doesn't start with /auth/
+      expect(isAllowedLoginRedirect("/authtest")).toBe(true); // doesn't start with /auth/
+      expect(isAllowedLoginRedirect("/auth")).toBe(true); // doesn't start with /auth/
+      expect(isAllowedLoginRedirect("/share")).toBe(true); // doesn't start with /s/
+      expect(isAllowedLoginRedirect("/support")).toBe(true); // doesn't start with /s/
+      expect(isAllowedLoginRedirect("/s")).toBe(true); // doesn't start with /s/
+    });
+
+    test("should handle paths with fragments", () => {
+      expect(isAllowedLoginRedirect("/documents#section1")).toBe(true);
+      expect(isAllowedLoginRedirect("/auth/login#forgot")).toBe(false);
+      expect(isAllowedLoginRedirect("/s/share#public")).toBe(false);
+      expect(isAllowedLoginRedirect("/#top")).toBe(false);
+    });
   });
 });

--- a/app/utils/urls.ts
+++ b/app/utils/urls.ts
@@ -53,6 +53,10 @@ export function redirectTo(url: string) {
  * @returns boolean indicating if the path is a valid redirect
  */
 export const isAllowedLoginRedirect = (input: string) => {
-  const path = input.split("?")[0];
-  return !["/", "/create", "/home", "/logout", "/auth/"].includes(path);
+  const path = input.split("?")[0].split("#")[0];
+  return (
+    !["/", "/create", "/home", "/logout"].includes(path) &&
+    !path.startsWith("/auth/") &&
+    !path.startsWith("/s/")
+  );
 };


### PR DESCRIPTION
closes #9848