### PR TITLE
feat: increase doc length value

### DIFF
--- a/shared/validations.ts
+++ b/shared/validations.ts
@@ -63,7 +63,7 @@ export const DocumentValidation = {
   maxStateLength: 1500 * 1024,
 
   /** The maximum recommended size of the document content */
-  maxRecommendedLength: 250000,
+  maxRecommendedLength: 1000 * 1024,
 };
 
 export const GroupValidation = {


### PR DESCRIPTION
While trying to import a large report into outline I have stumbled upon this limit which seems artificial to me.

I am aware that importing such a large files might impact performance and be unreadable.
Usually though content this large is rare, not human created or not destined to be read by humans. 

I would like to increase this limit to `1024_000` unless:
* There is benchmark proving that existence of that large documents significantly degrades performance.
* The fail of the import wasn't caused by the warning that this limit is tied to. Warnings by definition shall warn users, but still let them to do what they want.
* There is any other reason I am not aware of to keep the limit as it is. (`250_000`)

