### PR TITLE
perf: Add Model.replica getter for opt-in read replica queries

### DIFF
--- a/server/storage/database.ts
+++ b/server/storage/database.ts
@@ -256,13 +256,9 @@ export const sequelize = createDatabaseInstance(databaseConfig, models);
  * Falls back to the main connection if DATABASE_URL_READ_ONLY is not set.
  */
 export const sequelizeReadOnly = env.DATABASE_URL_READ_ONLY
-  ? createDatabaseInstance(
-      env.DATABASE_URL_READ_ONLY,
-      {},
-      {
-        readOnly: true,
-      }
-    )
+  ? createDatabaseInstance(env.DATABASE_URL_READ_ONLY, models, {
+      readOnly: true,
+    })
   : sequelize;
 
 export const migrations = createMigrationRunner(sequelize, [


### PR DESCRIPTION
Allows Sequelize ORM queries to explicitly opt-in to using the read replica connection via a static getter on the base Model class.

A bit wary of the memory impact