### PR TITLE
fix: Scope incorrectly translated on API key creation

### DIFF
--- a/server/routes/api/apiKeys/apiKeys.test.ts
+++ b/server/routes/api/apiKeys/apiKeys.test.ts
@@ -47,7 +47,13 @@ describe("#apiKeys.create", () => {
       body: {
         token: user.getJwtToken(),
         name: "My API Key",
-        scope: ["/api/documents.list", "*.info", "users.*"],
+        scope: [
+          "/api/documents.list",
+          "/revisions.list",
+          "*.info",
+          "users.*",
+          "collections:read",
+        ],
       },
     });
     const body = await res.json();
@@ -56,8 +62,10 @@ describe("#apiKeys.create", () => {
     expect(body.data.name).toEqual("My API Key");
     expect(body.data.scope).toEqual([
       "/api/documents.list",
+      "/api/revisions.list",
       "/api/*.info",
       "/api/users.*",
+      "collections:read",
     ]);
   });
 

--- a/server/routes/api/apiKeys/apiKeys.ts
+++ b/server/routes/api/apiKeys/apiKeys.ts
@@ -31,7 +31,11 @@ router.post(
       name,
       userId: user.id,
       expiresAt,
-      scope: scope?.map((s) => (s.startsWith("/api/") ? s : `/api/${s}`)),
+      scope: scope?.map((s) =>
+        s.startsWith("/api/") || s.includes(":")
+          ? s
+          : `/api/${s.replace(/^\//, "")}`
+      ),
     });
 
     apiKey.user = user;


### PR DESCRIPTION
closes #10130