### PR TITLE
feat(linear): add automatic backlink attachments for issue mentions

### DIFF
--- a/plugins/linear/server/index.ts
+++ b/plugins/linear/server/index.ts
@@ -1,10 +1,12 @@
 import { Minute } from "@shared/utils/time";
 import { Hook, PluginManager } from "@server/utils/PluginManager";
+import UploadIntegrationLogoTask from "@server/queues/tasks/UploadIntegrationLogoTask";
 import config from "../plugin.json";
 import router from "./api/linear";
 import env from "./env";
 import { Linear } from "./linear";
-import UploadIntegrationLogoTask from "@server/queues/tasks/UploadIntegrationLogoTask";
+import LinearBacklinksProcessor from "./processors/LinearBacklinksProcessor";
+import SyncLinearBacklinksTask from "./tasks/SyncLinearBacklinksTask";
 import { uninstall } from "./uninstall";
 
 const enabled = !!env.LINEAR_CLIENT_ID && !!env.LINEAR_CLIENT_SECRET;
@@ -23,6 +25,14 @@ if (enabled) {
     {
       type: Hook.UnfurlProvider,
       value: { unfurl: Linear.unfurl, cacheExpiry: Minute.seconds },
+    },
+    {
+      type: Hook.Processor,
+      value: LinearBacklinksProcessor,
+    },
+    {
+      type: Hook.Task,
+      value: SyncLinearBacklinksTask,
     },
     {
       type: Hook.Uninstall,

--- a/plugins/linear/server/processors/LinearBacklinksProcessor.test.ts
+++ b/plugins/linear/server/processors/LinearBacklinksProcessor.test.ts
@@ -1,0 +1,553 @@
+import { v4 as uuidv4 } from "uuid";
+import {
+  IntegrationService,
+  type IntegrationSettings,
+  IntegrationType,
+} from "@shared/types";
+import {
+  buildCollection,
+  buildDocument,
+  buildIntegration,
+  buildTeam,
+  buildUser,
+} from "@server/test/factories";
+import type { CollectionEvent, DocumentEvent } from "@server/types";
+import SyncLinearBacklinksTask from "../tasks/SyncLinearBacklinksTask";
+import LinearBacklinksProcessor from "./LinearBacklinksProcessor";
+
+jest.mock("../tasks/SyncLinearBacklinksTask");
+
+const ip = "127.0.0.1";
+
+/**
+ * Builds Linear integration settings with required workspace fields.
+ *
+ * @param workspaceKey The workspace key (e.g., "myteam").
+ * @param workspaceName The workspace display name.
+ * @returns Settings object typed for Linear embed integration.
+ */
+function buildLinearSettings(
+  workspaceKey: string,
+  workspaceName = "My Team"
+): IntegrationSettings<IntegrationType.Embed> {
+  return {
+    linear: {
+      workspace: {
+        id: uuidv4(),
+        key: workspaceKey,
+        name: workspaceName,
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+/**
+ * Builds markdown text containing a Linear issue mention node.
+ *
+ * @param issueUrl The Linear issue URL.
+ * @param label The display label for the mention.
+ * @returns ProsemirrorData content array with a mention node.
+ */
+function buildLinearMentionContent(
+  issueUrl: string,
+  label = "ENG-456"
+) {
+  return {
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "text",
+            text: "Relates to ",
+          },
+          {
+            type: "mention",
+            attrs: {
+              id: uuidv4(),
+              type: "issue",
+              label,
+              modelId: uuidv4(),
+              actorId: undefined,
+              href: issueUrl,
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe("LinearBacklinksProcessor", () => {
+  describe("documents.publish", () => {
+    it("should dispatch sync task with issue identifiers", async () => {
+      const team = await buildTeam();
+      const user = await buildUser({ teamId: team.id });
+
+      await buildIntegration({
+        teamId: team.id,
+        service: IntegrationService.Linear,
+        type: IntegrationType.Embed,
+        settings: buildLinearSettings("myteam"),
+      });
+
+      const content = buildLinearMentionContent(
+        "https://linear.app/myteam/issue/ENG-456/some-title"
+      );
+      const document = await buildDocument({
+        teamId: team.id,
+        userId: user.id,
+        content,
+        text: "Relates to ENG-456",
+      });
+
+      const processor = new LinearBacklinksProcessor();
+      await processor.perform({
+        name: "documents.publish",
+        documentId: document.id,
+        collectionId: document.collectionId!,
+        teamId: team.id,
+        actorId: user.id,
+        ip,
+      } as DocumentEvent);
+
+      expect(
+        jest.mocked(SyncLinearBacklinksTask.prototype.schedule)
+      ).toHaveBeenCalledWith({
+        documentId: document.id,
+        teamId: team.id,
+        currentIssueIdentifiers: ["ENG-456"],
+      });
+    });
+
+    it("should extract multiple unique issue identifiers", async () => {
+      const team = await buildTeam();
+      const user = await buildUser({ teamId: team.id });
+
+      await buildIntegration({
+        teamId: team.id,
+        service: IntegrationService.Linear,
+        type: IntegrationType.Embed,
+        settings: buildLinearSettings("myteam"),
+      });
+
+      const content = {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "mention",
+                attrs: {
+                  id: uuidv4(),
+                  type: "issue",
+                  label: "ENG-100",
+                  modelId: uuidv4(),
+                  actorId: undefined,
+                  href: "https://linear.app/myteam/issue/ENG-100/title",
+                },
+              },
+              { type: "text", text: " and " },
+              {
+                type: "mention",
+                attrs: {
+                  id: uuidv4(),
+                  type: "issue",
+                  label: "ENG-200",
+                  modelId: uuidv4(),
+                  actorId: undefined,
+                  href: "https://linear.app/myteam/issue/ENG-200/title",
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      const document = await buildDocument({
+        teamId: team.id,
+        userId: user.id,
+        content,
+        text: "ENG-100 and ENG-200",
+      });
+
+      const processor = new LinearBacklinksProcessor();
+      await processor.perform({
+        name: "documents.publish",
+        documentId: document.id,
+        collectionId: document.collectionId!,
+        teamId: team.id,
+        actorId: user.id,
+        ip,
+      } as DocumentEvent);
+
+      const scheduledArgs = jest.mocked(
+        SyncLinearBacklinksTask.prototype.schedule
+      ).mock.calls[0][0];
+
+      expect(scheduledArgs.currentIssueIdentifiers).toHaveLength(2);
+      expect(scheduledArgs.currentIssueIdentifiers).toContain("ENG-100");
+      expect(scheduledArgs.currentIssueIdentifiers).toContain("ENG-200");
+    });
+
+    it("should exclude mentions from other workspaces", async () => {
+      const team = await buildTeam();
+      const user = await buildUser({ teamId: team.id });
+
+      await buildIntegration({
+        teamId: team.id,
+        service: IntegrationService.Linear,
+        type: IntegrationType.Embed,
+        settings: buildLinearSettings("myteam"),
+      });
+
+      const content = {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "mention",
+                attrs: {
+                  id: uuidv4(),
+                  type: "issue",
+                  label: "ENG-100",
+                  modelId: uuidv4(),
+                  actorId: undefined,
+                  href: "https://linear.app/myteam/issue/ENG-100/title",
+                },
+              },
+              { type: "text", text: " and " },
+              {
+                type: "mention",
+                attrs: {
+                  id: uuidv4(),
+                  type: "issue",
+                  label: "OTHER-200",
+                  modelId: uuidv4(),
+                  actorId: undefined,
+                  href: "https://linear.app/otherteam/issue/OTHER-200/title",
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      const document = await buildDocument({
+        teamId: team.id,
+        userId: user.id,
+        content,
+        text: "ENG-100 and OTHER-200",
+      });
+
+      const processor = new LinearBacklinksProcessor();
+      await processor.perform({
+        name: "documents.publish",
+        documentId: document.id,
+        collectionId: document.collectionId!,
+        teamId: team.id,
+        actorId: user.id,
+        ip,
+      } as DocumentEvent);
+
+      const scheduledArgs = jest.mocked(
+        SyncLinearBacklinksTask.prototype.schedule
+      ).mock.calls[0][0];
+
+      expect(scheduledArgs.currentIssueIdentifiers).toEqual(["ENG-100"]);
+    });
+
+    it("should not dispatch task if no Linear integration exists", async () => {
+      const team = await buildTeam();
+      const user = await buildUser({ teamId: team.id });
+
+      const content = buildLinearMentionContent(
+        "https://linear.app/myteam/issue/ENG-456/title"
+      );
+      const document = await buildDocument({
+        teamId: team.id,
+        userId: user.id,
+        content,
+        text: "ENG-456",
+      });
+
+      const processor = new LinearBacklinksProcessor();
+      await processor.perform({
+        name: "documents.publish",
+        documentId: document.id,
+        collectionId: document.collectionId!,
+        teamId: team.id,
+        actorId: user.id,
+        ip,
+      } as DocumentEvent);
+
+      expect(
+        jest.mocked(SyncLinearBacklinksTask.prototype.schedule)
+      ).not.toHaveBeenCalled();
+    });
+
+    it("should not dispatch task for unpublished documents", async () => {
+      const team = await buildTeam();
+      const user = await buildUser({ teamId: team.id });
+
+      await buildIntegration({
+        teamId: team.id,
+        service: IntegrationService.Linear,
+        type: IntegrationType.Embed,
+        settings: buildLinearSettings("myteam"),
+      });
+
+      const content = buildLinearMentionContent(
+        "https://linear.app/myteam/issue/ENG-456/title"
+      );
+      const document = await buildDocument({
+        teamId: team.id,
+        userId: user.id,
+        content,
+        text: "ENG-456",
+        collectionId: null,
+      });
+
+      const processor = new LinearBacklinksProcessor();
+      await processor.perform({
+        name: "documents.publish",
+        documentId: document.id,
+        collectionId: "",
+        teamId: team.id,
+        actorId: user.id,
+        ip,
+      } as DocumentEvent);
+
+      expect(
+        jest.mocked(SyncLinearBacklinksTask.prototype.schedule)
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("documents.delete", () => {
+    it("should dispatch sync task with empty identifiers", async () => {
+      const team = await buildTeam();
+      const user = await buildUser({ teamId: team.id });
+
+      await buildIntegration({
+        teamId: team.id,
+        service: IntegrationService.Linear,
+        type: IntegrationType.Embed,
+        settings: buildLinearSettings("myteam"),
+      });
+
+      const document = await buildDocument({
+        teamId: team.id,
+        userId: user.id,
+      });
+
+      const processor = new LinearBacklinksProcessor();
+      await processor.perform({
+        name: "documents.delete",
+        documentId: document.id,
+        collectionId: document.collectionId!,
+        teamId: team.id,
+        actorId: user.id,
+        ip,
+      } as DocumentEvent);
+
+      expect(
+        jest.mocked(SyncLinearBacklinksTask.prototype.schedule)
+      ).toHaveBeenCalledWith({
+        documentId: document.id,
+        teamId: team.id,
+        currentIssueIdentifiers: [],
+      });
+    });
+  });
+
+  describe("documents.update.debounced", () => {
+    it("should dispatch sync task with current identifiers", async () => {
+      const team = await buildTeam();
+      const user = await buildUser({ teamId: team.id });
+
+      await buildIntegration({
+        teamId: team.id,
+        service: IntegrationService.Linear,
+        type: IntegrationType.Embed,
+        settings: buildLinearSettings("myteam"),
+      });
+
+      const content = buildLinearMentionContent(
+        "https://linear.app/myteam/issue/ENG-789/title",
+        "ENG-789"
+      );
+      const document = await buildDocument({
+        teamId: team.id,
+        userId: user.id,
+        content,
+        text: "ENG-789",
+      });
+
+      const processor = new LinearBacklinksProcessor();
+      await processor.perform({
+        name: "documents.update.debounced",
+        documentId: document.id,
+        collectionId: document.collectionId!,
+        teamId: team.id,
+        actorId: user.id,
+        createdAt: new Date().toISOString(),
+        ip,
+      } as DocumentEvent);
+
+      expect(
+        jest.mocked(SyncLinearBacklinksTask.prototype.schedule)
+      ).toHaveBeenCalledWith({
+        documentId: document.id,
+        teamId: team.id,
+        currentIssueIdentifiers: ["ENG-789"],
+      });
+    });
+  });
+
+  describe("collections.update", () => {
+    it("should dispatch sync task with issue identifiers from collection overview", async () => {
+      const team = await buildTeam();
+      const user = await buildUser({ teamId: team.id });
+
+      await buildIntegration({
+        teamId: team.id,
+        service: IntegrationService.Linear,
+        type: IntegrationType.Embed,
+        settings: buildLinearSettings("myteam"),
+      });
+
+      const content = buildLinearMentionContent(
+        "https://linear.app/myteam/issue/ENG-456/some-title"
+      );
+      const collection = await buildCollection({
+        teamId: team.id,
+        userId: user.id,
+        content,
+      });
+
+      const processor = new LinearBacklinksProcessor();
+      await processor.perform({
+        name: "collections.update",
+        collectionId: collection.id,
+        teamId: team.id,
+        actorId: user.id,
+        ip,
+      } as CollectionEvent);
+
+      expect(
+        jest.mocked(SyncLinearBacklinksTask.prototype.schedule)
+      ).toHaveBeenCalledWith({
+        collectionId: collection.id,
+        teamId: collection.teamId,
+        currentIssueIdentifiers: ["ENG-456"],
+      });
+    });
+
+    it("should dispatch empty identifiers for collection without mentions", async () => {
+      const team = await buildTeam();
+      const user = await buildUser({ teamId: team.id });
+
+      await buildIntegration({
+        teamId: team.id,
+        service: IntegrationService.Linear,
+        type: IntegrationType.Embed,
+        settings: buildLinearSettings("myteam"),
+      });
+
+      const collection = await buildCollection({
+        teamId: team.id,
+        userId: user.id,
+        content: { type: "doc", content: [] },
+      });
+
+      const processor = new LinearBacklinksProcessor();
+      await processor.perform({
+        name: "collections.update",
+        collectionId: collection.id,
+        teamId: team.id,
+        actorId: user.id,
+        ip,
+      } as CollectionEvent);
+
+      expect(
+        jest.mocked(SyncLinearBacklinksTask.prototype.schedule)
+      ).toHaveBeenCalledWith({
+        collectionId: collection.id,
+        teamId: collection.teamId,
+        currentIssueIdentifiers: [],
+      });
+    });
+
+    it("should not dispatch task if no Linear integration exists", async () => {
+      const team = await buildTeam();
+      const user = await buildUser({ teamId: team.id });
+
+      const content = buildLinearMentionContent(
+        "https://linear.app/myteam/issue/ENG-456/title"
+      );
+      const collection = await buildCollection({
+        teamId: team.id,
+        userId: user.id,
+        content,
+      });
+
+      const processor = new LinearBacklinksProcessor();
+      await processor.perform({
+        name: "collections.update",
+        collectionId: collection.id,
+        teamId: team.id,
+        actorId: user.id,
+        ip,
+      } as CollectionEvent);
+
+      expect(
+        jest.mocked(SyncLinearBacklinksTask.prototype.schedule)
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("collections.delete", () => {
+    it("should dispatch sync task with empty identifiers", async () => {
+      const team = await buildTeam();
+      const user = await buildUser({ teamId: team.id });
+
+      await buildIntegration({
+        teamId: team.id,
+        service: IntegrationService.Linear,
+        type: IntegrationType.Embed,
+        settings: buildLinearSettings("myteam"),
+      });
+
+      const collection = await buildCollection({
+        teamId: team.id,
+        userId: user.id,
+      });
+
+      const processor = new LinearBacklinksProcessor();
+      await processor.perform({
+        name: "collections.delete",
+        collectionId: collection.id,
+        teamId: team.id,
+        actorId: user.id,
+        ip,
+      } as CollectionEvent);
+
+      expect(
+        jest.mocked(SyncLinearBacklinksTask.prototype.schedule)
+      ).toHaveBeenCalledWith({
+        collectionId: collection.id,
+        teamId: team.id,
+        currentIssueIdentifiers: [],
+      });
+    });
+  });
+});

--- a/plugins/linear/server/processors/LinearBacklinksProcessor.ts
+++ b/plugins/linear/server/processors/LinearBacklinksProcessor.ts
@@ -1,0 +1,209 @@
+import { MentionType } from "@shared/types";
+import Collection from "@server/models/Collection";
+import Document from "@server/models/Document";
+import { DocumentHelper } from "@server/models/helpers/DocumentHelper";
+import { ProsemirrorHelper } from "@server/models/helpers/ProsemirrorHelper";
+import Logger from "@server/logging/Logger";
+import BaseProcessor from "@server/queues/processors/BaseProcessor";
+import type {
+  CollectionEvent,
+  DocumentEvent,
+  RevisionEvent,
+  Event,
+} from "@server/types";
+import { Linear } from "../linear";
+import SyncLinearBacklinksTask from "../tasks/SyncLinearBacklinksTask";
+
+/**
+ * Processor that creates backlink attachments on Linear issues when they are
+ * mentioned in Outline documents or collection overviews, and removes them
+ * when mentions are deleted.
+ */
+export default class LinearBacklinksProcessor extends BaseProcessor {
+  static applicableEvents: Event["name"][] = [
+    "documents.publish",
+    "documents.update.debounced",
+    "documents.delete",
+    "documents.permanent_delete",
+    "collections.update",
+    "collections.delete",
+  ];
+
+  async perform(event: DocumentEvent | RevisionEvent | CollectionEvent) {
+    switch (event.name) {
+      case "documents.publish":
+      case "documents.update.debounced":
+        return this.handleDocumentUpdate(event);
+      case "documents.delete":
+      case "documents.permanent_delete":
+        return this.handleDelete({
+          documentId: event.documentId,
+          teamId: "teamId" in event ? event.teamId : undefined,
+        });
+      case "collections.update":
+        return this.handleCollectionUpdate(event as CollectionEvent);
+      case "collections.delete":
+        return this.handleDelete({
+          collectionId: (event as CollectionEvent).collectionId,
+          teamId: "teamId" in event ? event.teamId : undefined,
+        });
+      default:
+    }
+  }
+
+  /**
+   * Retrieves the Linear workspace key for a team's integration.
+   *
+   * @param teamId The team ID to find the integration for.
+   * @returns The workspace key, or undefined if not available.
+   */
+  private async getWorkspaceKey(teamId: string): Promise<string | undefined> {
+    const integration = await Linear.getIntegrationForTeam(teamId);
+    if (!integration) {
+      return undefined;
+    }
+
+    const workspaceKey = integration.settings.linear?.workspace.key;
+    if (!workspaceKey) {
+      Logger.warn("Linear integration has no workspace key configured", {
+        integrationId: integration.id,
+        teamId,
+      });
+      return undefined;
+    }
+
+    return workspaceKey;
+  }
+
+  /**
+   * Extracts Linear issue identifiers from document mentions and dispatches
+   * a sync task to create or remove backlink attachments on Linear.
+   *
+   * @param event The document event that triggered the processor.
+   */
+  private async handleDocumentUpdate(event: DocumentEvent | RevisionEvent) {
+    const document = await Document.findByPk(event.documentId);
+    if (!document || !document.publishedAt) {
+      return;
+    }
+
+    const workspaceKey = await this.getWorkspaceKey(document.teamId);
+    if (!workspaceKey) {
+      return;
+    }
+
+    const identifiers = this.extractLinearIssueIdentifiers(
+      document,
+      workspaceKey
+    );
+
+    await new SyncLinearBacklinksTask().schedule({
+      documentId: document.id,
+      teamId: document.teamId,
+      currentIssueIdentifiers: identifiers,
+    });
+  }
+
+  /**
+   * Extracts Linear issue identifiers from collection overview content and
+   * dispatches a sync task to create or remove backlink attachments on Linear.
+   *
+   * @param event The collection event that triggered the processor.
+   */
+  private async handleCollectionUpdate(event: CollectionEvent) {
+    const collection = await Collection.findByPk(event.collectionId);
+    if (!collection) {
+      return;
+    }
+
+    const workspaceKey = await this.getWorkspaceKey(collection.teamId);
+    if (!workspaceKey) {
+      return;
+    }
+
+    const identifiers = this.extractLinearIssueIdentifiers(
+      collection,
+      workspaceKey
+    );
+
+    await new SyncLinearBacklinksTask().schedule({
+      collectionId: collection.id,
+      teamId: collection.teamId,
+      currentIssueIdentifiers: identifiers,
+    });
+  }
+
+  /**
+   * Dispatches a sync task with an empty identifier list, which causes
+   * all existing backlink attachments for the entity to be removed.
+   *
+   * @param params The document or collection ID and team ID.
+   */
+  private async handleDelete(params: {
+    documentId?: string;
+    collectionId?: string;
+    teamId?: string;
+  }) {
+    const { documentId, collectionId, teamId } = params;
+    if (!teamId) {
+      return;
+    }
+
+    const integration = await Linear.getIntegrationForTeam(teamId);
+    if (!integration) {
+      return;
+    }
+
+    await new SyncLinearBacklinksTask().schedule({
+      documentId,
+      collectionId,
+      teamId,
+      currentIssueIdentifiers: [],
+    });
+  }
+
+  /**
+   * Extracts Linear issue identifiers from a document or collection using
+   * the polymorphic DocumentHelper.toProsemirror method.
+   *
+   * @param entity The document or collection to extract identifiers from.
+   * @param workspaceKey The Linear workspace key to filter by.
+   * @returns An array of unique Linear issue identifiers.
+   */
+  private extractLinearIssueIdentifiers(
+    entity: Document | Collection,
+    workspaceKey: string
+  ): string[] {
+    try {
+      const node = DocumentHelper.toProsemirror(entity);
+      const mentions = ProsemirrorHelper.parseMentions(node, {
+        type: MentionType.Issue,
+      });
+
+      const identifiers: string[] = [];
+
+      for (const mention of mentions) {
+        if (!mention.href) {
+          continue;
+        }
+
+        const parsed = Linear.parseUrl(mention.href);
+        if (parsed && parsed.id && parsed.workspaceKey === workspaceKey) {
+          identifiers.push(parsed.id);
+        }
+      }
+
+      return [...new Set(identifiers)];
+    } catch (err) {
+      const isDocument = entity instanceof Document;
+      Logger.warn(
+        `Failed to extract Linear issue identifiers from ${isDocument ? "document" : "collection"}`,
+        {
+          ...(isDocument ? { documentId: entity.id } : { collectionId: entity.id }),
+          error: err,
+        }
+      );
+      return [];
+    }
+  }
+}

--- a/plugins/linear/server/tasks/SyncLinearBacklinksTask.test.ts
+++ b/plugins/linear/server/tasks/SyncLinearBacklinksTask.test.ts
@@ -1,0 +1,328 @@
+import { v4 as uuidv4 } from "uuid";
+import fetchMock from "jest-fetch-mock";
+import {
+  IntegrationService,
+  type IntegrationSettings,
+  IntegrationType,
+} from "@shared/types";
+import {
+  buildDocument,
+  buildIntegration,
+  buildTeam,
+  buildUser,
+} from "@server/test/factories";
+import SyncLinearBacklinksTask from "./SyncLinearBacklinksTask";
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  fetchMock.resetMocks();
+  fetchMock.doMock();
+});
+
+/**
+ * Builds Linear integration settings with required workspace fields.
+ *
+ * @param workspaceKey The workspace key (e.g., "myteam").
+ * @param workspaceName The workspace display name.
+ * @returns Settings object typed for Linear embed integration.
+ */
+function buildLinearSettings(
+  workspaceKey: string,
+  workspaceName = "My Team"
+): IntegrationSettings<IntegrationType.Embed> {
+  return {
+    linear: {
+      workspace: {
+        id: uuidv4(),
+        key: workspaceKey,
+        name: workspaceName,
+      },
+    },
+  };
+}
+
+/**
+ * Returns a mock Linear GraphQL response body.
+ *
+ * @param data The data payload to include in the response.
+ * @returns A JSON string representing the GraphQL response.
+ */
+function graphqlResponse(data: Record<string, unknown>) {
+  return JSON.stringify({ data });
+}
+
+/**
+ * Returns a mock attachmentsForURL response with the given attachments.
+ *
+ * @param attachments Array of attachment objects to return.
+ * @returns A JSON string representing the GraphQL response.
+ */
+function attachmentsForUrlResponse(
+  attachments: Array<{
+    id: string;
+    url: string;
+    issue: { id: string; identifier: string };
+  }>
+) {
+  return graphqlResponse({
+    attachmentsForURL: { nodes: attachments },
+  });
+}
+
+describe("SyncLinearBacklinksTask", () => {
+  it("should create attachments for new issue mentions", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    await buildIntegration({
+      teamId: team.id,
+      service: IntegrationService.Linear,
+      type: IntegrationType.Embed,
+      settings: buildLinearSettings("myteam"),
+    });
+
+    const document = await buildDocument({
+      teamId: team.id,
+      userId: user.id,
+    });
+
+    // Mock responses in order:
+    // 1. attachmentsForURL → empty (no existing attachments)
+    // 2. issue(id: "ENG-456") → resolve to UUID
+    // 3. attachmentCreate → success
+    fetchMock
+      .mockResponseOnce(attachmentsForUrlResponse([]))
+      .mockResponseOnce(
+        graphqlResponse({ issue: { id: "linear-issue-uuid-456" } })
+      )
+      .mockResponseOnce(
+        graphqlResponse({
+          attachmentCreate: {
+            success: true,
+            attachment: { id: "attachment-uuid-1" },
+          },
+        })
+      );
+
+    const task = new SyncLinearBacklinksTask();
+    await task.perform({
+      documentId: document.id,
+      teamId: team.id,
+      currentIssueIdentifiers: ["ENG-456"],
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    // Verify attachmentsForURL query
+    const firstCall = JSON.parse(fetchMock.mock.calls[0]![1]!.body!.toString());
+    expect(firstCall.query).toContain("attachmentsForURL");
+
+    // Verify issue resolution
+    const secondCall = JSON.parse(
+      fetchMock.mock.calls[1]![1]!.body!.toString()
+    );
+    expect(secondCall.query).toContain("issue");
+    expect(secondCall.variables.id).toBe("ENG-456");
+
+    // Verify attachmentCreate
+    const thirdCall = JSON.parse(
+      fetchMock.mock.calls[2]![1]!.body!.toString()
+    );
+    expect(thirdCall.query).toContain("attachmentCreate");
+    expect(thirdCall.variables.input.issueId).toBe("linear-issue-uuid-456");
+    expect(thirdCall.variables.input.title).toBe(document.title);
+    expect(thirdCall.variables.input.subtitle).toBe("Outline");
+  });
+
+  it("should delete attachments for removed mentions", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    await buildIntegration({
+      teamId: team.id,
+      service: IntegrationService.Linear,
+      type: IntegrationType.Embed,
+      settings: buildLinearSettings("myteam"),
+    });
+
+    const document = await buildDocument({
+      teamId: team.id,
+      userId: user.id,
+    });
+
+    // Mock: existing attachment for ENG-456, but no current mentions
+    fetchMock
+      .mockResponseOnce(
+        attachmentsForUrlResponse([
+          {
+            id: "attachment-to-delete",
+            url: `https://app.outline.dev${document.path}`,
+            issue: { id: "issue-uuid", identifier: "ENG-456" },
+          },
+        ])
+      )
+      .mockResponseOnce(
+        graphqlResponse({ attachmentDelete: { success: true } })
+      );
+
+    const task = new SyncLinearBacklinksTask();
+    await task.perform({
+      documentId: document.id,
+      teamId: team.id,
+      currentIssueIdentifiers: [],
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // Verify attachmentDelete
+    const deleteCall = JSON.parse(
+      fetchMock.mock.calls[1]![1]!.body!.toString()
+    );
+    expect(deleteCall.query).toContain("attachmentDelete");
+    expect(deleteCall.variables.id).toBe("attachment-to-delete");
+  });
+
+  it("should skip already existing attachments", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    await buildIntegration({
+      teamId: team.id,
+      service: IntegrationService.Linear,
+      type: IntegrationType.Embed,
+      settings: buildLinearSettings("myteam"),
+    });
+
+    const document = await buildDocument({
+      teamId: team.id,
+      userId: user.id,
+    });
+
+    // Mock: ENG-456 already exists as attachment, and it's still mentioned
+    fetchMock.mockResponseOnce(
+      attachmentsForUrlResponse([
+        {
+          id: "existing-attachment",
+          url: `https://app.outline.dev${document.path}`,
+          issue: { id: "issue-uuid", identifier: "ENG-456" },
+        },
+      ])
+    );
+
+    const task = new SyncLinearBacklinksTask();
+    await task.perform({
+      documentId: document.id,
+      teamId: team.id,
+      currentIssueIdentifiers: ["ENG-456"],
+    });
+
+    // Only the attachmentsForURL call, no create or delete
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should handle missing document gracefully", async () => {
+    const team = await buildTeam();
+    await buildIntegration({
+      teamId: team.id,
+      service: IntegrationService.Linear,
+      type: IntegrationType.Embed,
+      settings: buildLinearSettings("myteam"),
+    });
+
+    const task = new SyncLinearBacklinksTask();
+    await task.perform({
+      documentId: "non-existent-id",
+      teamId: team.id,
+      currentIssueIdentifiers: [],
+    });
+
+    // No API calls since document not found
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("should handle no Linear integration gracefully", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const document = await buildDocument({
+      teamId: team.id,
+      userId: user.id,
+    });
+
+    const task = new SyncLinearBacklinksTask();
+    await task.perform({
+      documentId: document.id,
+      teamId: team.id,
+      currentIssueIdentifiers: ["ENG-456"],
+    });
+
+    // No API calls since no integration
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("should handle 403 from Linear gracefully", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    await buildIntegration({
+      teamId: team.id,
+      service: IntegrationService.Linear,
+      type: IntegrationType.Embed,
+      settings: buildLinearSettings("myteam"),
+    });
+
+    const document = await buildDocument({
+      teamId: team.id,
+      userId: user.id,
+    });
+
+    fetchMock
+      .mockResponseOnce(attachmentsForUrlResponse([]))
+      .mockResponseOnce(
+        graphqlResponse({ issue: { id: "linear-issue-uuid" } })
+      )
+      .mockResponseOnce("Forbidden", { status: 403 });
+
+    const task = new SyncLinearBacklinksTask();
+
+    // Should not throw despite 403
+    await expect(
+      task.perform({
+        documentId: document.id,
+        teamId: team.id,
+        currentIssueIdentifiers: ["ENG-456"],
+      })
+    ).resolves.not.toThrow();
+  });
+
+  it("should handle issue not found gracefully", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    await buildIntegration({
+      teamId: team.id,
+      service: IntegrationService.Linear,
+      type: IntegrationType.Embed,
+      settings: buildLinearSettings("myteam"),
+    });
+
+    const document = await buildDocument({
+      teamId: team.id,
+      userId: user.id,
+    });
+
+    fetchMock
+      .mockResponseOnce(attachmentsForUrlResponse([]))
+      .mockResponseOnce(
+        JSON.stringify({
+          data: null,
+          errors: [{ message: "Not found", extensions: { code: "NOT_FOUND" } }],
+        })
+      );
+
+    const task = new SyncLinearBacklinksTask();
+
+    // Should not throw — issue resolution failure is handled
+    await expect(
+      task.perform({
+        documentId: document.id,
+        teamId: team.id,
+        currentIssueIdentifiers: ["NONEXISTENT-999"],
+      })
+    ).resolves.not.toThrow();
+  });
+});

--- a/plugins/linear/server/tasks/SyncLinearBacklinksTask.ts
+++ b/plugins/linear/server/tasks/SyncLinearBacklinksTask.ts
@@ -1,0 +1,358 @@
+import type { LinearClient } from "@linear/sdk";
+import env from "@server/env";
+import Logger from "@server/logging/Logger";
+import Collection from "@server/models/Collection";
+import Document from "@server/models/Document";
+import { BaseTask, TaskPriority } from "@server/queues/tasks/base/BaseTask";
+import { Linear } from "../linear";
+
+interface Props {
+  /** The Outline document ID (mutually exclusive with collectionId). */
+  documentId?: string;
+  /** The Outline collection ID (mutually exclusive with documentId). */
+  collectionId?: string;
+  /** The team ID for finding the Linear integration. */
+  teamId: string;
+  /** Current Linear issue identifiers mentioned in the document/collection (e.g., ["ENG-456"]). */
+  currentIssueIdentifiers: string[];
+}
+
+interface LinearAttachment {
+  id: string;
+  url: string;
+  issue: {
+    id: string;
+    identifier: string;
+  };
+}
+
+/** Subtitle used to identify attachments created by Outline. */
+const OUTLINE_ATTACHMENT_SUBTITLE = "Outline";
+
+/** Query parameter name used to identify Outline-created attachments. */
+const OUTLINE_REF_PARAM = "ref";
+
+/** Query parameter value used to identify Outline-created attachments. */
+const OUTLINE_REF_VALUE = "outline-backlink";
+
+/**
+ * Builds the attachment URL with the Outline source identifier.
+ *
+ * @param baseUrl The base document/collection URL.
+ * @returns URL with the source query parameter.
+ * @throws If baseUrl is not a valid URL.
+ */
+function buildAttachmentUrl(baseUrl: string): string {
+  try {
+    const url = new URL(baseUrl);
+    url.searchParams.set(OUTLINE_REF_PARAM, OUTLINE_REF_VALUE);
+    return url.toString();
+  } catch (err) {
+    throw new Error(`Invalid attachment base URL: ${baseUrl}`);
+  }
+}
+
+/**
+ * Task that synchronizes backlink attachments on Linear issues. For each
+ * document update, it compares the current set of Linear issue mentions
+ * against existing attachments in Linear and creates or deletes as needed.
+ */
+export default class SyncLinearBacklinksTask extends BaseTask<Props> {
+  public get options() {
+    return {
+      attempts: 3,
+      priority: TaskPriority.Background,
+      backoff: {
+        type: "exponential" as const,
+        delay: 30 * 1000,
+      },
+    };
+  }
+
+  public async perform({
+    documentId,
+    collectionId,
+    teamId,
+    currentIssueIdentifiers,
+  }: Props) {
+    const client = await Linear.getClientForTeam(teamId);
+    if (!client) {
+      return;
+    }
+
+    // Load either document or collection based on what ID was provided
+    const { title, url: baseUrl } = await this.resolveTarget(
+      documentId,
+      collectionId
+    );
+    if (!baseUrl) {
+      Logger.debug(
+        "task",
+        "Target not found, skipping Linear backlinks sync",
+        { documentId, collectionId }
+      );
+      return;
+    }
+
+    // Build the full URL with Outline identifier for consistent matching
+    const attachmentUrl = buildAttachmentUrl(baseUrl);
+
+    // Query Linear for existing attachments linked to this URL
+    const existingAttachments = await this.fetchAttachmentsForUrl(
+      client,
+      attachmentUrl
+    );
+
+    // Since we query with the full Outline URL (including ref parameter),
+    // all returned attachments are Outline-created by definition
+    const existingIdentifiers = new Set(
+      existingAttachments.map((a) => a.issue.identifier)
+    );
+    const desiredIdentifiers = new Set(currentIssueIdentifiers);
+
+    // Create attachments for newly added mentions
+    const toCreate = currentIssueIdentifiers.filter(
+      (id) => !existingIdentifiers.has(id)
+    );
+    // Delete attachments for removed mentions
+    const toDelete = existingAttachments.filter(
+      (a) => !desiredIdentifiers.has(a.issue.identifier)
+    );
+
+    const targetTitle = title || "Untitled";
+
+    const operations = [
+      ...toCreate.map((identifier) => ({
+        type: "create" as const,
+        identifier,
+        promise: this.createAttachment(client, {
+          issueIdentifier: identifier,
+          title: targetTitle,
+          url: attachmentUrl,
+        }),
+      })),
+      ...toDelete.map((attachment) => ({
+        type: "delete" as const,
+        identifier: attachment.issue.identifier,
+        promise: this.deleteAttachment(client, attachment.id),
+      })),
+    ];
+
+    const results = await Promise.allSettled(
+      operations.map((op) => op.promise)
+    );
+
+    let succeeded = 0;
+    let failed = 0;
+
+    for (let i = 0; i < results.length; i++) {
+      if (results[i].status === "rejected") {
+        failed++;
+        const rejected = results[i] as PromiseRejectedResult;
+        Logger.warn("Linear backlink sync operation failed", {
+          documentId,
+          collectionId,
+          operation: operations[i].type,
+          issueIdentifier: operations[i].identifier,
+          error:
+            rejected.reason instanceof Error
+              ? rejected.reason.message
+              : String(rejected.reason),
+        });
+      } else {
+        succeeded++;
+      }
+    }
+
+    if (operations.length > 0) {
+      Logger.info("task", "Linear backlinks sync completed", {
+        documentId,
+        collectionId,
+        created: toCreate.length,
+        deleted: toDelete.length,
+        succeeded,
+        failed,
+      });
+    }
+  }
+
+  /**
+   * Resolves either a document or collection ID to its title and URL.
+   *
+   * @param documentId The document ID (optional).
+   * @param collectionId The collection ID (optional).
+   * @returns An object with title and url, or empty strings if not found.
+   */
+  private async resolveTarget(
+    documentId?: string,
+    collectionId?: string
+  ): Promise<{ title: string; url: string }> {
+    if (documentId && collectionId) {
+      Logger.warn(
+        "Both documentId and collectionId provided to resolveTarget, using documentId",
+        { documentId, collectionId }
+      );
+    }
+
+    if (!env.URL) {
+      Logger.warn(
+        "env.URL is not configured, cannot construct attachment URL"
+      );
+      return { title: "", url: "" };
+    }
+
+    if (documentId) {
+      const document = await Document.findByPk(documentId);
+      if (!document?.path) {
+        return { title: "", url: "" };
+      }
+      return {
+        title: document.title || "Untitled",
+        url: this.buildEntityUrl(document.path),
+      };
+    }
+
+    if (collectionId) {
+      const collection = await Collection.findByPk(collectionId);
+      if (!collection?.path) {
+        return { title: "", url: "" };
+      }
+      return {
+        title: collection.name || "Untitled Collection",
+        url: this.buildEntityUrl(collection.path),
+      };
+    }
+
+    return { title: "", url: "" };
+  }
+
+  /**
+   * Constructs a full URL for a document or collection path.
+   *
+   * @param path The entity path (e.g., "/doc/slug-abc123").
+   * @returns The full URL including the base URL.
+   */
+  private buildEntityUrl(path: string): string {
+    return `${env.URL}${path.startsWith("/") ? path : `/${path}`}`;
+  }
+
+  /**
+   * Queries Linear for existing attachments linked to the given document URL.
+   *
+   * @param client The Linear SDK client.
+   * @param url The Outline document URL to search for.
+   * @returns An array of existing attachments.
+   */
+  private async fetchAttachmentsForUrl(
+    client: LinearClient,
+    url: string
+  ): Promise<LinearAttachment[]> {
+    try {
+      const result = await client.attachmentsForURL(url);
+
+      // Fetch all issues in parallel to avoid N+1 queries
+      const issuePromises = result.nodes.map(async (attachment) => {
+        const issue = await attachment.issue;
+        return { attachment, issue };
+      });
+      const resolved = await Promise.all(issuePromises);
+
+      return resolved
+        .filter((r): r is typeof r & { issue: NonNullable<typeof r.issue> } =>
+          r.issue !== undefined
+        )
+        .map((r) => ({
+          id: r.attachment.id,
+          url: r.attachment.url,
+          issue: {
+            id: r.issue.id,
+            identifier: r.issue.identifier,
+          },
+        }));
+    } catch (err) {
+      Logger.warn("Failed to fetch Linear attachments for URL", {
+        url,
+        error: err,
+      });
+      return [];
+    }
+  }
+
+  /**
+   * Creates a backlink attachment on a Linear issue.
+   *
+   * @param client The Linear SDK client.
+   * @param params The attachment parameters.
+   */
+  private async createAttachment(
+    client: LinearClient,
+    params: {
+      issueIdentifier: string;
+      title: string;
+      url: string;
+    }
+  ) {
+    // First resolve the issue identifier to get the issue ID
+    const issue = await client.issue(params.issueIdentifier);
+    if (!issue) {
+      Logger.debug(
+        "task",
+        `Linear issue ${params.issueIdentifier} not found, skipping attachment`
+      );
+      return;
+    }
+
+    try {
+      const result = await client.createAttachment({
+        issueId: issue.id,
+        title: params.title,
+        subtitle: OUTLINE_ATTACHMENT_SUBTITLE,
+        url: params.url,
+        iconUrl: `${env.URL}/images/icon-192.png`,
+      });
+
+      if (!result.success) {
+        throw new Error(
+          `Linear attachmentCreate returned success=false for issue ${params.issueIdentifier}`
+        );
+      }
+    } catch (err) {
+      // Check for permission errors (need re-auth with write scope)
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.includes("Forbidden") || message.includes("403")) {
+        Logger.warn(
+          "Linear integration lacks write permission for attachments. " +
+            "Please re-authorize the Linear integration with updated scopes.",
+          { issueIdentifier: params.issueIdentifier }
+        );
+        return;
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Deletes a backlink attachment from Linear.
+   *
+   * @param client The Linear SDK client.
+   * @param attachmentId The Linear attachment ID to delete.
+   */
+  private async deleteAttachment(client: LinearClient, attachmentId: string) {
+    try {
+      const result = await client.deleteAttachment(attachmentId);
+
+      if (!result.success) {
+        throw new Error(
+          `Linear attachmentDelete returned success=false for attachment ${attachmentId}`
+        );
+      }
+    } catch (err) {
+      // Ignore 404 - attachment already deleted
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.includes("Not found") || message.includes("404")) {
+        return;
+      }
+      throw err;
+    }
+  }
+}

--- a/plugins/linear/shared/LinearUtils.ts
+++ b/plugins/linear/shared/LinearUtils.ts
@@ -7,7 +7,10 @@ export type OAuthState = {
 };
 
 export class LinearUtils {
-  private static oauthScopes = "read,issues:create";
+  // TODO: "write" is broader than ideal — Linear does not offer a granular
+  // scope for attachments alone, so we request "write" to allow
+  // attachmentCreate / attachmentDelete for backlink sync.
+  private static oauthScopes = "read,write";
 
   public static tokenUrl = "https://api.linear.app/oauth/token";
   public static revokeUrl = "https://api.linear.app/oauth/revoke";


### PR DESCRIPTION
## Summary

When an Outline document mentions a Linear issue (via paste → mention node), this automatically creates a backlink attachment on that Linear issue pointing back to the Outline document. When the mention is removed or the document is deleted, the attachment is cleaned up from Linear.

<img width="2444" height="1362" alt="CleanShot 2026-02-06 at 10 55 43@2x" src="https://github.com/user-attachments/assets/0e1f66f4-0116-4e43-a1f9-5c140a958ae7" />


- Stateless approach using Linear's `attachmentsForURL` API for diff calculation — no new database tables required
- Uses `@linear/sdk` for all Linear API operations
- Filters mentions to only process issues from the configured workspace

### Changes

- **LinearBacklinksProcessor** — listens to `documents.publish`, `documents.update.debounced`, `documents.delete`, `documents.permanent_delete`
- **SyncLinearBacklinksTask** — performs Linear SDK API calls (attachmentsForURL → diff → create/delete) with retry logic
- **Linear.getClientForTeam / getIntegrationForTeam** — shared helpers for Linear integration access
- OAuth scopes updated from `read,issues:create` to `read,write` (Linear doesn't offer granular attachment scopes)

## Test plan

- [x] Backlink attachment appears on Linear issue after mentioning it in Outline document
- [x] Attachment is removed when mention is deleted from document
- [x] Attachment is removed when document is deleted
- [x] No duplicate attachments on repeated saves (idempotency via Linear API)
- [x] Graceful handling when Linear integration lacks write scope (logs warning)
- [x] Only issues from configured workspace are processed (cross-workspace filtering)
- [x] Unit tests pass

🤖 Generated [OnSteroids](https://onsteroids.ai)