### PR TITLE
fix: Framer motion chunking

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -186,6 +186,11 @@ export default () =>
                 priority: 20,
               },
               {
+                name: "vendor-framer-motion",
+                test: /node_modules[\\/]framer-motion/,
+                priority: 20,
+              },
+              {
                 name: "vendor-styled",
                 test: /node_modules[\\/]styled-components/,
                 priority: 20,


### PR DESCRIPTION
Adding framer-motion to the vendor chunk config consolidates all `framer-motion` code into a single eagerly-loaded chunk, ensuring featureNames is computed exactly once before any mutation happens.