### PR TITLE
fix: Revoking parent permission not correctly reflected on open children

### DIFF
--- a/app/models/base/NavigableModel.ts
+++ b/app/models/base/NavigableModel.ts
@@ -1,10 +1,10 @@
 import { action, computed, observable, runInAction } from "mobx";
 import { JSONObject, type NavigationNode } from "@shared/types";
 import { client } from "~/utils/ApiClient";
-import ParanoidModel from "./ParanoidModel";
+import Model from "./Model";
 import type Document from "../Document";
 
-export default abstract class NavigableModel extends ParanoidModel {
+export default abstract class NavigableModel extends Model {
   private isFetching = false;
 
   /** The document ID associated with this model. */

--- a/app/scenes/Document/components/DataLoader.tsx
+++ b/app/scenes/Document/components/DataLoader.tsx
@@ -86,17 +86,20 @@ function DataLoader({ match, children }: Props) {
   const isEditing = isEditRoute || !user?.separateEditMode;
   const can = usePolicy(document);
   const location = useLocation<LocationState>();
+  const missingPolicy = !can || Object.keys(can).length === 0;
 
   React.useEffect(() => {
     async function fetchDocument() {
       try {
-        await documents.fetch(documentSlug);
+        await documents.fetch(documentSlug, {
+          force: missingPolicy,
+        });
       } catch (err) {
         setError(err);
       }
     }
     void fetchDocument();
-  }, [ui, documents, documentSlug]);
+  }, [ui, documents, missingPolicy, documentSlug]);
 
   React.useEffect(() => {
     async function fetchRevision() {


### PR DESCRIPTION
This also fixes a bug where removing a user in the share panel would not be correctly reflected

closes #10616