### PR TITLE
fix: Read-only collection editor does not remount correctly on nav

### DIFF
--- a/app/scenes/Shared/Collection.tsx
+++ b/app/scenes/Shared/Collection.tsx
@@ -83,7 +83,7 @@ function SharedCollection({ collection }: Props) {
             </SharedMeta>
           ) : null}
         </Flex>
-        <Overview collection={collection} readOnly />
+        <Overview collection={collection} key={collection.id} readOnly />
       </CenteredContent>
     </Scene>
   );


### PR DESCRIPTION
Interesting case when linking between two shared collections and navigating back and forth the editor would not remount the new content.