### PR TITLE
fix: Prefetch non-archived notifications only

### DIFF
--- a/app/components/Notifications/NotificationsPopover.tsx
+++ b/app/components/Notifications/NotificationsPopover.tsx
@@ -20,7 +20,7 @@ const NotificationsPopover: React.FC = ({ children }: Props) => {
   const scrollableRef = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
-    void notifications.fetchPage({});
+    void notifications.fetchPage({ archived: false });
   }, [notifications]);
 
   const handleRequestClose = React.useCallback(() => {

--- a/app/stores/NotificationsStore.ts
+++ b/app/stores/NotificationsStore.ts
@@ -17,7 +17,7 @@ export default class NotificationsStore extends Store<Notification> {
 
   @action
   fetchPage = async (
-    options: PaginationParams | undefined
+    options: ({ archived?: boolean } & PaginationParams) | undefined
   ): Promise<Notification[]> => {
     this.isFetching = true;
 


### PR DESCRIPTION
Regressed in #9583 

Stumbled on it when migrating notifications menu to Radix.