### PR TITLE
perf: Remove serialization of tasks for public API responses

### DIFF
--- a/server/presenters/document.ts
+++ b/server/presenters/document.ts
@@ -14,7 +14,7 @@ type Options = {
   includeText?: boolean;
   /** Always include the data of the document in the payload. */
   includeData?: boolean;
-
+  /** Include the updatedAt timestamp for public documents. */
   includeUpdatedAt?: boolean;
 };
 
@@ -56,7 +56,6 @@ async function presentDocument(
     text,
     icon: document.icon,
     color: document.color,
-    tasks: document.tasks,
     language: document.language,
     createdAt: document.createdAt,
     createdBy: undefined,
@@ -85,6 +84,7 @@ async function presentDocument(
   if (!options.isPublic) {
     const source = await document.$get("import");
 
+    res.tasks = document.tasks;
     res.isCollectionDeleted = await document.isCollectionDeleted();
     res.collectionId = document.collectionId;
     res.parentDocumentId = document.parentDocumentId;


### PR DESCRIPTION
Returning the `tasks` key necessitated parsing the document, we don't need this at all for public shares and can remove the work.