### PR TITLE
feat(linear): add option to hide embed in paste menu

### DIFF
--- a/app/models/Integration.test.ts
+++ b/app/models/Integration.test.ts
@@ -1,0 +1,101 @@
+import { IntegrationService, IntegrationType } from "@shared/types";
+import Integration from "./Integration";
+import stores from "~/stores";
+
+describe("Integration model", () => {
+  const integrations = stores.integrations;
+
+  describe("shouldHideEmbed", () => {
+    test("should return false for non-Linear integration", () => {
+      const integration = new Integration(
+        {
+          id: "1",
+          service: IntegrationService.Slack,
+          type: IntegrationType.Embed,
+          settings: {},
+        },
+        integrations
+      );
+      expect(integration.shouldHideEmbed).toBe(false);
+    });
+
+    test("should return false for Linear integration without hideEmbedOption", () => {
+      const integration = new Integration(
+        {
+          id: "2",
+          service: IntegrationService.Linear,
+          type: IntegrationType.Embed,
+          settings: {
+            linear: {
+              workspace: { id: "ws1", name: "Test", key: "TEST" },
+            },
+          },
+        },
+        integrations
+      );
+      expect(integration.shouldHideEmbed).toBe(false);
+    });
+
+    test("should return false for Linear integration with hideEmbedOption set to false", () => {
+      const integration = new Integration(
+        {
+          id: "3",
+          service: IntegrationService.Linear,
+          type: IntegrationType.Embed,
+          settings: {
+            linear: {
+              workspace: { id: "ws1", name: "Test", key: "TEST" },
+              hideEmbedOption: false,
+            },
+          },
+        },
+        integrations
+      );
+      expect(integration.shouldHideEmbed).toBe(false);
+    });
+
+    test("should return true for Linear integration with hideEmbedOption set to true", () => {
+      const integration = new Integration(
+        {
+          id: "4",
+          service: IntegrationService.Linear,
+          type: IntegrationType.Embed,
+          settings: {
+            linear: {
+              workspace: { id: "ws1", name: "Test", key: "TEST" },
+              hideEmbedOption: true,
+            },
+          },
+        },
+        integrations
+      );
+      expect(integration.shouldHideEmbed).toBe(true);
+    });
+
+    test("should return false for Linear integration with empty settings", () => {
+      const integration = new Integration(
+        {
+          id: "5",
+          service: IntegrationService.Linear,
+          type: IntegrationType.Embed,
+          settings: {},
+        },
+        integrations
+      );
+      expect(integration.shouldHideEmbed).toBe(false);
+    });
+
+    test("should return false for Linear integration with null settings", () => {
+      const integration = new Integration(
+        {
+          id: "6",
+          service: IntegrationService.Linear,
+          type: IntegrationType.Embed,
+          settings: null,
+        },
+        integrations
+      );
+      expect(integration.shouldHideEmbed).toBe(false);
+    });
+  });
+});

--- a/app/models/Integration.ts
+++ b/app/models/Integration.ts
@@ -1,6 +1,9 @@
 import { observable } from "mobx";
-import type { IntegrationService } from "@shared/types";
-import { type IntegrationSettings, type IntegrationType } from "@shared/types";
+import {
+  IntegrationService,
+  type IntegrationSettings,
+  type IntegrationType,
+} from "@shared/types";
 import User from "~/models/User";
 import Model from "~/models/base/Model";
 import Field from "~/models/decorators/Field";
@@ -9,8 +12,10 @@ import Relation from "~/models/decorators/Relation";
 class Integration<T = unknown> extends Model {
   static modelName = "Integration";
 
+  @observable
   type: IntegrationType;
 
+  @observable
   service: IntegrationService;
 
   collectionId: string;
@@ -22,10 +27,24 @@ class Integration<T = unknown> extends Model {
 
   @Field
   @observable
-  events: string[];
+  events: string[] = [];
 
   @observable
   settings: IntegrationSettings<T>;
+
+  /**
+   * Whether the embed option should be hidden in paste menu for this integration.
+   * Currently only applies to Linear integration.
+   *
+   * @returns True if embed option should be hidden for this integration, false otherwise.
+   */
+  get shouldHideEmbed(): boolean {
+    if (this.service !== IntegrationService.Linear) {
+      return false;
+    }
+    const settings = this.settings as IntegrationSettings<IntegrationType.Embed>;
+    return !!settings?.linear?.hideEmbedOption;
+  }
 }
 
 export default Integration;

--- a/plugins/linear/client/Settings.tsx
+++ b/plugins/linear/client/Settings.tsx
@@ -2,6 +2,7 @@ import { observer } from "mobx-react";
 import { PlusIcon } from "outline-icons";
 import * as React from "react";
 import { useTranslation, Trans } from "react-i18next";
+import { toast } from "sonner";
 import { IntegrationService } from "@shared/types";
 import { ConnectedButton } from "~/scenes/Settings/components/ConnectedButton";
 import { IntegrationScene } from "~/scenes/Settings/components/IntegrationScene";
@@ -12,6 +13,7 @@ import List from "~/components/List";
 import ListItem from "~/components/List/Item";
 import Notice from "~/components/Notice";
 import PlaceholderText from "~/components/PlaceholderText";
+import Switch from "~/components/Switch";
 import TeamLogo from "~/components/TeamLogo";
 import Text from "~/components/Text";
 import Time from "~/components/Time";
@@ -125,6 +127,45 @@ function Linear() {
                   );
                 })}
               </List>
+              <Switch
+                label={t("Hide embed option")}
+                note={t("Hide 'Embed' in paste menu for Linear links")}
+                checked={integrations.linear.some(
+                  (i) => i.settings?.linear?.hideEmbedOption
+                )}
+                onChange={async (checked: boolean) => {
+                  try {
+                    await Promise.all(
+                      integrations.linear.map((integration) => {
+                        const workspace =
+                          integration.settings?.linear?.workspace;
+                        if (!workspace) {
+                          return Promise.resolve();
+                        }
+                        const newSettings = {
+                          ...integration.settings,
+                          linear: {
+                            workspace,
+                            hideEmbedOption: checked,
+                          },
+                        };
+                        integration.settings = newSettings;
+                        return integration.save({
+                          settings: newSettings,
+                          events: integration.events ?? [],
+                        });
+                      })
+                    );
+                    toast.success(t("Settings saved"));
+                  } catch (error) {
+                    toast.error(
+                      error instanceof Error
+                        ? error.message
+                        : t("Failed to save settings")
+                    );
+                  }
+                }}
+              />
             </>
           ) : (
             <p>

--- a/server/routes/api/integrations/schema.ts
+++ b/server/routes/api/integrations/schema.ts
@@ -98,6 +98,19 @@ export const IntegrationsUpdateSchema = BaseSchema.extend({
         })
       )
       .or(z.object({ serviceTeamId: z.string() }))
+      .or(
+        z.object({
+          linear: z.object({
+            workspace: z.object({
+              id: z.string(),
+              name: z.string(),
+              key: z.string(),
+              logoUrl: z.string().url().optional(),
+            }),
+            hideEmbedOption: z.boolean().optional(),
+          }),
+        })
+      )
       .optional(),
 
     /** Integration events */

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -197,6 +197,7 @@ export type IntegrationSettings<T> = T extends IntegrationType.Embed
       };
       linear?: {
         workspace: { id: string; name: string; key: string; logoUrl?: string };
+        hideEmbedOption?: boolean;
       };
       diagrams?: {
         url: string;


### PR DESCRIPTION
## Summary

Linear sets `frame-ancestors 'self' https://cms.linear.app` in their CSP headers, which means embedding Linear links via iframe simply doesn't work — the browser blocks it silently. Despite this, Outline still shows an "Embed" option in the paste menu when you paste a Linear link, which leads to a blank/broken embed.

This PR adds a simple toggle in Linear integration settings: "Hide embed option". When enabled, the broken "Embed" choice is hidden from the paste menu for Linear links, so users only see the "Link" option that actually works.

Related discussion: https://github.com/outline/outline/discussions/4427

You can verify Linear's CSP yourself:
```
curl -sI https://linear.app | grep frame-ancestors
# frame-ancestors 'self' https://cms.linear.app
```