### PR TITLE
fix: prevent duplicate Korean IME character on Enter in search

### DIFF
--- a/app/scenes/Search/Search.tsx
+++ b/app/scenes/Search/Search.tsx
@@ -184,6 +184,10 @@ function Search() {
   };
 
   const handleKeyDown = (ev: React.KeyboardEvent<HTMLInputElement>) => {
+    if (ev.nativeEvent.isComposing) {
+      return;
+    }
+
     if (ev.key === "Enter") {
       updateLocation(ev.currentTarget.value);
       return;


### PR DESCRIPTION
## Summary
- Added `isComposing` check to `handleKeyDown` in the Search page to prevent the last Korean IME character from being duplicated when pressing Enter during composition
- On Mac with Korean (and other CJK) IME, pressing Enter during composition triggers `keydown` with `isComposing=true`, followed by `compositionend`. Without this check, `updateLocation` is called prematurely, causing the `SearchInput` to remount (due to key change from `"recent"` to `"search"`), and the subsequent `compositionend` inserts the last character again
- This fix is consistent with the existing pattern used in `InputSearchPage`, `SearchPopover`, `EditableTitle`, and other components throughout the codebase

## Test plan
- [x] Verified Korean IME input "한글입력" + Enter no longer duplicates the last character
- [x] Verified Enter after composition ends triggers search normally (`?q=한글입력`)
- [x] Confirmed no side effects on non-IME languages (English, etc.) — `isComposing` is always `false` for non-IME input
- [x] Confirmed filter buttons (collection, user, date) are unaffected (click events, not keydown)