### PR TITLE
fix: Code words should wrap on mobile

### DIFF
--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -1,7 +1,7 @@
 /* oxlint-disable no-irregular-whitespace */
 import { lighten, transparentize } from "polished";
 import styled, { DefaultTheme, css, keyframes } from "styled-components";
-import { hover } from "../../styles";
+import { breakpoints, hover } from "../../styles";
 import { EditorStyleHelper } from "../styles/EditorStyleHelper";
 import { videoStyle } from "./Video";
 
@@ -1468,7 +1468,9 @@ code {
   font-size: 90%;
 
   .${EditorStyleHelper.codeWord} {
-    white-space: nowrap;
+    @media (min-width: ${breakpoints.tablet}px) {
+      white-space: nowrap;
+    }
     color: ${props.theme.codeKeyword};
   }
 }


### PR DESCRIPTION
Given the limited width it is too easy for the layout to break and cause horizontal scrolling