### PR TITLE
fix: Combination of `<br>` and inline nodes in table cell is not imported correctly

### DIFF
--- a/shared/editor/rules/tables.ts
+++ b/shared/editor/rules/tables.ts
@@ -47,9 +47,7 @@ export default function markdownTables(md: MarkdownIt): void {
               }
             });
           } else {
-            const token = new state.Token("text", "", 1);
-            token.content = content;
-            tokens[i].children?.push(token);
+            tokens[i].children?.push(child);
           }
         });
       }


### PR DESCRIPTION
closes #10404