### PR TITLE
chore: update minimall Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/sponsors/outline"
   },
   "engines": {
-    "node": ">=20.12 || 22"
+    "node": ">=20.12 <21 || 22"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR updates the minimal `Node.js` engine in package.json to `22`. This PR is part of #10398.