### PR TITLE
fix: Multiple fixes to sticky headers on tables

### DIFF
--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -1954,8 +1954,10 @@ table {
     padding: 4px 0;
   }
 
-  td[data-bgcolor] {
+  td[data-bgcolor],
+  th[data-bgcolor] {
     color: var(--cell-text-color);
+    background: linear-gradient(var(--cell-bg-color), var(--cell-bg-color)), linear-gradient(${props.theme.background}, ${props.theme.background});
 
     p, a, p a {
       color: var(--cell-text-color, inherit);
@@ -2287,7 +2289,7 @@ table {
 }
 
 .${EditorStyleHelper.tableStickyHeader} {
-  th {
+  tr:first-child th {
     transform: translateY(calc(var(--header-offset, 64px) + var(--sticky-scroll-offset, 0px)));
     border-bottom: 1px solid ${props.theme.divider};
 

--- a/shared/editor/lib/table.ts
+++ b/shared/editor/lib/table.ts
@@ -90,7 +90,7 @@ export function setCellAttrs(node: Node): Attrs {
       attrs["data-bgcolor"] = backgroundMark.attrs.color;
       attrs.style =
         (attrs.style ?? "") +
-        `background-color: ${backgroundMark.attrs.color}; --cell-text-color: ${readableColor(backgroundMark.attrs.color)};`;
+        `--cell-bg-color: ${backgroundMark.attrs.color}; --cell-text-color: ${readableColor(backgroundMark.attrs.color)};`;
     }
   }
 


### PR DESCRIPTION
- Custom header color incorrect text color
- Header column sticky unnecessarily
- Incorrect text color used on header with custom background 
- Header with custom background showing content behind when sticky 

closes #11477