### PR TITLE
fix: Incorrect handling of missing refresh token

### DIFF
--- a/plugins/azure/server/azure.ts
+++ b/plugins/azure/server/azure.ts
@@ -28,7 +28,7 @@ export default class AzureClient extends OAuthClient {
   ): Promise<{
     accessToken: string;
     refreshToken?: string;
-    expiresAt: Date;
+    expiresAt?: Date;
   }> {
     if (env.isCloudHosted) {
       return super.rotateToken(accessToken, refreshToken);

--- a/server/models/UserAuthentication.ts
+++ b/server/models/UserAuthentication.ts
@@ -43,7 +43,7 @@ class UserAuthentication extends IdModel<
   providerId: string;
 
   @Column(DataType.DATE)
-  expiresAt: Date;
+  expiresAt: Date | null;
 
   @Column(DataType.DATE)
   lastValidatedAt: Date;
@@ -145,7 +145,7 @@ class UserAuthentication extends IdModel<
     authenticationProvider: AuthenticationProvider,
     options: SaveOptions
   ): Promise<boolean> {
-    if (this.expiresAt > addMinutes(Date.now(), 5)) {
+    if (this.expiresAt && this.expiresAt > addMinutes(Date.now(), 5)) {
       Logger.debug(
         "authentication",
         "Existing token is still valid, skipping refresh"
@@ -186,7 +186,7 @@ class UserAuthentication extends IdModel<
         this.refreshToken = response.refreshToken;
       }
       this.accessToken = response.accessToken;
-      this.expiresAt = response.expiresAt;
+      this.expiresAt = response.expiresAt ?? null;
       await this.save(options);
     }
 

--- a/server/utils/oauth.ts
+++ b/server/utils/oauth.ts
@@ -55,7 +55,7 @@ export default abstract class OAuthClient {
   ): Promise<{
     accessToken: string;
     refreshToken?: string;
-    expiresAt: Date;
+    expiresAt?: Date;
   }> {
     let data;
     let response;
@@ -89,7 +89,9 @@ export default abstract class OAuthClient {
     return {
       refreshToken: data.refresh_token,
       accessToken: data.access_token,
-      expiresAt: new Date(Date.now() + data.expires_in * 1000),
+      expiresAt: data.expires_in
+        ? new Date(Date.now() + data.expires_in * 1000)
+        : undefined,
     };
   }
 }


### PR DESCRIPTION
Actual vs. expected: When expires_in is missing, the code creates new Date(Date.now() + undefined * 1000) which results in an Invalid Date object, instead of handling the missing field gracefully (e.g., by returning undefined for expiresAt).
