### PR TITLE
chore: Pin Dockerfile to node `22.21.0`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG APP_PATH
 WORKDIR $APP_PATH
 
 # ---
-FROM node:22-slim AS runner
+FROM node:22.21.0-slim AS runner
 
 LABEL org.opencontainers.image.source="https://github.com/outline/outline"
 
@@ -16,9 +16,9 @@ ENV NODE_ENV=production
 
 # Create a non-root user compatible with Debian and BusyBox based images
 RUN addgroup --gid 1001 nodejs && \
-  adduser --uid 1001 --ingroup nodejs nodejs && \
-  mkdir -p /var/lib/outline && \
-  chown -R nodejs:nodejs /var/lib/outline
+    adduser --uid 1001 --ingroup nodejs nodejs && \
+    mkdir -p /var/lib/outline && \
+    chown -R nodejs:nodejs /var/lib/outline
 
 COPY --from=base --chown=nodejs:nodejs $APP_PATH/build ./build
 COPY --from=base $APP_PATH/server ./server
@@ -29,13 +29,13 @@ COPY --from=base $APP_PATH/package.json ./package.json
 
 # Install wget to healthcheck the server
 RUN  apt-get update \
-  && apt-get install -y wget \
-  && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y wget \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV FILE_STORAGE_LOCAL_ROOT_DIR=/var/lib/outline/data
 RUN mkdir -p "$FILE_STORAGE_LOCAL_ROOT_DIR" && \
-  chown -R nodejs:nodejs "$FILE_STORAGE_LOCAL_ROOT_DIR" && \
-  chmod 1777 "$FILE_STORAGE_LOCAL_ROOT_DIR"
+    chown -R nodejs:nodejs "$FILE_STORAGE_LOCAL_ROOT_DIR" && \
+    chmod 1777 "$FILE_STORAGE_LOCAL_ROOT_DIR"
 
 VOLUME /var/lib/outline/data
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,5 +1,5 @@
 ARG APP_PATH=/opt/outline
-FROM node:22 AS deps
+FROM node:22.21.0 AS deps
 
 ARG APP_PATH
 WORKDIR $APP_PATH


### PR DESCRIPTION
Fixes a [memory regression](https://github.com/nodejs/node/pull/59888) introduced in 22.19.

closes #10495