### PR TITLE
perf: Remove default `fetchDocuments` call

### DIFF
--- a/app/components/DocumentMeta.tsx
+++ b/app/components/DocumentMeta.tsx
@@ -182,7 +182,7 @@ const DocumentMeta: React.FC<Props> = ({
         <span>
           &nbsp;{t("in")}&nbsp;
           <Strong>
-            <DocumentBreadcrumb document={document} onlyText />
+            <DocumentBreadcrumb document={document} maxDepth={1} onlyText />
           </Strong>
         </span>
       )}

--- a/app/stores/CollectionsStore.ts
+++ b/app/stores/CollectionsStore.ts
@@ -149,13 +149,6 @@ export default class CollectionsStore extends Store<Collection> {
   }
 
   @action
-  async fetch(id: string, options?: { force: boolean }): Promise<Collection> {
-    const model = await super.fetch(id, options);
-    await model.fetchDocuments(options);
-    return model;
-  }
-
-  @action
   fetchNamedPage = async (
     request = "list",
     options:


### PR DESCRIPTION
We already have `fetchDocuments` calls everywhere it is strictly required, this ends up loading a lot of document trees just for a giant breadcrumb on lists which is unwieldy anyway.

Pulled out of #10858