### PR TITLE
fix : Handles Adding Text below pictures for doc import ( #11219 )

### DIFF
--- a/shared/editor/extensions/TrailingNode.ts
+++ b/shared/editor/extensions/TrailingNode.ts
@@ -41,6 +41,12 @@ export default class TrailingNode extends Extension {
         state: {
           init: (_, state) => {
             const lastNode = state.tr.doc.lastChild;
+            
+            // If paragraph has no text (only images/media), add trailing node
+            if (lastNode?.type.name === "paragraph" && lastNode.content.size > 0 && lastNode.textContent.length === 0) {
+              return true;
+            }
+            
             return lastNode ? !disabledNodes.includes(lastNode.type) : false;
           },
           apply: (tr, value) => {
@@ -49,6 +55,12 @@ export default class TrailingNode extends Extension {
             }
 
             const lastNode = tr.doc.lastChild;
+            
+            // If paragraph has no text (only images/media), add trailing node
+            if (lastNode?.type.name === "paragraph" && lastNode.content.size > 0 && lastNode.textContent.length === 0) {
+              return true;
+            }
+            
             return lastNode ? !disabledNodes.includes(lastNode.type) : false;
           },
         },


### PR DESCRIPTION
Fix for one of the bugs in Word Document Imports ( #11219  )

(Cursor Trap): Cannot type after images at document end because ProseMirror needs a trailing paragraph when the last paragraph contains only images (no text).