### PR TITLE
fix: Change behavior of `SMTP_SECURE=false`

### DIFF
--- a/server/emails/mailer.tsx
+++ b/server/emails/mailer.tsx
@@ -215,13 +215,17 @@ export class Mailer {
       name: env.SMTP_NAME,
       host: env.SMTP_HOST,
       port: env.SMTP_PORT,
+      // If not explicitly configured we default to using TLS in production
       secure: env.SMTP_SECURE ?? env.isProduction,
+      // Allow connections with no authentication if no username is provided
       auth: env.SMTP_USERNAME
         ? {
             user: env.SMTP_USERNAME,
             pass: env.SMTP_PASSWORD,
           }
         : undefined,
+      // Disable STARTTLS entirely when secure is set to false
+      ignoreTLS: !env.SMTP_SECURE,
       tls: env.SMTP_SECURE
         ? env.SMTP_TLS_CIPHERS
           ? {


### PR DESCRIPTION
Currently this setting _defaults_ the SMTP connection to insecure but it will follow the mail servers lead and upgrade to secure if STARTTLS is supported.

This change makes it so that `SMTP_SECURE=false` will always use an insecure connection, increasing server compatibility.