### PR TITLE
chore: Remove `collection.url`, fix post-signin redirect

### DIFF
--- a/plugins/slack/server/processors/SlackProcessor.ts
+++ b/plugins/slack/server/processors/SlackProcessor.ts
@@ -72,7 +72,7 @@ export default class SlackProcessor extends BaseProcessor {
           {
             color: collection.color,
             title: collection.name,
-            title_link: `${env.URL}${collection.url}`,
+            title_link: `${env.URL}${collection.path}`,
             text: collection.description,
           },
         ],

--- a/server/commands/shareLoader.test.ts
+++ b/server/commands/shareLoader.test.ts
@@ -40,7 +40,7 @@ describe("shareLoader", () => {
       expect(result.share.id).toEqual(share.id);
       expect(result.collection?.id).toEqual(collection.id);
       expect(result.sharedTree?.id).toEqual(collection.id);
-      expect(result.sharedTree?.url).toEqual(collection.url);
+      expect(result.sharedTree?.url).toEqual(collection.path);
       expect(result.sharedTree?.children[0].id).toEqual(document.id);
       expect(result.sharedTree?.children[0].children[0].id).toEqual(
         childDocument.id

--- a/server/emails/templates/CollectionCreatedEmail.tsx
+++ b/server/emails/templates/CollectionCreatedEmail.tsx
@@ -73,13 +73,13 @@ ${collection.name}
 
 ${collection.user.name} created the collection "${collection.name}"
 
-Open Collection: ${teamUrl}${collection.url}
+Open Collection: ${teamUrl}${collection.path}
 `;
   }
 
   protected render(props: Props) {
     const { collection, teamUrl, unsubscribeUrl } = props;
-    const collectionLink = `${teamUrl}${collection.url}`;
+    const collectionLink = `${teamUrl}${collection.path}`;
 
     return (
       <EmailTemplate

--- a/server/models/Collection.test.ts
+++ b/server/models/Collection.test.ts
@@ -20,7 +20,7 @@ describe("#url", () => {
     const collection = new Collection({
       id: "1234",
     });
-    expect(collection.url).toBe(`/collection/untitled-${collection.urlId}`);
+    expect(collection.path).toBe(`/collection/untitled-${collection.urlId}`);
   });
 });
 

--- a/server/models/Collection.ts
+++ b/server/models/Collection.ts
@@ -315,15 +315,6 @@ class Collection extends ParanoidModel<
 
   // getters
 
-  /**
-   * The frontend path to this collection.
-   *
-   * @deprecated Use `path` instead.
-   */
-  get url(): string {
-    return this.path;
-  }
-
   /** The frontend path to this collection. */
   get path(): string {
     if (!this.name) {

--- a/server/presenters/collection.ts
+++ b/server/presenters/collection.ts
@@ -22,7 +22,7 @@ export default async function presentCollection(
 
   const res: Record<string, any> = {
     id: collection.id,
-    url: collection.url,
+    url: collection.path,
     urlId: collection.urlId,
     name: collection.name,
     data: asData

--- a/server/routes/auth/index.test.ts
+++ b/server/routes/auth/index.test.ts
@@ -30,7 +30,7 @@ describe("auth/redirect", () => {
     );
     expect(res.status).toEqual(302);
     expect(res.headers.get("location")).not.toBeNull();
-    expect(res.headers.get("location")!.endsWith(collection.url)).toBeTruthy();
+    expect(res.headers.get("location")!.endsWith(collection.path)).toBeTruthy();
   });
 
   it("should prevent token extension by rejecting JWT tokens", async () => {

--- a/server/routes/auth/index.ts
+++ b/server/routes/auth/index.ts
@@ -66,7 +66,7 @@ router.get("/redirect", authMiddleware(), async (ctx: APIContext) => {
     });
 
     if (collection) {
-      ctx.redirect(`${team.url}${collection.url}`);
+      ctx.redirect(`${team.url}${collection.path}`);
       return;
     }
   }
@@ -75,7 +75,7 @@ router.get("/redirect", authMiddleware(), async (ctx: APIContext) => {
 
   ctx.redirect(
     !hasViewedDocuments && collection
-      ? `${team?.url}${collection.url}`
+      ? `${team?.url}${collection.path}/recent`
       : `${team?.url}/home`
   );
 });

--- a/server/utils/authentication.ts
+++ b/server/utils/authentication.ts
@@ -151,7 +151,7 @@ export async function signIn(
       });
 
       if (collection) {
-        ctx.redirect(`${team.url}${collection.url}`);
+        ctx.redirect(`${team.url}${collection.path}`);
         return;
       }
     }
@@ -171,7 +171,7 @@ export async function signIn(
 
     ctx.redirect(
       !hasViewedDocuments && collection
-        ? `${team.url}${collection.url}`
+        ? `${team.url}${collection.path}/recent`
         : `${team.url}/home`
     );
   }


### PR DESCRIPTION
Removing this long-deprecated property and improving the post-sign-in redirect to go to the document list. 