### PR TITLE
fix: undefined width/height when pasting HTML images

### DIFF
--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -609,6 +609,7 @@ iframe.embed {
     EditorStyleHelper.padding
   }px + var(--container-width) * -0.5 + var(--full-width-transform-offset)));
 
+  .${EditorStyleHelper.tableScrollable},
   table {
     width: calc(var(--container-width) - ${EditorStyleHelper.padding * 2}px);
   }


### PR DESCRIPTION
- fixes issue where image dimensions were undefined when pasting HTML content that contained images with CSS style dimensions instead of HTML attributes.

fix: #9810 

**Problem:**
- When pasting HTML content, images often have dimensions set via CSS styles (`style="width: 300px; height: 200px"`) rather than HTML attributes (`width="300" height="200"`)
- The image parser only checked HTML attributes, leaving width/height undefined for CSS-styled images

**Solution:**
- Enhanced the `parseDOM` logic in `Image.tsx` to fallback to CSS style dimensions when HTML attributes are not available
- Added support for parsing `img.style.width` and `img.style.height` (px values)
- Maintains backward compatibility with existing HTML attribute parsing

**Testing:**
- Images pasted from various sources (web pages, documents) now retain their dimensions
- Both HTML attributes and CSS styles are properly parsed