### PR TITLE
feat: Ordered alphabetical lists

### DIFF
--- a/app/editor/menus/formatting.tsx
+++ b/app/editor/menus/formatting.tsx
@@ -185,7 +185,7 @@ export default function formattingMenuItems(
       visible: !isCodeBlock && (!isMobile || isEmpty),
     },
     {
-      name: "ordered_list",
+      name: "toggleOrderedList",
       tooltip: dictionary.orderedList,
       shortcut: `⇧+Ctrl+9`,
       icon: <OrderedListIcon />,

--- a/app/editor/menus/formatting.tsx
+++ b/app/editor/menus/formatting.tsx
@@ -185,7 +185,7 @@ export default function formattingMenuItems(
       visible: !isCodeBlock && (!isMobile || isEmpty),
     },
     {
-      name: "toggleOrderedList",
+      name: "ordered_list",
       tooltip: dictionary.orderedList,
       shortcut: `⇧+Ctrl+9`,
       icon: <OrderedListIcon />,

--- a/shared/editor/commands/toggleList.ts
+++ b/shared/editor/commands/toggleList.ts
@@ -29,7 +29,10 @@ export default function toggleList(
       const currentStyle = parentList.node.attrs.listStyle;
       const differentListStyle = currentStyle && currentStyle !== listStyle;
 
-      if (parentList.node.type === listType && !differentListStyle) {
+      if (
+        parentList.node.type === listType &&
+        (!differentListStyle || !listStyle)
+      ) {
         return liftListItem(itemType)(state, dispatch);
       }
 

--- a/shared/editor/commands/toggleList.ts
+++ b/shared/editor/commands/toggleList.ts
@@ -8,7 +8,8 @@ import clearNodes from "./clearNodes";
 
 export default function toggleList(
   listType: NodeType,
-  itemType: NodeType
+  itemType: NodeType,
+  listStyle?: string
 ): Command {
   return (state, dispatch) => {
     const { schema, selection } = state;
@@ -25,36 +26,46 @@ export default function toggleList(
     );
 
     if (range.depth >= 1 && parentList && range.depth - parentList.depth <= 1) {
-      if (parentList.node.type === listType) {
+      const currentStyle = parentList.node.attrs.listStyle;
+      const differentListStyle = currentStyle && currentStyle !== listStyle;
+
+      if (parentList.node.type === listType && !differentListStyle) {
         return liftListItem(itemType)(state, dispatch);
       }
 
       const currentItemType = parentList.node.content.firstChild?.type;
-      if (currentItemType && currentItemType !== itemType) {
-        return chainTransactions(clearNodes(), wrapInList(listType))(
-          state,
-          dispatch
-        );
+      const differentType = currentItemType && currentItemType !== itemType;
+
+      if (differentType || differentListStyle) {
+        return chainTransactions(
+          clearNodes(),
+          wrapInList(listType, { listStyle })
+        )(state, dispatch);
       }
 
       if (
         isList(parentList.node, schema) &&
         listType.validContent(parentList.node.content)
       ) {
-        tr.setNodeMarkup(parentList.pos, listType);
+        tr.setNodeMarkup(
+          parentList.pos,
+          listType,
+          listStyle ? { listStyle } : {}
+        );
 
         dispatch?.(tr);
         return false;
       }
     }
 
-    const canWrapInList = wrapInList(listType)(state);
+    const attrs = listStyle ? { listStyle } : undefined;
+    const canWrapInList = wrapInList(listType, attrs)(state);
 
     if (canWrapInList) {
-      return wrapInList(listType)(state, dispatch);
+      return wrapInList(listType, attrs)(state, dispatch);
     }
 
-    return chainTransactions(clearNodes(), wrapInList(listType))(
+    return chainTransactions(clearNodes(), wrapInList(listType, attrs))(
       state,
       dispatch
     );

--- a/shared/editor/nodes/OrderedList.ts
+++ b/shared/editor/nodes/OrderedList.ts
@@ -121,24 +121,30 @@ export default class OrderedList extends Node {
     state.write("\n");
 
     const start = node.attrs.order !== undefined ? node.attrs.order : 1;
+    const upperOrLowerAlpha =
+      node.attrs.listStyle === "lower-alpha" ||
+      node.attrs.listStyle === "upper-alpha";
 
-    if (node.attrs.listStyle && node.attrs.listStyle === "lower-alpha") {
+    if (upperOrLowerAlpha) {
       const space = state.repeat(" ", 4);
 
       state.renderList(node, space, (index: number) => {
-        const letterIndex = ((start + index - 1) % 26) + 1;
-        const charCode = 96 + letterIndex;
-        const letter = String.fromCharCode(charCode);
-        return `${letter}. `;
-      });
-    } else if (node.attrs.listStyle && node.attrs.listStyle === "upper-alpha") {
-      const space = state.repeat(" ", 4);
+        const alphabetSize = 26;
+        const position = start + index;
+        const asciiStart = node.attrs.listStyle === "lower-alpha" ? 97 : 65;
 
-      state.renderList(node, space, (index: number) => {
-        const letterIndex = ((start + index - 1) % 26) + 1;
-        const charCode = 64 + letterIndex;
-        const letter = String.fromCharCode(charCode);
-        return `${letter}. `;
+        let result = "";
+        // wraps around the alphabet size, so that 0 -> a, 26 -> a
+        let letterIndex = position;
+        while (letterIndex >= 0) {
+          // determine how much overflow we have at the end
+          const overFlow = letterIndex % alphabetSize;
+          letterIndex = Math.floor(letterIndex / alphabetSize) - 1;
+
+          result = String.fromCharCode(asciiStart + overFlow) + result;
+        }
+
+        return result + ". ";
       });
     } else {
       const maxW = `${start + node.childCount - 1}`.length;

--- a/shared/editor/nodes/OrderedList.ts
+++ b/shared/editor/nodes/OrderedList.ts
@@ -134,16 +134,15 @@ export default class OrderedList extends Node {
         const position = start + index;
         const asciiStart = node.attrs.listStyle === "lower-alpha" ? 97 : 65;
 
+        let n = position - 1;
         let result = "";
-        // wraps around the alphabet size, so that 0 -> a, 26 -> a
-        let letterIndex = position;
-        while (letterIndex >= 0) {
-          // determine how much overflow we have at the end
-          const overFlow = letterIndex % alphabetSize;
-          letterIndex = Math.floor(letterIndex / alphabetSize) - 1;
 
-          result = String.fromCharCode(asciiStart + overFlow) + result;
-        }
+        do {
+          const charCode = asciiStart + (n % alphabetSize);
+          result = String.fromCharCode(charCode) + result;
+
+          n = Math.floor(n / alphabetSize) - 1;
+        } while (n >= 0);
 
         return result + ". ";
       });

--- a/shared/editor/nodes/OrderedList.ts
+++ b/shared/editor/nodes/OrderedList.ts
@@ -71,8 +71,8 @@ export default class OrderedList extends Node {
   keys({ type, schema }: { type: NodeType; schema: Schema }) {
     return {
       "Shift-Ctrl-9": toggleList(type, schema.nodes.list_item),
-      "Alt-Shift-L": this.commands({ type, schema }).toggleLowerLetterList(),
-      "Alt-Shift-U": this.commands({ type, schema }).toggleUpperLetterList(),
+      "Shift-Ctrl-8": this.commands({ type, schema }).toggleUpperLetterList(),
+      "Shift-Ctrl-7": this.commands({ type, schema }).toggleLowerLetterList(),
     };
   }
 

--- a/shared/editor/nodes/OrderedList.ts
+++ b/shared/editor/nodes/OrderedList.ts
@@ -126,7 +126,8 @@ export default class OrderedList extends Node {
       const space = state.repeat(" ", 4);
 
       state.renderList(node, space, (index: number) => {
-        const charCode = 96 + start + index;
+        const letterIndex = ((start + index - 1) % 26) + 1;
+        const charCode = 96 + letterIndex;
         const letter = String.fromCharCode(charCode);
         return `${letter}. `;
       });
@@ -134,7 +135,8 @@ export default class OrderedList extends Node {
       const space = state.repeat(" ", 4);
 
       state.renderList(node, space, (index: number) => {
-        const charCode = 64 + start + index;
+        const letterIndex = ((start + index - 1) % 26) + 1;
+        const charCode = 64 + letterIndex;
         const letter = String.fromCharCode(charCode);
         return `${letter}. `;
       });

--- a/shared/editor/nodes/OrderedList.ts
+++ b/shared/editor/nodes/OrderedList.ts
@@ -71,8 +71,8 @@ export default class OrderedList extends Node {
   keys({ type, schema }: { type: NodeType; schema: Schema }) {
     return {
       "Shift-Ctrl-9": toggleList(type, schema.nodes.list_item),
-      "Shift-Ctrl-8": this.commands({ type, schema }).toggleUpperLetterList(),
-      "Shift-Ctrl-7": this.commands({ type, schema }).toggleLowerLetterList(),
+      "Shift-Ctrl-5": this.commands({ type, schema }).toggleUpperLetterList(),
+      "Shift-Ctrl-6": this.commands({ type, schema }).toggleLowerLetterList(),
     };
   }
 

--- a/shared/editor/nodes/OrderedList.ts
+++ b/shared/editor/nodes/OrderedList.ts
@@ -9,6 +9,7 @@ import {
 import toggleList from "../commands/toggleList";
 import { MarkdownSerializerState } from "../lib/markdown/serializer";
 import Node from "./Node";
+import { EditorState, Transaction } from "prosemirror-state";
 
 export default class OrderedList extends Node {
   get name() {
@@ -22,6 +23,10 @@ export default class OrderedList extends Node {
           default: 1,
           validate: "number",
         },
+        listStyle: {
+          default: "number",
+          validate: "string",
+        },
       },
       content: "list_item+",
       group: "block list",
@@ -32,23 +37,80 @@ export default class OrderedList extends Node {
             order: dom.hasAttribute("start")
               ? parseInt(dom.getAttribute("start") || "1", 10)
               : 1,
+            listStyle: getValidListStyle(dom.style.listStyleType),
           }),
         },
       ],
-      toDOM: (node) =>
-        node.attrs.order === 1
-          ? ["ol", 0]
-          : ["ol", { start: node.attrs.order }, 0],
+      toDOM: (node) => {
+        const attrs: { start?: number; style?: string } = {};
+
+        if (node.attrs.order !== 1) {
+          attrs.start = node.attrs.order;
+        }
+
+        if (node.attrs.listStyle !== "number") {
+          attrs.style = `list-style-type: ${node.attrs.listStyle}`;
+        }
+
+        return ["ol", attrs, 0];
+      },
     };
   }
 
   commands({ type, schema }: { type: NodeType; schema: Schema }) {
-    return () => toggleList(type, schema.nodes.list_item);
+    return {
+      toggleOrderedList: () => toggleList(type, schema.nodes.list_item),
+
+      toggleLowerLetterList:
+        () => (state: EditorState, dispatch?: (tr: Transaction) => void) =>
+          this._toggleListStyle(state, type, schema, "lower-alpha", dispatch),
+
+      toggleUpperLetterList:
+        () => (state: EditorState, dispatch?: (tr: Transaction) => void) =>
+          this._toggleListStyle(state, type, schema, "upper-alpha", dispatch),
+    };
+  }
+
+  _toggleListStyle(
+    state: EditorState,
+    type: NodeType,
+    schema: Schema,
+    listStyle: string,
+    dispatch?: (tr: Transaction) => void
+  ) {
+    const result = toggleList(type, schema.nodes.list_item)(state, dispatch);
+    if (!result) {return false;}
+
+    if (dispatch) {
+      const { $from } = state.selection;
+      let depth = $from.depth;
+
+      while (depth > 0 && $from.node(depth).type !== type) {
+        depth--;
+      }
+
+      if (depth > 0) {
+        const listPos = $from.before(depth);
+        const node = state.doc.nodeAt(listPos);
+
+        if (node && node.type === type) {
+          const tr = state.tr.setNodeMarkup(listPos, null, {
+            ...node.attrs,
+            listStyle,
+          });
+          dispatch(tr);
+        }
+      }
+    }
+
+    return true;
   }
 
   keys({ type, schema }: { type: NodeType; schema: Schema }) {
     return {
       "Shift-Ctrl-9": toggleList(type, schema.nodes.list_item),
+      "Alt-Shift-L": this.commands({ type, schema }).toggleLowerLetterList(),
+      "Alt-Shift-U": this.commands({ type, schema }).toggleUpperLetterList(),
     };
   }
 
@@ -57,8 +119,38 @@ export default class OrderedList extends Node {
       wrappingInputRule(
         /^(\d+)\.\s$/,
         type,
-        (match) => ({ order: +match[1] }),
+        (match) => ({ order: +match[1], listStyle: "number" }),
         (match, node) => node.childCount + node.attrs.order === +match[1]
+      ),
+
+      wrappingInputRule(
+        /^([a-z])\.\s$/,
+        type,
+        (match) => ({
+          order: match[1].charCodeAt(0) - 96,
+          listStyle: "lower-alpha",
+        }),
+        (match, node) => {
+          const expectedChar = String.fromCharCode(
+            96 + node.childCount + node.attrs.order
+          );
+          return expectedChar === match[1];
+        }
+      ),
+
+      wrappingInputRule(
+        /^([A-Z])\.\s$/,
+        type,
+        (match) => ({
+          order: match[1].charCodeAt(0) - 64,
+          listStyle: "upper-alpha",
+        }),
+        (match, node) => {
+          const expectedChar = String.fromCharCode(
+            64 + node.childCount + node.attrs.order
+          );
+          return expectedChar === match[1];
+        }
       ),
     ];
   }
@@ -67,21 +159,60 @@ export default class OrderedList extends Node {
     state.write("\n");
 
     const start = node.attrs.order !== undefined ? node.attrs.order : 1;
-    const maxW = `${start + node.childCount - 1}`.length;
-    const space = state.repeat(" ", maxW + 2);
 
-    state.renderList(node, space, (index: number) => {
-      const nStr = `${start + index}`;
-      return state.repeat(" ", maxW - nStr.length) + nStr + ". ";
-    });
+    if (node.attrs.listStyle && node.attrs.listStyle === "lower-alpha") {
+      const space = state.repeat(" ", 4);
+
+      state.renderList(node, space, (index: number) => {
+        const charCode = 96 + start + index;
+        const letter = String.fromCharCode(charCode);
+        return `${letter}. `;
+      });
+    } else if (node.attrs.listStyle && node.attrs.listStyle === "upper-alpha") {
+      const space = state.repeat(" ", 4);
+
+      state.renderList(node, space, (index: number) => {
+        const charCode = 64 + start + index;
+        const letter = String.fromCharCode(charCode);
+        return `${letter}. `;
+      });
+    } else {
+      const maxW = `${start + node.childCount - 1}`.length;
+      const space = state.repeat(" ", maxW + 2);
+
+      state.renderList(node, space, (index: number) => {
+        const nStr = `${start + index}`;
+        return state.repeat(" ", maxW - nStr.length) + nStr + ". ";
+      });
+    }
   }
 
   parseMarkdown() {
     return {
       block: "ordered_list",
-      getAttrs: (tok: Token) => ({
-        order: parseInt(tok.attrGet("start") || "1", 10),
-      }),
+      getAttrs: (tok: Token) => {
+        const start = tok.attrGet("start") || "1";
+
+        let listStyle = "number";
+        if (tok.markup && /^[a-z]/.test(tok.markup)) {
+          listStyle = "lower-alpha";
+        } else if (tok.markup && /^[A-Z]/.test(tok.markup)) {
+          listStyle = "upper-alpha";
+        }
+
+        return {
+          order: parseInt(start, 10),
+          listStyle,
+        };
+      },
     };
   }
 }
+
+const getValidListStyle = (listStyle: string) => {
+  if (listStyle === "lower-alpha" || listStyle === "upper-alpha") {
+    return listStyle;
+  }
+
+  return "number";
+};

--- a/shared/editor/nodes/OrderedList.ts
+++ b/shared/editor/nodes/OrderedList.ts
@@ -59,7 +59,7 @@ export default class OrderedList extends Node {
 
   commands({ type, schema }: { type: NodeType; schema: Schema }) {
     return {
-      toggleOrderedList: () => toggleList(type, schema.nodes.list_item),
+      ordered_list: () => toggleList(type, schema.nodes.list_item),
 
       toggleLowerLetterList: () =>
         toggleList(type, schema.nodes.list_item, "lower-alpha"),

--- a/shared/editor/nodes/OrderedList.ts
+++ b/shared/editor/nodes/OrderedList.ts
@@ -24,7 +24,8 @@ export default class OrderedList extends Node {
         },
         listStyle: {
           default: "number",
-          validate: "string",
+          validate: (style: string) =>
+            ["number", "lower-alpha", "upper-alpha"].includes(style),
         },
       },
       content: "list_item+",


### PR DESCRIPTION
This PR adds lettered lists to the editor. This means users can now use uppercase, or lowercase letters for their ordered lists instead of just numbers.

## Video Demo

https://github.com/user-attachments/assets/2412e465-fffd-4ce7-87ee-f99de38e5a01

fixes #9489 