### PR TITLE
Fix print layout in Firefox

### DIFF
--- a/server/static/index.html
+++ b/server/static/index.html
@@ -62,6 +62,12 @@
         height: 100%;
       }
 
+      @media print {
+        body {
+          display: block;
+        }
+      }
+
       #root {
         flex: 1;
         min-height: 100%;


### PR DESCRIPTION
Add print media query to display body as block, as explained in #10223

Fixes #10223
