### PR TITLE
fix: Document move/copy/publish dialog behavior

### DIFF
--- a/app/components/DocumentCopy.tsx
+++ b/app/components/DocumentCopy.tsx
@@ -1,4 +1,3 @@
-import flatten from "lodash/flatten";
 import { observer } from "mobx-react";
 import * as React from "react";
 import { Trans, useTranslation } from "react-i18next";
@@ -11,7 +10,6 @@ import Button from "~/components/Button";
 import DocumentExplorer from "~/components/DocumentExplorer";
 import useCollectionTrees from "~/hooks/useCollectionTrees";
 import useStores from "~/hooks/useStores";
-import { flattenTree } from "~/utils/tree";
 import Switch from "./Switch";
 import Text from "./Text";
 

--- a/app/components/DocumentCopy.tsx
+++ b/app/components/DocumentCopy.tsx
@@ -32,7 +32,7 @@ function DocumentCopy({ document, onSubmit }: Props) {
   );
 
   const items = React.useMemo(() => {
-    const nodes = flatten(collectionTrees.map(flattenTree)).filter((node) =>
+    const nodes = collectionTrees.filter((node) =>
       node.collectionId
         ? policies.get(node.collectionId)?.abilities.createDocument
         : true
@@ -78,34 +78,32 @@ function DocumentCopy({ document, onSubmit }: Props) {
         onSelect={selectPath}
         defaultValue={document.parentDocumentId || document.collectionId || ""}
       />
-      <OptionsContainer>
-        {!document.isTemplate && (
-          <>
-            {document.collectionId && (
-              <Text size="small">
-                <Switch
-                  name="publish"
-                  label={t("Publish")}
-                  labelPosition="right"
-                  checked={publish}
-                  onChange={setPublish}
-                />
-              </Text>
-            )}
-            {document.publishedAt && document.childDocuments.length > 0 && (
-              <Text size="small">
-                <Switch
-                  name="recursive"
-                  label={t("Include nested documents")}
-                  labelPosition="right"
-                  checked={recursive}
-                  onChange={setRecursive}
-                />
-              </Text>
-            )}
-          </>
-        )}
-      </OptionsContainer>
+      {!document.isTemplate && (
+        <OptionsContainer>
+          {document.collectionId && (
+            <Text size="small">
+              <Switch
+                name="publish"
+                label={t("Publish")}
+                labelPosition="right"
+                checked={publish}
+                onChange={setPublish}
+              />
+            </Text>
+          )}
+          {document.publishedAt && document.childDocuments.length > 0 && (
+            <Text size="small">
+              <Switch
+                name="recursive"
+                label={t("Include nested documents")}
+                labelPosition="right"
+                checked={recursive}
+                onChange={setRecursive}
+              />
+            </Text>
+          )}
+        </OptionsContainer>
+      )}
       <Footer justify="space-between" align="center" gap={8}>
         <StyledText type="secondary">
           {selectedPath ? (
@@ -127,9 +125,11 @@ function DocumentCopy({ document, onSubmit }: Props) {
 }
 
 const OptionsContainer = styled.div`
-  margin: 16px 0 8px 0;
-  padding-left: 24px;
-  padding-right: 24px;
+  border-top: 1px solid ${(props) => props.theme.horizontalRule};
+  padding: 16px 24px 0;
+  margin-bottom: -1px;
+  background: ${(props) => props.theme.modalBackground};
+  z-index: 1;
 `;
 
 export default observer(DocumentCopy);

--- a/app/components/DocumentExplorer.tsx
+++ b/app/components/DocumentExplorer.tsx
@@ -134,6 +134,7 @@ function DocumentExplorer({ onSubmit, onSelect, items, defaultValue }: Props) {
     (min, node) => (node.depth ? Math.min(min, node.depth) : min),
     Infinity
   );
+  const normalizedBaseDepth = baseDepth === Infinity ? 0 : baseDepth;
 
   const scrollNodeIntoView = React.useCallback(
     (node: number) => {
@@ -307,7 +308,7 @@ function DocumentExplorer({ onSubmit, onSelect, items, defaultValue }: Props) {
           expanded={isExpanded(index)}
           icon={renderedIcon}
           title={title}
-          depth={(node.depth ?? 0) - baseDepth}
+          depth={(node.depth ?? 0) - normalizedBaseDepth}
           hasChildren={hasChildren(index)}
           ref={itemRefs[index]}
         />

--- a/app/components/DocumentExplorer.tsx
+++ b/app/components/DocumentExplorer.tsx
@@ -26,7 +26,8 @@ import InputSearch from "~/components/InputSearch";
 import Text from "~/components/Text";
 import useMobile from "~/hooks/useMobile";
 import useStores from "~/hooks/useStores";
-import { ancestors, descendants } from "~/utils/tree";
+import { ancestors, descendants, flattenTree } from "~/utils/tree";
+import flatten from "lodash/flatten";
 
 type Props = {
   /** Action taken upon submission of selected item, could be publish, move etc. */
@@ -80,7 +81,7 @@ function DocumentExplorer({ onSubmit, onSelect, items, defaultValue }: Props) {
 
   const searchIndex = React.useMemo(
     () =>
-      new FuzzySearch(items, ["title"], {
+      new FuzzySearch(flatten(items.map(flattenTree)), ["title"], {
         caseSensitive: false,
       }),
     [items]
@@ -125,11 +126,7 @@ function DocumentExplorer({ onSubmit, onSelect, items, defaultValue }: Props) {
 
     return searchTerm
       ? searchIndex.search(searchTerm)
-      : items
-          .concat(
-            items.filter((item) => item.type === NavigationNodeType.Collection)
-          )
-          .flatMap(includeDescendants);
+      : items.flatMap(includeDescendants);
   }
 
   const nodes = getNodes();

--- a/app/hooks/useCollectionTrees.ts
+++ b/app/hooks/useCollectionTrees.ts
@@ -73,7 +73,7 @@ export default function useCollectionTrees(): NavigationNode[] {
       parent: null,
     };
 
-    return addParent(addCollectionId(addDepth(addType(collectionNode))));
+    return addParent(addCollectionId(addDepth(addType(collectionNode), 1)));
   };
 
   const key = collections.orderedData.map((o) => o.documents?.length).join("-");

--- a/app/scenes/DocumentMove.tsx
+++ b/app/scenes/DocumentMove.tsx
@@ -1,4 +1,3 @@
-import flatten from "lodash/flatten";
 import { observer } from "mobx-react";
 import { useState, useMemo } from "react";
 import { useTranslation, Trans } from "react-i18next";
@@ -13,7 +12,6 @@ import Flex from "~/components/Flex";
 import Text from "~/components/Text";
 import useCollectionTrees from "~/hooks/useCollectionTrees";
 import useStores from "~/hooks/useStores";
-import { flattenTree } from "~/utils/tree";
 
 type Props = {
   document: Document;

--- a/app/scenes/DocumentMove.tsx
+++ b/app/scenes/DocumentMove.tsx
@@ -36,12 +36,7 @@ function DocumentMove({ document }: Props) {
         .map(filterSourceDocument),
     });
 
-    // Filter out the document itself and its existing parent doc, if any.
-    const nodes = flatten(collectionTrees.map(flattenTree))
-      .filter(
-        (node) =>
-          node.id !== document.id && node.id !== document.parentDocumentId
-      )
+    const nodes = collectionTrees
       .map(filterSourceDocument)
       // Filter out collections that we don't have permission to create documents in.
       .filter((node) =>
@@ -100,7 +95,7 @@ function DocumentMove({ document }: Props) {
             <Trans
               defaults="Move to <em>{{ location }}</em>"
               values={{
-                location: selectedPath.title,
+                location: selectedPath.title || t("Untitled"),
               }}
               components={{
                 em: <strong />,

--- a/app/scenes/DocumentPublish.tsx
+++ b/app/scenes/DocumentPublish.tsx
@@ -1,4 +1,3 @@
-import flatten from "lodash/flatten";
 import { observer } from "mobx-react";
 import { useState, useMemo } from "react";
 import { useTranslation, Trans } from "react-i18next";
@@ -13,7 +12,6 @@ import Flex from "~/components/Flex";
 import Text from "~/components/Text";
 import useCollectionTrees from "~/hooks/useCollectionTrees";
 import useStores from "~/hooks/useStores";
-import { flattenTree } from "~/utils/tree";
 
 type Props = {
   /** Document to publish */
@@ -27,7 +25,7 @@ function DocumentPublish({ document }: Props) {
   const [selectedPath, selectPath] = useState<NavigationNode | null>(null);
   const publishOptions = useMemo(
     () =>
-      flatten(collectionTrees.map(flattenTree)).filter((node) =>
+      collectionTrees.filter((node) =>
         node.collectionId
           ? policies.get(node.collectionId)?.abilities.createDocument
           : true


### PR DESCRIPTION
I said it in the issue, but I just can't quite understand how this was so broken – items in the dialog seemed quite "random" in use as a consequence of passing flattened trees into `DocumentExplorer`. Perhaps will dig deeper into the history tomorrow

closes #9946 