### PR TITLE
fix: Header selection in Safari

### DIFF
--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -818,13 +818,6 @@ img.ProseMirror-separator {
   }
 }
 
-.heading-content {
-  &::before {
-    content: "​";
-    display: inline;
-  }
-}
-
 .${EditorStyleHelper.headingPositionAnchor}, .${EditorStyleHelper.imagePositionAnchor} {
   color: ${props.theme.text};
   pointer-events: none;
@@ -935,8 +928,9 @@ h6:not(.placeholder)::before {
   margin-left: -26px;
   flex-direction: row;
   display: none;
-  position: relative;
-  top: -2px;
+  position: absolute;
+  left: 0;
+  top: calc(.5em - 6px);
   width: 26px;
   height: 24px;
 
@@ -1182,6 +1176,10 @@ strong {
 p {
   margin: 0;
   min-height: 1.6em;
+}
+
+.heading-content {
+  position: relative;
 }
 
 .heading-content a,

--- a/shared/editor/nodes/Heading.ts
+++ b/shared/editor/nodes/Heading.ts
@@ -55,6 +55,7 @@ export default class Heading extends Node {
         `h${node.attrs.level + (this.options.offset || 0)}`,
         {
           dir: "auto",
+          class: "heading-content",
         },
         0,
       ],
@@ -220,8 +221,11 @@ export default class Heading extends Node {
               container.appendChild(fold);
 
               decorations.push(
-                Decoration.widget(pos + 1, container, {
-                  side: -1,
+                Decoration.widget(pos + node.nodeSize - 1, container, {
+                  side: 1,
+                  ignoreSelection: true,
+                  relaxedSide: true,
+                  key: pos.toString(),
                 })
               );
             }


### PR DESCRIPTION
First commit is just a refactor hoping it would fix, but apparently not.
Second commit actually fixes by moving the actions to the other side of the heading node. Why _specifically_ this works I don't know, it's essentially a subtle bug in Safari as far as I can tell.

closes https://github.com/outline/outline/issues/10633