### PR TITLE
feat(redis-key-prefix): configurable key prefix for redis usages

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -61,6 +61,10 @@ DATABASE_CONNECTION_POOL_MAX=
 # DOCS: https://docs.getoutline.com/s/hosting/doc/redis-LGM4BFXYp4
 REDIS_URL=redis://redis:6379
 
+# Optional key prefix for all Redis keys. Useful for key namespacing when
+# sharing a Redis instance between multiple applications.
+# REDIS_KEY_PREFIX=
+
 
 # ––––––––––––––––––––––––––––––––––––––
 # –––––––––––  FILE STORAGE  –––––––––––

--- a/server/env.ts
+++ b/server/env.ts
@@ -199,6 +199,13 @@ export class Environment {
   public REDIS_COLLABORATION_URL = environment.REDIS_COLLABORATION_URL;
 
   /**
+   * An optional key prefix for all Redis keys. Useful for key namespacing when
+   * sharing a Redis instance between multiple applications.
+   */
+  @IsOptional()
+  public REDIS_KEY_PREFIX = this.toOptionalString(environment.REDIS_KEY_PREFIX);
+
+  /**
    * The fully qualified, external facing domain name of the server.
    */
   @Public


### PR DESCRIPTION
New Redis Adapter options to set a key prefix based on an environment variable.
Split the bull's redis usage to not use the option as described [by the docs](https://github.com/OptimalBits/bull/blob/develop/PATTERNS.md#reusing-redis-connections), making the implementation compatible with Redis clusters:
> do not set a keyPrefix on the connection you create, use bull's built-in prefix feature if you need a key prefix

> In summary, to make bull compatible with Redis cluster, use a queue prefix inside brackets. 
