### PR TITLE
fix: Replace base64 encoded images in `documents.update`

### DIFF
--- a/server/commands/documentUpdater.ts
+++ b/server/commands/documentUpdater.ts
@@ -88,7 +88,9 @@ export default async function documentUpdater(
   if (text !== undefined) {
     document = DocumentHelper.applyMarkdownToDocument(
       document,
-      await TextHelper.replaceImagesWithAttachments(ctx, text, user),
+      await TextHelper.replaceImagesWithAttachments(ctx, text, user, {
+        base64Only: true,
+      }),
       append
     );
   }

--- a/server/models/helpers/TextHelper.ts
+++ b/server/models/helpers/TextHelper.ts
@@ -66,7 +66,11 @@ export class TextHelper {
   static async replaceImagesWithAttachments(
     ctx: APIContext,
     markdown: string,
-    user: User
+    user: User,
+    options: {
+      /** If true, only process base64 encoded images */
+      base64Only?: boolean;
+    } = {}
   ) {
     let output = markdown;
     const images = parseImages(markdown);
@@ -86,6 +90,9 @@ export class TextHelper {
           }
 
           if (isInternalUrl(image.src)) {
+            return;
+          }
+          if (options.base64Only && !image.src.startsWith("data:")) {
             return;
           }
 


### PR DESCRIPTION
closes #10293