### PR TITLE
 fix: Unable to delete last character before inline image (#10681)

### DIFF
--- a/shared/editor/extensions/DeleteNearAtom.ts
+++ b/shared/editor/extensions/DeleteNearAtom.ts
@@ -1,0 +1,90 @@
+import { Command, TextSelection } from "prosemirror-state";
+import Extension from "../lib/Extension";
+
+/**
+ * GitHub Issue: https://github.com/outline/outline/issues/10681
+ */
+export default class DeleteNearAtom extends Extension {
+  get name() {
+    return "deleteNearAtom";
+  }
+
+  keys(): Record<string, Command> {
+    return {
+      Delete: deleteForwardNearAtom(),
+      Backspace: deleteBackwardNearAtom(),
+    };
+  }
+}
+
+function deleteForwardNearAtom(): Command {
+  return (state, dispatch) => {
+    const { selection } = state;
+    if (!(selection instanceof TextSelection)) {
+      return false;
+    }
+
+    const { $cursor } = selection;
+    if (!$cursor) {
+      return false;
+    }
+    if ($cursor.textOffset !== 0) {
+      return false;
+    }
+
+    const nodeAfter = $cursor.nodeAfter;
+    if (!nodeAfter?.isText || nodeAfter.nodeSize !== 1) {
+      return false;
+    }
+
+    const textEndPos = $cursor.pos + nodeAfter.nodeSize;
+    if (textEndPos >= $cursor.end()) {
+      return false;
+    }
+
+    const $afterText = state.doc.resolve(textEndPos);
+    const nodeAfterText = $afterText.nodeAfter;
+
+    if (nodeAfterText?.isAtom && nodeAfterText.isInline) {
+      if (dispatch) {
+        dispatch(
+          state.tr.delete($cursor.pos, $cursor.pos + 1).scrollIntoView()
+        );
+      }
+      return true;
+    }
+
+    return false;
+  };
+}
+
+function deleteBackwardNearAtom(): Command {
+  return (state, dispatch) => {
+    const { selection } = state;
+    if (!(selection instanceof TextSelection)) {
+      return false;
+    }
+
+    const { $cursor } = selection;
+    if (!$cursor) {
+      return false;
+    }
+
+    const nodeBefore = $cursor.nodeBefore;
+    const nodeAfter = $cursor.nodeAfter;
+    if (!nodeBefore?.isText || nodeBefore.nodeSize !== 1) {
+      return false;
+    }
+
+    if (nodeAfter?.isAtom && nodeAfter.isInline) {
+      if (dispatch) {
+        dispatch(
+          state.tr.delete($cursor.pos - 1, $cursor.pos).scrollIntoView()
+        );
+      }
+      return true;
+    }
+
+    return false;
+  };
+}

--- a/shared/editor/nodes/index.ts
+++ b/shared/editor/nodes/index.ts
@@ -1,4 +1,5 @@
 import DateTime from "../extensions/DateTime";
+import DeleteNearAtom from "../extensions/DeleteNearAtom";
 import History from "../extensions/History";
 import MaxLength from "../extensions/MaxLength";
 import TrailingNode from "../extensions/TrailingNode";
@@ -66,6 +67,7 @@ export const basicExtensions: Nodes = [
   MaxLength,
   DateTime,
   HardBreak,
+  DeleteNearAtom,
 ];
 
 export const listExtensions: Nodes = [


### PR DESCRIPTION
## Summary

Fixes #10681 

When text and an inline image exist in the same paragraph (inside a table cell or anywhere else), the last character before the image cannot be deleted using Delete or Backspace keys.

Added a new extension `DeleteNearAtom` that explicitly handles Delete/Backspace.
- Delete: cursor is at `|x[image]` position (1 character before atom)
- Backspace: cursor is at `x|[image]` position (1 character before atom)

## How to validate

- Create a table and insert an image using `/image` command
- Move cursor before the image and type some text (e.g., "Hello")
  1. Position cursor before the character `H` and press Delete repeatedly
  2. Verify all characters including the last one are deleted

- Move cursor before the image and type another text like "World"
  1. Position the cursor after the character `d` and press Backspace repeatedly.
  2. Test the same scenario outside of tables (regular paragraph)
- Verify normal text deletion still works when no atom node is adjacent