### PR TITLE
fix: Overly greedy background -> highlight

### DIFF
--- a/shared/editor/marks/Highlight.ts
+++ b/shared/editor/marks/Highlight.ts
@@ -77,8 +77,12 @@ export default class Highlight extends Mark {
           },
         },
         {
-          style: "background-color",
-          getAttrs: (style: string) => {
+          tag: "span[style]",
+          getAttrs: (dom) => {
+            const style = dom.style.backgroundColor;
+            if (!style) {
+              return false;
+            }
             const matchedColor = Highlight.findMatchingPresetColor(style);
             // Only apply highlight if we found a matching preset color
             // or if the color is clearly a highlight (not white/transparent)


### PR DESCRIPTION
The current logic for converting background color to a highlight mark was overly greedy and ended up picking up background colors on tables and other elements. 