### PR TITLE
fix: Admins unable to revoke workspace API keys created by other users

### DIFF
--- a/server/models/ApiKey.ts
+++ b/server/models/ApiKey.ts
@@ -12,6 +12,7 @@ import {
   DataType,
   AfterFind,
   BeforeSave,
+  Scopes,
 } from "sequelize-typescript";
 import { randomString } from "@shared/random";
 import { ApiKeyValidation } from "@shared/validations";
@@ -24,6 +25,15 @@ import AuthenticationHelper from "./helpers/AuthenticationHelper";
 import Length from "./validators/Length";
 
 @Table({ tableName: "apiKeys", modelName: "apiKey" })
+@Scopes(() => ({
+  withUser: {
+    include: [
+      {
+        association: "user",
+      },
+    ],
+  },
+}))
 @Fix
 class ApiKey extends ParanoidModel<
   InferAttributes<ApiKey>,

--- a/server/policies/apiKey.ts
+++ b/server/policies/apiKey.ts
@@ -33,8 +33,13 @@ allow(User, "listApiKeys", Team, (actor, team) =>
 
 allow(User, ["read", "update", "delete"], ApiKey, (actor, apiKey) =>
   and(
-    or(isOwner(actor, apiKey), actor.teamId === apiKey?.user.teamId),
-    actor.isAdmin ||
-      !!actor.team?.getPreference(TeamPreference.MembersCanCreateApiKey)
+    isTeamModel(actor, apiKey?.user),
+    or(
+      actor.isAdmin,
+      and(
+        isOwner(actor, apiKey),
+        !!actor.team?.getPreference(TeamPreference.MembersCanCreateApiKey)
+      )
+    )
   )
 );

--- a/server/policies/apiKey.ts
+++ b/server/policies/apiKey.ts
@@ -7,6 +7,7 @@ import {
   isOwner,
   isTeamModel,
   isTeamMutable,
+  or,
 } from "./utils";
 
 allow(User, "createApiKey", Team, (actor, team) =>
@@ -32,7 +33,7 @@ allow(User, "listApiKeys", Team, (actor, team) =>
 
 allow(User, ["read", "update", "delete"], ApiKey, (actor, apiKey) =>
   and(
-    isOwner(actor, apiKey),
+    or(isOwner(actor, apiKey), actor.teamId === apiKey?.user.teamId),
     actor.isAdmin ||
       !!actor.team?.getPreference(TeamPreference.MembersCanCreateApiKey)
   )

--- a/server/routes/api/apiKeys/apiKeys.test.ts
+++ b/server/routes/api/apiKeys/apiKeys.test.ts
@@ -146,6 +146,25 @@ describe("#apiKeys.delete", () => {
     expect(res.status).toEqual(200);
   });
 
+  it("should allow admin to delete another user's api key", async () => {
+    const user = await buildUser();
+    const admin = await buildAdmin({ teamId: user.teamId });
+
+    const apiKey = await buildApiKey({
+      name: "User's API Key",
+      userId: user.id,
+    });
+
+    const res = await server.post("/api/apiKeys.delete", {
+      body: {
+        token: admin.getJwtToken(),
+        id: apiKey.id,
+      },
+    });
+
+    expect(res.status).toEqual(200);
+  });
+
   it("should require authentication", async () => {
     const res = await server.post("/api/apiKeys.delete");
     expect(res.status).toEqual(401);

--- a/server/routes/api/apiKeys/apiKeys.test.ts
+++ b/server/routes/api/apiKeys/apiKeys.test.ts
@@ -146,6 +146,23 @@ describe("#apiKeys.delete", () => {
     expect(res.status).toEqual(200);
   });
 
+  it("should not allow deleting another user's api key", async () => {
+    const user = await buildUser();
+    const otherUser = await buildUser({ teamId: user.teamId });
+    const apiKey = await buildApiKey({
+      name: "Other User's API Key",
+      userId: otherUser.id,
+    });
+
+    const res = await server.post("/api/apiKeys.delete", {
+      body: {
+        token: user.getJwtToken(),
+        id: apiKey.id,
+      },
+    });
+    expect(res.status).toEqual(403);
+  });
+
   it("should allow admin to delete another user's api key", async () => {
     const user = await buildUser();
     const admin = await buildAdmin({ teamId: user.teamId });

--- a/server/routes/api/apiKeys/apiKeys.ts
+++ b/server/routes/api/apiKeys/apiKeys.ts
@@ -104,8 +104,11 @@ router.post(
     const { user } = ctx.state.auth;
     const { transaction } = ctx.state;
 
-    const key = await ApiKey.findByPk(id, {
-      lock: transaction.LOCK.UPDATE,
+    const key = await ApiKey.scope("withUser").findByPk(id, {
+      lock: {
+        level: transaction.LOCK.UPDATE,
+        of: ApiKey,
+      },
       transaction,
     });
     authorize(user, "delete", key);


### PR DESCRIPTION
closes #9864