### PR TITLE
fix CORS err on img download

### DIFF
--- a/shared/editor/components/Image.tsx
+++ b/shared/editor/components/Image.tsx
@@ -21,10 +21,12 @@ type Props = ComponentProps & {
   /** The editor view */
   view: EditorView;
   children?: React.ReactElement;
+  isDownloading?: boolean;
 };
 
 const Image = (props: Props) => {
-  const { isSelected, node, isEditable, onChangeSize, onClick } = props;
+  const { isSelected, node, isEditable, onChangeSize, onClick, isDownloading } =
+    props;
   const { src, layoutClass } = node.attrs;
   const { t } = useTranslation();
   const className = layoutClass ? `image image-${layoutClass}` : "image";
@@ -102,7 +104,11 @@ const Image = (props: Props) => {
                 <GlobeIcon />
               </Button>
             )}
-            <Button onClick={props.onDownload} aria-label={t("Download")}>
+            <Button
+              onClick={props.onDownload}
+              aria-label={t("Download")}
+              disabled={isDownloading}
+            >
               <DownloadIcon />
             </Button>
           </Actions>
@@ -224,7 +230,7 @@ const Button = styled.button`
   width: 24px;
   height: 24px;
   display: inline-block;
-  cursor: var(--pointer) !important;
+  cursor: var(--pointer);
   transition: opacity 150ms ease-in-out;
 
   &:first-child:not(:last-child) {
@@ -243,6 +249,20 @@ const Button = styled.button`
 
   &:hover {
     color: ${s("text")};
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: wait;
+    pointer-events: none;
+
+    &:hover {
+      color: ${s("textSecondary")};
+    }
+
+    &:active {
+      transform: none;
+    }
   }
 `;
 

--- a/shared/editor/nodes/Image.tsx
+++ b/shared/editor/nodes/Image.tsx
@@ -335,7 +335,9 @@ export default class Image extends SimpleImage {
         event.preventDefault();
         event.stopPropagation();
 
-        if (isDownloading) {return;}
+        if (isDownloading) {
+          return;
+        }
         setIsDownloading(true);
         await downloadImageNode(props.node);
         setIsDownloading(false);
@@ -346,6 +348,7 @@ export default class Image extends SimpleImage {
     return (
       <ImageComponent
         {...props}
+        isDownloading={isDownloading}
         onClick={this.handleClick(props)}
         onDownload={handleDownload}
         onChangeSize={this.handleChangeSize(props)}


### PR DESCRIPTION
## Description
This PR address the chrome specific issue where downloading an image can lead to a CORS error if the image isn't properly cached.

It does this by catching the error and rerunning the download action with an added instruction to force an update on the image cache.

It also adds a fallback to open the image on a separate tab if the image cannot be downloaded for some reason or another.

fixes: #10261
 
## Video Demo:
Before: 

https://github.com/user-attachments/assets/59f0e545-bf00-48e6-ad5c-d5ee1e40d7e8


After: 

https://github.com/user-attachments/assets/97720566-cd41-4048-bd4d-89633f58f88e

