### PR TITLE
Refactor `ActionContextProvider` to allow more model coverage

### DIFF
--- a/app/components/DocumentListItem.tsx
+++ b/app/components/DocumentListItem.tsx
@@ -101,11 +101,10 @@ function DocumentListItem(
   return (
     <ActionContextProvider
       value={{
-        activeDocumentId: document.id,
-        activeCollectionId:
-          !isShared && document.collectionId
-            ? document.collectionId
-            : undefined,
+        activeModels: [
+          document,
+          ...(!isShared && document.collection ? [document.collection] : []),
+        ],
       }}
     >
       <ContextMenu

--- a/app/components/RevisionListItem.tsx
+++ b/app/components/RevisionListItem.tsx
@@ -125,7 +125,7 @@ const RevisionListItem = ({ item, document, ...rest }: Props) => {
   }
 
   return (
-    <ActionContextProvider value={{ activeDocumentId: document.id }}>
+    <ActionContextProvider value={{ activeModels: [document] }}>
       <ContextMenu
         action={contextMenuAction}
         ariaLabel={t("Revision options")}

--- a/app/components/Sidebar/components/CollectionLink.tsx
+++ b/app/components/Sidebar/components/CollectionLink.tsx
@@ -127,7 +127,7 @@ const CollectionLink: React.FC<Props> = ({
   });
 
   return (
-    <ActionContextProvider value={{ activeCollectionId: collection.id }}>
+    <ActionContextProvider value={{ activeModels: [collection] }}>
       <Relative ref={mergeRefs([parentRef, dropRef])}>
         <DropToImport collectionId={collection.id}>
           <SidebarLink

--- a/app/components/Sidebar/components/DocumentLink.tsx
+++ b/app/components/Sidebar/components/DocumentLink.tsx
@@ -416,7 +416,7 @@ function InnerDocumentLink(
   return (
     <ActionContextProvider
       value={{
-        activeDocumentId: node.id,
+        activeModels: document ? [document] : [],
       }}
     >
       <Relative ref={parentRef}>

--- a/app/components/Sidebar/components/StarredLink.tsx
+++ b/app/components/Sidebar/components/StarredLink.tsx
@@ -103,7 +103,7 @@ const StarredDocumentLink = observer(function StarredDocumentLink({
   return (
     <ActionContextProvider
       value={{
-        activeDocumentId: document.id,
+        activeModels: [document],
       }}
     >
       <Draggable key={star.id} ref={draggableRef} $isDragging={isDragging}>

--- a/app/components/Star.tsx
+++ b/app/components/Star.tsx
@@ -37,8 +37,9 @@ function Star({ size, document, collection, color, ...rest }: Props) {
   return (
     <ActionContextProvider
       value={{
-        activeDocumentId: document?.id,
-        activeCollectionId: collection?.id,
+        activeModels: [document, collection].filter(
+          (m): m is Document | Collection => !!m
+        ),
       }}
     >
       <NudeButton

--- a/app/menus/CollectionMenu.tsx
+++ b/app/menus/CollectionMenu.tsx
@@ -53,7 +53,7 @@ function CollectionMenu({
   });
 
   return (
-    <ActionContextProvider value={{ activeCollectionId: collection.id }}>
+    <ActionContextProvider value={{ activeModels: [collection] }}>
       <DropdownMenu
         action={rootAction}
         align={align}

--- a/app/menus/DocumentMenu.tsx
+++ b/app/menus/DocumentMenu.tsx
@@ -198,11 +198,10 @@ function DocumentMenu({
   return (
     <ActionContextProvider
       value={{
-        activeDocumentId: document.id,
-        activeCollectionId:
-          !isShared && document.collectionId
-            ? document.collectionId
-            : undefined,
+        activeModels: [
+          document,
+          ...(!isShared && document.collection ? [document.collection] : []),
+        ],
       }}
     >
       <DropdownMenu

--- a/app/menus/RevisionMenu.tsx
+++ b/app/menus/RevisionMenu.tsx
@@ -33,7 +33,7 @@ function RevisionMenu({ document, revisionId }: Props) {
   const rootAction = useMenuAction(actions);
 
   return (
-    <ActionContextProvider value={{ activeDocumentId: document.id }}>
+    <ActionContextProvider value={{ activeModels: [document] }}>
       <DropdownMenu
         action={rootAction}
         align="end"


### PR DESCRIPTION
This is useful for https://github.com/outline/outline/pull/11027, which needs the concept of an active template