### PR TITLE
fix: Middle click read-only doc link in FF opens duplicate tabs

### DIFF
--- a/app/hooks/useEditorClickHandlers.ts
+++ b/app/hooks/useEditorClickHandlers.ts
@@ -5,6 +5,7 @@ import { isDocumentUrl, isInternalUrl } from "@shared/utils/urls";
 import { sharedModelPath } from "~/utils/routeHelpers";
 import { isHash } from "~/utils/urls";
 import useStores from "./useStores";
+import { isFirefox } from "@shared/utils/browser";
 
 type Params = {
   /** The share ID of the document being viewed, if any */
@@ -78,6 +79,12 @@ export default function useEditorClickHandlers({ shareId }: Params) {
           window.open(navigateTo, "_blank");
         }
       } else {
+        // Middle-click events in Firefox are not prevented in the same way as other browsers
+        // so we need to explicitly return here to prevent two tabs from being opened when
+        // middle-clicking a link (#10083).
+        if (event?.button === 1 && isFirefox()) {
+          return;
+        }
         window.open(href, "_blank");
       }
     },

--- a/shared/editor/marks/Link.tsx
+++ b/shared/editor/marks/Link.tsx
@@ -230,7 +230,7 @@ export default class Link extends Mark {
           click: (_view: EditorView, event: MouseEvent) => {
             if (
               !(event.target instanceof HTMLAnchorElement) ||
-              event.button !== 0
+              (event.button !== 0 && event.button !== 1)
             ) {
               return false;
             }

--- a/shared/utils/browser.ts
+++ b/shared/utils/browser.ts
@@ -91,6 +91,13 @@ export function isSafari(): boolean {
   );
 }
 
+export function isFirefox(): boolean {
+  if (!isBrowser) {
+    return false;
+  }
+  return window.navigator.userAgent.includes("Firefox");
+}
+
 let supportsPassive = false;
 
 try {


### PR DESCRIPTION
closes #10083