### PR TITLE
fix: Restore `EventBoundary` in a better location

### DIFF
--- a/app/editor/components/ToolbarMenu.tsx
+++ b/app/editor/components/ToolbarMenu.tsx
@@ -16,6 +16,7 @@ import { MenuContent } from "~/components/primitives/Menu";
 import { MenuProvider } from "~/components/primitives/Menu/MenuContext";
 import { Menu, MenuTrigger } from "~/components/primitives/Menu";
 import { useTranslation } from "react-i18next";
+import EventBoundary from "@shared/components/EventBoundary";
 
 type Props = {
   items: MenuItem[];
@@ -84,7 +85,7 @@ function ToolbarDropdown(props: { active: boolean; item: MenuItem }) {
           aria-label={item.tooltip || t("More options")}
           onCloseAutoFocus={handleCloseAutoFocus}
         >
-          {toMenuItems(items)}
+          <EventBoundary>{toMenuItems(items)}</EventBoundary>
         </MenuContent>
       </Menu>
     </MenuProvider>


### PR DESCRIPTION
This was still needed, but wrapping tightly around the menu items is better as it doesn't mess with trigger layout