### PR TITLE
fix: Notion import fails for large workspaces due to search cursor expiration

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -246,6 +246,14 @@ SENTRY_TUNNEL=
 NOTION_CLIENT_ID=
 NOTION_CLIENT_SECRET=
 
+# Comma-separated list of Notion page/database IDs to use as import roots.
+# Required for large workspaces (10k+ pages) where the search API cursor
+# expires before pagination completes. When set, root pages are fetched
+# directly by ID instead of scanning the workspace via search.
+# To find a page ID: open it in Notion > Share > Copy link. The ID is the
+# 32-char hex string at the end of the URL (before any ?v= parameter).
+# NOTION_ROOT_PAGE_IDS=
+
 # The Iframely integration allows previews of third-party content within Outline.
 # For example, hovering over an external link will show a preview.
 # DOCS: https://docs.getoutline.com/s/hosting/doc/iframely-HwLF1EZ9mo

--- a/plugins/notion/server/env.ts
+++ b/plugins/notion/server/env.ts
@@ -14,6 +14,24 @@ class NotionPluginEnvironment extends Environment {
   public NOTION_CLIENT_SECRET = this.toOptionalString(
     environment.NOTION_CLIENT_SECRET
   );
+
+  /**
+   * Comma-separated list of Notion page/database IDs to use as import roots.
+   * When set, fetchRootPages() will fetch these directly instead of scanning
+   * the entire workspace via the search API. This is necessary for large
+   * workspaces (10k+ pages) where search cursor expiration prevents a full
+   * scan from completing.
+   *
+   * To find a page ID: open the page in Notion > Share > Copy link.
+   * The ID is the 32-char hex string before the ?v= parameter:
+   *   https://notion.so/workspace/Page-Title-<PAGE_ID>?v=...
+   *
+   * Example: NOTION_ROOT_PAGE_IDS=0e1a242c18a04ae5a63dd17b2cf702f2,d0f0beed48a7461298762c5af0b58ab
+   */
+  @IsOptional()
+  public NOTION_ROOT_PAGE_IDS = this.toOptionalString(
+    environment.NOTION_ROOT_PAGE_IDS
+  );
 }
 
 export default new NotionPluginEnvironment();

--- a/plugins/notion/server/notion.ts
+++ b/plugins/notion/server/notion.ts
@@ -59,7 +59,7 @@ const AccessTokenResponseSchema = z.object({
 export class NotionClient {
   private client: Client;
   private limiter: ReturnType<typeof RateLimit>;
-  private pageSize = 25;
+  private pageSize = 100;
   private maxRetries = 3;
   private retryDelay = 1000;
   private skipChildrenForBlock = [
@@ -178,23 +178,88 @@ export class NotionClient {
   }
 
   async fetchRootPages() {
-    const pages: Page[] = [];
+    // When root page IDs are provided via environment variable, fetch them
+    // directly instead of scanning the workspace via search. This bypasses
+    // the search API entirely, avoiding cursor expiration issues in large
+    // workspaces (10k+ pages).
+    const rootPageIds = env.NOTION_ROOT_PAGE_IDS;
+    if (rootPageIds) {
+      const ids = rootPageIds
+        .split(",")
+        .map((id) => id.trim())
+        .filter(Boolean);
 
-    let cursor: string | undefined;
-    let hasMore = true;
-
-    while (hasMore) {
-      const response = await this.fetchWithRetry(() =>
-        this.client.search({
-          start_cursor: cursor,
-          page_size: this.pageSize,
-        })
+      Logger.info(
+        "task",
+        `Fetching ${ids.length} root pages by ID (NOTION_ROOT_PAGE_IDS)`
       );
 
-      response.results.forEach((item) => {
-        if (!isFullPageOrDatabase(item)) {
-          return;
+      const pages: Page[] = [];
+      for (const id of ids) {
+        const page = await this.fetchRootPageById(id);
+        if (page) {
+          pages.push(page);
         }
+      }
+
+      Logger.info(
+        "task",
+        `Notion fetchRootPages complete: ${pages.length} pages fetched by ID`
+      );
+      return pages;
+    }
+
+    const pages: Page[] = [];
+    let cursor: string | undefined;
+    let hasMore = true;
+    let totalScanned = 0;
+
+    while (hasMore) {
+      let response;
+      try {
+        response = await this.fetchWithRetry(() =>
+          this.client.search({
+            start_cursor: cursor,
+            page_size: this.pageSize,
+          })
+        );
+      } catch (error) {
+        // Notion search cursors have an undocumented positional limit. For
+        // large workspaces (10k+ pages) the cursor expires before pagination
+        // completes, causing a validation_error on start_cursor. Rather than
+        // returning partial results (which would silently produce an
+        // incomplete import), fail with an actionable error message directing
+        // the admin to the env var bypass.
+        if (
+          error instanceof APIResponseError &&
+          error.message.includes("start_cursor")
+        ) {
+          // Log the full remediation instructions (not truncated)
+          Logger.info(
+            "task",
+            `Notion search cursor expired after scanning ${totalScanned} pages. ` +
+              `To fix: set NOTION_ROOT_PAGE_IDS env var to a comma-separated list ` +
+              `of workspace-level page IDs. To find a page ID, open the page in ` +
+              `Notion, click Share > Copy link. The ID is the 32-char hex string ` +
+              `before the ?v= parameter in the URL.`
+          );
+          // GUI error is truncated to 255 chars, so keep it concise
+          throw new Error(
+            `Notion search cursor expired after scanning ${totalScanned} pages. ` +
+              `Workspace too large for search API. Set NOTION_ROOT_PAGE_IDS env ` +
+              `var to comma-separated workspace-level page IDs (from Notion ` +
+              `Share links) to bypass search.`
+          );
+        }
+        throw error;
+      }
+
+      for (const item of response.results) {
+        if (!isFullPageOrDatabase(item)) {
+          continue;
+        }
+
+        totalScanned++;
 
         if (item.parent.type === "workspace") {
           pages.push({
@@ -206,13 +271,80 @@ export class NotionClient {
             emoji: this.parseEmoji(item),
           });
         }
-      });
+      }
 
       hasMore = response.has_more;
       cursor = response.next_cursor ?? undefined;
     }
 
+    Logger.info(
+      "task",
+      `Notion fetchRootPages complete: ${pages.length} workspace-level pages found ` +
+        `(${totalScanned} total pages scanned)`
+    );
+
     return pages;
+  }
+
+  /**
+   * Fetch a single root page or database by ID. Tries pages.retrieve first,
+   * falls back to databases.retrieve if the ID refers to a database.
+   */
+  private async fetchRootPageById(id: string): Promise<Page | undefined> {
+    // Try as a page first. If the ID is actually a database, the API returns
+    // a validation_error rather than ObjectNotFound, so catch both.
+    try {
+      const page = (await this.fetchWithRetry(() =>
+        this.client.pages.retrieve({ page_id: id })
+      )) as PageObjectResponse;
+
+      return {
+        type: PageType.Page,
+        id: page.id,
+        name: this.parseTitle(page, {
+          maxLength: CollectionValidation.maxNameLength,
+        }),
+        emoji: this.parseEmoji(page),
+      };
+    } catch (error) {
+      if (
+        error instanceof APIResponseError &&
+        (error.code === APIErrorCode.ObjectNotFound ||
+          error.code === APIErrorCode.ValidationError)
+      ) {
+        // Fall through to try as database
+      } else {
+        throw error;
+      }
+    }
+
+    // Not a page, try as a database
+    try {
+      const database = (await this.fetchWithRetry(() =>
+        this.client.databases.retrieve({ database_id: id })
+      )) as DatabaseObjectResponse;
+
+      return {
+        type: PageType.Database,
+        id: database.id,
+        name: this.parseTitle(database, {
+          maxLength: CollectionValidation.maxNameLength,
+        }),
+        emoji: this.parseEmoji(database),
+      };
+    } catch (error) {
+      if (
+        error instanceof APIResponseError &&
+        error.code === APIErrorCode.ObjectNotFound
+      ) {
+        Logger.warn(
+          `Notion root page ID ${id} not found as page or database, skipping. ` +
+            `Verify the ID is correct and that the page is shared with the integration.`
+        );
+        return undefined;
+      }
+      throw error;
+    }
   }
 
   async fetchPage(


### PR DESCRIPTION
## Summary

`fetchRootPages()` paginates through all workspace pages via the Notion search API to find workspace-level items. The search cursor has an undocumented positional limit (~11,200 pages) that causes it to expire before pagination completes on large workspaces, failing the import with `The start_cursor provided is invalid`.

This PR adds a `NOTION_ROOT_PAGE_IDS` environment variable and improves the existing search path:

- **When `NOTION_ROOT_PAGE_IDS` is set:** fetches root pages directly via `pages.retrieve`/`databases.retrieve`, bypassing the search API entirely. The existing tree traversal in `parseChildPages()` handles all child content discovery, so only top-level entry points are needed.
- **When not set:** existing search behavior is preserved with `pageSize` increased from 25 to 100 (Notion API max, 4x fewer API calls). On cursor expiry, the error message now directs the admin to set `NOTION_ROOT_PAGE_IDS` instead of showing the raw Notion API error.

Changes are in `plugins/notion/server/notion.ts`, `plugins/notion/server/env.ts`, and `.env.sample`. No interface changes to `fetchRootPages()` — it returns the same `Page[]` either way.

## Context

See #11573 for investigation details and test results.

## Test plan

- [ ] Import from a Notion workspace under 10k pages (search path, should work as before)
- [ ] Import from a large Notion workspace (10k+) with `NOTION_ROOT_PAGE_IDS` set to workspace-level page/database IDs
- [ ] Verify `NOTION_ROOT_PAGE_IDS` with a mix of page and database IDs resolves both types correctly
- [ ] Verify invalid/inaccessible IDs in `NOTION_ROOT_PAGE_IDS` are skipped with a warning
- [ ] Verify cursor expiry without env var produces actionable error message