### PR TITLE
feat: Add Heroku Review Apps support for preview deployments

### DIFF
--- a/app.json
+++ b/app.json
@@ -21,7 +21,23 @@
     }
   ],
   "scripts": {
-    "postdeploy": "yarn sequelize db:migrate"
+    "postdeploy": "yarn sequelize db:migrate",
+    "pr-predeploy": "yarn sequelize db:migrate"
+  },
+  "environments": {
+    "review": {
+      "scripts": {
+        "postdeploy": "yarn sequelize db:migrate"
+      },
+      "addons": [
+        {
+          "plan": "heroku-redis:mini"
+        },
+        {
+          "plan": "heroku-postgresql:essential-0"
+        }
+      ]
+    }
   },
   "env": {
     "NODE_ENV": {
@@ -43,8 +59,12 @@
       "required": true
     },
     "URL": {
-      "description": "https://{your app name}.herokuapp.com, or the domain you are binding to",
-      "required": true
+      "description": "https://{your app name}.herokuapp.com, or the domain you are binding to. For review apps, this is auto-generated.",
+      "required": false
+    },
+    "HEROKU_APP_NAME": {
+      "description": "Automatically set by Heroku for review apps",
+      "required": false
     },
     "GOOGLE_CLIENT_ID": {
       "description": "See https://developers.google.com/identity/protocols/OAuth2 to create a new Google OAuth client. You must configure at least one of Slack or Google to control login.",

--- a/server/env.ts
+++ b/server/env.ts
@@ -200,6 +200,7 @@ export class Environment {
 
   /**
    * The fully qualified, external facing domain name of the server.
+   * If not set, will be derived from HEROKU_APP_NAME for Heroku deployments.
    */
   @Public
   @IsNotEmpty()
@@ -208,7 +209,12 @@ export class Environment {
     require_protocol: true,
     require_tld: false,
   })
-  public URL = (environment.URL ?? "").replace(/\/$/, "");
+  public URL = (
+    environment.URL ??
+    (environment.HEROKU_APP_NAME
+      ? `https://${environment.HEROKU_APP_NAME}.herokuapp.com`
+      : "")
+  ).replace(/\/$/, "");
 
   /**
    * If using a Cloudfront/Cloudflare distribution or similar it can be set below.


### PR DESCRIPTION
- Add pr-predeploy script and review environment config in app.json
- Use smaller addon tiers for review apps to reduce costs
- Auto-derive URL from HEROKU_APP_NAME when URL is not set
- Make URL optional for review apps