### PR TITLE
fix: skip ACL parameter for GCS uniform bucket-level access

### DIFF
--- a/server/storage/files/S3Storage.ts
+++ b/server/storage/files/S3Storage.ts
@@ -52,7 +52,7 @@ export default class S3Storage extends BaseStorage {
       Fields: {
         "Content-Disposition": this.getContentDisposition(contentType),
         key,
-        acl,
+        ...(acl && { acl }),
       },
       Expires: 3600,
     };
@@ -114,7 +114,7 @@ export default class S3Storage extends BaseStorage {
     const upload = new Upload({
       client: this.client,
       params: {
-        ACL: acl as ObjectCannedACL,
+        ...(acl && { ACL: acl as ObjectCannedACL }),
         Bucket: this.getBucket(),
         Key: key,
         ContentType: contentType,


### PR DESCRIPTION
## Summary
- Makes ACL parameter conditional in `S3Storage.store()` and `S3Storage.getPresignedPost()` methods
- Allows users to set `AWS_S3_ACL=` (empty) to disable object-level ACLs
- Fixes compatibility with Google Cloud Storage buckets that have uniform bucket-level access enabled

## Problem
When using GCS with **uniform bucket-level access** enabled, file uploads fail with:
```
InvalidArgument: Cannot insert legacy ACL for an object when uniform bucket-level access is enabled
```

This happens because `S3Storage` always passes an ACL parameter, even when it should be omitted.

## Solution
Only include ACL in the upload params when it has a truthy value:
```typescript
...(acl && { ACL: acl as ObjectCannedACL })
```

## Test plan
- [x] Set `AWS_S3_ACL=` (empty) in environment
- [x] Upload a file via document import
- [x] Verify upload succeeds without ACL-related errors
- [x] Verify existing behavior unchanged when `AWS_S3_ACL=private` is set

Fixes #11221