### PR TITLE
fix: CSRF validation issues on Firefox

### DIFF
--- a/server/services/web.ts
+++ b/server/services/web.ts
@@ -46,7 +46,6 @@ export default function init(app: Koa = new Koa(), server?: Server) {
   }
 
   app.use(compress());
-  app.use(attachCSRFToken());
 
   // Monitor server connections
   if (server) {
@@ -65,6 +64,9 @@ export default function init(app: Koa = new Koa(), server?: Server) {
   });
 
   app.use(mount("/api", api));
+
+  // Generate and attach a CSRF token to the session on non-API requests
+  app.use(attachCSRFToken());
 
   // Apply CSP middleware after API as these responses are rendered in the browser
   app.use(csp());


### PR DESCRIPTION
> Okay, finally cracked this – it seems like it's caused by Firefox's handling of Set-Cookie inside of a 302 response to another domain being incorrect, it gets partially set. S3 storage is key as this is what results in the third-party domain redirect vs same domain for local file storage.

The quick and somewhat correct solution is to not attach a new CSRF on _any_ API requests, moving the middleware after the `/api` routes achieves this.