### PR TITLE
fix: 'undefined' changed document log

### DIFF
--- a/server/collaboration/PersistenceExtension.ts
+++ b/server/collaboration/PersistenceExtension.ts
@@ -78,12 +78,12 @@ export default class PersistenceExtension implements Extension {
   async onChange({ context, documentName }: withContext<onChangePayload>) {
     const [, documentId] = documentName.split(".");
 
-    Logger.debug(
-      "multiplayer",
-      `${context.user?.name} changed ${documentName}`
-    );
-
     if (context.user) {
+      Logger.debug(
+        "multiplayer",
+        `${context.user.name} changed ${documentName}`
+      );
+
       const key = Document.getCollaboratorKey(documentId);
       await Redis.defaultClient.sadd(key, context.user.id);
     }


### PR DESCRIPTION
When the collaboration process is scaled to multiple servers you could see logs like the following due to event forwarding between servers.

```
debug: [multiplayer] undefined changed document.4207fa9c-6b80-41a8-ad73-28464e800257
```