### PR TITLE
perf: Separate memberships query

### DIFF
--- a/server/models/Document.ts
+++ b/server/models/Document.ts
@@ -200,6 +200,7 @@ type AdditionalFindOptions = {
             userId,
           },
           required: false,
+          separate: true,
         },
         {
           association: "groupMemberships",


### PR DESCRIPTION
  - Before: memberships are `LEFT JOIN`ed into the main document query, which widens every row in the result set and forces the database to do more work in the main subquery.
  - After: Sequelize issues a separate `SELECT * FROM user_memberships WHERE "documentId" IN (...)` query, which is a simple indexed lookup. 