### PR TITLE
fix: Upgrade `framer-motion` to v5, fix tab animation

### DIFF
--- a/app/components/Tab.tsx
+++ b/app/components/Tab.tsx
@@ -95,6 +95,13 @@ const transition = {
   damping: 30,
 };
 
+/** Restrict shared layout animation to the X axis only. */
+const horizontalOnly = (transform: Record<string, string>, generated: string) =>
+  generated.replace(
+    /translate3d\(([^,]+),\s*[^,]+,\s*([^)]+)\)/,
+    "translate3d($1, 0px, $2)"
+  );
+
 const Tab: React.FC<Props> = (props: Props) => {
   const { children, exact, exactQueryString } = props;
   const theme = useTheme();
@@ -112,6 +119,7 @@ const Tab: React.FC<Props> = (props: Props) => {
             layoutId="underline"
             initial={false}
             transition={transition}
+            transformTemplate={horizontalOnly}
           />
         )}
       </TabButton>
@@ -140,6 +148,7 @@ const Tab: React.FC<Props> = (props: Props) => {
                 layoutId="underline"
                 initial={false}
                 transition={transition}
+                transformTemplate={horizontalOnly}
               />
             )}
         </>

--- a/app/components/Tabs.tsx
+++ b/app/components/Tabs.tsx
@@ -1,4 +1,4 @@
-import { AnimateSharedLayout } from "framer-motion";
+import { LayoutGroup } from "framer-motion";
 import { transparentize } from "polished";
 import * as React from "react";
 import styled from "styled-components";
@@ -84,13 +84,13 @@ const Tabs: React.FC = ({ children }: Props) => {
   }, [width, updateShadows]);
 
   return (
-    <AnimateSharedLayout>
+    <LayoutGroup>
       <Sticky>
         <Nav ref={ref} onScroll={updateShadows} $shadowVisible={shadowVisible}>
           {children}
         </Nav>
       </Sticky>
-    </AnimateSharedLayout>
+    </LayoutGroup>
   );
 };
 

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "fetch-retry": "^5.0.6",
     "form-data": "^4.0.5",
     "fractional-index": "^1.0.0",
-    "framer-motion": "^4.1.17",
+    "framer-motion": "^5.6.0",
     "franc": "^6.2.0",
     "fs-extra": "^11.3.2",
     "fuzzy-search": "^3.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12960,32 +12960,41 @@ __metadata:
   languageName: node
   linkType: hard
 
-"framer-motion@npm:^4.1.17":
-  version: 4.1.17
-  resolution: "framer-motion@npm:4.1.17"
+"framer-motion@npm:^5.6.0":
+  version: 5.6.0
+  resolution: "framer-motion@npm:5.6.0"
   dependencies:
     "@emotion/is-prop-valid": "npm:^0.8.2"
-    framesync: "npm:5.3.0"
+    framesync: "npm:6.0.1"
     hey-listen: "npm:^1.0.8"
-    popmotion: "npm:9.3.6"
-    style-value-types: "npm:4.1.4"
+    popmotion: "npm:11.0.3"
+    react-merge-refs: "npm:^1.1.0"
+    react-use-measure: "npm:^2.1.1"
+    style-value-types: "npm:5.0.0"
     tslib: "npm:^2.1.0"
   peerDependencies:
+    "@react-three/fiber": "*"
     react: ">=16.8 || ^17.0.0"
     react-dom: ">=16.8 || ^17.0.0"
+    three: ^0.135.0
   dependenciesMeta:
     "@emotion/is-prop-valid":
       optional: true
-  checksum: 10c0/37a3e05f70c370703465f68964cfe795a1fcc6a8cca28813e11be853fff0324891676be4bf514c85ce6a63a78cb1a123b54847f2563325880e0878c8942249f1
+  peerDependenciesMeta:
+    "@react-three/fiber":
+      optional: true
+    three:
+      optional: true
+  checksum: 10c0/48df78fd6f2e0b895881108510158f36b5ec1271df10746c37396a6f6f5ac1ddb5e0f6b5c1856e0f04da412a65e2e0116bde0a5e76b31d28badff33c840dc356
   languageName: node
   linkType: hard
 
-"framesync@npm:5.3.0":
-  version: 5.3.0
-  resolution: "framesync@npm:5.3.0"
+"framesync@npm:6.0.1":
+  version: 6.0.1
+  resolution: "framesync@npm:6.0.1"
   dependencies:
     tslib: "npm:^2.1.0"
-  checksum: 10c0/c11771528171354b508c3b367b76deb2be542d4214946f2db46fc4db92eceb89eb9aa97c9386c3062536d7068e4d63689d58a35f8e5b0c456a6e86c23a2f35bc
+  checksum: 10c0/ce84ce548a8612be070204b9cf3ce7258acead2d51df05586995340e501d1439dfc1f9402ede921a9c0dde854d80fd46e97c699a3657f8d7abd5bc705553bf2b
   languageName: node
   linkType: hard
 
@@ -17703,7 +17712,7 @@ __metadata:
     fetch-retry: "npm:^5.0.6"
     form-data: "npm:^4.0.5"
     fractional-index: "npm:^1.0.0"
-    framer-motion: "npm:^4.1.17"
+    framer-motion: "npm:^5.6.0"
     franc: "npm:^6.2.0"
     fs-extra: "npm:^11.3.2"
     fuzzy-search: "npm:^3.2.1"
@@ -18604,15 +18613,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"popmotion@npm:9.3.6":
-  version: 9.3.6
-  resolution: "popmotion@npm:9.3.6"
+"popmotion@npm:11.0.3":
+  version: 11.0.3
+  resolution: "popmotion@npm:11.0.3"
   dependencies:
-    framesync: "npm:5.3.0"
+    framesync: "npm:6.0.1"
     hey-listen: "npm:^1.0.8"
-    style-value-types: "npm:4.1.4"
+    style-value-types: "npm:5.0.0"
     tslib: "npm:^2.1.0"
-  checksum: 10c0/c0936cbd00006f2872eaa4716e176399f11622369a216f397ac6bc690d9211b993f94a8336586fd4ab9f67a53d6dc9098ec485874542e559a357be2050605f7a
+  checksum: 10c0/ed196cf034c199a2ab6095f047924b38e24f386c33a182970ad6e1769002b72adff34a72ba7ab2cf34ff5bbfd711ef4caf2e9843ebb7a5c9cafa27c50e525f70
   languageName: node
   linkType: hard
 
@@ -19317,6 +19326,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-merge-refs@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "react-merge-refs@npm:1.1.0"
+  checksum: 10c0/afb937156d834a058e5021535a63fd8a35984365c38b613478c31186da920b3b469e38b0b161a2075fbf5db7118fb8e96bb8a52a563f271d8f8f166fe8ffe2a4
+  languageName: node
+  linkType: hard
+
 "react-merge-refs@npm:^2.1.1":
   version: 2.1.1
   resolution: "react-merge-refs@npm:2.1.1"
@@ -19430,7 +19446,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-use-measure@npm:^2.1.7":
+"react-use-measure@npm:^2.1.1, react-use-measure@npm:^2.1.7":
   version: 2.1.7
   resolution: "react-use-measure@npm:2.1.7"
   peerDependencies:
@@ -21222,13 +21238,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"style-value-types@npm:4.1.4":
-  version: 4.1.4
-  resolution: "style-value-types@npm:4.1.4"
+"style-value-types@npm:5.0.0":
+  version: 5.0.0
+  resolution: "style-value-types@npm:5.0.0"
   dependencies:
     hey-listen: "npm:^1.0.8"
     tslib: "npm:^2.1.0"
-  checksum: 10c0/96415a82217890e11bf8b9c278a0870fc343508c1e8fd614ef0b17a1a75d387ae0220d53dbe8acf60226cfdb7dd898678b4fa3d90d23d778bd606ccb069cdc7f
+  checksum: 10c0/a7b693269d48c0cab73da6c88eade845e71b5f330541a9ccb6a065468739d9bafdeb34f94fb89581931371275846da53e35989218cbc0c2d1a38f127e4d765fd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Tabs included some annoying vertical motion when the parent element moved 