### PR TITLE
feat: Use diagrams.net theme that matches editor theme

### DIFF
--- a/shared/editor/extensions/Diagrams.ts
+++ b/shared/editor/extensions/Diagrams.ts
@@ -217,10 +217,11 @@ export default class Diagrams extends Extension {
     const integration = this.editor.props.embeds?.find(
       (integ) => integ.name === IntegrationService.Diagrams
     );
+    const uiTheme = this.editor.props.theme.isDark ? 'dark' : 'atlas';
     return (
       sanitizeUrl(
         integration?.settings?.diagrams?.url ?? "https://embed.diagrams.net/"
-      ) + "?embed=1&ui=atlas&spin=1&modified=unsavedChanges&proto=json"
+      ) + `?embed=1&ui=${uiTheme}&spin=1&modified=unsavedChanges&proto=json`
     );
   }
 


### PR DESCRIPTION
I noticed that with the new draw.io integration, it always opened it in light mode. And since the embedded draw.io editor has no way of setting the theme in the UI, it's kind of unpleasant to work with it at night 😁 

Therefore, this PR adds a tiny feature to use draw.io's `dark` view instead, when the editor is set to dark mode.

This is what it looks like:

https://github.com/user-attachments/assets/21e8d87a-7a87-4133-b3de-e70420446287

