### PR TITLE
fix: Notification badge does not appear until notification popover opened

### DIFF
--- a/app/components/AuthenticatedLayout.tsx
+++ b/app/components/AuthenticatedLayout.tsx
@@ -28,6 +28,7 @@ import {
 } from "~/utils/routeHelpers";
 import { DocumentContextProvider } from "./DocumentContext";
 import Fade from "./Fade";
+import NotificationBadge from "./NotificationBadge";
 import { PortalContext } from "./Portal";
 import CommandBar from "./CommandBar";
 
@@ -132,6 +133,7 @@ const AuthenticatedLayout: React.FC = ({ children }: Props) => {
           <RegisterKeyDown trigger="/" handler={goToSearch} />
           {children}
           <CommandBar />
+          <NotificationBadge />
         </Layout>
       </PortalContext.Provider>
     </DocumentContextProvider>

--- a/app/components/NotificationBadge.tsx
+++ b/app/components/NotificationBadge.tsx
@@ -1,0 +1,47 @@
+import { observer } from "mobx-react";
+import * as React from "react";
+import { NotificationBadgeType, UserPreference } from "@shared/types";
+import useCurrentUser from "~/hooks/useCurrentUser";
+import useStores from "~/hooks/useStores";
+import Desktop from "~/utils/Desktop";
+
+/**
+ * Component that keeps the app icon notification badge in sync with unread
+ * notification count. Renders nothing visible — mount near the app root so it
+ * stays alive as long as the user is authenticated.
+ */
+function NotificationBadge() {
+  const { notifications } = useStores();
+  const user = useCurrentUser();
+
+  const badgeType = user.getPreference(UserPreference.NotificationBadge);
+  const unreadCount = notifications.approximateUnreadCount;
+
+  React.useEffect(() => {
+    // Desktop app badge
+    if (Desktop.bridge && "setNotificationCount" in Desktop.bridge) {
+      if (badgeType === NotificationBadgeType.Disabled || unreadCount === 0) {
+        void Desktop.bridge.setNotificationCount(0);
+      } else if (badgeType === NotificationBadgeType.Count) {
+        void Desktop.bridge.setNotificationCount(unreadCount);
+      } else {
+        void Desktop.bridge.setNotificationCount("・");
+      }
+    }
+
+    // PWA badge
+    if ("setAppBadge" in navigator) {
+      if (unreadCount > 0 && badgeType !== NotificationBadgeType.Disabled) {
+        void navigator.setAppBadge(
+          badgeType === NotificationBadgeType.Count ? unreadCount : undefined
+        );
+      } else {
+        void navigator.clearAppBadge();
+      }
+    }
+  }, [unreadCount, badgeType]);
+
+  return null;
+}
+
+export default observer(NotificationBadge);

--- a/app/components/Notifications/Notifications.tsx
+++ b/app/components/Notifications/Notifications.tsx
@@ -4,13 +4,10 @@ import * as React from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { s, hover } from "@shared/styles";
-import { NotificationBadgeType, UserPreference } from "@shared/types";
 import Notification, { type NotificationFilter } from "~/models/Notification";
 import { markNotificationsAsRead } from "~/actions/definitions/notifications";
-import useCurrentUser from "~/hooks/useCurrentUser";
 import useStores from "~/hooks/useStores";
 import NotificationMenu from "~/menus/NotificationMenu";
-import Desktop from "~/utils/Desktop";
 import Empty from "../Empty";
 import ErrorBoundary from "../ErrorBoundary";
 import Flex from "../Flex";
@@ -36,7 +33,6 @@ function Notifications(
   ref: React.RefObject<HTMLDivElement>
 ) {
   const { notifications } = useStores();
-  const user = useCurrentUser();
   const { t } = useTranslation();
   const [filter, setFilter] = React.useState<NotificationFilter>("all");
 
@@ -64,34 +60,7 @@ function Notifications(
     );
   }, [notifications.active, filter]);
 
-  const badgeType = user.getPreference(UserPreference.NotificationBadge);
   const unreadCount = notifications.approximateUnreadCount;
-
-  // Update the notification count in the dock icon, if possible.
-  React.useEffect(() => {
-    // Account for old versions of the desktop app that don't have the
-    // setNotificationCount method on the bridge.
-    if (Desktop.bridge && "setNotificationCount" in Desktop.bridge) {
-      if (badgeType === NotificationBadgeType.Disabled || unreadCount === 0) {
-        void Desktop.bridge.setNotificationCount(0);
-      } else if (badgeType === NotificationBadgeType.Count) {
-        void Desktop.bridge.setNotificationCount(unreadCount);
-      } else {
-        void Desktop.bridge.setNotificationCount("・");
-      }
-    }
-
-    // PWA badging
-    if ("setAppBadge" in navigator) {
-      if (unreadCount > 0 && badgeType !== NotificationBadgeType.Disabled) {
-        void navigator.setAppBadge(
-          badgeType === NotificationBadgeType.Count ? unreadCount : undefined
-        );
-      } else {
-        void navigator.clearAppBadge();
-      }
-    }
-  }, [unreadCount, badgeType]);
 
   return (
     <ErrorBoundary>

--- a/app/models/User.ts
+++ b/app/models/User.ts
@@ -247,6 +247,7 @@ class User extends ParanoidModel implements Searchable {
    * @param key The UserPreference key to retrieve
    * @param value The value to set
    */
+  @action
   setPreference<K extends UserPreference>(
     key: K,
     value: NonNullable<UserPreferences[K]>


### PR DESCRIPTION
Logic needs to be ran in a separately mounted component