### PR TITLE
fix: Unused subdomains should redirect to root

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -157,7 +157,7 @@ router.get("*", async (ctx, next) => {
   if (env.isCloudHosted) {
     // Redirect to main domain if no team is found
     if (!team || team.isSuspended) {
-      if (ctx.hostname !== parseDomain(env.URL).host) {
+      if (env.isProduction && ctx.hostname !== parseDomain(env.URL).host) {
         ctx.redirect(env.URL);
         return;
       }


### PR DESCRIPTION
Prevents abuse through apparent existence of subdomains that don't actually exist in the db, or have been suspended.