### PR TITLE
fix: Letter icon not displayed correctly in 'Starred' section

### DIFF
--- a/app/components/Sidebar/hooks/useSidebarLabelAndIcon.tsx
+++ b/app/components/Sidebar/hooks/useSidebarLabelAndIcon.tsx
@@ -22,7 +22,11 @@ export function useSidebarLabelAndIcon(
       return {
         label: document.titleWithDefault,
         icon: document.icon ? (
-          <Icon value={document.icon} color={document.color ?? undefined} />
+          <Icon
+            value={document.icon}
+            initial={document.initial}
+            color={document.color ?? undefined}
+          />
         ) : (
           icon
         ),


### PR DESCRIPTION
Noticed that documents starred with a letter icon show as "?" in the sidebar