### PR TITLE
fix: SQL errors do not correctly bubble in Jest

### DIFF
--- a/server/collaboration/ConnectionLimitExtension.test.ts
+++ b/server/collaboration/ConnectionLimitExtension.test.ts
@@ -21,6 +21,7 @@ describe("ConnectionLimitExtension", () => {
     server = Server.configure({
       port,
       extensions: [extension, new EditorVersionExtension()],
+      quiet: true,
     });
     await server.listen();
   });

--- a/server/storage/database.ts
+++ b/server/storage/database.ts
@@ -101,6 +101,10 @@ export function createDatabaseInstance(
 
     sequelizeStrictAttributes(instance);
 
+    if (env.isTest) {
+      instance = monkeyPatchSequelizeErrorsForJest(instance);
+    }
+
     // Add hooks to warn about write operations on read-only connections
     if (isReadOnly) {
       const warnWriteOperation = (operation: string) => {
@@ -206,6 +210,43 @@ export function createMigrationRunner(
         ),
     },
   });
+}
+
+/**
+ * Fixed in Sequelize v7, but hasn't been back-ported to Sequelize v6.
+ * See https://github.com/sequelize/sequelize/issues/14807#issuecomment-1854398131
+ */
+export function monkeyPatchSequelizeErrorsForJest(instance: Sequelize) {
+  if (typeof jest === "undefined") {
+    return instance;
+  }
+
+  const sequelizeVersion = (Sequelize as any).version;
+  const major = sequelizeVersion.split(".").map(Number)[0];
+
+  if (major >= 7) {
+    Logger.fatal(
+      "Redundant patch",
+      new Error(
+        "This patch was made redundant in Sequelize v7, you should check!"
+      )
+    );
+  }
+
+  const origQueryFunc = instance.query;
+  instance.query = async function query(this: Sequelize, ...args: any[]) {
+    let result;
+    try {
+      result = await origQueryFunc.apply(this, args as any);
+    } catch (err: any) {
+      // Ensure error appears in Jest output, not swallowed by Sequelize internals
+      Logger.error(err.message, err.parent);
+      throw err;
+    }
+    return result;
+  } as typeof origQueryFunc;
+
+  return instance;
 }
 
 export const sequelize = createDatabaseInstance(databaseConfig, models);


### PR DESCRIPTION
Adds a monkey patch to ensure that SQL error details are visible without try/catch hacking.