### PR TITLE
chore: Remove usage of `vite-static-copy` plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -363,7 +363,6 @@
     "rollup-plugin-webpack-stats": "^2.1.3",
     "terser": "^5.43.1",
     "typescript": "^5.9.2",
-    "vite-plugin-static-copy": "^0.17.0",
     "yarn-deduplicate": "^6.0.2"
   },
   "resolutions": {

--- a/server/static/index.html
+++ b/server/static/index.html
@@ -25,7 +25,7 @@
     <link
       rel="apple-touch-icon"
       type="image/png"
-      href="{cdn-url}/static/images/apple-touch-icon.png"
+      href="{cdn-url}/images/apple-touch-icon.png"
       sizes="192x192"
     />
     <link

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,6 @@ import browserslistToEsbuild from "browserslist-to-esbuild";
 import webpackStats from "rollup-plugin-webpack-stats";
 import { ServerOptions, defineConfig } from "vite";
 import { VitePWA } from "vite-plugin-pwa";
-import { viteStaticCopy } from "vite-plugin-static-copy";
 import environment from "./server/utils/environment";
 
 let httpsConfig: ServerOptions["https"] | undefined;
@@ -46,15 +45,6 @@ export default () =>
     },
     plugins: [
       react(),
-      // https://github.com/sapphi-red/vite-plugin-static-copy#readme
-      viteStaticCopy({
-        targets: [
-          {
-            src: "./public/images",
-            dest: "./",
-          },
-        ],
-      }),
       // https://vite-pwa-org.netlify.app/
       VitePWA({
         injectRegister: "inline",
@@ -128,18 +118,18 @@ export default () =>
           // pixel-perfection, provide icons in increments of 48dp.
           icons: [
             {
-              src: "/static/images/icon-192.png",
+              src: "/images/icon-192.png",
               sizes: "192x192",
               type: "image/png",
             },
             {
-              src: "/static/images/icon-512.png",
+              src: "/images/icon-512.png",
               sizes: "512x512",
               type: "image/png",
             },
             // last one duplicated for purpose: 'any maskable'
             {
-              src: "/static/images/icon-512.png",
+              src: "/images/icon-512.png",
               sizes: "512x512",
               type: "image/png",
               purpose: "any maskable",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6423,7 +6423,7 @@ chevrotain@~11.0.3:
     "@chevrotain/utils" "11.0.3"
     lodash-es "4.17.21"
 
-chokidar@^3.5.2, chokidar@^3.5.3, chokidar@^3.6.0:
+chokidar@^3.5.2, chokidar@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
   integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
@@ -8136,7 +8136,7 @@ fast-fifo@^1.3.2:
   resolved "https://registry.yarnpkg.com/fast-fifo/-/fast-fifo-1.3.2.tgz#286e31de96eb96d38a97899815740ba2a4f3640c"
   integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
 
-fast-glob@^3.2.11, fast-glob@^3.3.2:
+fast-glob@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
   integrity "sha1-qQRQHlfP3S/83tRemaVP71XkYSk= sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow=="
@@ -11915,7 +11915,7 @@ pgpass@1.x:
   dependencies:
     split2 "^3.1.1"
 
-picocolors@^1.0.0, picocolors@^1.1.1:
+picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
@@ -14673,16 +14673,6 @@ vite-plugin-pwa@^0.21.2:
     tinyglobby "^0.2.10"
     workbox-build "^7.3.0"
     workbox-window "^7.3.0"
-
-vite-plugin-static-copy@^0.17.0:
-  version "0.17.1"
-  resolved "https://registry.yarnpkg.com/vite-plugin-static-copy/-/vite-plugin-static-copy-0.17.1.tgz#0de35c4a4c760d5f344b5559d0a8d7d417a52093"
-  integrity "sha1-DeNcSkx2DV80S1VZ0KjX1BelIJM= sha512-9h3iaVs0bqnqZOM5YHJXGHqdC5VAVlTZ2ARYsuNpzhEJUHmFqXY7dAK4ZFpjEQ4WLFKcaN8yWbczr81n01U4sQ=="
-  dependencies:
-    chokidar "^3.5.3"
-    fast-glob "^3.2.11"
-    fs-extra "^11.1.0"
-    picocolors "^1.0.0"
 
 "vite@npm:rolldown-vite@latest":
   version "7.0.4"


### PR DESCRIPTION
This was vestigial, best I can tell.

ref OUT-Q325-02