### PR TITLE
fix: Tighten rate limits on `email.callback` endpoint

### DIFF
--- a/plugins/email/server/auth/email.ts
+++ b/plugins/email/server/auth/email.ts
@@ -177,7 +177,17 @@ const emailCallback = async (ctx: APIContext<T.EmailCallbackReq>) => {
     client,
   });
 };
-router.get("email.callback", validate(T.EmailCallbackSchema), emailCallback);
-router.post("email.callback", validate(T.EmailCallbackSchema), emailCallback);
+router.get(
+  "email.callback",
+  rateLimiter(RateLimiterStrategy.TenPerHour),
+  validate(T.EmailCallbackSchema),
+  emailCallback
+);
+router.post(
+  "email.callback",
+  rateLimiter(RateLimiterStrategy.TenPerHour),
+  validate(T.EmailCallbackSchema),
+  emailCallback
+);
 
 export default router;


### PR DESCRIPTION
Currently uses the defaults, however now that OTP is an option this is more vulnerable to brute-force attacks than previously.