### PR TITLE
fix: `pins.list` does not check collection policy

### DIFF
--- a/server/routes/api/pins/pins.ts
+++ b/server/routes/api/pins/pins.ts
@@ -100,6 +100,13 @@ router.post(
     const { collectionId } = ctx.input.body;
     const { user } = ctx.state.auth;
 
+    if (collectionId) {
+      const collection = await Collection.findByPk(collectionId, {
+        userId: user.id,
+      });
+      authorize(user, "read", collection);
+    }
+
     const [pins, collectionIds] = await Promise.all([
       Pin.findAll({
         where: {


### PR DESCRIPTION
This does not leak document info, by may leak IDs – allowing for future IDOR style attacks