### PR TITLE
Link bar cleanup

### DIFF
--- a/app/editor/components/LinkEditor.tsx
+++ b/app/editor/components/LinkEditor.tsx
@@ -146,6 +146,11 @@ const LinkEditor: React.FC<Props> = ({
         if (!initialValue) {
           handleRemoveLink();
         }
+
+        // Moving selection to end causes editor state to change,
+        // forcing a re-render of the top-level editor component. As
+        // a result, the new selection, being devoid of any link mark,
+        // prevents LinkEditor from re-rendering.
         moveSelectionToEnd();
         return;
       }


### PR DESCRIPTION
> What do you think is natural? I take it partly back, to me it should be:
Enter saves
Click outside saves
Esc discards changes
Empty input removes comment mark