### PR TITLE
enhancement: return group total

### DIFF
--- a/server/routes/api/groups/groups.test.ts
+++ b/server/routes/api/groups/groups.test.ts
@@ -360,6 +360,23 @@ describe("#groups.list", () => {
     expect(body.data.groups.length).toEqual(1);
     expect(body.data.groups[0].id).toEqual(group.id);
   });
+
+  it.only("should return correct group total even when the limit is less than the total", async () => {
+    const user = await buildUser();
+    await buildGroup({ teamId: user.teamId });
+    await buildGroup({ teamId: user.teamId });
+
+    const res = await server.post("/api/groups.list", {
+      body: {
+        limit: 1,
+        token: user.getJwtToken(),
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.pagination.total).toEqual(2);
+    expect(body.data.groups.length).toEqual(1);
+  });
 });
 
 describe("#groups.info", () => {

--- a/server/routes/api/groups/groups.test.ts
+++ b/server/routes/api/groups/groups.test.ts
@@ -209,6 +209,7 @@ describe("#groups.list", () => {
     });
     const body = await res.json();
     expect(res.status).toEqual(200);
+    expect(body.pagination.total).toEqual(1);
     expect(body.data.groups.length).toEqual(1);
     expect(body.data.groups[0].id).toEqual(group.id);
     expect(body.data.groupMemberships.length).toEqual(1);
@@ -245,6 +246,7 @@ describe("#groups.list", () => {
     const body = await res.json();
     expect(res.status).toEqual(200);
     expect(body.data.groups.length).toEqual(1);
+    expect(body.pagination.total).toEqual(1);
     expect(body.data.groups[0].id).toEqual(group.id);
     expect(body.data.groupMemberships.length).toEqual(1);
     expect(body.data.groupMemberships[0].groupId).toEqual(group.id);
@@ -282,6 +284,7 @@ describe("#groups.list", () => {
     const body = await res.json();
 
     expect(res.status).toEqual(200);
+    expect(body.pagination.total).toEqual(2);
     expect(body.data.groups.length).toEqual(2);
     expect(body.data.groups[0].id).toEqual(anotherGroup.id);
     expect(body.data.groups[1].id).toEqual(group.id);
@@ -306,6 +309,7 @@ describe("#groups.list", () => {
     });
     const anotherBody = await anotherRes.json();
     expect(anotherRes.status).toEqual(200);
+    expect(anotherBody.pagination.total).toEqual(1);
     expect(anotherBody.data.groups.length).toEqual(1);
     expect(anotherBody.data.groups[0].id).toEqual(group.id);
     expect(anotherBody.data.groupMemberships.length).toEqual(2);
@@ -334,6 +338,7 @@ describe("#groups.list", () => {
     });
     const body = await res.json();
     expect(res.status).toEqual(200);
+    expect(body.pagination.total).toEqual(1);
     expect(body.data.groups.length).toEqual(1);
     expect(body.data.groups[0].id).toEqual(group.id);
   });
@@ -351,6 +356,7 @@ describe("#groups.list", () => {
     });
     const body = await res.json();
     expect(res.status).toEqual(200);
+    expect(body.pagination.total).toEqual(1);
     expect(body.data.groups.length).toEqual(1);
     expect(body.data.groups[0].id).toEqual(group.id);
   });

--- a/server/routes/api/groups/groups.ts
+++ b/server/routes/api/groups/groups.ts
@@ -73,25 +73,30 @@ router.post(
       };
     }
 
-    const groups = await Group.findAll({
-      where,
-      include: [
-        {
-          model: GroupUser,
-          as: "groupUsers",
-          required: false,
-          where: {
-            userId: user.id,
+    const [groups, total] = await Promise.all([
+      Group.findAll({
+        where,
+        include: [
+          {
+            model: GroupUser,
+            as: "groupUsers",
+            required: false,
+            where: {
+              userId: user.id,
+            },
           },
-        },
-      ],
-      order: [[sort, direction]],
-      offset: ctx.state.pagination.offset,
-      limit: ctx.state.pagination.limit,
-    });
+        ],
+        order: [[sort, direction]],
+        offset: ctx.state.pagination.offset,
+        limit: ctx.state.pagination.limit,
+      }),
+      Group.count({
+        where,
+      }),
+    ]);
 
     ctx.body = {
-      pagination: ctx.state.pagination,
+      pagination: { ...ctx.state.pagination, total },
       data: {
         groups: await Promise.all(groups.map(presentGroup)),
         // TODO: Deprecated, will remove in the future as language conflicts with GroupMembership


### PR DESCRIPTION
## Description
This PR aims to allow users get the total number of groups when accessing the groups.list endpoint.
fixes: #10265

## Screenshot
<img width="1512" height="982" alt="Screenshot 2025-09-28 at 23 51 29" src="https://github.com/user-attachments/assets/abdac6bd-e0e9-4597-9709-56c94beef036" />
