### PR TITLE
Update rate limiter to prefer userId over ip address for client sessions

### DIFF
--- a/server/middlewares/rateLimiter.ts
+++ b/server/middlewares/rateLimiter.ts
@@ -1,11 +1,38 @@
-import type { Context, Next } from "koa";
+import type { Next } from "koa";
 import defaults from "lodash/defaults";
 import env from "@server/env";
 import { RateLimitExceededError } from "@server/errors";
 import Logger from "@server/logging/Logger";
 import Metrics from "@server/logging/Metrics";
+import { ApiKey, OAuthAuthentication } from "@server/models";
 import Redis from "@server/storage/redis";
+import type { AppContext } from "@server/types";
+import { getJWTPayload } from "@server/utils/jwt";
 import RateLimiter from "@server/utils/RateLimiter";
+import { parseAuthentication } from "./authentication";
+
+/**
+ * Returns a unique identifier for rate limiting based on the request context.
+ * Uses the authenticated user's ID if a valid JWT is present, otherwise falls
+ * back to the client's IP address.
+ *
+ * @param ctx The application context.
+ * @returns A string identifier for rate limiting (user ID or IP address).
+ */
+function getRateLimiterIdentifier(ctx: AppContext): string {
+  try {
+    const { token } = parseAuthentication(ctx);
+    if (token && !ApiKey.match(token) && !OAuthAuthentication.match(token)) {
+      const payload = getJWTPayload(token);
+      if (payload.id) {
+        return `user:${payload.id}`;
+      }
+    }
+  } catch {
+    // Fall through to IP-based rate limiting
+  }
+  return ctx.ip;
+}
 
 /**
  * Middleware that limits the number of requests that are allowed within a given
@@ -15,16 +42,17 @@ import RateLimiter from "@server/utils/RateLimiter";
  * @returns The middleware function.
  */
 export function defaultRateLimiter() {
-  return async function rateLimiterMiddleware(ctx: Context, next: Next) {
+  return async function rateLimiterMiddleware(ctx: AppContext, next: Next) {
     if (!env.RATE_LIMITER_ENABLED) {
       return next();
     }
 
     const fullPath = `${ctx.mountPath ?? ""}${ctx.path}`;
+    const identifier = getRateLimiterIdentifier(ctx);
 
     const key = RateLimiter.hasRateLimiter(fullPath)
-      ? `${fullPath}:${ctx.ip}`
-      : `${ctx.ip}`;
+      ? `${fullPath}:${identifier}`
+      : identifier;
     const limiter = RateLimiter.getRateLimiter(fullPath);
 
     try {
@@ -56,19 +84,20 @@ export function defaultRateLimiter() {
 type RateLimiterConfig = {
   /** The window for which this rate limiter is considered (defaults to 60s) */
   duration?: number;
-  /** The number of requests per IP address that are allowed within the window */
+  /** The number of requests allowed within the window (per user if authenticated, per IP otherwise) */
   requests: number;
 };
 
 /**
- * Middleware that limits the number of requests per IP address that are allowed
- * within a window, overrides default middleware when used on a route.
+ * Middleware that limits the number of requests that are allowed within a
+ * window, overrides default middleware when used on a route. Uses user ID for
+ * authenticated requests and IP address otherwise.
  *
  * @returns The middleware function.
  */
 export function rateLimiter(config: RateLimiterConfig) {
   return async function registerRateLimiterMiddleware(
-    ctx: Context,
+    ctx: AppContext,
     next: Next
   ) {
     if (!env.RATE_LIMITER_ENABLED) {


### PR DESCRIPTION
Avoids punishing many users behind one NAT (office, café, carrier NAT)

closes #10692