### PR TITLE
fix: Overlap of unread badge on long titles in sidebar

### DIFF
--- a/app/components/Sidebar/components/SidebarLink.tsx
+++ b/app/components/Sidebar/components/SidebarLink.tsx
@@ -78,8 +78,16 @@ function SidebarLink(
   const style = React.useMemo(
     () => ({
       paddingLeft: `${(depth || 0) * 16 + 12}px`,
+      paddingRight: unreadBadge ? "32px" : undefined,
     }),
     [depth]
+  );
+
+  const unreadStyle = React.useMemo(
+    () => ({
+      right: -12,
+    }),
+    []
   );
 
   const activeStyle = React.useMemo(
@@ -139,7 +147,7 @@ function SidebarLink(
             )}
             {icon && <IconWrapper>{icon}</IconWrapper>}
             <Label>{label}</Label>
-            {unreadBadge && <UnreadBadge />}
+            {unreadBadge && <UnreadBadge style={unreadStyle} />}
           </Content>
         </Link>
       </ContextMenu>


### PR DESCRIPTION
### Before
<img width="304" height="84" alt="image" src="https://github.com/user-attachments/assets/55da6297-32db-41f9-b535-1a2ef929dd6a" />

### After

<img width="299" height="92" alt="image" src="https://github.com/user-attachments/assets/1757d68c-1c86-4e4d-8652-967cfdda4775" />
