### PR TITLE
Change Mermaid code block language from "mermaidjs" to "mermaid"

### DIFF
--- a/app/editor/menus/block.tsx
+++ b/app/editor/menus/block.tsx
@@ -234,7 +234,7 @@ export default function blockMenuItems(
       title: "Mermaid Diagram",
       icon: <Img src="/images/mermaidjs.png" alt="Mermaid Diagram" />,
       keywords: "diagram flowchart",
-      attrs: { language: "mermaidjs" },
+      attrs: { language: "mermaid" },
     },
     {
       name: "editDiagram",

--- a/app/editor/menus/code.tsx
+++ b/app/editor/menus/code.tsx
@@ -10,6 +10,7 @@ import {
   codeLanguages,
   getLabelForLanguage,
 } from "@shared/editor/lib/code";
+import { isMermaid } from "@shared/editor/lib/isCode";
 import type { MenuItem } from "@shared/editor/types";
 import type { Dictionary } from "~/hooks/useDictionary";
 
@@ -61,7 +62,7 @@ export default function codeMenuItems(
       tooltip: dictionary.editDiagram,
       visible:
         !(mermaidPluginKey.getState(state) as MermaidState)?.editingId &&
-        node?.attrs.language === "mermaidjs" &&
+        isMermaid(node) &&
         !readOnly,
     },
     {

--- a/server/models/helpers/ProsemirrorHelper.tsx
+++ b/server/models/helpers/ProsemirrorHelper.tsx
@@ -548,10 +548,10 @@ export class ProsemirrorHelper {
         }
       }
 
-      // Inject mermaidjs scripts if the document contains mermaid diagrams
+      // Inject mermaidjs scripts if the document contains mermaid diagrams (supports both "mermaid" and "mermaidjs")
       if (options?.includeMermaid) {
         const mermaidElements = dom.window.document.querySelectorAll(
-          `[data-language="mermaidjs"] pre code`
+          `[data-language="mermaid"] pre code, [data-language="mermaidjs"] pre code`
         );
 
         // Unwrap <pre> tags to enable Mermaid script to correctly render inner content

--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -1676,6 +1676,7 @@ mark {
   }
 }
 
+.code-block[data-language=mermaid],
 .code-block[data-language=mermaidjs] {
   ${
     !props.staticHTML &&
@@ -1702,6 +1703,7 @@ mark {
   }
 }
 
+.ProseMirror[contenteditable="false"] .code-block[data-language=mermaid],
 .ProseMirror[contenteditable="false"] .code-block[data-language=mermaidjs] {
     height: 0;
     overflow: hidden;
@@ -1712,6 +1714,7 @@ mark {
 }
 
 .ProseMirror.exported {
+    .code-block[data-language=mermaid],
     .code-block[data-language=mermaidjs] {
         height: auto;
         overflow: visible;

--- a/shared/editor/extensions/Mermaid.ts
+++ b/shared/editor/extensions/Mermaid.ts
@@ -7,7 +7,7 @@ import type { Transaction } from "prosemirror-state";
 import { Plugin, PluginKey, TextSelection } from "prosemirror-state";
 import { Decoration, DecorationSet } from "prosemirror-view";
 import { toast } from "sonner";
-import { isCode } from "../lib/isCode";
+import { isCode, isMermaid } from "../lib/isCode";
 import { isRemoteTransaction } from "../lib/multiplayer";
 import { findBlockNodes } from "../queries/findChildren";
 import { findParentNode } from "../queries/findParentNode";
@@ -167,9 +167,9 @@ function getNewState({
 }): MermaidState {
   const decorations: Decoration[] = [];
 
-  // Find all blocks that represent Mermaid diagrams
+  // Find all blocks that represent Mermaid diagrams (supports both "mermaid" and "mermaidjs")
   const blocks = findBlockNodes(doc).filter(
-    (item) => isCode(item.node) && item.node.attrs.language === "mermaidjs"
+    (item) => isMermaid(item.node)
   );
 
   blocks.forEach((block) => {
@@ -274,8 +274,7 @@ export default function Mermaid({
           const codeBlock = findParentNode(isCode)(state.selection);
           let isEditing =
             codeBlock &&
-            isCode(codeBlock.node) &&
-            codeBlock.node.attrs.language === "mermaidjs";
+            isMermaid(codeBlock.node);
 
           if (isEditing && codeBlock && !transaction.docChanged) {
             const decorations = nextPluginState.decorationSet.find(
@@ -297,8 +296,6 @@ export default function Mermaid({
 
         const node = state.selection.$head.parent;
         const previousNode = oldState.selection.$head.parent;
-        const isMermaid = (n: Node) =>
-          isCode(n) && n.attrs.language === "mermaidjs";
         const codeBlockChanged =
           transaction.docChanged &&
           (isMermaid(node) || isMermaid(previousNode));
@@ -406,8 +403,7 @@ export default function Mermaid({
 
               if (
                 nextBlock &&
-                isCode(nextBlock) &&
-                nextBlock.attrs.language === "mermaidjs"
+                isMermaid(nextBlock)
               ) {
                 view.dispatch(
                   view.state.tr
@@ -432,8 +428,7 @@ export default function Mermaid({
 
               if (
                 prevBlock &&
-                isCode(prevBlock) &&
-                prevBlock.attrs.language === "mermaidjs"
+                isMermaid(prevBlock)
               ) {
                 view.dispatch(
                   view.state.tr

--- a/shared/editor/lib/Lightbox.ts
+++ b/shared/editor/lib/Lightbox.ts
@@ -1,5 +1,5 @@
 import type { Node } from "prosemirror-model";
-import { isCode } from "./isCode";
+import { isMermaid } from "./isCode";
 import type { EditorView } from "prosemirror-view";
 import { sanitizeUrl } from "@shared/utils/urls";
 
@@ -80,7 +80,5 @@ export class LightboxImageFactory {
 }
 
 const isImage = (node: Node) => node.type.name === "image";
-const isMermaid = (node: Node) =>
-  isCode(node) && node.attrs.language === "mermaidjs";
 
 export const isLightboxNode = (node: Node) => isImage(node) || isMermaid(node);

--- a/shared/editor/lib/code.test.ts
+++ b/shared/editor/lib/code.test.ts
@@ -3,6 +3,7 @@ import { getRefractorLangForLanguage, getLabelForLanguage } from "./code";
 describe("getRefractorLangForLanguage", () => {
   it("should return the correct lang identifier for a given language", () => {
     expect(getRefractorLangForLanguage("javascript")).toBe("javascript");
+    expect(getRefractorLangForLanguage("mermaid")).toBe("mermaid");
     expect(getRefractorLangForLanguage("mermaidjs")).toBe("mermaid");
     expect(getRefractorLangForLanguage("xml")).toBe("markup");
     expect(getRefractorLangForLanguage("unknown")).toBeUndefined();
@@ -13,6 +14,7 @@ describe("getRefractorLangForLanguage", () => {
 describe("getLabelForLanguage", () => {
   it("should return the correct human-readable label for a given language", () => {
     expect(getLabelForLanguage("javascript")).toBe("JavaScript");
+    expect(getLabelForLanguage("mermaid")).toBe("Mermaid");
     expect(getLabelForLanguage("mermaidjs")).toBe("Mermaid");
     expect(getLabelForLanguage("xml")).toBe("XML");
     expect(getLabelForLanguage("unknown")).toBe("Plain text");

--- a/shared/editor/lib/code.ts
+++ b/shared/editor/lib/code.ts
@@ -162,6 +162,12 @@ export const codeLanguages: Record<string, CodeLanguage> = {
     label: "Markdown",
     loader: () => import("refractor/lang/markdown").then((m) => m.default),
   },
+  mermaid: {
+    lang: "mermaid",
+    label: "Mermaid",
+    // @ts-expect-error Mermaid is not in types but exists
+    loader: () => import("refractor/lang/mermaid").then((m) => m.default),
+  },
   mermaidjs: {
     lang: "mermaid",
     label: "Mermaid",

--- a/shared/editor/lib/isCode.ts
+++ b/shared/editor/lib/isCode.ts
@@ -3,3 +3,13 @@ import type { Node } from "prosemirror-model";
 export function isCode(node: Node) {
   return node.type.name === "code_block" || node.type.name === "code_fence";
 }
+
+/**
+ * Returns true if the node is a code block with Mermaid language (supports both "mermaid" and "mermaidjs").
+ *
+ * @param node The node to check.
+ * @returns true if the node is a Mermaid code block.
+ */
+export function isMermaid(node: Node) {
+  return isCode(node) && (node.attrs.language === "mermaid" || node.attrs.language === "mermaidjs");
+}

--- a/shared/editor/nodes/CodeFence.ts
+++ b/shared/editor/nodes/CodeFence.ts
@@ -36,7 +36,7 @@ import {
   getRecentlyUsedCodeLanguage,
   setRecentlyUsedCodeLanguage,
 } from "../lib/code";
-import { isCode } from "../lib/isCode";
+import { isCode, isMermaid } from "../lib/isCode";
 import type { MarkdownSerializerState } from "../lib/markdown/serializer";
 import { findNextNewline, findPreviousNewline } from "../queries/findNewlines";
 import { findParentNode } from "../queries/findParentNode";
@@ -125,7 +125,7 @@ export default class CodeFence extends Node {
       },
       edit_mermaid: (): Command => (state, dispatch) => {
         const codeBlock = findParentNode(isCode)(state.selection);
-        if (!codeBlock || codeBlock.node.attrs.language !== "mermaidjs") {
+        if (!codeBlock || !isMermaid(codeBlock.node)) {
           return false;
         }
 
@@ -224,7 +224,7 @@ export default class CodeFence extends Node {
         return DecorationSet.empty;
       }
 
-      if (codeBlock.node.attrs.language === "mermaidjs") {
+      if (isMermaid(codeBlock.node)) {
         const mermaidState = mermaidPluginKey.getState(state) as MermaidState;
         const decorations = mermaidState?.decorationSet.find(
           codeBlock.pos,


### PR DESCRIPTION
- Add "mermaid" as the primary language identifier for new diagrams
- Maintain backward compatibility with existing "mermaidjs" blocks
- Create isMermaid() helper function for consistent language checking
- Update all Mermaid-related code to support both language variants
- Update CSS selectors to style both "mermaid" and "mermaidjs" blocks
- Update server-side HTML export to handle both language formats

closes #11120