### PR TITLE
Small improvements to the Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,13 @@ ARG APP_PATH
 WORKDIR $APP_PATH
 ENV NODE_ENV=production
 
-COPY --from=base $APP_PATH/build ./build
+# Create a non-root user compatible with Debian and BusyBox based images
+RUN addgroup --gid 1001 nodejs && \
+  adduser --uid 1001 --ingroup nodejs nodejs && \
+  mkdir -p /var/lib/outline && \
+  chown -R nodejs:nodejs /var/lib/outline
+
+COPY --from=base --chown=nodejs:nodejs $APP_PATH/build ./build
 COPY --from=base $APP_PATH/server ./server
 COPY --from=base $APP_PATH/public ./public
 COPY --from=base $APP_PATH/.sequelizerc ./.sequelizerc
@@ -25,13 +31,6 @@ COPY --from=base $APP_PATH/package.json ./package.json
 RUN  apt-get update \
   && apt-get install -y wget \
   && rm -rf /var/lib/apt/lists/*
-
-# Create a non-root user compatible with Debian and BusyBox based images
-RUN addgroup --gid 1001 nodejs && \
-  adduser --uid 1001 --ingroup nodejs nodejs && \
-  chown -R nodejs:nodejs $APP_PATH/build && \
-  mkdir -p /var/lib/outline && \
-  chown -R nodejs:nodejs /var/lib/outline
 
 ENV FILE_STORAGE_LOCAL_ROOT_DIR=/var/lib/outline/data
 RUN mkdir -p "$FILE_STORAGE_LOCAL_ROOT_DIR" && \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,5 +1,5 @@
 ARG APP_PATH=/opt/outline
-FROM node:20 AS deps
+FROM node:22 AS deps
 
 ARG APP_PATH
 WORKDIR $APP_PATH


### PR DESCRIPTION
- Use same Node.js version in build and runner image
- Reduce size of the image by applying the chown directly in the COPY