### PR TITLE
fix: Input in embed toolbar grabs focus

### DIFF
--- a/app/editor/components/MediaLinkEditor.tsx
+++ b/app/editor/components/MediaLinkEditor.tsx
@@ -14,9 +14,10 @@ type Props = {
   node: Node;
   view: EditorView;
   dictionary: Dictionary;
+  autoFocus?: boolean;
 };
 
-export function MediaLinkEditor({ node, view, dictionary }: Props) {
+export function MediaLinkEditor({ node, view, dictionary, autoFocus }: Props) {
   const url = (node.attrs.href ?? node.attrs.src) as string;
   const [localUrl, setLocalUrl] = useState(url);
 
@@ -80,7 +81,7 @@ export function MediaLinkEditor({ node, view, dictionary }: Props) {
   return (
     <Wrapper>
       <Input
-        autoFocus
+        autoFocus={autoFocus}
         value={localUrl}
         placeholder={dictionary.pasteLink}
         onChange={(e) => setLocalUrl(e.target.value)}

--- a/app/editor/components/SelectionToolbar.tsx
+++ b/app/editor/components/SelectionToolbar.tsx
@@ -237,6 +237,7 @@ export function SelectionToolbar(props: Props) {
           node={selection.node}
           view={view}
           dictionary={dictionary}
+          autoFocus={isEditingImgUrl}
         />
       ) : (
         <ToolbarMenu


### PR DESCRIPTION
Selecting an embed in the editor opens a toolbar with input that grabs focus, this is very annoying.