### PR TITLE
fix: Plain text copy-to-clipboard serializer squashes blocks

### DIFF
--- a/app/editor/extensions/ClipboardTextSerializer.ts
+++ b/app/editor/extensions/ClipboardTextSerializer.ts
@@ -55,7 +55,7 @@ export default class ClipboardTextSerializer extends Extension {
             return usePlainText
               ? slice.content.content
                   .map((node) => ProsemirrorHelper.toPlainText(node))
-                  .join("")
+                  .join("\n")
               : mdSerializer.serialize(slice.content, {
                   softBreak: true,
                 });


### PR DESCRIPTION
closes #10673