### PR TITLE
Restore color picker

### DIFF
--- a/app/components/SwatchButton.tsx
+++ b/app/components/SwatchButton.tsx
@@ -96,8 +96,8 @@ const StyledContent = styled(PopoverContent)`
   padding: 8px;
 `;
 
-const ColorPicker = lazyWithRetry(
-  () => import("react-color/lib/components/chrome/Chrome")
+const ColorPicker = lazyWithRetry(() =>
+  import("react-color").then((mod) => ({ default: mod.ChromePicker }))
 );
 
 const StyledColorPicker = styled(ColorPicker)`


### PR DESCRIPTION
Clicking on the rainbow swatch in icon picker crashes the app! Let's restore that.