### PR TITLE
fix: restore comment content on error

### DIFF
--- a/app/scenes/Document/components/CommentForm.tsx
+++ b/app/scenes/Document/components/CommentForm.tsx
@@ -107,6 +107,7 @@ function CommentForm({
     setForceRender((s) => ++s);
     setInputFocused(false);
 
+    const commentDraft = draft;
     const comment =
       thread ??
       new Comment(
@@ -126,6 +127,9 @@ function CommentForm({
       })
       .then(() => onSubmit?.())
       .catch(() => {
+        onSaveDraft(commentDraft);
+        setForceRender((s) => ++s);
+
         comment.isNew = true;
         toast.error(t("Error creating comment"));
       });
@@ -142,6 +146,7 @@ function CommentForm({
       return;
     }
 
+    const commentDraft = draft;
     onSaveDraft(undefined);
     setForceRender((s) => ++s);
 
@@ -163,6 +168,9 @@ function CommentForm({
       .save()
       .then(() => onSubmit?.())
       .catch(() => {
+        onSaveDraft(commentDraft);
+        setForceRender((s) => ++s);
+
         comments.remove(comment.id);
         comment.isNew = true;
         toast.error(t("Error creating comment"));


### PR DESCRIPTION
## Description
This PR restores the content in the comment editor when the upload fails.

fixes: #10308 

## Video Demo

https://github.com/user-attachments/assets/8f66068a-e294-43b8-88c0-90a09614ef45

