### PR TITLE
feat: store avatars and logos in dedicated prefix for granular S3 access control

### DIFF
--- a/server/commands/attachmentCreator.ts
+++ b/server/commands/attachmentCreator.ts
@@ -50,6 +50,7 @@ export default async function attachmentCreator({
     id: randomUUID(),
     name,
     userId: user.id,
+    preset,
   });
 
   let attachment;

--- a/server/models/helpers/AttachmentHelper.test.ts
+++ b/server/models/helpers/AttachmentHelper.test.ts
@@ -1,3 +1,4 @@
+import { AttachmentPreset } from "@shared/types";
 import AttachmentHelper from "./AttachmentHelper";
 
 describe("AttachmentHelper", () => {
@@ -10,6 +11,28 @@ describe("AttachmentHelper", () => {
       });
 
       expect(key).toEqual("uploads/456/123/test.png");
+    });
+
+    it("should return the correct key for an avatar attachment", () => {
+      const key = AttachmentHelper.getKey({
+        id: "123",
+        name: "avatar.png",
+        userId: "456",
+        preset: AttachmentPreset.Avatar,
+      });
+
+      expect(key).toEqual("avatars/456/123/avatar.png");
+    });
+
+    it("should return uploads key for non-avatar presets", () => {
+      const key = AttachmentHelper.getKey({
+        id: "123",
+        name: "doc.pdf",
+        userId: "456",
+        preset: AttachmentPreset.DocumentAttachment,
+      });
+
+      expect(key).toEqual("uploads/456/123/doc.pdf");
     });
 
     it("should return the correct key for a long file name", () => {

--- a/server/models/helpers/AttachmentHelper.ts
+++ b/server/models/helpers/AttachmentHelper.ts
@@ -19,17 +19,23 @@ export default class AttachmentHelper {
    * @param id The ID of the attachment
    * @param name The name of the attachment
    * @param userId The ID of the user uploading the attachment
+   * @param preset The attachment preset (optional, affects storage location)
    */
   static getKey({
     id,
     name,
     userId,
+    preset,
   }: {
     id: string;
     name: string;
     userId: string;
+    preset?: AttachmentPreset;
   }) {
-    const keyPrefix = `${Buckets.uploads}/${userId}/${id}`;
+    // Use avatars bucket for public avatar uploads, uploads bucket for everything else
+    const bucket =
+      preset === AttachmentPreset.Avatar ? Buckets.avatars : Buckets.uploads;
+    const keyPrefix = `${bucket}/${userId}/${id}`;
     return ValidateKey.sanitize(
       `${keyPrefix}/${name.slice(0, this.maximumFileNameLength)}`
     );

--- a/server/queues/tasks/APIImportTask.ts
+++ b/server/queues/tasks/APIImportTask.ts
@@ -291,13 +291,13 @@ export default abstract class APIImportTask<
     await sequelize.transaction(async (transaction) => {
       const dbPromises = attachmentsData.map(async (item) => {
         const modelId = randomUUID();
-        const acl = AttachmentHelper.presetToAcl(
-          AttachmentPreset.DocumentAttachment
-        );
+        const preset = AttachmentPreset.DocumentAttachment;
+        const acl = AttachmentHelper.presetToAcl(preset);
         const key = AttachmentHelper.getKey({
           id: modelId,
           name: item.name,
           userId: createdBy.id,
+          preset,
         });
 
         const attachment = await Attachment.create(

--- a/server/routes/api/attachments/attachments.ts
+++ b/server/routes/api/attachments/attachments.ts
@@ -124,6 +124,7 @@ router.post(
       id: modelId,
       name,
       userId: user.id,
+      preset,
     });
 
     const attachment = await Attachment.createWithCtx(ctx, {
@@ -190,6 +191,7 @@ router.post(
       id: modelId,
       name,
       userId: user.id,
+      preset,
     });
 
     // Does not use transaction middleware, as attachment must be persisted


### PR DESCRIPTION
## Summary

This enables S3 bucket policies to restrict public-read ACLs to only the `avatars/` prefix, providing defense-in-depth security:

- Anonymous reads can be denied for all prefixes except `avatars/`
- Even if a document accidentally gets public-read ACL, it remains inaccessible to anonymous users

## Backward Compatibility

The change is backward compatible — existing uploads without preset continue to use the `uploads/` prefix.

Related discussion: https://github.com/outline/outline/discussions/11220