### PR TITLE
fix: Viewer role replacement on downgrade

### DIFF
--- a/server/models/User.ts
+++ b/server/models/User.ts
@@ -763,7 +763,7 @@ class User extends ParanoidModel<
       previousRole &&
       model.changed("role") &&
       UserRoleHelper.isRoleLower(model.role, UserRole.Member) &&
-      UserRoleHelper.isRoleHigher(previousRole, UserRole.Viewer)
+      !UserRoleHelper.isRoleLower(previousRole, UserRole.Viewer)
     ) {
       await UserMembership.update(
         {


### PR DESCRIPTION
When a user is downgraded from Viewer to Guest role, their collection permissions are NOT downgraded to Read-only as they should be.
