### PR TITLE
perf: Cache `user.collectionIds`

### DIFF
--- a/server/utils/RedisPrefixHelper.ts
+++ b/server/utils/RedisPrefixHelper.ts
@@ -32,4 +32,14 @@ export class RedisPrefixHelper {
   public static getEmbedCheckKey(url: string) {
     return `embed:${url}`;
   }
+
+  /**
+   * Gets key for caching a user's accessible collection IDs.
+   *
+   * @param userId The user ID to generate a key for.
+   * @returns the cache key string.
+   */
+  public static getUserCollectionIdsKey(userId: string) {
+    return `uc:${userId}`;
+  }
 }


### PR DESCRIPTION
Complex join used in lots of list endpoints. Cache for 10s (maybe more in the future) and invalidate on membership changes.

Note that it is not invalidated on collection permission changes, allowing upto cache expiry of access in those rare cases.