### PR TITLE
docs: Fix typo in TSDoc comment

### DIFF
--- a/app/stores/CommentsStore.ts
+++ b/app/stores/CommentsStore.ts
@@ -91,7 +91,7 @@ export default class CommentsStore extends Store<Comment> {
   }
 
   /**
-   * Returns the total number of unresolbed comments in the given document.
+   * Returns the total number of unresolved comments in the given document.
    *
    * @param documentId ID of the document to get comments for
    * @returns A number of comments


### PR DESCRIPTION
Spotted a small typo while reading through the codebase — couldn’t let it get away 😄