### PR TITLE
fix: Inline math formatting should trigger on last $ only

### DIFF
--- a/shared/editor/rules/math.ts
+++ b/shared/editor/rules/math.ts
@@ -1,6 +1,6 @@
 import MarkdownIt, { StateBlock, StateInline } from "markdown-it";
 
-export const REGEX_INLINE_MATH_DOLLARS = /\$\$(.+)\$\$/;
+export const REGEX_INLINE_MATH_DOLLARS = /\$\$(.+)\$\$$/;
 
 export const REGEX_BLOCK_MATH_DOLLARS = /\$\$\$\s+$/;
 


### PR DESCRIPTION
PM rules should always end with an anchor