### PR TITLE
chore: Convert dashes to underscores instead of removing

### DIFF
--- a/app/utils/emoji.test.ts
+++ b/app/utils/emoji.test.ts
@@ -15,7 +15,7 @@ describe("generateEmojiNameFromFilename", () => {
     );
   });
 
-  test("should replace spaces with underscores", () => {
+  test("should replace spaces and dashes with underscores", () => {
     expect(generateEmojiNameFromFilename("party parrot.gif")).toBe(
       "party_parrot"
     );
@@ -26,7 +26,7 @@ describe("generateEmojiNameFromFilename", () => {
 
   test("should remove invalid characters", () => {
     expect(generateEmojiNameFromFilename("party-parrot.gif")).toBe(
-      "partyparrot"
+      "party_parrot"
     );
     expect(generateEmojiNameFromFilename("happy!@#$%.png")).toBe("happy");
     expect(generateEmojiNameFromFilename("emoji(1).png")).toBe("emoji");
@@ -65,7 +65,7 @@ describe("generateEmojiNameFromFilename", () => {
       "party_parrot"
     );
     expect(generateEmojiNameFromFilename("dumpster-fire-2023.png")).toBe(
-      "dumpsterfire"
+      "dumpster_fire"
     );
   });
 

--- a/app/utils/emoji.ts
+++ b/app/utils/emoji.ts
@@ -6,7 +6,7 @@ export function emojiToUrl(text: string) {
  * Generates a valid emoji name from a filename by:
  * - Removing file extension
  * - Converting to lowercase
- * - Replacing spaces with underscores
+ * - Replacing spaces and dashes with underscores
  * - Removing invalid characters (only allowing lowercase letters and underscores)
  * - Removing numbers
  * - Removing leading/trailing underscores
@@ -18,8 +18,11 @@ export function generateEmojiNameFromFilename(filename: string): string {
   // Remove file extension
   const nameWithoutExt = filename.replace(/\.[^.]+$/, "");
 
-  // Convert to lowercase, replace spaces with underscores
-  let name = nameWithoutExt.toLowerCase().replace(/\s+/g, "_");
+  // Convert to lowercase, replace spaces and dashes with underscores
+  let name = nameWithoutExt
+    .toLowerCase()
+    .replace(/\s+/g, "_")
+    .replace(/-+/g, "_");
 
   // Remove all characters that aren't lowercase letters or underscores (including numbers)
   name = name.replace(/[^a-z_]/g, "");


### PR DESCRIPTION
When auto-generating an emoji name from a file name, we should convert dashes to underscores. 