### PR TITLE
fix: Ignore browser cache for diagram extension

### DIFF
--- a/shared/editor/lib/FileHelper.ts
+++ b/shared/editor/lib/FileHelper.ts
@@ -354,14 +354,20 @@ export default class FileHelper {
   }
 
   /**
-   * Converts an image URL to base64 encoded data.
+   * Converts an image URL to a base64 data URI string.
    *
    * @param url - the URL of the image to convert.
-   * @returns promise resolving to base64 string (without data URI prefix).
+   * @returns promise resolving to a data URI string.
    * @throws Error if the image cannot be fetched or converted.
    */
   static async urlToBase64(url: string): Promise<string> {
-    const response = await fetch(url);
+    // Use "no-store" to skip the HTTP cache entirely. Without this, the
+    // browser may reuse a cached response that was originally fetched by an
+    // <img> tag (which omits the Origin header). S3/CloudFront can cache
+    // that response without Access-Control-Allow-Origin, causing a CORS
+    // error when fetch later tries to read the same URL with an Origin
+    // header.
+    const response = await fetch(url, { cache: "no-store" });
     if (!response.ok) {
       throw new Error(`Failed to fetch image: ${response.statusText}`);
     }


### PR DESCRIPTION
closes #11496