### PR TITLE
feat: Allow public shares to be retrieved as MD with accept `text/markdown` header

### DIFF
--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -57,4 +57,34 @@ describe("/s/:id", () => {
     expect(res.status).toEqual(200);
     expect(body).toContain(`<title>${document.title}</title>`);
   });
+
+  it("should return markdown when Accept header prefers text/markdown", async () => {
+    const document = await buildDocument();
+    const share = await buildShare({
+      documentId: document.id,
+      teamId: document.teamId,
+    });
+    const res = await server.get(`/s/${share.id}`, {
+      headers: { Accept: "text/markdown" },
+    });
+    const body = await res.text();
+    expect(res.status).toEqual(200);
+    expect(res.headers.get("content-type")).toContain("text/markdown");
+    expect(body).toContain(`# ${document.title}`);
+  });
+
+  it("should return html when Accept header prefers text/html over text/markdown", async () => {
+    const document = await buildDocument();
+    const share = await buildShare({
+      documentId: document.id,
+      teamId: document.teamId,
+    });
+    const res = await server.get(`/s/${share.id}`, {
+      headers: { Accept: "text/html, text/markdown" },
+    });
+    const body = await res.text();
+    expect(res.status).toEqual(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    expect(body).toContain(`<title>${document.title}</title>`);
+  });
 });


### PR DESCRIPTION
ref https://x.com/rauchg/status/2011152152623005736