### PR TITLE
fix: Move Slack credentials to Authorization header in token exchange

### DIFF
--- a/plugins/slack/server/slack.ts
+++ b/plugins/slack/server/slack.ts
@@ -6,9 +6,16 @@ import env from "./env";
 
 const SLACK_API_URL = "https://slack.com/api";
 
+/**
+ * Makes a POST request to the Slack API with JSON body.
+ *
+ * @param endpoint - the Slack API endpoint to call.
+ * @param body - the request body containing token and other parameters.
+ * @returns the parsed JSON response from Slack.
+ */
 export async function post(endpoint: string, body: Record<string, any>) {
   let data;
-  const token = body.token;
+  const { token, ...bodyWithoutToken } = body;
 
   try {
     const response = await fetch(`${SLACK_API_URL}/${endpoint}`, {
@@ -17,7 +24,7 @@ export async function post(endpoint: string, body: Record<string, any>) {
         Authorization: `Bearer ${token}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(body),
+      body: JSON.stringify(bodyWithoutToken),
     });
     data = await response.json();
   } catch (err) {
@@ -30,13 +37,37 @@ export async function post(endpoint: string, body: Record<string, any>) {
   return data;
 }
 
+/**
+ * Makes a POST request to the Slack API with form-urlencoded body.
+ *
+ * @param endpoint - the Slack API endpoint to call.
+ * @param body - the request parameters.
+ * @returns the parsed JSON response from Slack.
+ */
 export async function request(endpoint: string, body: Record<string, any>) {
   let data;
+  const { client_id, client_secret, ...params } = body;
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/x-www-form-urlencoded",
+  };
+
+  // Use HTTP Basic authentication for client credentials as recommended by
+  // Slack documentation and OAuth 2.0 RFC 6749 Section 2.3.1.
+  // This prevents client_secret from being exposed in URLs and logs.
+  if (client_id && client_secret) {
+    const credentials = Buffer.from(`${client_id}:${client_secret}`).toString(
+      "base64"
+    );
+    headers["Authorization"] = `Basic ${credentials}`;
+  }
 
   try {
-    const response = await fetch(
-      `${SLACK_API_URL}/${endpoint}?${querystring.stringify(body)}`
-    );
+    const response = await fetch(`${SLACK_API_URL}/${endpoint}`, {
+      method: "POST",
+      headers,
+      body: querystring.stringify(params),
+    });
     data = await response.json();
   } catch (err) {
     throw InvalidRequestError(err.message);
@@ -48,6 +79,13 @@ export async function request(endpoint: string, body: Record<string, any>) {
   return data;
 }
 
+/**
+ * Exchanges an OAuth authorization code for an access token.
+ *
+ * @param code - the authorization code received from Slack.
+ * @param redirect_uri - the redirect URI used in the OAuth flow.
+ * @returns the OAuth access response containing the access token.
+ */
 export async function oauthAccess(
   code: string,
   redirect_uri = SlackUtils.callbackUrl()


### PR DESCRIPTION
Previously these appeared in the get parameters and could theoretically be logged