### PR TITLE
fix: Prefer non-deleted teams in teamProvisioner

### DIFF
--- a/server/commands/teamProvisioner.test.ts
+++ b/server/commands/teamProvisioner.test.ts
@@ -93,6 +93,36 @@ describe("teamProvisioner", () => {
       expect(isNewTeam).toEqual(false);
     });
 
+    it("should return non-deleted team if multiple matches", async () => {
+      const subdomain = faker.internet.domainWord();
+      const authenticationProvider = {
+        name: "google",
+        providerId: `${subdomain}.com`,
+      };
+      await buildTeam({
+        subdomain: undefined,
+        deletedAt: new Date(),
+        authenticationProviders: [authenticationProvider],
+      });
+      const notDeleted = await buildTeam({
+        subdomain: undefined,
+        authenticationProviders: [authenticationProvider],
+      });
+      await buildTeam({
+        subdomain: undefined,
+        deletedAt: new Date(),
+        authenticationProviders: [authenticationProvider],
+      });
+      const result = await teamProvisioner(ctx, {
+        name: faker.company.name(),
+        subdomain,
+        authenticationProvider,
+      });
+      const { team, isNewTeam } = result;
+      expect(team.id).toEqual(notDeleted.id);
+      expect(isNewTeam).toEqual(false);
+    });
+
     it("should error on mismatched team and authentication provider", async () => {
       const subdomain = faker.internet.domainWord();
 

--- a/server/commands/teamProvisioner.ts
+++ b/server/commands/teamProvisioner.ts
@@ -57,7 +57,10 @@ async function teamProvisioner(
         paranoid: false,
       },
     ],
-    order: [["enabled", "DESC"]],
+    order: [
+      [Team, "deletedAt", "DESC"],
+      ["enabled", "DESC"],
+    ],
   });
 
   // This authentication provider already exists which means we have a team and

--- a/server/commands/userProvisioner.test.ts
+++ b/server/commands/userProvisioner.test.ts
@@ -186,7 +186,7 @@ describe("userProvisioner", () => {
     expect(isNewUser).toEqual(true);
   });
 
-  it("should prefer isAdmin argument over defaultUserRole", async () => {
+  it("should prefer role argument over defaultUserRole", async () => {
     const team = await buildTeam({
       defaultUserRole: UserRole.Viewer,
     });
@@ -208,7 +208,7 @@ describe("userProvisioner", () => {
     expect(user.role).toEqual(UserRole.Admin);
   });
 
-  it("should prefer defaultUserRole when isAdmin is undefined or false", async () => {
+  it("should prefer defaultUserRole when role is undefined or false", async () => {
     const team = await buildTeam({
       defaultUserRole: UserRole.Viewer,
     });


### PR DESCRIPTION
If logging in from the root domain and the users authentication provider exists in multiple teams, prefer any that are not deleted.