### PR TITLE
fix: show Passkeys settings to non-admin users

### DIFF
--- a/plugins/passkeys/client/index.tsx
+++ b/plugins/passkeys/client/index.tsx
@@ -19,6 +19,7 @@ PluginManager.add([
       description:
         "Manage your passkeys for passwordless authentication using biometrics or security keys.",
       component: createLazyComponent(() => import("./Settings")),
+      enabled: () => true,
     },
   },
 ]);


### PR DESCRIPTION
closes https://github.com/outline/outline/issues/11281

I have added following code to fix this issue:

Add enabled: () => true to the passkeys plugin in plugins/passkeys/client/index.tsx:

```typescript
{
  ...config,
  type: Hook.Settings,
  value: {
    group: "Account",
    after: "Notifications",
    icon: KeyIcon,
    description:
      "Manage your passkeys for passwordless authentication using biometrics or security keys.",
    component: createLazyComponent(() => import("./Settings")),
    enabled: () => true,  // <-- add this
  },
},
```