### PR TITLE
Add security option to allow `file://` links for self-hosted instances

### DIFF
--- a/app.json
+++ b/app.json
@@ -42,6 +42,11 @@
       "value": "true",
       "required": true
     },
+    "ALLOW_FILE_PROTOCOL": {
+      "description": "Allow file:// links in documents. This is a security risk and should only be enabled in self-hosted environments.",
+      "value": "false",
+      "required": false
+    },
     "URL": {
       "description": "https://{your app name}.herokuapp.com, or the domain you are binding to",
       "required": true

--- a/app/scenes/Settings/Security.tsx
+++ b/app/scenes/Settings/Security.tsx
@@ -363,10 +363,10 @@ function Security() {
       </SettingRow>
       {!isCloudHosted && (
         <SettingRow
-          label={t("Allow file:// links")}
+          label={t("Allow file protocol")}
           name="allowFileProtocol"
           description={t(
-            "Allow file:// links in documents. This is useful for companies with a local NAS but is a security risk. To enable, set the ALLOW_FILE_PROTOCOL=true environment variable and restart the server."
+            "To allow file:// links in documents, set the ALLOW_FILE_PROTOCOL=true environment variable and restart the server."
           )}
         >
           <Switch

--- a/app/scenes/Settings/Security.tsx
+++ b/app/scenes/Settings/Security.tsx
@@ -361,6 +361,21 @@ function Security() {
           onChange={handleDocumentEmbedsChange}
         />
       </SettingRow>
+      {!isCloudHosted && (
+        <SettingRow
+          label={t("Allow file:// links")}
+          name="allowFileProtocol"
+          description={t(
+            "Allow file:// links in documents. This is useful for companies with a local NAS but is a security risk. To enable, set the ALLOW_FILE_PROTOCOL=true environment variable and restart the server."
+          )}
+        >
+          <Switch
+            id="allowFileProtocol"
+            checked={env.ALLOW_FILE_PROTOCOL === "true"}
+            disabled
+          />
+        </SettingRow>
+      )}
       <SettingRow
         label={t("Collection creation")}
         name="memberCollectionCreate"

--- a/server/env.ts
+++ b/server/env.ts
@@ -793,6 +793,18 @@ export class Environment {
   public get isTest() {
     return this.ENVIRONMENT === "test";
   }
+  
+  /**
+   * Allow file:// protocol links in the editor. This is a security risk and should
+   * only be enabled in self-hosted environments where you trust your users.
+   * This is useful for companies with a local NAS.
+   */
+  @Public
+  @IsBoolean()
+  @IsOptional()
+  public ALLOW_FILE_PROTOCOL = this.toBoolean(
+    environment.ALLOW_FILE_PROTOCOL ?? "false"
+  );
 
   protected toOptionalString(value: string | undefined) {
     return value ? value : undefined;

--- a/shared/utils/urls.ts
+++ b/shared/utils/urls.ts
@@ -113,9 +113,21 @@ export function isUrl(
 
   try {
     const url = new URL(text);
-    const blockedProtocols = ["javascript:", "file:", "vbscript:", "data:"];
-
-    if (blockedProtocols.includes(url.protocol)) {
+    // Define protocols that are always blocked
+    const alwaysBlockedProtocols = ["javascript:", "vbscript:", "data:"];
+    // Define protocols that can be conditionally allowed
+    const conditionallyBlockedProtocols = ["file:"];
+    
+    // Check if file:// links are allowed via environment variable
+    const allowFileProtocol = env.ALLOW_FILE_PROTOCOL === "true";
+    
+    // Block always-blocked protocols
+    if (alwaysBlockedProtocols.includes(url.protocol)) {
+      return false;
+    }
+    
+    // Block conditionally-blocked protocols if not explicitly allowed
+    if (conditionallyBlockedProtocols.includes(url.protocol) && !allowFileProtocol) {
       return false;
     }
     if (url.hostname) {


### PR DESCRIPTION
This change adds a new environment variable ALLOW_FILE_PROTOCOL that, when set to true, allows file:// links in documents. This is useful for companies with a local NAS but is a security risk, so it's disabled by default and only recommended for self-hosted instances.

- Added ALLOW_FILE_PROTOCOL environment variable
- Modified URL validation to conditionally allow file:// protocol
- Added UI option in Security settings (disabled, with instructions)
- Updated documentation

closes #9998