### PR TITLE
fix: Use shared link for collection in public breadcrumb

### DIFF
--- a/app/scenes/Document/components/PublicBreadcrumb.tsx
+++ b/app/scenes/Document/components/PublicBreadcrumb.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import Icon from "@shared/components/Icon";
-import { NavigationNode } from "@shared/types";
+import { NavigationNode, NavigationNodeType } from "@shared/types";
 import Breadcrumb from "~/components/Breadcrumb";
 import { MenuInternalLink } from "~/types";
 import { sharedModelPath } from "~/utils/routeHelpers";
@@ -50,7 +50,7 @@ const PublicBreadcrumb: React.FC<Props> = ({
   const items: MenuInternalLink[] = React.useMemo(
     () =>
       pathToDocument(sharedTree, documentId)
-        .slice(1, -1)
+        .slice(0, -1)
         .map((item) => ({
           ...item,
           icon: item.icon ? (
@@ -58,7 +58,10 @@ const PublicBreadcrumb: React.FC<Props> = ({
           ) : undefined,
           title: item.title,
           type: "route",
-          to: sharedModelPath(shareId, item.url),
+          to: sharedModelPath(
+            shareId,
+            item.type === NavigationNodeType.Collection ? undefined : item.url
+          ),
         })),
     [sharedTree, shareId, documentId]
   );

--- a/server/models/Collection.ts
+++ b/server/models/Collection.ts
@@ -46,7 +46,11 @@ import {
 } from "sequelize-typescript";
 import isUUID from "validator/lib/isUUID";
 import type { CollectionSort, ProsemirrorData } from "@shared/types";
-import { CollectionPermission, NavigationNode } from "@shared/types";
+import {
+  CollectionPermission,
+  NavigationNode,
+  NavigationNodeType,
+} from "@shared/types";
 import { UrlHelper } from "@shared/utils/UrlHelper";
 import { sortNavigationNodes } from "@shared/utils/collections";
 import slugify from "@shared/utils/slugify";
@@ -993,6 +997,7 @@ class Collection extends ParanoidModel<
     id: this.id,
     title: this.name,
     url: this.path,
+    type: NavigationNodeType.Collection,
     icon: isNil(this.icon) ? undefined : this.icon,
     color: isNil(this.color) ? undefined : this.color,
     children: sortNavigationNodes(this.documentStructure ?? [], this.sort),


### PR DESCRIPTION
Couple of tiny bug fixes related to public breadcrumbs
- Clicking on collection was redirecting to auth page
- Breadcrumb wasn't shown for the first level document