### PR TITLE
fix: alt+shift header selection in Safari

### DIFF
--- a/app/actions/definitions/navigation.tsx
+++ b/app/actions/definitions/navigation.tsx
@@ -224,13 +224,13 @@ export const openKeyboardShortcuts = createAction({
 export const downloadApp = createExternalLinkAction({
   name: ({ t }) =>
     t("Download {{ platform }} app", {
-      platform: isMac() ? "macOS" : "Windows",
+      platform: isMac ? "macOS" : "Windows",
     }),
   analyticsName: "Download app",
   section: NavigationSection,
   iconInContextMenu: false,
   icon: <BrowserIcon />,
-  visible: () => !Desktop.isElectron() && isMac() && isCloudHosted,
+  visible: () => !Desktop.isElectron() && isMac && isCloudHosted,
   url: "https://desktop.getoutline.com",
   target: "_blank",
 });

--- a/app/components/Sidebar/components/HistoryNavigation.tsx
+++ b/app/components/Sidebar/components/HistoryNavigation.tsx
@@ -17,7 +17,7 @@ function HistoryNavigation(props: React.ComponentProps<typeof Flex>) {
 
   useKeyDown(
     (event) =>
-      isMac()
+      isMac
         ? event.metaKey && event.key === "["
         : event.altKey && event.key === "ArrowLeft",
     () => {
@@ -28,7 +28,7 @@ function HistoryNavigation(props: React.ComponentProps<typeof Flex>) {
 
   useKeyDown(
     (event) =>
-      isMac()
+      isMac
         ? event.metaKey && event.key === "]"
         : event.altKey && event.key === "ArrowRight",
     () => {

--- a/app/hooks/useEditorClickHandlers.ts
+++ b/app/hooks/useEditorClickHandlers.ts
@@ -28,7 +28,7 @@ export default function useEditorClickHandlers({ shareId }: Params) {
       // Middle-click events in Firefox are not prevented in the same way as other browsers
       // so we need to explicitly return here to prevent two tabs from being opened when
       // middle-clicking a link (#10083).
-      if (event?.button === 1 && isFirefox()) {
+      if (event?.button === 1 && isFirefox) {
         return;
       }
 

--- a/app/scenes/KeyboardShortcuts.tsx
+++ b/app/scenes/KeyboardShortcuts.tsx
@@ -123,7 +123,7 @@ function KeyboardShortcuts() {
           {
             shortcut: (
               <>
-                <Key symbol>{isMac() ? metaDisplay : "⇧"}</Key> + <Key>Esc</Key>
+                <Key symbol>{isMac ? metaDisplay : "⇧"}</Key> + <Key>Esc</Key>
               </>
             ),
             label: t("Cancel editing"),

--- a/app/utils/Desktop.ts
+++ b/app/utils/Desktop.ts
@@ -12,14 +12,14 @@ export default class Desktop {
    * Returns true if the client is running in the macOS app.
    */
   static isMacApp() {
-    return this.isElectron() && isMac();
+    return this.isElectron() && isMac;
   }
 
   /**
    * Returns true if the client is running in the Windows app.
    */
   static isWindowsApp() {
-    return this.isElectron() && isWindows();
+    return this.isElectron() && isWindows;
   }
 
   /**

--- a/shared/components/IssueStatusIcon/LinearIssueStatusIcon.tsx
+++ b/shared/components/IssueStatusIcon/LinearIssueStatusIcon.tsx
@@ -28,7 +28,7 @@ export function LinearIssueStatusIcon(props: BaseIconProps) {
   const isCompleted = state.type === StateType.Completed;
   // Due to some rendering issues and differences between browsers, the logical constant 4 in the rendering below
   // needs to be a bit less to make 50% look like half a circle.
-  const magicFour = isSafari() ? 3.895 : 3.98;
+  const magicFour = isSafari ? 3.895 : 3.98;
 
   return (
     <svg width={size} height={size} viewBox="0 0 14 14" fill="none">

--- a/shared/editor/components/PDF.tsx
+++ b/shared/editor/components/PDF.tsx
@@ -53,7 +53,7 @@ export default function PdfViewer(props: Props) {
   useEffect(() => {
     // firefox handles resizing on its own
     // and forced reload causes the parent to collapse while resizing
-    if (isFirefox() || !ref.current) {
+    if (isFirefox || !ref.current) {
       return;
     }
 

--- a/shared/editor/nodes/CodeFence.ts
+++ b/shared/editor/nodes/CodeFence.ts
@@ -206,7 +206,7 @@ export default class CodeFence extends Node {
       "Mod-[": outdentInCode,
     };
 
-    if (isMac()) {
+    if (isMac) {
       return {
         ...output,
         "Ctrl-a": moveToPreviousNewline,

--- a/shared/editor/nodes/Heading.ts
+++ b/shared/editor/nodes/Heading.ts
@@ -224,7 +224,7 @@ export default class Heading extends Node {
             Decoration.widget(
               // Safari requires the widget to be placed at the end of the node rather than the beginning
               // or caret selection is not correct, browser quirk – see issue #1234
-              isSafari() ? pos + node.nodeSize - 1 : pos + 1,
+              isSafari ? pos + node.nodeSize - 1 : pos + 1,
               container,
               {
                 side: -1,

--- a/shared/utils/browser.ts
+++ b/shared/utils/browser.ts
@@ -21,7 +21,7 @@ export const isPWA =
 
 /**
  * Returns true if the client is a touch device. Note that laptops with touch screens are
- * considered touch devices.
+ * considered touch devices, this does not neccessarily map to a small screen.
  */
 export function isTouchDevice(): boolean {
   if (!isBrowser) {
@@ -31,7 +31,7 @@ export function isTouchDevice(): boolean {
 }
 
 /**
- * Returns true if the client is a mobile device.
+ * Returns true if the client is the size of a mobile device.
  */
 export function isMobile(): boolean {
   if (!isBrowser) {
@@ -69,43 +69,29 @@ export function getSafeAreaInsets(): {
 }
 
 /**
- * Returns true if the client is running on a Mac.
+ * Is true if the client is running on a Mac.
  */
-export function isMac(): boolean {
-  if (!isBrowser) {
-    return false;
-  }
-  return window.navigator.platform === "MacIntel";
-}
+export const isMac = isBrowser && window.navigator.platform === "MacIntel";
 
 /**
- * Returns true if the client is running on Windows.
+ * Is true if the client is running on Windows.
  */
-export function isWindows(): boolean {
-  if (!isBrowser) {
-    return false;
-  }
-  return window.navigator.platform === "Win32";
-}
+export const isWindows = isBrowser && window.navigator.platform === "Win32";
 
-export function isSafari(): boolean {
-  if (!isBrowser) {
-    return false;
-  }
-  const userAgent = window.navigator.userAgent;
-  return (
-    userAgent.includes("Safari") &&
-    !userAgent.includes("Chrome") &&
-    !userAgent.includes("Chromium")
-  );
-}
+/**
+ * Is true if the client is running Safari.
+ */
+export const isSafari =
+  isBrowser &&
+  window.navigator.userAgent.includes("Safari") &&
+  !window.navigator.userAgent.includes("Chrome") &&
+  !window.navigator.userAgent.includes("Chromium");
 
-export function isFirefox(): boolean {
-  if (!isBrowser) {
-    return false;
-  }
-  return window.navigator.userAgent.includes("Firefox");
-}
+/**
+ * Is true if the client is running Firefox.
+ */
+export const isFirefox =
+  isBrowser && window.navigator.userAgent.includes("Firefox");
 
 let supportsPassive = false;
 

--- a/shared/utils/files.test.ts
+++ b/shared/utils/files.test.ts
@@ -1,21 +1,18 @@
 import { bytesToHumanReadable, getFileNameFromUrl } from "./files";
-import * as browser from "./browser";
 
-// Mock the browser detection
+// Mock the browser detection with a mutable value
+let mockIsMacValue = false;
+
 jest.mock("./browser", () => ({
-  isMac: jest.fn(),
+  get isMac() {
+    return mockIsMacValue;
+  },
 }));
 
-const mockIsMac = browser.isMac as jest.MockedFunction<typeof browser.isMac>;
-
 describe("bytesToHumanReadable", () => {
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
   describe("on macOS (decimal units)", () => {
     beforeEach(() => {
-      mockIsMac.mockReturnValue(true);
+      mockIsMacValue = true;
     });
 
     it("outputs readable string using decimal units", () => {
@@ -35,7 +32,7 @@ describe("bytesToHumanReadable", () => {
 
   describe("on Windows/other platforms (binary units)", () => {
     beforeEach(() => {
-      mockIsMac.mockReturnValue(false);
+      mockIsMacValue = false;
     });
 
     it("outputs readable string using binary units", () => {
@@ -59,12 +56,12 @@ describe("bytesToHumanReadable", () => {
     const fileSize = 91435827; // 87.2MB in binary, ~91.44MB in decimal
 
     it("displays correctly on macOS (decimal)", () => {
-      mockIsMac.mockReturnValue(true);
+      mockIsMacValue = true;
       expect(bytesToHumanReadable(fileSize)).toBe("91.44 MB");
     });
 
     it("displays correctly on Windows (binary)", () => {
-      mockIsMac.mockReturnValue(false);
+      mockIsMacValue = false;
       expect(bytesToHumanReadable(fileSize)).toBe("87.2 MB");
     });
   });

--- a/shared/utils/files.ts
+++ b/shared/utils/files.ts
@@ -14,7 +14,7 @@ export function bytesToHumanReadable(bytes: number | undefined) {
   }
 
   // Use decimal units (base 1000) on macOS, binary units (base 1024) on other platforms
-  const useMacUnits = isMac();
+  const useMacUnits = isMac;
   const base = useMacUnits ? 1000 : 1024;
   const threshold = useMacUnits ? 1000 : 1024;
 

--- a/shared/utils/keyboard.ts
+++ b/shared/utils/keyboard.ts
@@ -3,17 +3,17 @@ import { isMac } from "./browser";
 /**
  * Returns the display string for the alt key
  */
-export const altDisplay = isMac() ? "⌥" : "Alt";
+export const altDisplay = isMac ? "⌥" : "Alt";
 
 /**
  * Returns the display string for the meta key
  */
-export const metaDisplay = isMac() ? "⌘" : "Ctrl";
+export const metaDisplay = isMac ? "⌘" : "Ctrl";
 
 /**
  * Returns the name of the modifier key
  */
-export const meta = isMac() ? "cmd" : "ctrl";
+export const meta = isMac ? "cmd" : "ctrl";
 
 /**
  * Returns true if the given event is a modifier key (Cmd or Ctrl on Mac, Alt on
@@ -23,7 +23,7 @@ export const meta = isMac() ? "cmd" : "ctrl";
 export function isModKey(
   event: KeyboardEvent | MouseEvent | React.KeyboardEvent
 ) {
-  return isMac() ? event.metaKey : event.ctrlKey;
+  return isMac ? event.metaKey : event.ctrlKey;
 }
 
 /**


### PR DESCRIPTION
There is no single solution that works for all browsers – Safari is the exception for now.

closes #10633