### PR TITLE
fix: STARTTLS is not used

### DIFF
--- a/app.json
+++ b/app.json
@@ -194,6 +194,11 @@
       "description": "Use a secure SMTP connection (optional)",
       "required": false
     },
+    "SMTP_DISABLE_STARTTLS": {
+      "value": "false",
+      "description": "Disable STARTTLS even if the server supports it (optional)",
+      "required": false
+    },
     "SMTP_TLS_CIPHERS": {
       "description": "Override SMTP cipher configuration (optional)",
       "required": false

--- a/server/emails/mailer.tsx
+++ b/server/emails/mailer.tsx
@@ -224,8 +224,8 @@ export class Mailer {
             pass: env.SMTP_PASSWORD,
           }
         : undefined,
-      // Disable STARTTLS entirely when secure is set to false
-      ignoreTLS: !env.SMTP_SECURE,
+      // Disable STARTTLS entirely when SMTP_DISABLE_STARTTLS is set to true
+      ignoreTLS: env.SMTP_DISABLE_STARTTLS,
       tls: env.SMTP_SECURE
         ? env.SMTP_TLS_CIPHERS
           ? {

--- a/server/env.ts
+++ b/server/env.ts
@@ -447,6 +447,15 @@ export class Environment {
   public SMTP_SECURE = this.toBoolean(environment.SMTP_SECURE ?? "true");
 
   /**
+   * If true then STARTTLS is disabled even if the server supports it.
+   * If false (the default) then STARTTLS is used if server supports it.
+   *
+   * Setting secure to false therefore does not mean that you would not use an
+   * encrypted connection.
+   */
+  public SMTP_DISABLE_STARTTLS = this.toBoolean(environment.SMTP_DISABLE_STARTTLS ?? "false");
+
+  /**
    * Dropbox app key for embedding Dropbox files
    */
   @Public


### PR DESCRIPTION
STARTTLS is different from TLS. According to the doc of Nodemailer (https://nodemailer.com/smtp), the `ignoreTLS` actually disables STARTTLS. Outline disables STARTTLS when `SMTP_SECURE` is set to `false`. However, my SMTP provider use STARTTLS, not TLS. We need a separate control of STARTTLS.