### PR TITLE
fix: Remove `attachments.redirect` sw caching

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -85,20 +85,6 @@ export default () =>
               },
             },
             {
-              urlPattern: /api\/attachments\.redirect/,
-              handler: "CacheFirst",
-              options: {
-                cacheName: "attachments-redirect-cache",
-                expiration: {
-                  maxEntries: 100,
-                  maxAgeSeconds: 120, // 120 seconds
-                },
-                cacheableResponse: {
-                  statuses: [0, 200, 302], // Include redirects
-                },
-              },
-            },
-            {
               urlPattern: /api\/files\.get/,
               handler: "CacheFirst",
               options: {
@@ -110,6 +96,7 @@ export default () =>
                 cacheableResponse: {
                   statuses: [0, 200, 206], // Include partial content for range requests
                 },
+                rangeRequests: true, // Allow range requests for partial content
               },
             },
           ],


### PR DESCRIPTION
Add support for `range` requests when using local file storage