### PR TITLE
Use `leafText` when converting mention nodes to its text content

### DIFF
--- a/shared/editor/nodes/Mention.tsx
+++ b/shared/editor/nodes/Mention.tsx
@@ -120,6 +120,7 @@ export default class Mention extends Node {
         toPlainText(node),
       ],
       toPlainText,
+      leafText: toPlainText,
     };
   }
 


### PR DESCRIPTION
Closes #10000

Keeping it scoped to the bug here - As a follow-on, we should remove the custom `toPlainText` method in favor of prosemirror's `leafText`.