### PR TITLE
fix: Creating new doc from sidebar should land in edit mode

### DIFF
--- a/app/scenes/Document/components/DataLoader.tsx
+++ b/app/scenes/Document/components/DataLoader.tsx
@@ -162,7 +162,7 @@ function DataLoader({ match, children }: Props) {
 
       // If we're attempting to update an archived, deleted, or otherwise
       // uneditable document then forward to the canonical read url.
-      if (!can.update && isEditRoute && !document.template) {
+      if (!missingPolicy && !can.update && isEditRoute && !document.template) {
         history.push(document.url);
         return;
       }


### PR DESCRIPTION
Currently it redirects to non-edit mode when using separate modes