### PR TITLE
fix: Do not update `lastModifiedById` on deleted documents

### DIFF
--- a/server/commands/documentCollaborativeUpdater.ts
+++ b/server/commands/documentCollaborativeUpdater.ts
@@ -44,9 +44,11 @@ export default async function documentCollaborativeUpdater({
     const state = Y.encodeStateAsUpdate(ydoc);
     const content = yDocToProsemirrorJSON(ydoc, "default") as ProsemirrorData;
     const isUnchanged = isEqual(document.content, content);
-    const lastModifiedById =
-      sessionCollaboratorIds[sessionCollaboratorIds.length - 1] ??
-      document.lastModifiedById;
+    const isDeleted = !!document.deletedAt;
+    const lastModifiedById = isDeleted
+      ? document.lastModifiedById
+      : (sessionCollaboratorIds[sessionCollaboratorIds.length - 1] ??
+        document.lastModifiedById);
 
     if (isUnchanged) {
       return;


### PR DESCRIPTION
Going with suppressing the timestamp modification here for now, the history is accurately stored in `revisions` table and this is a somewhat rare race condition.

closes  #10259