### PR TITLE
feat: Add `includePrivate` param to `export_all` endpoint

### DIFF
--- a/app/components/ExportDialog.tsx
+++ b/app/components/ExportDialog.tsx
@@ -25,6 +25,7 @@ function ExportDialog({ collection, onSubmit }: Props) {
   );
   const [includeAttachments, setIncludeAttachments] =
     React.useState<boolean>(true);
+  const [includePrivate, setIncludePrivate] = React.useState<boolean>(true);
   const user = useCurrentUser();
   const { collections } = useStores();
   const { t } = useTranslation();
@@ -44,6 +45,13 @@ function ExportDialog({ collection, onSubmit }: Props) {
     []
   );
 
+  const handleIncludePrivateChange = React.useCallback(
+    (ev: React.ChangeEvent<HTMLInputElement>) => {
+      setIncludePrivate(ev.target.checked);
+    },
+    []
+  );
+
   const handleSubmit = async () => {
     if (collection) {
       await collection.export(format, includeAttachments);
@@ -59,7 +67,7 @@ function ExportDialog({ collection, onSubmit }: Props) {
         },
       });
     } else {
-      await collections.export(format, includeAttachments);
+      await collections.export({ format, includeAttachments, includePrivate });
       toast.success(t("Export started"));
     }
     onSubmit();
@@ -123,36 +131,61 @@ function ExportDialog({ collection, onSubmit }: Props) {
               <Text as="p" size="small" weight="bold">
                 {item.title}
               </Text>
-              <Text size="small">{item.description}</Text>
+              <Text size="small" type="secondary">
+                {item.description}
+              </Text>
             </div>
           </Option>
         ))}
       </Flex>
-      <hr />
-      <Option>
-        <input
-          type="checkbox"
-          name="includeAttachments"
-          checked={includeAttachments}
-          onChange={handleIncludeAttachmentsChange}
-        />
-        <div>
-          <Text as="p" size="small" weight="bold">
-            {t("Include attachments")}
-          </Text>
-          <Text size="small">
-            {t("Including uploaded images and files in the exported data")}.
-          </Text>{" "}
-        </div>
-      </Option>
+      <HR />
+      <Flex gap={12} column>
+        <Option>
+          <input
+            type="checkbox"
+            name="includeAttachments"
+            checked={includeAttachments}
+            onChange={handleIncludeAttachmentsChange}
+          />
+          <div>
+            <Text as="p" size="small" weight="bold">
+              {t("Include attachments")}
+            </Text>
+            <Text size="small" type="secondary">
+              {t("Including uploaded images and files in the exported data")}.
+            </Text>{" "}
+          </div>
+        </Option>
+        <Option>
+          <input
+            type="checkbox"
+            name="includePrivate"
+            checked={includePrivate}
+            onChange={handleIncludePrivateChange}
+          />
+          <div>
+            <Text as="p" size="small" weight="bold">
+              {t("Include private collections")}
+            </Text>
+          </div>
+        </Option>
+      </Flex>
     </ConfirmationDialog>
   );
 }
 
+const HR = styled.hr`
+  margin: 16px 0;
+`;
+
 const Option = styled.label`
   display: flex;
-  align-items: center;
+  align-items: start;
   gap: 16px;
+
+  input {
+    margin-top: 4px;
+  }
 
   p {
     margin: 0;

--- a/app/stores/CollectionsStore.ts
+++ b/app/stores/CollectionsStore.ts
@@ -247,9 +247,9 @@ export default class CollectionsStore extends Store<Collection> {
     await this.rootStore.documents.fetchRecentlyViewed();
   }
 
-  export = (format: FileOperationFormat, includeAttachments: boolean) =>
-    client.post("/collections.export_all", {
-      format,
-      includeAttachments,
-    });
+  export = (options: {
+    format: FileOperationFormat;
+    includeAttachments: boolean;
+    includePrivate: boolean;
+  }) => client.post("/collections.export_all", options);
 }

--- a/server/commands/collectionExporter.ts
+++ b/server/commands/collectionExporter.ts
@@ -15,6 +15,7 @@ type Props = {
   user: User;
   format?: FileOperationFormat;
   includeAttachments?: boolean;
+  includePrivate?: boolean;
   ctx: APIContext;
 };
 
@@ -34,6 +35,7 @@ async function collectionExporter({
   user,
   format = FileOperationFormat.MarkdownZip,
   includeAttachments = true,
+  includePrivate = true,
   ctx,
 }: Props) {
   const collectionId = collection?.id;
@@ -52,6 +54,7 @@ async function collectionExporter({
     collectionId,
     options: {
       includeAttachments,
+      includePrivate,
     },
     userId: user.id,
     teamId: user.teamId,

--- a/server/models/FileOperation.ts
+++ b/server/models/FileOperation.ts
@@ -28,6 +28,7 @@ import Fix from "./decorators/Fix";
 
 export type FileOperationOptions = {
   includeAttachments?: boolean;
+  includePrivate?: boolean;
   permission?: CollectionPermission | null;
 };
 

--- a/server/queues/tasks/ExportTask.ts
+++ b/server/queues/tasks/ExportTask.ts
@@ -19,6 +19,7 @@ import fileOperationPresenter from "@server/presenters/fileOperation";
 import FileStorage from "@server/storage/files";
 import BaseTask, { TaskPriority } from "./BaseTask";
 import { Op } from "sequelize";
+import { WhereOptions } from "sequelize";
 
 type Props = {
   fileOperationId: string;
@@ -41,16 +42,26 @@ export default abstract class ExportTask extends BaseTask<Props> {
       User.findByPk(fileOperation.userId, { rejectOnEmpty: true }),
     ]);
 
-    const where = fileOperation.collectionId
+    const where: WhereOptions<Collection> = fileOperation.collectionId
       ? {
           teamId: user.teamId,
           id: fileOperation.collectionId,
+          permission: fileOperation.options?.includePrivate
+            ? undefined
+            : {
+                [Op.ne]: null,
+              },
         }
       : {
           teamId: user.teamId,
           archivedAt: {
             [Op.eq]: null,
           },
+          permission: fileOperation.options?.includePrivate
+            ? undefined
+            : {
+                [Op.ne]: null,
+              },
         };
 
     const collections = await Collection.scope("withDocumentStructure").findAll(

--- a/server/routes/api/collections/collections.ts
+++ b/server/routes/api/collections/collections.ts
@@ -533,7 +533,7 @@ router.post(
   validate(T.CollectionsExportAllSchema),
   transaction(),
   async (ctx: APIContext<T.CollectionsExportAllReq>) => {
-    const { format, includeAttachments } = ctx.input.body;
+    const { format, includeAttachments, includePrivate } = ctx.input.body;
     const { user } = ctx.state.auth;
     const { transaction } = ctx.state;
     const team = await Team.findByPk(user.teamId, { transaction });
@@ -544,6 +544,7 @@ router.post(
       team,
       format,
       includeAttachments,
+      includePrivate,
       ctx,
     });
 

--- a/server/routes/api/collections/schema.ts
+++ b/server/routes/api/collections/schema.ts
@@ -154,6 +154,7 @@ export const CollectionsExportAllSchema = BaseSchema.extend({
       .nativeEnum(FileOperationFormat)
       .default(FileOperationFormat.MarkdownZip),
     includeAttachments: z.boolean().default(true),
+    includePrivate: z.boolean().default(true),
   }),
 });
 

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -285,6 +285,7 @@
   "You will receive an email when it's complete.": "You will receive an email when it's complete.",
   "Include attachments": "Include attachments",
   "Including uploaded images and files in the exported data": "Including uploaded images and files in the exported data",
+  "Include private collections": "Include private collections",
   "{{count}} more user": "{{count}} more user",
   "{{count}} more user_plural": "{{count}} more users",
   "Filter options": "Filter options",


### PR DESCRIPTION
Currently private collections are always included in the export, this provides the option to prevent that.