### PR TITLE
fix: Use `safeEqual` in `VerificationCode` verify method

### DIFF
--- a/server/utils/VerificationCode.ts
+++ b/server/utils/VerificationCode.ts
@@ -1,6 +1,7 @@
 import { randomInt } from "crypto";
 import { Minute } from "@shared/utils/time";
 import Redis from "@server/storage/redis";
+import { safeEqual } from "./crypto";
 
 /**
  * This class manages verification codes for email authentication.
@@ -53,9 +54,9 @@ export class VerificationCode {
    * @param email The email address associated with the code
    * @returns Promise resolving to the code or null if not found
    */
-  public static async retrieve(email: string): Promise<string | null> {
+  public static async retrieve(email: string): Promise<string | undefined> {
     const key = this.getKey(email);
-    return await this.redis.get(key);
+    return (await this.redis.get(key)) ?? undefined;
   }
 
   /**
@@ -67,7 +68,7 @@ export class VerificationCode {
    */
   public static async verify(email: string, code: string): Promise<boolean> {
     const storedCode = await this.retrieve(email);
-    return storedCode === code;
+    return safeEqual(storedCode, code);
   }
 
   /**


### PR DESCRIPTION
`safeEqual` is timing attack safe and should be used to compare all fixed secrets against user input.

ref OUT-Q325-05