### PR TITLE
feat: Support rendering shared docs as Markdown with .md extension

### DIFF
--- a/server/routes/app.ts
+++ b/server/routes/app.ts
@@ -247,11 +247,13 @@ export const renderShare = async (ctx: Context, next: Next) => {
   }
 
   // If the client explicitly requests markdown and prefers it over HTML,
-  // return the document as markdown. This is useful for LLMs and API clients.
+  // or the URL path ends with .md, return the document as markdown. This is
+  // useful for LLMs and API clients.
   const acceptHeader = ctx.request.headers.accept || "";
   const prefersMarkdown =
-    acceptHeader.includes("text/markdown") &&
-    ctx.accepts("text/markdown", "text/html") === "text/markdown";
+    ctx.params.format === "md" ||
+    (acceptHeader.includes("text/markdown") &&
+      ctx.accepts("text/markdown", "text/html") === "text/markdown");
 
   if (prefersMarkdown && (document || collection)) {
     let markdown = await DocumentHelper.toMarkdown(document || collection!, {

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -73,6 +73,19 @@ describe("/s/:id", () => {
     expect(body).toContain(`# ${document.title}`);
   });
 
+  it("should return markdown when URL path ends with .md", async () => {
+    const document = await buildDocument();
+    const share = await buildShare({
+      documentId: document.id,
+      teamId: document.teamId,
+    });
+    const res = await server.get(`/s/${share.id}.md`);
+    const body = await res.text();
+    expect(res.status).toEqual(200);
+    expect(res.headers.get("content-type")).toContain("text/markdown");
+    expect(body).toContain(`# ${document.title}`);
+  });
+
   it("should return html when Accept header prefers text/html over text/markdown", async () => {
     const document = await buildDocument();
     const share = await buildShare({

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -174,7 +174,13 @@ router.get("/opensearch.xml", (ctx) => {
   ctx.body = opensearchResponse(ctx.request.URL.origin);
 });
 
+router.get("/s/:shareId.:format", shareDomains(), renderShare);
 router.get("/s/:shareId", shareDomains(), renderShare);
+router.get(
+  "/s/:shareId/doc/:documentSlug.:format",
+  shareDomains(),
+  renderShare
+);
 router.get("/s/:shareId/doc/:documentSlug", shareDomains(), renderShare);
 router.get("/s/:shareId/*", shareDomains(), renderShare);
 


### PR DESCRIPTION
We already supported the text/markdown mime type, and this adds support for a .md extension as well. 