### PR TITLE
fix: Enter in empty heading after collapsed heading

### DIFF
--- a/shared/editor/commands/splitHeading.ts
+++ b/shared/editor/commands/splitHeading.ts
@@ -23,8 +23,9 @@ export default function splitHeading(type: NodeType): Command {
       const previousBlockIsCollapsed = !!collapsedNodes.find(
         (a) => a.pos === previousBlock?.pos
       );
+      const isEmpty = $from.parent.content.size === 0;
 
-      if (previousBlockIsCollapsed) {
+      if (previousBlockIsCollapsed && !isEmpty) {
         // Insert a new heading directly before this one
         const transaction = state.tr.insert(
           $from.before(),


### PR DESCRIPTION
closes #10193