### PR TITLE
fix: del action at list end

### DIFF
--- a/shared/editor/commands/mergeForward.ts
+++ b/shared/editor/commands/mergeForward.ts
@@ -1,0 +1,26 @@
+import { Command } from "prosemirror-state";
+import { joinPoint } from "prosemirror-transform";
+
+/**
+ * A prosemirror command that joins the current list item with the next one
+ *
+ * @returns A prosemirror command.
+ */
+export default function mergeForward(): Command {
+  return (state, dispatch) => {
+    const { $from } = state.selection;
+    const point = joinPoint(state.doc, $from.pos, 1);
+
+    if (point === null || point === undefined) {
+      return false;
+    }
+
+    const tr = state.tr.join(point, 2);
+
+    if (dispatch) {
+      dispatch(tr);
+    }
+
+    return true;
+  };
+}


### PR DESCRIPTION
This PR fixes an issue where pressing the DEL key (fn + delete on MacBook) at the end of a list would create a new list item instead of deleting the character in front of the cursor (the expected behavior).

The fix works by manually controlling how the editor handles this key press when it occurs at the end of a list.

fixes #9488 