### PR TITLE
fix: cap height of popovers

### DIFF
--- a/app/components/primitives/Popover.tsx
+++ b/app/components/primitives/Popover.tsx
@@ -90,7 +90,7 @@ type StyledContentProps = {
 
 const StyledContent = styled(PopoverPrimitive.Content)<StyledContentProps>`
   z-index: ${depths.modal};
-  max-height: var(--radix-popover-content-available-height);
+  max-height: min(85vh, var(--radix-popover-content-available-height));
   transform-origin: var(--radix-popover-content-transform-origin);
 
   background: ${s("menuBackground")};


### PR DESCRIPTION
Notifications popover takes the full height of screen which makes for poor UX