### PR TITLE
feat: add anchorText parameter to comments.create API

### DIFF
--- a/server/routes/api/comments/comments.test.ts
+++ b/server/routes/api/comments/comments.test.ts
@@ -773,6 +773,103 @@ describe("#comments.create", () => {
   });
 });
 
+describe("#comments.create anchorText", () => {
+  it("should anchor comment to text in document", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const document = await buildDocument({
+      userId: user.id,
+      teamId: user.teamId,
+      text: "# Heading\n\nThis is some paragraph text with important content here.",
+    });
+
+    const comment = await buildComment({
+      userId: user.id,
+      documentId: document.id,
+    });
+
+    const res = await server.post("/api/comments.create", {
+      body: {
+        token: user.getJwtToken(),
+        documentId: document.id,
+        data: comment.data,
+        anchorText: "important content",
+      },
+    });
+
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+
+    // Verify the document now has the comment mark
+    await document.reload();
+    const content = document.content as any;
+    const hasCommentMark = JSON.stringify(content).includes(body.data.id);
+    expect(hasCommentMark).toBeTruthy();
+  });
+
+  it("should create unanchored comment when text not found", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const document = await buildDocument({
+      userId: user.id,
+      teamId: user.teamId,
+      text: "# Heading\n\nSome text here.",
+    });
+
+    const comment = await buildComment({
+      userId: user.id,
+      documentId: document.id,
+    });
+
+    const res = await server.post("/api/comments.create", {
+      body: {
+        token: user.getJwtToken(),
+        documentId: document.id,
+        data: comment.data,
+        anchorText: "nonexistent text that does not appear anywhere",
+      },
+    });
+
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.data.id).toBeDefined();
+  });
+
+  it("should not anchor reply comments", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const document = await buildDocument({
+      userId: user.id,
+      teamId: user.teamId,
+      text: "# Heading\n\nSome target text here.",
+    });
+
+    const parentComment = await buildComment({
+      userId: user.id,
+      documentId: document.id,
+    });
+
+    const res = await server.post("/api/comments.create", {
+      body: {
+        token: user.getJwtToken(),
+        documentId: document.id,
+        parentCommentId: parentComment.id,
+        data: parentComment.data,
+        anchorText: "target text",
+      },
+    });
+
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+
+    // Verify the document does NOT have the comment mark (replies shouldn't anchor)
+    await document.reload();
+    const content = document.content as any;
+    const hasCommentMark = JSON.stringify(content).includes(body.data.id);
+    expect(hasCommentMark).toBeFalsy();
+  });
+});
+
 describe("#comments.update", () => {
   it("should require authentication", async () => {
     const res = await server.post("/api/comments.update");

--- a/server/routes/api/comments/comments.ts
+++ b/server/routes/api/comments/comments.ts
@@ -16,7 +16,9 @@ import { rateLimiter } from "@server/middlewares/rateLimiter";
 import { transaction } from "@server/middlewares/transaction";
 import validate from "@server/middlewares/validate";
 import { Document, Comment, Collection, Reaction, Emoji } from "@server/models";
+import { DocumentHelper } from "@server/models/helpers/DocumentHelper";
 import { ProsemirrorHelper } from "@server/models/helpers/ProsemirrorHelper";
+import { ProsemirrorHelper as SharedProsemirrorHelper } from "@shared/utils/ProsemirrorHelper";
 import { TextHelper } from "@server/models/helpers/TextHelper";
 import { authorize } from "@server/policies";
 import { presentComment, presentPolicies } from "@server/presenters";
@@ -35,7 +37,7 @@ router.post(
   validate(T.CommentsCreateSchema),
   transaction(),
   async (ctx: APIContext<T.CommentsCreateReq>) => {
-    const { id, documentId, parentCommentId } = ctx.input.body;
+    const { id, documentId, parentCommentId, anchorText } = ctx.input.body;
     const { user } = ctx.state.auth;
     const { transaction } = ctx.state;
 
@@ -63,6 +65,25 @@ router.post(
       documentId,
       parentCommentId,
     });
+
+    // If anchorText is provided, add a comment mark to the document content
+    // linking this comment to the specified text.
+    if (anchorText && !parentCommentId) {
+      const prosemirrorNode = DocumentHelper.toProsemirror(document);
+      const docJSON = prosemirrorNode.toJSON();
+      const updatedDoc = SharedProsemirrorHelper.addCommentMark(
+        docJSON,
+        comment.id,
+        anchorText,
+        user.id
+      );
+
+      if (updatedDoc) {
+        document.content = updatedDoc;
+        document.changed("content", true);
+        await document.save({ transaction });
+      }
+    }
 
     comment.createdBy = user;
 

--- a/server/routes/api/comments/schema.ts
+++ b/server/routes/api/comments/schema.ts
@@ -41,6 +41,15 @@ export const CommentsCreateSchema = BaseSchema.extend({
 
       /** Create comment with this text */
       text: z.string().optional(),
+
+      /**
+       * Text to anchor the comment to within the document. When provided, the
+       * comment will be linked to the first occurrence of this text in the
+       * document by adding a comment mark to the document's ProseMirror content.
+       * If the text is not found, the comment is created as a document-level
+       * comment (unanchored).
+       */
+      anchorText: z.string().max(1000).optional(),
     })
     .refine((obj) => !(isEmpty(obj.data) && isEmpty(obj.text)), {
       error: "One of data or text is required",

--- a/shared/utils/ProsemirrorHelper.test.ts
+++ b/shared/utils/ProsemirrorHelper.test.ts
@@ -90,6 +90,161 @@ describe("ProsemirrorHelper", () => {
     });
   });
 
+  describe("addCommentMark", () => {
+    it("should add a comment mark to matching text", () => {
+      const doc: ProsemirrorData = {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              { type: "text", text: "Hello world, this is important text here." },
+            ],
+          },
+        ],
+      };
+
+      const result = ProsemirrorHelper.addCommentMark(
+        doc,
+        "comment-123",
+        "important text",
+        "user-456"
+      );
+
+      expect(result).not.toBeNull();
+      const paragraph = result!.content![0];
+      expect(paragraph.content).toHaveLength(3);
+      expect(paragraph.content![0].text).toEqual("Hello world, this is ");
+      expect(paragraph.content![1].text).toEqual("important text");
+      expect(paragraph.content![1].marks).toEqual([
+        { type: "comment", attrs: { id: "comment-123", userId: "user-456", resolved: false } },
+      ]);
+      expect(paragraph.content![2].text).toEqual(" here.");
+    });
+
+    it("should return null when text is not found", () => {
+      const doc: ProsemirrorData = {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "Hello world." }],
+          },
+        ],
+      };
+
+      const result = ProsemirrorHelper.addCommentMark(
+        doc,
+        "comment-123",
+        "nonexistent",
+        "user-456"
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("should preserve existing marks on text", () => {
+      const doc: ProsemirrorData = {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "text",
+                text: "bold and commented",
+                marks: [{ type: "bold" }],
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = ProsemirrorHelper.addCommentMark(
+        doc,
+        "comment-123",
+        "and commented",
+        "user-456"
+      );
+
+      expect(result).not.toBeNull();
+      const paragraph = result!.content![0];
+      expect(paragraph.content).toHaveLength(2);
+      expect(paragraph.content![0].text).toEqual("bold ");
+      expect(paragraph.content![0].marks).toEqual([{ type: "bold" }]);
+      expect(paragraph.content![1].text).toEqual("and commented");
+      expect(paragraph.content![1].marks).toEqual([
+        { type: "bold" },
+        { type: "comment", attrs: { id: "comment-123", userId: "user-456", resolved: false } },
+      ]);
+    });
+
+    it("should only mark the first occurrence", () => {
+      const doc: ProsemirrorData = {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "hello hello hello" }],
+          },
+        ],
+      };
+
+      const result = ProsemirrorHelper.addCommentMark(
+        doc,
+        "comment-123",
+        "hello",
+        "user-456"
+      );
+
+      expect(result).not.toBeNull();
+      const paragraph = result!.content![0];
+      expect(paragraph.content).toHaveLength(2);
+      expect(paragraph.content![0].text).toEqual("hello");
+      expect(paragraph.content![0].marks).toBeDefined();
+      expect(paragraph.content![1].text).toEqual(" hello hello");
+      expect(paragraph.content![1].marks).toBeUndefined();
+    });
+
+    it("should find text in nested nodes", () => {
+      const doc: ProsemirrorData = {
+        type: "doc",
+        content: [
+          {
+            type: "heading",
+            attrs: { level: 1 },
+            content: [{ type: "text", text: "Title" }],
+          },
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "First paragraph." }],
+          },
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "Second paragraph with target." }],
+          },
+        ],
+      };
+
+      const result = ProsemirrorHelper.addCommentMark(
+        doc,
+        "comment-123",
+        "target",
+        "user-456"
+      );
+
+      expect(result).not.toBeNull();
+      // First two nodes should be unchanged
+      expect(result!.content![0]).toEqual(doc.content![0]);
+      expect(result!.content![1]).toEqual(doc.content![1]);
+      // Third node should have the mark
+      const thirdParagraph = result!.content![2];
+      expect(thirdParagraph.content).toHaveLength(3);
+      expect(thirdParagraph.content![1].text).toEqual("target");
+      expect(thirdParagraph.content![1].marks![0].type).toEqual("comment");
+    });
+  });
+
   describe("getPlainParagraphs", () => {
     it("should return an array of plain paragraphs", async () => {
       const data = {

--- a/shared/utils/ProsemirrorHelper.ts
+++ b/shared/utils/ProsemirrorHelper.ts
@@ -284,6 +284,171 @@ export class ProsemirrorHelper {
   }
 
   /**
+   * Adds a comment mark to the first occurrence of `anchorText` in the
+   * document. The mark wraps the matching text range with the given comment ID
+   * and user ID. If the anchor text spans multiple adjacent text nodes within
+   * a single parent, all are wrapped.
+   *
+   * @param data The document as raw ProseMirror JSON
+   * @param commentId The UUID of the comment to anchor
+   * @param anchorText The exact text to search for and wrap
+   * @param userId The UUID of the user creating the comment
+   * @returns The modified document JSON, or null if the text was not found
+   */
+  static addCommentMark(
+    data: ProsemirrorData,
+    commentId: string,
+    anchorText: string,
+    userId: string
+  ): ProsemirrorData | null {
+    const result = this.addCommentMarkToNode(
+      data,
+      commentId,
+      anchorText,
+      userId
+    );
+    return result.found ? result.node : null;
+  }
+
+  private static addCommentMarkToNode(
+    node: ProsemirrorData,
+    commentId: string,
+    anchorText: string,
+    userId: string
+  ): { node: ProsemirrorData; found: boolean } {
+    const content = node.content;
+    if (!content) {
+      return { node, found: false };
+    }
+
+    // Build concatenated text from child text nodes to find anchor position
+    let concat = "";
+    const textRanges: Array<{
+      start: number;
+      end: number;
+      index: number;
+    }> = [];
+
+    for (let i = 0; i < content.length; i++) {
+      const child = content[i];
+      if (child.type === "text" && child.text) {
+        const start = concat.length;
+        concat += child.text;
+        textRanges.push({ start, end: concat.length, index: i });
+      } else {
+        // Non-text children contribute to position but can't be marked
+        concat += this.flattenText(child);
+      }
+    }
+
+    const pos = concat.indexOf(anchorText);
+    if (pos !== -1) {
+      const anchorEnd = pos + anchorText.length;
+      const newContent: ProsemirrorData[] = [];
+      let handled = false;
+
+      for (let i = 0; i < content.length; i++) {
+        const child = content[i];
+        if (child.type !== "text" || !child.text) {
+          newContent.push(child);
+          continue;
+        }
+
+        const range = textRanges.find((r) => r.index === i);
+        if (!range) {
+          newContent.push(child);
+          continue;
+        }
+
+        // Calculate overlap with anchor range
+        const overlapStart = Math.max(pos, range.start);
+        const overlapEnd = Math.min(anchorEnd, range.end);
+
+        if (overlapStart >= overlapEnd) {
+          newContent.push(child);
+          continue;
+        }
+
+        handled = true;
+        const existingMarks = child.marks || [];
+        const commentMark = {
+          type: "comment" as const,
+          attrs: { id: commentId, userId, resolved: false },
+        };
+
+        const relStart = overlapStart - range.start;
+        const relEnd = overlapEnd - range.start;
+        const text = child.text;
+
+        const beforeText = text.substring(0, relStart);
+        const markedText = text.substring(relStart, relEnd);
+        const afterText = text.substring(relEnd);
+
+        if (beforeText) {
+          const beforeNode: ProsemirrorData = {
+            type: "text",
+            text: beforeText,
+          };
+          if (existingMarks.length) {
+            beforeNode.marks = [...existingMarks];
+          }
+          newContent.push(beforeNode);
+        }
+
+        if (markedText) {
+          newContent.push({
+            type: "text",
+            text: markedText,
+            marks: [...existingMarks, commentMark],
+          });
+        }
+
+        if (afterText) {
+          const afterNode: ProsemirrorData = {
+            type: "text",
+            text: afterText,
+          };
+          if (existingMarks.length) {
+            afterNode.marks = [...existingMarks];
+          }
+          newContent.push(afterNode);
+        }
+      }
+
+      if (handled) {
+        return { node: { ...node, content: newContent }, found: true };
+      }
+    }
+
+    // Recurse into children
+    const newContent: ProsemirrorData[] = [];
+    let found = false;
+    for (const child of content) {
+      if (found) {
+        newContent.push(child);
+      } else {
+        const result = this.addCommentMarkToNode(
+          child,
+          commentId,
+          anchorText,
+          userId
+        );
+        newContent.push(result.node);
+        found = result.found;
+      }
+    }
+
+    return { node: { ...node, content: newContent }, found };
+  }
+
+  private static flattenText(node: ProsemirrorData): string {
+    if (node.type === "text") {
+      return node.text || "";
+    }
+    return (node.content || []).map((c) => this.flattenText(c)).join("");
+  }
+
+  /**
    * Iterates through the document to find all of the images.
    *
    * @param doc Prosemirror document node


### PR DESCRIPTION
## Problem

Currently, the `comments.create` API endpoint can only create **document-level (unanchored) comments** — they appear in the sidebar but don't link to any specific text in the document. Anchoring a comment to text requires browser-based editor interaction, which makes it impossible for API consumers (AI agents, MCP servers, CI/CD pipelines, code review bots) to create contextual inline comments.

The API already supports *reading* anchor text (`includeAnchorText` on `comments.list` and `comments.info`), but has no way to *write* it.

## Solution

Add an optional `anchorText` string parameter to the `comments.create` endpoint. When provided:

1. The server creates the comment as normal
2. Finds the first occurrence of `anchorText` in the document's ProseMirror content
3. Wraps the matching text range with a `comment` mark containing the new comment's ID
4. Saves the updated document content

If the text is not found, the comment is created as a document-level comment (graceful degradation). Reply comments (`parentCommentId` set) ignore `anchorText` since they inherit the parent's anchor.

## Changes

- **`schema.ts`**: Add `anchorText` (optional, max 1000 chars) to `CommentsCreateSchema`
- **`ProsemirrorHelper.ts`**: Add `addCommentMark()` static method that finds text in a ProseMirror JSON tree and injects a comment mark — handles text node splitting, preserves existing marks, and only marks the first occurrence
- **`comments.ts`**: Update `comments.create` handler to apply the mark when `anchorText` is provided
- **Tests**: Unit tests for `addCommentMark()` (5 cases) and integration tests for the API endpoint (3 cases)

## API Usage

```json
POST /api/comments.create
{
  "documentId": "<uuid>",
  "text": "This section needs legal review.",
  "anchorText": "Non-Compete"
}
```

The comment will appear anchored to the text "Non-Compete" in the document, highlighted in the editor with the comment linked in the sidebar — identical to how it looks when created through the UI.

## Use Cases

- **AI document review**: Agents can annotate specific sections of documents with feedback
- **MCP servers**: Model Context Protocol integrations for Outline (e.g., `dts-outline-mcp-server`)
- **Import/migration tools**: Preserve inline comments when migrating from other platforms
- **CI/CD**: Automated documentation review pipelines
- **Relates to #7362** (backend editing of documents for comment anchoring)

## Testing

- Unit tests for `ProsemirrorHelper.addCommentMark()`: exact match, not found, preserve existing marks, first-occurrence-only, nested nodes
- Integration tests: anchor created, text not found (graceful), reply comments ignored
