### PR TITLE
Include cookies with S3 POST upload

### DIFF
--- a/app/utils/files.ts
+++ b/app/utils/files.ts
@@ -88,6 +88,7 @@ export const uploadFile = async (
     xhr.addEventListener("loadend", () => {
       resolve(xhr.readyState === 4 && xhr.status >= 200 && xhr.status < 400);
     });
+    xhr.withCredentials = true;
     xhr.open("POST", data.uploadUrl, true);
     xhr.send(formData);
   });


### PR DESCRIPTION
Fixes #10561

I'm currently running Outline using Ceph Object Gateway to provide the S3 storage, and running behind Cloudflare's application proxy system. Pretty much everything works except for file uploading.

Because the XMLHttpRequest doesn't include cookies by default the `CF_Authorization` cookie is not sent in the POST to the S3 endpoint. No `CF_Authorization` means a redirect to the Cloudflare login page, breaking uploading. Because this is the only place XMLHttpRequest is used this is the only broken feature.

This one-line change includes cookies in the request, resolving the issue.