### PR TITLE
fix: Table with merged cells behave incorrectly when sorting

### DIFF
--- a/app/editor/components/ToolbarMenu.tsx
+++ b/app/editor/components/ToolbarMenu.tsx
@@ -109,7 +109,10 @@ function ToolbarDropdown(props: ToolbarDropdownProps) {
       <MenuProvider variant="dropdown">
         <Menu open={isOpen} onOpenChange={handleOpenChange}>
           <MenuTrigger>
-            <ToolbarButton aria-label={item.label ? undefined : item.tooltip}>
+            <ToolbarButton
+              aria-label={item.label ? undefined : item.tooltip}
+              disabled={item.disabled}
+            >
               {item.label && <Label>{item.label}</Label>}
               {item.icon}
             </ToolbarButton>
@@ -190,6 +193,7 @@ function ToolbarMenu(props: Props) {
                       onClick={handleClick(item)}
                       active={isActive && !item.label}
                       aria-label={item.label ? undefined : item.tooltip}
+                      disabled={item.disabled}
                     >
                       {item.label && <Label>{item.label}</Label>}
                       {item.icon}

--- a/app/editor/menus/tableCol.tsx
+++ b/app/editor/menus/tableCol.tsx
@@ -22,6 +22,7 @@ import {
   getCellsInColumn,
   isMergedCellSelection,
   isMultipleCellSelection,
+  tableHasRowspan,
 } from "@shared/editor/queries/table";
 import type { MenuItem, NodeAttrMark } from "@shared/editor/types";
 import type { Dictionary } from "~/hooks/useDictionary";
@@ -127,12 +128,14 @@ export default function tableColMenuItems(
       tooltip: dictionary.sortAsc,
       attrs: { index, direction: "asc" },
       icon: <SortAscendingIcon />,
+      disabled: tableHasRowspan(state),
     },
     {
       name: "sortTable",
       tooltip: dictionary.sortDesc,
       attrs: { index, direction: "desc" },
       icon: <SortDescendingIcon />,
+      disabled: tableHasRowspan(state),
     },
     {
       name: "separator",

--- a/shared/editor/queries/table.ts
+++ b/shared/editor/queries/table.ts
@@ -338,6 +338,39 @@ export function isMergedCellSelection(state: EditorState): boolean {
   return false;
 }
 
+/**
+ * Check if the table contains any cells with rowspan > 1.
+ * Cells with rowspan span multiple rows and would break table sorting.
+ *
+ * @param state The editor state.
+ * @returns true if the table has any cells with rowspan > 1, false otherwise.
+ */
+export function tableHasRowspan(state: EditorState): boolean {
+  if (!isInTable(state)) {
+    return false;
+  }
+
+  const rect = selectedRect(state);
+  const seen = new Set<number>();
+
+  for (let i = 0; i < rect.map.map.length; i++) {
+    const pos = rect.map.map[i];
+
+    // Skip already checked cells
+    if (seen.has(pos)) {
+      continue;
+    }
+    seen.add(pos);
+
+    const cell = rect.table.nodeAt(pos);
+    if (cell && cell.attrs.rowspan > 1) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 export function getAllSelectedColumns(state: EditorState): number[] {
   const rect = selectedRect(state);
 


### PR DESCRIPTION
- Table that contains rowspan's are no longer sortable
- Table with colspan now sorts correctly without duplicating cells
- Adds support for `disabled` toolbar buttons

closes #11258