### PR TITLE
Revert "chore: Move to `findAndCountAll` instead of separate queries"

### DIFF
--- a/server/routes/api/attachments/attachments.ts
+++ b/server/routes/api/attachments/attachments.ts
@@ -59,13 +59,17 @@ router.post(
       where.documentId = documentId;
     }
 
-    const { rows: attachments, count: total } =
-      await Attachment.findAndCountAll({
+    const [attachments, total] = await Promise.all([
+      Attachment.findAll({
         where,
         order: [["createdAt", "DESC"]],
         offset: ctx.state.pagination.offset,
         limit: ctx.state.pagination.limit,
-      });
+      }),
+      Attachment.count({
+        where,
+      }),
+    ]);
 
     ctx.body = {
       pagination: { ...ctx.state.pagination, total },

--- a/server/routes/api/collections/collections.ts
+++ b/server/routes/api/collections/collections.ts
@@ -333,13 +333,15 @@ router.post(
       ],
     };
 
-    const { rows: memberships, count: total } =
-      await GroupMembership.findAndCountAll({
+    const [total, memberships] = await Promise.all([
+      GroupMembership.count(options),
+      GroupMembership.findAll({
         ...options,
         order: [["createdAt", "DESC"]],
         offset: ctx.state.pagination.offset,
         limit: ctx.state.pagination.limit,
-      });
+      }),
+    ]);
 
     const groupMemberships = memberships.map(presentGroupMembership);
 
@@ -482,13 +484,15 @@ router.post(
       ],
     };
 
-    const { rows: memberships, count: total } =
-      await UserMembership.findAndCountAll({
+    const [total, memberships] = await Promise.all([
+      UserMembership.count(options),
+      UserMembership.findAll({
         ...options,
         order: [["createdAt", "DESC"]],
         offset: ctx.state.pagination.offset,
         limit: ctx.state.pagination.limit,
-      });
+      }),
+    ]);
 
     ctx.body = {
       pagination: { ...ctx.state.pagination, total },

--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -111,7 +111,6 @@ router.post(
       userId: createdById,
       statusFilter,
     } = ctx.input.body;
-    const { offset, limit } = ctx.state.pagination;
 
     // always filter by the current team
     const { user } = ctx.state.auth;
@@ -156,8 +155,11 @@ router.post(
       if (sort === "index") {
         // Extract all document IDs from the collection structure.
         documentIds = (collection.documentStructure || [])
-          .slice(offset, offset + limit)
-          .map((node) => node.id);
+          .map((node) => node.id)
+          .slice(
+            ctx.state.pagination.offset,
+            ctx.state.pagination.offset + ctx.state.pagination.limit
+          );
         where[Op.and].push({ id: documentIds });
       } // if it's not a backlink request, filter by all collections the user has access to
     } else if (!backlinkDocumentId) {
@@ -284,7 +286,7 @@ router.post(
           ? [
               [
                 Sequelize.literal(
-                  `array_position(ARRAY[:documentIds]::uuid[], "document"."id")`
+                  `array_position(ARRAY[${documentIds.map((id) => `'${id}'`).join(",")}]::uuid[], "document"."id")`
                 ),
                 direction,
               ],
@@ -294,16 +296,15 @@ router.post(
 
     // When sorting by index, pagination is already handled by slicing documentIds,
     // so we skip the SQL-level offset to avoid double-pagination
-    const { rows: documents, count: total } =
-      await Document.withMembershipScope(user.id).findAndCountAll({
+    const [documents, total] = await Promise.all([
+      Document.withMembershipScope(user.id).findAll({
         where,
         order: orderClause as Order,
-        offset: sort === "index" ? 0 : offset,
-        limit,
-        replacements: {
-          documentIds,
-        },
-      });
+        offset: sort === "index" ? 0 : ctx.state.pagination.offset,
+        limit: ctx.state.pagination.limit,
+      }),
+      Document.count({ where }),
+    ]);
 
     const data = await Promise.all(
       documents.map((document) => presentDocument(ctx, document))
@@ -693,12 +694,14 @@ router.post(
 
     const replacements = { query: `%${query}%` };
 
-    const { rows: users, count: total } = await User.findAndCountAll({
-      where,
-      replacements,
-      offset,
-      limit,
-    });
+    const [users, total] = await Promise.all([
+      User.findAll({ where, replacements, offset, limit }),
+      User.count({
+        where,
+        // @ts-expect-error Types are incorrect for count
+        replacements,
+      }),
+    ]);
 
     ctx.body = {
       pagination: { ...ctx.state.pagination, total },
@@ -2001,13 +2004,15 @@ router.post(
       ],
     };
 
-    const { rows: memberships, count: total } =
-      await UserMembership.findAndCountAll({
+    const [total, memberships] = await Promise.all([
+      UserMembership.count(options),
+      UserMembership.findAll({
         ...options,
         order: [["createdAt", "DESC"]],
         offset: ctx.state.pagination.offset,
         limit: ctx.state.pagination.limit,
-      });
+      }),
+    ]);
 
     ctx.body = {
       pagination: { ...ctx.state.pagination, total },
@@ -2060,13 +2065,15 @@ router.post(
       ],
     };
 
-    const { rows: memberships, count: total } =
-      await GroupMembership.findAndCountAll({
+    const [total, memberships] = await Promise.all([
+      GroupMembership.count(options),
+      GroupMembership.findAll({
         ...options,
         order: [["createdAt", "DESC"]],
         offset: ctx.state.pagination.offset,
         limit: ctx.state.pagination.limit,
-      });
+      }),
+    ]);
 
     const groupMemberships = memberships.map(presentGroupMembership);
 

--- a/server/routes/api/emojis/emojis.ts
+++ b/server/routes/api/emojis/emojis.ts
@@ -132,24 +132,29 @@ router.post(
       };
     }
 
-    const { rows: emojis, count: total } = await Emoji.findAndCountAll({
-      where,
-      include: [
-        {
-          model: User,
-          as: "createdBy",
-          paranoid: false,
-        },
-        {
-          model: Attachment,
-          as: "attachment",
-          paranoid: false,
-        },
-      ],
-      order: [["createdAt", "DESC"]],
-      offset: ctx.state.pagination.offset,
-      limit: ctx.state.pagination.limit,
-    });
+    const [emojis, total] = await Promise.all([
+      Emoji.findAll({
+        where,
+        include: [
+          {
+            model: User,
+            as: "createdBy",
+            paranoid: false,
+          },
+          {
+            model: Attachment,
+            as: "attachment",
+            paranoid: false,
+          },
+        ],
+        order: [["createdAt", "DESC"]],
+        offset: ctx.state.pagination.offset,
+        limit: ctx.state.pagination.limit,
+      }),
+      Emoji.count({
+        where,
+      }),
+    ]);
 
     ctx.body = {
       pagination: { ...ctx.state.pagination, total },

--- a/server/routes/api/fileOperations/fileOperations.ts
+++ b/server/routes/api/fileOperations/fileOperations.ts
@@ -51,13 +51,17 @@ router.post(
     const team = await Team.findByPk(user.teamId);
     authorize(user, "update", team);
 
-    const { rows: fileOperations, count: total } =
-      await FileOperation.findAndCountAll({
+    const [fileOperations, total] = await Promise.all([
+      FileOperation.findAll({
         where,
         order: [[sort, direction]],
         offset: ctx.state.pagination.offset,
         limit: ctx.state.pagination.limit,
-      });
+      }),
+      FileOperation.count({
+        where,
+      }),
+    ]);
 
     ctx.body = {
       pagination: { ...ctx.state.pagination, total },

--- a/server/routes/api/notifications/notifications.ts
+++ b/server/routes/api/notifications/notifications.ts
@@ -109,12 +109,15 @@ router.post(
             },
       };
     }
-    const [{ rows: notifications, count: total }, unseen] = await Promise.all([
-      Notification.findAndCountAll({
+    const [notifications, total, unseen] = await Promise.all([
+      Notification.findAll({
         where,
         order: [["createdAt", "DESC"]],
         offset: ctx.state.pagination.offset,
         limit: ctx.state.pagination.limit,
+      }),
+      Notification.count({
+        where,
       }),
       Notification.count({
         where: {

--- a/server/routes/api/oauthClients/oauthClients.ts
+++ b/server/routes/api/oauthClients/oauthClients.ts
@@ -35,13 +35,15 @@ router.post(
     };
     authorize(user, "listOAuthClients", user.team);
 
-    const { rows: oauthClients, count: total } =
-      await OAuthClient.findAndCountAll({
+    const [oauthClients, total] = await Promise.all([
+      OAuthClient.findAll({
         where,
         order: [["createdAt", "DESC"]],
         offset: ctx.state.pagination.offset,
         limit: ctx.state.pagination.limit,
-      });
+      }),
+      OAuthClient.count({ where }),
+    ]);
 
     ctx.body = {
       pagination: { ...ctx.state.pagination, total },

--- a/server/routes/api/reactions/reactions.ts
+++ b/server/routes/api/reactions/reactions.ts
@@ -41,13 +41,19 @@ router.post(
       },
     ];
 
-    const { rows: reactions, count: total } = await Reaction.findAndCountAll({
-      where,
-      include,
-      order: [["createdAt", "DESC"]],
-      offset: ctx.state.pagination.offset,
-      limit: ctx.state.pagination.limit,
-    });
+    const [reactions, total] = await Promise.all([
+      Reaction.findAll({
+        where,
+        include,
+        order: [["createdAt", "DESC"]],
+        offset: ctx.state.pagination.offset,
+        limit: ctx.state.pagination.limit,
+      }),
+      Reaction.count({
+        where,
+        include,
+      }),
+    ]);
 
     ctx.body = {
       pagination: { ...ctx.state.pagination, total },

--- a/server/routes/api/users/users.ts
+++ b/server/routes/api/users/users.ts
@@ -154,13 +154,20 @@ router.post(
 
     const replacements = { query: `%${query}%` };
 
-    const { rows: users, count: total } = await User.findAndCountAll({
-      where,
-      replacements,
-      order: [[sort, direction]],
-      offset: ctx.state.pagination.offset,
-      limit: ctx.state.pagination.limit,
-    });
+    const [users, total] = await Promise.all([
+      User.findAll({
+        where,
+        replacements,
+        order: [[sort, direction]],
+        offset: ctx.state.pagination.offset,
+        limit: ctx.state.pagination.limit,
+      }),
+      User.count({
+        where,
+        // @ts-expect-error Types are incorrect for count
+        replacements,
+      }),
+    ]);
 
     ctx.body = {
       pagination: { ...ctx.state.pagination, total },


### PR DESCRIPTION
Reverts outline/outline#11536, this made no difference – and may have made things worse as now the count query includes the unneccessary extra membership joins