### PR TITLE
fix: prevent extra newlines in pasted code blocks

### DIFF
--- a/shared/editor/lib/markdown/normalize.ts
+++ b/shared/editor/lib/markdown/normalize.ts
@@ -6,6 +6,17 @@
  */
 export default function normalizePastedMarkdown(text: string): string {
   const CHECKBOX_REGEX = /^\s?(\[(X|\s|_|-)\]\s(.*)?)/gim;
+  const CODE_BLOCK_REGEX = /^ {0,3}(`{3,}|~{3,})[\s\S]*?^ {0,3}\1/gm;
+
+  const placeholders: string[] = [];
+  const placeholderPrefix = "REPLACED_CODE_BLOCK_";
+
+  // Replace code blocks with placeholders to prevent normalization
+  text = text.replace(CODE_BLOCK_REGEX, (match) => {
+    const placeholder = `${placeholderPrefix}${placeholders.length}`;
+    placeholders.push(match);
+    return placeholder;
+  });
 
   // find checkboxes not contained in a list and wrap them in list items
   while (text.match(CHECKBOX_REGEX)) {
@@ -17,6 +28,12 @@ export default function normalizePastedMarkdown(text: string): string {
 
   // find single newlines and insert an extra to ensure they are treated as paragraphs
   text = text.replace(/\b\n\b/g, "\n\n");
+
+  // Restore placeholders
+  placeholders.forEach((match, index) => {
+    const placeholder = `${placeholderPrefix}${index}`;
+    text = text.replace(placeholder, match);
+  });
 
   return text;
 }


### PR DESCRIPTION
## Description

This PR fixes an issue where pasting code blocks (especially those with newlines immediately following the opening fence) resulted in extra empty lines being inserted at the beginning of the block.

The issue was caused by `normalizePastedMarkdown` aggressively normalizing newlines to ensure paragraphs are respected. This change updates `normalizePastedMarkdown` to:
1. Identify code blocks using a robust regex.
2. Temporarily replace these blocks with placeholders.
3. Perform the newline normalization on the rest of the text.
4. Restore the original code blocks.

## Verification

### Reproduction Steps
When copying and pasting a code block like:
````md
```bash
echo hello
```
````
**Before this change**, the editor would incorrectly add a newline:
<img width="885" height="138" alt="image" src="https://github.com/user-attachments/assets/4e23faae-aaa5-4452-b6db-9396d127968f" />
**After this change**, the content is pasted correctly without the leading newline.
<img width="885" height="102" alt="image" src="https://github.com/user-attachments/assets/e8e5fcac-02ac-4ff4-abe0-1e4888485200" />