### PR TITLE
fix: User with "can edit" permission on sub-document cannot sort

### DIFF
--- a/app/components/Sidebar/hooks/useDragAndDrop.tsx
+++ b/app/components/Sidebar/hooks/useDragAndDrop.tsx
@@ -466,7 +466,7 @@ export function useDropToReorderDocument(
           } catch (err) {
             if (err instanceof AuthorizationError) {
               toast.error(
-                t("The {{ documentName }} cannot be moved here", {
+                t("{{ documentName }} cannot be moved here", {
                   documentName: item.title,
                 })
               );

--- a/server/policies/document.test.ts
+++ b/server/policies/document.test.ts
@@ -392,7 +392,7 @@ describe("read_write document", () => {
       expect(abilities.manageUsers).toEqual(false);
       expect(abilities.archive).toEqual(false);
       expect(abilities.share).toEqual(false);
-      expect(abilities.move).toEqual(false);
+      expect(abilities.move).toBeTruthy();
     });
   }
 
@@ -428,7 +428,7 @@ describe("read_write document", () => {
     expect(abilities.manageUsers).toBeTruthy();
     expect(abilities.archive).toBeTruthy();
     expect(abilities.share).toEqual(false);
-    expect(abilities.move).toEqual(false);
+    expect(abilities.move).toBeTruthy();
   });
 });
 
@@ -468,7 +468,7 @@ describe("manage document", () => {
       expect(abilities.createChildDocument).toBeTruthy();
       expect(abilities.manageUsers).toBeTruthy();
       expect(abilities.archive).toBeTruthy();
-      expect(abilities.move).toEqual(false);
+      expect(abilities.move).toBeTruthy();
       expect(abilities.share).toEqual(false);
     });
   }

--- a/server/policies/document.ts
+++ b/server/policies/document.ts
@@ -155,6 +155,10 @@ allow(User, "move", Document, (actor, document) =>
   and(
     can(actor, "update", document),
     or(
+      includesMembership(document, [
+        DocumentPermission.ReadWrite,
+        DocumentPermission.Admin,
+      ]),
       can(actor, "updateDocument", document?.collection),
       and(!!document?.isDraft && actor.id === document?.createdById),
       and(!!document?.isDraft && !document?.collection),

--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -1341,18 +1341,6 @@ router.post(
     });
     authorize(user, "move", document);
 
-    if (collectionId) {
-      const collection = await Collection.findByPk(collectionId, {
-        userId: user.id,
-        transaction,
-      });
-      authorize(user, "updateDocument", collection);
-    } else if (document.template) {
-      authorize(user, "updateTemplate", user.team);
-    } else if (!parentDocumentId) {
-      throw InvalidRequestError("collectionId is required to move a document");
-    }
-
     if (parentDocumentId) {
       const parent = await Document.findByPk(parentDocumentId, {
         userId: user.id,
@@ -1364,6 +1352,16 @@ router.post(
       if (!parent.publishedAt) {
         throw InvalidRequestError("Cannot move document inside a draft");
       }
+    } else if (collectionId) {
+      const collection = await Collection.findByPk(collectionId, {
+        userId: user.id,
+        transaction,
+      });
+      authorize(user, "updateDocument", collection);
+    } else if (document.template) {
+      authorize(user, "updateTemplate", user.team);
+    } else {
+      throw InvalidRequestError("collectionId is required to move a document");
     }
 
     const { documents, collectionChanged } = await documentMover(ctx, {

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -474,7 +474,7 @@
   "Change permissions?": "Change permissions?",
   "{{ documentName }} cannot be moved within {{ parentDocumentName }}": "{{ documentName }} cannot be moved within {{ parentDocumentName }}",
   "You can't reorder documents in an alphabetically sorted collection": "You can't reorder documents in an alphabetically sorted collection",
-  "The {{ documentName }} cannot be moved here": "The {{ documentName }} cannot be moved here",
+  "{{ documentName }} cannot be moved here": "{{ documentName }} cannot be moved here",
   "Return to App": "Back to App",
   "Installation": "Installation",
   "Unstar document": "Unstar document",


### PR DESCRIPTION
Allows sorting sub-tree when user only has edit permissions for sub-documents.

closes #8576 