### PR TITLE
fix: `min-width` applied to all floating toolbars

### DIFF
--- a/app/editor/components/FloatingToolbar.tsx
+++ b/app/editor/components/FloatingToolbar.tsx
@@ -24,7 +24,6 @@ type Props = {
   active?: boolean;
   children: React.ReactNode;
   width?: number;
-  minWidth?: number;
   forwardedRef?: React.RefObject<HTMLDivElement> | null;
 };
 
@@ -300,7 +299,6 @@ const FloatingToolbar = React.forwardRef(function FloatingToolbar_(
         $offset={position.offset}
         style={{
           width: props.width,
-          minWidth: props.minWidth,
           maxWidth: `${position.maxWidth}px`,
           top: `${position.top}px`,
           left: `${position.left}px`,

--- a/app/editor/components/MediaLinkEditor.tsx
+++ b/app/editor/components/MediaLinkEditor.tsx
@@ -113,4 +113,5 @@ const Wrapper = styled(Flex)`
   pointer-events: all;
   gap: 6px;
   padding: 6px;
+  min-width: 350px;
 `;

--- a/app/editor/components/SelectionToolbar.tsx
+++ b/app/editor/components/SelectionToolbar.tsx
@@ -218,7 +218,6 @@ export function SelectionToolbar(props: Props) {
       align={align}
       active={isActive}
       ref={menuRef}
-      minWidth={350}
       width={showLinkToolbar || isEmbedSelection ? 336 : undefined}
     >
       {showLinkToolbar ? (


### PR DESCRIPTION
Regressed in https://github.com/outline/outline/pull/10258 – min width should only apply to media editor