### PR TITLE
Add optional S3 PUT uploads + per-folder reports for fashion model

### DIFF
--- a/server/env.ts
+++ b/server/env.ts
@@ -613,6 +613,14 @@ export class Environment {
   public AWS_S3_ACL = environment.AWS_S3_ACL ?? "private";
 
   /**
+   * Enable presigned PUT uploads for S3-compatible providers (e.g. Cloudflare R2)
+   */
+  @IsOptional()
+  public S3_SUPPORT_PUT_UPLOAD = this.toBoolean(
+    environment.S3_SUPPORT_PUT_UPLOAD ?? "false"
+  );
+
+  /**
    * Which file storage system to use
    */
   @IsIn(["local", "s3"])

--- a/server/routes/api/attachments/attachments.ts
+++ b/server/routes/api/attachments/attachments.ts
@@ -142,14 +142,34 @@ router.post(
       contentType
     );
 
+    const uploadMethod = presignedPost.method ?? "POST";
+    const uploadUrl =
+      uploadMethod === "PUT" && presignedPost.url
+        ? presignedPost.url
+        : FileStorage.getUploadUrl();
+    const form =
+      uploadMethod === "PUT"
+        ? {}
+        : {
+            "Cache-Control": "max-age=31557600",
+            "Content-Type": contentType,
+            ...presignedPost.fields,
+          };
+
+    const headers =
+      uploadMethod === "PUT"
+        ? (presignedPost.headers ?? {
+            "Cache-Control": "max-age=31557600",
+            "Content-Type": contentType,
+          })
+        : undefined;
+
     ctx.body = {
       data: {
-        uploadUrl: FileStorage.getUploadUrl(),
-        form: {
-          "Cache-Control": "max-age=31557600",
-          "Content-Type": contentType,
-          ...presignedPost.fields,
-        },
+        uploadUrl,
+        method: uploadMethod,
+        form,
+        headers,
         attachment: {
           ...presentAttachment(attachment),
           // always use the redirect url for document attachments, as the serializer

--- a/server/storage/files/BaseStorage.ts
+++ b/server/storage/files/BaseStorage.ts
@@ -9,6 +9,11 @@ import Logger from "@server/logging/Logger";
 import fetch, { chromeUserAgent, RequestInit } from "@server/utils/fetch";
 import { AppContext } from "@server/types";
 
+export type PresignedUpload = Partial<PresignedPost> & {
+  method?: "POST" | "PUT";
+  headers?: Record<string, string>;
+};
+
 export default abstract class BaseStorage {
   /** The default number of seconds until a signed URL expires. */
   public static defaultSignedUrlExpires = 300;
@@ -29,7 +34,7 @@ export default abstract class BaseStorage {
     acl: string,
     maxUploadSize: number,
     contentType: string
-  ): Promise<Partial<PresignedPost>>;
+  ): Promise<PresignedUpload>;
 
   /**
    * Returns a promise that resolves with a stream for reading a file from the storage provider.

--- a/server/storage/files/LocalStorage.ts
+++ b/server/storage/files/LocalStorage.ts
@@ -2,7 +2,6 @@ import { Blob } from "buffer";
 import { mkdir, unlink, rmdir } from "fs/promises";
 import path from "path";
 import { Readable } from "stream";
-import { PresignedPost } from "@aws-sdk/s3-presigned-post";
 import fs from "fs-extra";
 import invariant from "invariant";
 import JWT from "jsonwebtoken";
@@ -10,7 +9,7 @@ import safeResolvePath from "resolve-path";
 import env from "@server/env";
 import { InternalError, ValidationError } from "@server/errors";
 import Logger from "@server/logging/Logger";
-import BaseStorage from "./BaseStorage";
+import BaseStorage, { PresignedUpload } from "./BaseStorage";
 import { CSRF } from "@shared/constants";
 import { AppContext } from "@server/types";
 
@@ -21,7 +20,7 @@ export default class LocalStorage extends BaseStorage {
     acl: string,
     maxUploadSize: number,
     contentType = "image"
-  ): Promise<Partial<PresignedPost>> {
+  ): Promise<PresignedUpload> {
     return Promise.resolve({
       url: this.getUrlForKey(key),
       fields: {
@@ -31,6 +30,7 @@ export default class LocalStorage extends BaseStorage {
         contentType,
         [CSRF.fieldName]: ctx.cookies.get(CSRF.cookieName) || "",
       },
+      method: "POST",
     });
   }
 

--- a/server/storage/files/__mocks__/index.ts
+++ b/server/storage/files/__mocks__/index.ts
@@ -7,5 +7,5 @@ export default {
 
   getSignedUrl: jest.fn().mockReturnValue("http://s3mock"),
 
-  getPresignedPost: jest.fn().mockReturnValue({}),
+  getPresignedPost: jest.fn().mockReturnValue({ method: "POST", fields: {} }),
 };

--- a/server/test/setup.ts
+++ b/server/test/setup.ts
@@ -19,6 +19,7 @@ jest.mock("@aws-sdk/client-s3", () => ({
   })),
   DeleteObjectCommand: jest.fn(),
   GetObjectCommand: jest.fn(),
+  PutObjectCommand: jest.fn(),
   ObjectCannedACL: {},
 }));
 


### PR DESCRIPTION
@tommoor about #10609 

1. add an opt-in S3_SUPPORT_PUT_UPLOAD flag that switches presigned uploads from POST to PUT for S3-compatible backends like Cloudflare R2

2. propagate the new upload metadata through FileStorage.getPresignedPost, the attachments API, and the client uploader so PUT flows work transparently


