### PR TITLE
fix: Enable workspace creation from Discord without `DISCORD_SERVER_ID`

### DIFF
--- a/server/commands/accountProvisioner.ts
+++ b/server/commands/accountProvisioner.ts
@@ -94,8 +94,8 @@ async function accountProvisioner(
 
   try {
     result = await teamProvisioner(ctx, {
-      name: "Wiki",
       ...teamParams,
+      name: teamParams.name || "Wiki",
       authenticationProvider: authenticationProviderParams,
     });
   } catch (err) {


### PR DESCRIPTION
ref #8471