### PR TITLE
fix: change list children to match list parent when list style changes

### DIFF
--- a/shared/editor/commands/toggleList.ts
+++ b/shared/editor/commands/toggleList.ts
@@ -39,7 +39,7 @@ export default function toggleList(
       const currentItemType = parentList.node.content.firstChild?.type;
       const differentType = currentItemType && currentItemType !== itemType;
 
-      if (differentType || differentListStyle) {
+      if (differentType) {
         return chainTransactions(
           clearNodes(),
           wrapInList(listType, { listStyle })
@@ -50,10 +50,14 @@ export default function toggleList(
         isList(parentList.node, schema) &&
         listType.validContent(parentList.node.content)
       ) {
-        tr.setNodeMarkup(
+        tr.doc.nodesBetween(
           parentList.pos,
-          listType,
-          listStyle ? { listStyle } : {}
+          parentList.pos + parentList.node.nodeSize,
+          (node, pos) => {
+            if (isList(node, schema)) {
+              tr.setNodeMarkup(pos, listType, listStyle ? { listStyle } : {});
+            }
+          }
         );
 
         dispatch?.(tr);


### PR DESCRIPTION
## Description
This PR aims to fix the issue where changing a list type only applies to the list items at the top level and not the nested lists.

fixes #9382 

## Video Demo
https://github.com/user-attachments/assets/1e2a714d-102a-4559-96ad-2f438b304001

