### PR TITLE
fix: `hooks.unfurl` comment check

### DIFF
--- a/plugins/slack/server/api/hooks.ts
+++ b/plugins/slack/server/api/hooks.ts
@@ -96,7 +96,7 @@ router.post(
 
           if (commentId) {
             const comment = await Comment.findByPk(commentId as string);
-            if (!comment) {
+            if (!comment || comment.documentId !== doc.id) {
               continue;
             }
 


### PR DESCRIPTION
Ensure comment belongs to document