### PR TITLE
fix: overflow tables and math on (pdf) print

### DIFF
--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -1919,6 +1919,7 @@ table {
 
 .${EditorStyleHelper.table} {
   position: relative;
+  --print-table-scale: 1;
 }
 
 .${EditorStyleHelper.tableScrollable} {
@@ -2120,6 +2121,30 @@ del[data-operation-index] {
   em,
   blockquote {
     font-family: "SF Pro Text", ${props.theme.fontFamily};
+  }
+  .math-node {
+    overflow: visible !important;
+    white-space: pre-wrap !important;
+    word-break: break-word !important;
+  }
+
+  .${EditorStyleHelper.table} {
+    max-width: 100%;
+  }
+
+  .${EditorStyleHelper.tableScrollable} {
+    overflow: visible !important;
+    margin-left: 0;
+    margin-right: 0;
+    padding-left: 0;
+    padding-right: 0;
+    transform-origin: top left;
+  }
+
+  .${EditorStyleHelper.tableScrollable} table {
+    transform: scale(var(--print-table-scale, 1));
+    transform-origin: top left;
+    width: max-content;
   }
 }
 `;


### PR DESCRIPTION
This fixes tables and math overflow. Only affects print mode (media query enabled).

**Math overflow**:
When creating large math equations, they overflow into a scrollable element. Letting it overflow a bit is fine, as one usually does not create longer math equations anyway. Right now, in printing, they are cut. This is bad.

**Tables**
A more involved approach is needed. Only in print mode, the table is scaled down to fit the width.
before:
<img width="809" height="138" alt="image" src="https://github.com/user-attachments/assets/4890cdd8-4157-413b-b3bc-13d2dec856aa" />

after:
<img width="765" height="111" alt="image" src="https://github.com/user-attachments/assets/f1664408-e5fb-4053-894f-1d9eba590371" />
