### PR TITLE
fix: Guard against crawlers consuming magic links

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -6,7 +6,7 @@ import "./logging/tracer"; // must come before importing any instrumented module
 
 import http from "http";
 import https from "https";
-import Koa from "koa";
+import Koa, { Context } from "koa";
 import helmet from "koa-helmet";
 import logger from "koa-logger";
 import Router from "koa-router";
@@ -90,6 +90,7 @@ async function start(_id: number, disconnect: () => void) {
 
   /** Perform a redirect on the browser so that the user's auth cookies are included in the request. */
   app.context.redirectOnClient = function (
+    this: Context,
     /** The URL to redirect to */
     url: string,
     /**
@@ -113,6 +114,13 @@ async function start(_id: number, disconnect: () => void) {
         )}" value="${escape(value)}" />`;
       });
 
+      if (this.userAgent.isBot) {
+        formFields += `
+          <p>If you are not redirected automatically, please click the button below.</p>
+          <input type="submit" value="Continue" />
+        `;
+      }
+
       this.body = `
 <html>
 <head>
@@ -123,7 +131,7 @@ async function start(_id: number, disconnect: () => void) {
     ${formFields}
   </form>
   <script nonce="${this.state.cspNonce}">
-    document.getElementById('redirect-form').submit();
+    ${!this.userAgent.isBot} && document.getElementById('redirect-form').submit();
   </script>
 </body>
 </html>`;

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -1,10 +1,9 @@
 import crypto from "crypto";
 import path from "path";
 import { formatRFC7231 } from "date-fns";
-import Koa, { BaseContext } from "koa";
+import Koa from "koa";
 import Router from "koa-router";
 import send from "koa-send";
-import userAgent, { UserAgentContext } from "koa-useragent";
 import { languages } from "@shared/i18n";
 import { IntegrationType, TeamPreference } from "@shared/types";
 import { parseDomain } from "@shared/utils/domains";
@@ -23,8 +22,6 @@ import errors from "./errors";
 
 const koa = new Koa();
 const router = new Router();
-
-koa.use<BaseContext, UserAgentContext>(userAgent);
 
 // serve public assets
 router.use(["/images/*", "/email/*", "/fonts/*"], async (ctx, next) => {

--- a/server/services/web.ts
+++ b/server/services/web.ts
@@ -1,6 +1,6 @@
 /* oxlint-disable @typescript-eslint/no-var-requires */
 import { Server } from "https";
-import Koa from "koa";
+import Koa, { BaseContext } from "koa";
 import compress from "koa-compress";
 import { dnsPrefetchControl, referrerPolicy } from "koa-helmet";
 import mount from "koa-mount";
@@ -20,6 +20,7 @@ import routes from "../routes";
 import api from "../routes/api";
 import auth from "../routes/auth";
 import oauth from "../routes/oauth";
+import userAgent, { UserAgentContext } from "koa-useragent";
 
 export default function init(app: Koa = new Koa(), server?: Server) {
   void initI18n();
@@ -44,6 +45,9 @@ export default function init(app: Koa = new Koa(), server?: Server) {
     // trust header fields set by our proxy. eg X-Forwarded-For
     app.proxy = true;
   }
+
+  // Make `ctx.userAgent` available
+  app.use<BaseContext, UserAgentContext>(userAgent);
 
   app.use(compress());
 


### PR DESCRIPTION
Previous solution would still not work if crawler is running javascript, now we will require an actual form interaction if the user agent looks non-human