### PR TITLE
fix: `INSERT into subscriptions` deadlocked transactions

### DIFF
--- a/server/commands/subscriptionCreator.ts
+++ b/server/commands/subscriptionCreator.ts
@@ -118,10 +118,10 @@ export const createSubscriptionsForDocument = async (
   document: Document,
   event: DocumentEvent | RevisionEvent
 ): Promise<void> => {
-  await sequelize.transaction(async (transaction) => {
-    const users = await document.collaborators({ transaction });
+  const users = await document.collaborators();
 
-    for (const user of users) {
+  for (const user of users) {
+    await sequelize.transaction(async (transaction) => {
       await subscriptionCreator({
         ctx: createContext({
           user,
@@ -133,6 +133,6 @@ export const createSubscriptionsForDocument = async (
         event: SubscriptionType.Document,
         resubscribe: false,
       });
-    }
-  });
+    });
+  }
 };


### PR DESCRIPTION
Worker A and Worker B both lock subscription rows for the same set of collaborators. If they process users in slightly different orders (e.g., due to timing of the collaborators query), you get a classic
  circular wait:
  - Worker A holds lock on user1's row, waiting for user2's
  - Worker B holds lock on user2's row, waiting for user1's