### PR TITLE
Fix: Deleted image zooms out to `(0, 0)` upon closing Lightbox

### DIFF
--- a/app/components/Lightbox.tsx
+++ b/app/components/Lightbox.tsx
@@ -291,7 +291,7 @@ function Lightbox({ onUpdate, activePos }: Props) {
       // in editor
       const editorImageEl = imageElements[currentImageIndex];
       let to;
-      if (editorImageEl && editorImageEl.isConnected) {
+      if (editorImageEl?.isConnected) {
         const editorImgDOMRect = editorImageEl.getBoundingClientRect();
         const {
           top: editorImgTop,

--- a/app/components/Lightbox.tsx
+++ b/app/components/Lightbox.tsx
@@ -291,7 +291,7 @@ function Lightbox({ onUpdate, activePos }: Props) {
       // in editor
       const editorImageEl = imageElements[currentImageIndex];
       let to;
-      if (editorImageEl) {
+      if (editorImageEl && editorImageEl.isConnected) {
         const editorImgDOMRect = editorImageEl.getBoundingClientRect();
         const {
           top: editorImgTop,


### PR DESCRIPTION
When the active image in Lightbox is deleted in editor, it zooms out to `(0, 0)` coords upon closing Lightbox.