### PR TITLE
fix: table printing issues with clipping and pagination

### DIFF
--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -1958,6 +1958,61 @@ del[data-operation-index] {
   blockquote {
     font-family: "SF Pro Text", ${props.theme.fontFamily};
   }
+
+  /* Table print styles */
+  .${EditorStyleHelper.table} {
+    page-break-before: auto;
+    page-break-after: auto;
+    break-before: auto;
+    break-after: auto;
+  }
+
+  .${EditorStyleHelper.tableScrollable} {
+    overflow-x: visible !important;
+    overflow-y: visible !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    max-width: 100% !important;
+  }
+
+  .${EditorStyleHelper.tableShadowLeft}::before,
+  .${EditorStyleHelper.tableShadowRight}::after,
+  .${EditorStyleHelper.tableGrip},
+  .${EditorStyleHelper.tableGripRow},
+  .${EditorStyleHelper.tableGripColumn},
+  .${EditorStyleHelper.tableAddRow},
+  .${EditorStyleHelper.tableAddColumn} {
+    display: none !important;
+  }
+
+  table {
+    width: 100% !important;
+    max-width: 100% !important;
+    table-layout: auto !important;
+    border-collapse: collapse !important;
+  }
+
+  table thead {
+    display: table-header-group;
+  }
+
+  table tbody {
+    display: table-row-group;
+  }
+
+  table tr {
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+
+  table td,
+  table th {
+    overflow: visible !important;
+    word-wrap: break-word;
+    word-break: break-word;
+    hyphens: auto;
+    padding: 4px 8px !important;
+  }
 }
 `;
 


### PR DESCRIPTION
fixes: #10171


**Issues Fixed:**
- Tables now properly scale to page width instead of being clipped
- Removed horizontal scrolling behavior in print media
- Hidden interactive table elements (grips, shadows, controls) from print view
- Fixed page break handling to allow multi-page printing of long tables and content
- Improved text wrapping in table cells for better print layout

**Changes:**
- Added comprehensive print media CSS rules for tables in `Styles.ts`
- Ensured tables use full page width with `table-layout: auto`
- Proper page break management for table rows
- Enhanced cell content overflow handling