### PR TITLE
fix: Skip math content in tables rule to preserve LaTeX escape sequences

### DIFF
--- a/shared/editor/rules/tables.ts
+++ b/shared/editor/rules/tables.ts
@@ -24,6 +24,12 @@ export default function markdownTables(md: MarkdownIt): void {
         tokens[i].children = [];
 
         existing.forEach((child) => {
+          // Skip processing math content to preserve LaTeX escape sequences
+          if (child.type === "math_inline") {
+            tokens[i].children?.push(child);
+            return;
+          }
+
           let content = child.content;
 
           // First handle <br> tags


### PR DESCRIPTION
Fixes #10255 where LaTeX commands containing \n (like \neg, \neq, \nu) were being incorrectly interpreted as newline characters when pasted.
