### PR TITLE
Allow PKCE clients to refresh tokens

### DIFF
--- a/server/routes/oauth/index.ts
+++ b/server/routes/oauth/index.ts
@@ -22,6 +22,14 @@ const app = new Koa();
 const router = new Router();
 const oauth = new OAuth2Server({
   model: OAuthInterface,
+  // Allow PKCE clients to refresh tokens without client_secret.
+  // PKCE clients are public clients that cannot safely store secrets,
+  // so they authenticate via code_verifier during initial token exchange
+  // and should be allowed to refresh without a secret.
+  requireClientAuthentication: {
+    authorization_code: true,
+    refresh_token: false,
+  },
 });
 
 router.post(


### PR DESCRIPTION
## Summary

Allows PKCE (public) clients to refresh access tokens without providing a client_secret.

## Why

PKCE clients are public clients (e.g., mobile apps, SPAs) that cannot safely store secrets. They authenticate via `code_verifier` during the initial token exchange, but the current OAuth2 server configuration requires client authentication for all grant types, including `refresh_token`.

This blocks PKCE clients from refreshing their tokens since they have no secret to provide. The fix configures `oauth2-server` to skip client authentication for the `refresh_token` grant while still requiring it for `authorization_code`.

## Test plan

- PKCE client can exchange authorization code (with code_verifier) for tokens
- PKCE client can refresh tokens without providing client_secret
- Confidential clients still work as before