### PR TITLE
fix: Ignore missing `.env` in bootstrap.ts

### DIFF
--- a/server/scripts/bootstrap.ts
+++ b/server/scripts/bootstrap.ts
@@ -2,6 +2,7 @@ if (process.env.NODE_ENV !== "test") {
   // oxlint-disable-next-line @typescript-eslint/no-var-requires
   require("@dotenvx/dotenvx").config({
     silent: true,
+    ignore: ["MISSING_ENV_FILE"],
   });
 }
 


### PR DESCRIPTION
closes #10847