### PR TITLE
fix: Spurious link appears when typing enter at the end of a list with mention

### DIFF
--- a/shared/editor/marks/Link.tsx
+++ b/shared/editor/marks/Link.tsx
@@ -267,7 +267,12 @@ export default class Link extends Mark {
               return false;
             }
 
-            const textContent = selection.$from.parent.textContent;
+            let textContent = "";
+            selection.$from.parent.forEach((node) => {
+              if (node.isText && node.text) {
+                textContent += node.text;
+              }
+            });
             const words = textContent.split(/\s+/);
             if (!words.length) {
               return false;


### PR DESCRIPTION
This logic for auto-linking was taking the textual representation of all nodes into account, it should have been looking only at text nodes.

closes #11200