### PR TITLE
fix: mobile safari sidebar navigation issue

### DIFF
--- a/app/components/Sidebar/Shared.tsx
+++ b/app/components/Sidebar/Shared.tsx
@@ -2,6 +2,7 @@ import { observer } from "mobx-react";
 import { SidebarIcon } from "outline-icons";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
+import { hover } from "@shared/styles";
 import { metaDisplay } from "@shared/utils/keyboard";
 import Share from "~/models/Share";
 import Flex from "~/components/Flex";
@@ -146,7 +147,7 @@ const StyledSidebar = styled(Sidebar)<{ $hoverTransition: boolean }>`
     $hoverTransition &&
     `
       @media (hover: hover) {
-        &:hover {
+        &:${hover} {
         ${StyledSearchPopover} {
           width: 85%;
         }


### PR DESCRIPTION
I noticed an issue with the sidenav on mobile safari. Can be reproduced in device simulator.
So when you tap on a link in the sidenav, there is no navigation but instead the search field is slightly tightened. You need to double tap everything to have the expected action to happen (redirection to the tapped site or opening the expandable.

Looking into the code, it looks like this happens because of the active state on mobile and safaris weird handling of that. To fix it, I've added a wrapping statement for the hover state to only happen on devices that support hovering - assuming that the sidenav will never need to display the sidenav toggle on touch devices.

See the attached video for a demo of the current state of outline and the suggested fix  (localhost). 

https://github.com/user-attachments/assets/a8809018-39eb-4e38-a58d-116d5a53bdf5

