### PR TITLE
chore(queues): use `Second` from `@shared/utils/time`

### DIFF
--- a/server/queues/index.ts
+++ b/server/queues/index.ts
@@ -1,10 +1,11 @@
 import { createQueue } from "@server/queues/queue";
+import { Second } from "@shared/utils/time";
 
 export const globalEventQueue = createQueue("globalEvents", {
   attempts: 5,
   backoff: {
     type: "exponential",
-    delay: 1000,
+    delay: Second.ms,
   },
 });
 
@@ -12,18 +13,18 @@ export const processorEventQueue = createQueue("processorEvents", {
   attempts: 5,
   backoff: {
     type: "exponential",
-    delay: 10 * 1000,
+    delay: 10 * Second.ms,
   },
 });
 
 export const websocketQueue = createQueue("websockets", {
-  timeout: 10 * 1000,
+  timeout: 10 * Second.ms,
 });
 
 export const taskQueue = createQueue("tasks", {
   attempts: 5,
   backoff: {
     type: "exponential",
-    delay: 10 * 1000,
+    delay: 10 * Second.ms,
   },
 });


### PR DESCRIPTION
It's just a smol change of using the utils from `@shared/utils/time` instead of providing milliseconds directly.