### PR TITLE
fix: Using keys instead of values meant cron task fallback

### DIFF
--- a/server/routes/api/cron/cron.test.ts
+++ b/server/routes/api/cron/cron.test.ts
@@ -1,3 +1,4 @@
+import env from "@server/env";
 import { getTestServer } from "@server/test/support";
 
 const server = getTestServer();
@@ -107,5 +108,51 @@ describe("GET /api/utils.gc", () => {
     const body = await res.json();
     expect(res.status).toEqual(400);
     expect(body.message).toBe("limit: Number must be greater than 0");
+  });
+});
+
+describe("cron period parsing", () => {
+  it("should accept valid period 'daily'", async () => {
+    const res = await server.post("/api/cron.daily", {
+      body: {
+        token: env.UTILS_SECRET,
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.success).toBe(true);
+  });
+
+  it("should accept valid period 'hourly'", async () => {
+    const res = await server.post("/api/cron.hourly", {
+      body: {
+        token: env.UTILS_SECRET,
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.success).toBe(true);
+  });
+
+  it("should accept valid period 'minute'", async () => {
+    const res = await server.post("/api/cron.minute", {
+      body: {
+        token: env.UTILS_SECRET,
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.success).toBe(true);
+  });
+
+  it("should fallback to daily for invalid period", async () => {
+    const res = await server.post("/api/cron.invalid", {
+      body: {
+        token: env.UTILS_SECRET,
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.success).toBe(true);
   });
 });

--- a/server/routes/api/cron/cron.ts
+++ b/server/routes/api/cron/cron.ts
@@ -14,7 +14,9 @@ const router = new Router();
 const receivedPeriods = new Set<TaskSchedule>();
 
 const cronHandler = async (ctx: APIContext<T.CronSchemaReq>) => {
-  const period = Object.keys(TaskSchedule).includes(ctx.params.period)
+  const period = Object.values(TaskSchedule).includes(
+    ctx.params.period as TaskSchedule
+  )
     ? (ctx.params.period as TaskSchedule)
     : TaskSchedule.Day;
   const token = (ctx.input.body.token ?? ctx.input.query.token) as string;


### PR DESCRIPTION
This actually meant that the daily tasks were running 24 times a day. 