### PR TITLE
fix: Use event keycode for determining ToC shortcut keys

### DIFF
--- a/app/scenes/Document/components/Header.tsx
+++ b/app/scenes/Document/components/Header.tsx
@@ -166,7 +166,7 @@ function DocumentHeader({
   );
 
   useKeyDown(
-    (event) => event.ctrlKey && event.altKey && event.key === "˙",
+    (event) => event.ctrlKey && event.altKey && event.code === "KeyH",
     handleToggle,
     {
       allowInInput: true,


### PR DESCRIPTION
`AltKey` modifies the eventual value, so we must use the _key-code_ instead.

Closes #9993 