### PR TITLE
fix: `Empty trash` button should be hidden with no permissions

### DIFF
--- a/app/components/ActionButton.tsx
+++ b/app/components/ActionButton.tsx
@@ -30,19 +30,19 @@ const ActionButton = React.forwardRef<HTMLButtonElement, Props>(
     });
     const isMounted = useIsMounted();
     const [executing, setExecuting] = React.useState(false);
-    const disabled = rest.disabled;
 
     if (!actionContext || !action) {
       return <button {...rest} ref={ref} />;
     }
 
-    if (
-      action.visible &&
-      !resolve<boolean>(action.visible, actionContext) &&
-      hideOnActionDisabled
-    ) {
+    const actionIsDisabled =
+      action.visible && !resolve<boolean>(action.visible, actionContext);
+
+    if (actionIsDisabled && hideOnActionDisabled) {
       return null;
     }
+
+    const disabled = rest.disabled || actionIsDisabled;
 
     const label =
       rest["aria-label"] ??

--- a/app/scenes/Trash/index.tsx
+++ b/app/scenes/Trash/index.tsx
@@ -20,7 +20,11 @@ function Trash() {
       title={t("Trash")}
       actions={
         documents.deleted.length > 0 && (
-          <Button neutral action={permanentlyDeleteDocumentsInTrash}>
+          <Button
+            neutral
+            action={permanentlyDeleteDocumentsInTrash}
+            hideOnActionDisabled
+          >
             {t("Empty trash")}
           </Button>
         )


### PR DESCRIPTION
This also fixes an underlying issue where disabled actions passed to `ActionButton` would not correctly disable the button.

ref #10701