### PR TITLE
chore: Add a mutex lock around migrations 

### DIFF
--- a/server/utils/CacheHelper.ts
+++ b/server/utils/CacheHelper.ts
@@ -38,7 +38,7 @@ export class CacheHelper {
     const lockKey = `lock:${key}`;
     try {
       try {
-        lock = await MutexLock.lock.acquire([lockKey], lockTimeout);
+        lock = await MutexLock.acquire(lockKey, lockTimeout);
       } catch (err) {
         Logger.error(`Could not acquire lock for ${key}`, err);
       }
@@ -54,8 +54,8 @@ export class CacheHelper {
       }
       return value;
     } finally {
-      if (lock && lock.expiration > new Date().getTime()) {
-        await lock.release();
+      if (lock) {
+        await MutexLock.release(lock);
       }
     }
   }

--- a/server/utils/MutexLock.ts
+++ b/server/utils/MutexLock.ts
@@ -1,4 +1,4 @@
-import Redlock from "redlock";
+import Redlock, { type Lock } from "redlock";
 import Redis from "@server/storage/redis";
 
 export class MutexLock {
@@ -16,6 +16,29 @@ export class MutexLock {
     });
 
     return this.redlock;
+  }
+
+  /**
+   * Acquire a Mutex lock
+   *
+   * @param resource The resource to lock
+   * @param timeout The duration to acquire the lock for if not released in milliseconds
+   * @returns A promise that resolves a to a Lock
+   */
+  public static acquire(resource: string, timeout: number) {
+    return this.lock.acquire([resource], timeout);
+  }
+
+  /**
+   * Safely release a lock
+   *
+   * @param lock The lock to release
+   */
+  public static release(lock: Lock) {
+    if (lock && lock.expiration > new Date().getTime()) {
+      return lock.release();
+    }
+    return false;
   }
 
   private static redlock: Redlock;


### PR DESCRIPTION
To ensure in multi-instance deployments multiple machines don't attempt to run migrations at once