### PR TITLE
fix: Issue introduced when `document.editorVersion` is null

### DIFF
--- a/server/commands/documentCollaborativeUpdater.ts
+++ b/server/commands/documentCollaborativeUpdater.ts
@@ -72,16 +72,24 @@ export default async function documentCollaborativeUpdater({
       ...pudIds,
     ]);
 
+    // Either the client or server version could be null, or they could both be
+    // set. In that case we want to use the greater (newer) version.
+    const editorVersion =
+      document.editorVersion && clientVersion
+        ? semver.gt(clientVersion, document.editorVersion)
+          ? clientVersion
+          : document.editorVersion
+        : clientVersion
+          ? clientVersion
+          : document.editorVersion;
+
     await document.update(
       {
         content,
         state: Buffer.from(state),
         lastModifiedById,
         collaboratorIds,
-        editorVersion:
-          clientVersion && semver.gt(clientVersion, document.editorVersion)
-            ? clientVersion
-            : document.editorVersion,
+        editorVersion,
       },
       {
         transaction,

--- a/server/models/Document.ts
+++ b/server/models/Document.ts
@@ -315,7 +315,7 @@ class Document extends ArchivableModel<
     msg: `editorVersion must be 255 characters or less`,
   })
   @Column
-  editorVersion: string;
+  editorVersion: string | null;
 
   /** An icon to use as the document icon. */
   @Length({

--- a/server/models/Revision.ts
+++ b/server/models/Revision.ts
@@ -48,7 +48,7 @@ class Revision extends ParanoidModel<
   })
   @Column
   @SkipChangeset
-  editorVersion: string;
+  editorVersion: string | null;
 
   /** The document title at the time of the revision */
   @Length({


### PR DESCRIPTION
Fixes issue introduced in https://github.com/outline/outline/pull/10325