### PR TITLE
fix: Recognise authentication_required for some OIDC providers

### DIFF
--- a/server/utils/oauth.test.ts
+++ b/server/utils/oauth.test.ts
@@ -1,0 +1,31 @@
+import fetchMock from "jest-fetch-mock";
+import OAuthClient from "./oauth";
+
+class MinimalOAuthClient extends OAuthClient {
+  endpoints = {
+    authorize: 'http://example.com/authorize',
+    token: 'http://example.com/token',
+    userinfo: 'http://example.com/userinfo',
+  };
+}
+
+beforeEach(() => {
+  fetchMock.resetMocks();
+});
+
+describe("userInfo", () => {
+  it("should work with empty-body 401 Unauthorized responses", async () => {
+    fetchMock.mockResponseOnce('', {
+      status: 401,
+      statusText: 'unauthorized',
+    });
+
+    const client = new MinimalOAuthClient('clientid', 'clientsecret');
+    try {
+      expect.assertions(1);
+      await client.userInfo('token');
+    } catch (e) {
+      expect(e.id).toBe('authentication_required');
+    }
+  });
+});

--- a/server/utils/oauth.ts
+++ b/server/utils/oauth.ts
@@ -30,7 +30,6 @@ export default abstract class OAuthClient {
           "Content-Type": "application/json",
         },
       });
-      data = await response.json();
     } catch (err) {
       throw InvalidRequestError(err.message);
     }
@@ -38,6 +37,12 @@ export default abstract class OAuthClient {
     const success = response.status >= 200 && response.status < 300;
     if (!success) {
       throw AuthenticationError();
+    }
+
+    try {
+      data = await response.json();
+    } catch (err) {
+      throw InvalidRequestError(err.message);
     }
 
     return data;


### PR DESCRIPTION
Some OIDC providers return 401 Unauthorized errors with an empty body when the access token has expired.

Avoid trying to parse the body as JSON before we've checked whether the status code is OK.

Fixes #10251.