### PR TITLE
fix: Empty state of collection should be hidden with new inline doc creation

### DIFF
--- a/app/components/Sidebar/components/ArchivedCollectionLink.tsx
+++ b/app/components/Sidebar/components/ArchivedCollectionLink.tsx
@@ -2,8 +2,6 @@ import { useState, useCallback } from "react";
 import Collection from "~/models/Collection";
 import useStores from "~/hooks/useStores";
 import CollectionLink from "./CollectionLink";
-import CollectionLinkChildren from "./CollectionLinkChildren";
-import Relative from "./Relative";
 
 type Props = {
   collection: Collection;
@@ -12,7 +10,6 @@ type Props = {
 
 export function ArchivedCollectionLink({ collection, depth }: Props) {
   const { documents } = useStores();
-
   const [expanded, setExpanded] = useState(false);
 
   const handleDisclosureClick = useCallback((ev) => {
@@ -26,22 +23,13 @@ export function ArchivedCollectionLink({ collection, depth }: Props) {
   }, []);
 
   return (
-    <>
-      <CollectionLink
-        depth={depth ? depth : 0}
-        collection={collection}
-        expanded={expanded}
-        activeDocument={documents.active}
-        onDisclosureClick={handleDisclosureClick}
-        onClick={handleClick}
-      />
-      <Relative>
-        <CollectionLinkChildren
-          collection={collection}
-          expanded={expanded}
-          prefetchDocument={documents.prefetchDocument}
-        />
-      </Relative>
-    </>
+    <CollectionLink
+      depth={depth ? depth : 0}
+      collection={collection}
+      expanded={expanded}
+      activeDocument={documents.active}
+      onDisclosureClick={handleDisclosureClick}
+      onClick={handleClick}
+    />
   );
 }

--- a/app/components/Sidebar/components/CollectionLink.tsx
+++ b/app/components/Sidebar/components/CollectionLink.tsx
@@ -27,6 +27,7 @@ import { SidebarContextType, useSidebarContext } from "./SidebarContext";
 import SidebarLink from "./SidebarLink";
 import { useCollectionMenuAction } from "~/hooks/useCollectionMenuAction";
 import { ActionContextProvider } from "~/hooks/useActionContext";
+import CollectionLinkChildren from "./CollectionLinkChildren";
 
 type Props = {
   collection: Collection;
@@ -185,7 +186,7 @@ const CollectionLink: React.FC<Props> = ({
           />
         </DropToImport>
       </Relative>
-      {isAddingNewChild && (
+      {isAddingNewChild ? (
         <SidebarLink
           depth={2}
           isActive={() => true}
@@ -201,6 +202,12 @@ const CollectionLink: React.FC<Props> = ({
               ref={newChildTitleRef}
             />
           }
+        />
+      ) : (
+        <CollectionLinkChildren
+          collection={collection}
+          expanded={!!expanded}
+          prefetchDocument={documents.prefetchDocument}
         />
       )}
     </ActionContextProvider>

--- a/app/components/Sidebar/components/Collections.tsx
+++ b/app/components/Sidebar/components/Collections.tsx
@@ -92,7 +92,6 @@ function Collections() {
                   key={item.id}
                   collection={item}
                   activeDocument={documents.active}
-                  prefetchDocument={documents.prefetchDocument}
                   belowCollection={orderedCollections[index + 1]}
                 />
               )}

--- a/app/components/Sidebar/components/DraggableCollectionLink.tsx
+++ b/app/components/Sidebar/components/DraggableCollectionLink.tsx
@@ -11,7 +11,6 @@ import { useLocationSidebarContext } from "~/hooks/useLocationSidebarContext";
 import useStores from "~/hooks/useStores";
 import { DragObject } from "../hooks/useDragAndDrop";
 import CollectionLink from "./CollectionLink";
-import CollectionLinkChildren from "./CollectionLinkChildren";
 import DropCursor from "./DropCursor";
 import Relative from "./Relative";
 import { useSidebarContext } from "./SidebarContext";
@@ -19,14 +18,12 @@ import { useSidebarContext } from "./SidebarContext";
 type Props = {
   collection: Collection;
   activeDocument: Document | undefined;
-  prefetchDocument: (id: string) => Promise<Document | void>;
   belowCollection: Collection | void;
 };
 
 function DraggableCollectionLink({
   collection,
   activeDocument,
-  prefetchDocument,
   belowCollection,
 }: Props) {
   const locationSidebarContext = useLocationSidebarContext();
@@ -116,11 +113,6 @@ function DraggableCollectionLink({
         />
       </Draggable>
       <Relative>
-        <CollectionLinkChildren
-          collection={collection}
-          expanded={displayChildDocuments}
-          prefetchDocument={prefetchDocument}
-        />
         {isDraggingAnyCollection && (
           <DropCursor
             isActiveDrop={isCollectionDropping}

--- a/app/components/Sidebar/components/StarredLink.tsx
+++ b/app/components/Sidebar/components/StarredLink.tsx
@@ -18,7 +18,6 @@ import {
 } from "../hooks/useDragAndDrop";
 import { useSidebarLabelAndIcon } from "../hooks/useSidebarLabelAndIcon";
 import CollectionLink from "./CollectionLink";
-import CollectionLinkChildren from "./CollectionLinkChildren";
 import DocumentLink from "./DocumentLink";
 import DropCursor from "./DropCursor";
 import Folder from "./Folder";
@@ -185,13 +184,7 @@ function StarredCollectionLink({
           isDraggingAnyCollection={reorderStarProps.isDragging}
         />
       </Draggable>
-      <Relative>
-        <CollectionLinkChildren
-          collection={collection}
-          expanded={displayChildDocuments}
-        />
-        {cursor}
-      </Relative>
+      <Relative>{cursor}</Relative>
     </SidebarContext.Provider>
   );
 }


### PR DESCRIPTION
### Before
<img width="311" height="131" alt="image" src="https://github.com/user-attachments/assets/4febc479-de35-4e51-8daa-9b7c4b9c02a4" />


### After
<img width="310" height="104" alt="image" src="https://github.com/user-attachments/assets/d4b99e66-e695-43f7-89ed-b67039bff0d8" />
