### PR TITLE
perf: Improve slow query in `CleanupDeletedDocumentsTask`

### DIFF
--- a/server/queues/tasks/CleanupDeletedDocumentsTask.ts
+++ b/server/queues/tasks/CleanupDeletedDocumentsTask.ts
@@ -14,10 +14,8 @@ export default class CleanupDeletedDocumentsTask extends CronTask {
       "task",
       `Permanently destroying upto ${limit} documents older than 30 days…`
     );
-    const documents = await Document.scope([
-      "withDrafts",
-      "withoutState",
-    ]).findAll({
+    const documents = await Document.unscoped().findAll({
+      attributes: ["id", "teamId", "deletedAt", "content", "state"],
       where: {
         deletedAt: {
           [Op.lt]: subDays(new Date(), 30),


### PR DESCRIPTION
Remove unnecessary joins in one of the slowest queries on the worker