### PR TITLE
fix: `isUrl` `requireHttps` option is never hit

### DIFF
--- a/server/utils/oauth/OAuthInterface.test.ts
+++ b/server/utils/oauth/OAuthInterface.test.ts
@@ -115,6 +115,19 @@ describe("OAuthInterface", () => {
       );
       expect(result).toBe(false);
     });
+
+    it("should return false for HTTP redirect URI (security requirement)", async () => {
+      const httpClient = {
+        ...client,
+        redirectUris: ["http://example.com/callback"],
+      };
+      const redirectUri = "http://example.com/callback";
+      const result = await OAuthInterface.validateRedirectUri(
+        redirectUri,
+        httpClient
+      );
+      expect(result).toBe(false);
+    });
   });
 
   describe("#validateScope", () => {

--- a/shared/utils/urls.test.ts
+++ b/shared/utils/urls.test.ts
@@ -22,6 +22,51 @@ describe("isUrl", () => {
       true
     );
   });
+
+  describe("requireHttps option", () => {
+    it("should reject HTTP URLs when requireHttps is true", () => {
+      expect(
+        urlsUtils.isUrl("http://example.com", { requireHttps: true })
+      ).toBe(false);
+      expect(
+        urlsUtils.isUrl("http://example.com/callback", { requireHttps: true })
+      ).toBe(false);
+      expect(
+        urlsUtils.isUrl("http://localhost:3000/auth", { requireHttps: true })
+      ).toBe(false);
+    });
+
+    it("should accept HTTPS URLs when requireHttps is true", () => {
+      expect(
+        urlsUtils.isUrl("https://example.com", { requireHttps: true })
+      ).toBe(true);
+      expect(
+        urlsUtils.isUrl("https://example.com/callback", { requireHttps: true })
+      ).toBe(true);
+      expect(
+        urlsUtils.isUrl("https://localhost:3000/auth", { requireHttps: true })
+      ).toBe(true);
+    });
+
+    it("should accept HTTP URLs when requireHttps is false or not specified", () => {
+      expect(urlsUtils.isUrl("http://example.com")).toBe(true);
+      expect(
+        urlsUtils.isUrl("http://example.com", { requireHttps: false })
+      ).toBe(true);
+    });
+
+    it("should allow custom protocols when requireHttps is true", () => {
+      expect(
+        urlsUtils.isUrl("seafile://openfile", { requireHttps: true })
+      ).toBe(true);
+      expect(urlsUtils.isUrl("figma://launch", { requireHttps: true })).toBe(
+        true
+      );
+      expect(urlsUtils.isUrl("myapp://callback", { requireHttps: true })).toBe(
+        true
+      );
+    });
+  });
 });
 
 describe("isBase64Url", () => {

--- a/shared/utils/urls.ts
+++ b/shared/utils/urls.ts
@@ -131,11 +131,11 @@ export function isUrl(
     if (blockedProtocols.includes(url.protocol)) {
       return false;
     }
-    if (url.hostname) {
-      return true;
-    }
     if (requireHttps && url.protocol === "http:") {
       return false;
+    }
+    if (url.hostname) {
+      return true;
     }
 
     return (


### PR DESCRIPTION
Due to the early return, the HTTP URI is accepted previously.