### PR TITLE
fix: emdash replacement conflicts with horizontal rule

### DIFF
--- a/app/editor/extensions/SmartText.ts
+++ b/app/editor/extensions/SmartText.ts
@@ -3,7 +3,7 @@ import { InputRule } from "@shared/editor/lib/InputRule";
 
 const rightArrow = new InputRule(/->$/, "→");
 // Note that the suppression of pipe here prevents conflict with table creation rule.
-const emdash = new InputRule(/(?:^|[^\|])(--)$/, "—");
+const emdash = new InputRule(/(?:^|[^\|])(--\s)$/, "— ");
 const oneHalf = new InputRule(/(?:^|\s)(1\/2)$/, "½");
 const threeQuarters = new InputRule(/(?:^|\s)(3\/4)$/, "¾");
 const copyright = new InputRule(/\(c\)$/, "©️");


### PR DESCRIPTION
This rule prevented the hr rule ever triggering, so now we require a trailing space