### PR TITLE
Unset animation upon its completion

### DIFF
--- a/app/components/Lightbox.tsx
+++ b/app/components/Lightbox.tsx
@@ -442,6 +442,8 @@ function Lightbox({ onUpdate, activePos }: Props) {
     if (animation.current?.fadeIn) {
       animation.current = {
         ...(animation.current ?? {}),
+        zoomIn: undefined,
+        fadeIn: undefined,
         startTime: undefined,
       };
       setStatus({


### PR DESCRIPTION
The next/prev image animates when navigating away from "Error loading image" component 👇 

https://github.com/user-attachments/assets/58ed2beb-73f5-44bc-a035-fe46b5052f14

