### PR TITLE
perf: Minor React performance optimizations

### DIFF
--- a/app/components/Sharing/components/Suggestions.tsx
+++ b/app/components/Sharing/components/Suggestions.tsx
@@ -166,8 +166,9 @@ export const Suggestions = observer(
     }
 
     const isEmpty = suggestions.length === 0;
+    const pendingIdSet = new Set(pendingIds);
     const suggestionsWithPending = suggestions.filter(
-      (u) => !pendingIds.includes(u.id)
+      (u) => !pendingIdSet.has(u.id)
     );
 
     if (users.isFetching && isEmpty && neverRenderedList.current) {

--- a/app/components/Sidebar/components/DocumentLink.tsx
+++ b/app/components/Sidebar/components/DocumentLink.tsx
@@ -106,8 +106,7 @@ function InnerDocumentLink(
       membership?.pathToDocument(activeDocument.id);
 
     return !!(
-      pathToDocument?.map((entry) => entry.id).includes(node.id) ||
-      isActiveDocument
+      pathToDocument?.some((entry) => entry.id === node.id) || isActiveDocument
     );
   }, [
     hasChildDocuments,

--- a/app/components/WebsocketProvider.tsx
+++ b/app/components/WebsocketProvider.tsx
@@ -372,10 +372,7 @@ class WebsocketProvider extends Component<Props> {
         const group = groups.get(event.groupId!);
 
         // Any existing child policies are now invalid
-        if (
-          currentUserId &&
-          group?.users.map((u) => u.id).includes(currentUserId)
-        ) {
+        if (currentUserId && group?.users.some((u) => u.id === currentUserId)) {
           const document = documents.get(event.documentId!);
           if (document) {
             document.childDocuments.forEach((childDocument) => {

--- a/app/scenes/Settings/components/DomainManagement.tsx
+++ b/app/scenes/Settings/components/DomainManagement.tsx
@@ -20,7 +20,7 @@ function DomainManagement({ onSuccess }: Props) {
   const team = useCurrentTeam();
   const { t } = useTranslation();
 
-  const [allowedDomains, setAllowedDomains] = React.useState([
+  const [allowedDomains, setAllowedDomains] = React.useState(() => [
     ...(team.allowedDomains ?? []),
   ]);
   const [lastKnownDomainCount, updateLastKnownDomainCount] = React.useState(


### PR DESCRIPTION
- Replace .map().includes() with .some() for early exit in DocumentLink and WebsocketProvider
- Use Set for O(1) lookups instead of array.includes() in Suggestions filter
- Use lazy useState initializer in DomainManagement