### PR TITLE
fix: Mermaid injecting errors into page

### DIFF
--- a/shared/editor/extensions/Mermaid.ts
+++ b/shared/editor/extensions/Mermaid.ts
@@ -85,6 +85,7 @@ class MermaidRenderer {
       mermaid ??= (await import("mermaid")).default;
       mermaid.initialize({
         startOnLoad: true,
+        suppressErrorRendering: true,
         // TODO: Make dynamic based on the width of the editor or remove in
         // the future if Mermaid is able to handle this automatically.
         gantt: { useWidth: 700 },

--- a/shared/styles/globals.ts
+++ b/shared/styles/globals.ts
@@ -124,4 +124,11 @@ export default createGlobalStyle<Props>`
     --sab: env(safe-area-inset-bottom);
     --sal: env(safe-area-inset-left);
   }
+
+  /* Mermaid.js injects these into the root of the page. It's very annoying, but we have to deal with it or they affect layout */
+  [id^="doffscreen-mermaid"] {
+      position: absolute !important;
+      left: -9999px !important;
+      top: -9999px !important;
+  }
 `;


### PR DESCRIPTION
The mermaid.js interface is truly awful – if you don't pass this "suppressErrorRendering" it will just inject error elements into the root of the page?!