### PR TITLE
fix: editorVersion property on document should be updated through collaborative session

### DIFF
--- a/server/collaboration/PersistenceExtension.ts
+++ b/server/collaboration/PersistenceExtension.ts
@@ -94,8 +94,10 @@ export default class PersistenceExtension implements Extension {
     context,
     documentName,
     clientsCount,
+    requestParameters,
   }: onStoreDocumentPayload) {
     const [, documentId] = documentName.split(".");
+    const clientVersion = requestParameters.get("editorVersion");
 
     const key = Document.getCollaboratorKey(documentId);
     const sessionCollaboratorIds = await Redis.defaultClient.smembers(key);
@@ -110,6 +112,7 @@ export default class PersistenceExtension implements Extension {
         ydoc: document,
         sessionCollaboratorIds,
         isLastConnection: clientsCount === 0,
+        clientVersion,
       });
     } catch (err) {
       Logger.error("Unable to persist document", err, {

--- a/server/commands/documentCollaborativeUpdater.ts
+++ b/server/commands/documentCollaborativeUpdater.ts
@@ -7,6 +7,7 @@ import Logger from "@server/logging/Logger";
 import { Document, Event } from "@server/models";
 import { sequelize } from "@server/storage/database";
 import { AuthenticationType } from "@server/types";
+import semver from "semver";
 
 type Props = {
   /** The document ID to update. */
@@ -17,6 +18,8 @@ type Props = {
   sessionCollaboratorIds: string[];
   /** Whether the last connection to the document left. */
   isLastConnection: boolean;
+  /** The client version, if available. */
+  clientVersion: string | null;
 };
 
 export default async function documentCollaborativeUpdater({
@@ -24,6 +27,7 @@ export default async function documentCollaborativeUpdater({
   ydoc,
   sessionCollaboratorIds,
   isLastConnection,
+  clientVersion,
 }: Props) {
   return sequelize.transaction(async (transaction) => {
     const document = await Document.unscoped()
@@ -74,6 +78,10 @@ export default async function documentCollaborativeUpdater({
         state: Buffer.from(state),
         lastModifiedById,
         collaboratorIds,
+        editorVersion:
+          clientVersion && semver.gt(clientVersion, document.editorVersion)
+            ? clientVersion
+            : document.editorVersion,
       },
       {
         transaction,


### PR DESCRIPTION
Small fix that `editorVersion` was not updated for changes made through multiplayer collab