### PR TITLE
Prevent history search dropdown from opening in firefox

### DIFF
--- a/app/editor/components/SelectionToolbar.tsx
+++ b/app/editor/components/SelectionToolbar.tsx
@@ -163,6 +163,7 @@ export function SelectionToolbar(props: Props) {
         ev.key.toLowerCase() === "k" &&
         !view.state.selection.empty
       ) {
+        ev.preventDefault();
         ev.stopPropagation();
         if (activeToolbar === Toolbar.Link) {
           setActiveToolbar(Toolbar.Menu);


### PR DESCRIPTION
In firefox, `cmd-k` on selected text opens history search dropdown along with link toolbar.