### PR TITLE
 Enhancement: Fixed ALLOWED_DOMAINS env var for managing team domain restrictions

### DIFF
--- a/app/models/Team.ts
+++ b/app/models/Team.ts
@@ -79,7 +79,7 @@ class Team extends Model {
   allowedDomains: string[] | null | undefined;
 
   @observable
-  domainsManagedByEnv: boolean;
+  domainsManagedByEnv?: string[];
 
   @computed
   get signinMethods(): string {

--- a/app/scenes/Settings/components/DomainManagement.tsx
+++ b/app/scenes/Settings/components/DomainManagement.tsx
@@ -17,7 +17,27 @@ type Props = {
   onSuccess: () => void;
 };
 
-function DomainManagement({ onSuccess }: Props) {
+function EnvManagedDomains({ domains }: { domains: string[] }) {
+  const { t } = useTranslation();
+
+  return (
+    <SettingRow
+      label={t("Allowed domains")}
+      name="allowedDomains"
+      description={t(
+        "Allowed domains are managed by the ALLOWED_DOMAINS environment variable."
+      )}
+    >
+      {domains.map((domain, index) => (
+        <Text key={index} type="secondary">
+          {domain}
+        </Text>
+      ))}
+    </SettingRow>
+  );
+}
+
+function EditableDomains({ onSuccess }: Props) {
   const team = useCurrentTeam();
   const { t } = useTranslation();
 
@@ -77,30 +97,6 @@ function DomainManagement({ onSuccess }: Props) {
     allowedDomains.filter((value: string) => value !== "").length > // New domains were added
       lastKnownDomainCount;
 
-  if (team.domainsManagedByEnv) {
-    return (
-      <SettingRow
-        label={t("Allowed domains")}
-        name="allowedDomains"
-        description={t(
-          "Allowed domains are managed by the ALLOWED_DOMAINS environment variable."
-        )}
-      >
-        {allowedDomains.length > 0 ? (
-          allowedDomains.map((domain, index) => (
-            <Text key={index} type="secondary">
-              {domain}
-            </Text>
-          ))
-        ) : (
-          <Text type="secondary">
-            <Trans>No domains configured</Trans>
-          </Text>
-        )}
-      </SettingRow>
-    );
-  }
-
   return (
     <SettingRow
       label={t("Allowed domains")}
@@ -157,6 +153,16 @@ function DomainManagement({ onSuccess }: Props) {
       </Flex>
     </SettingRow>
   );
+}
+
+function DomainManagement({ onSuccess }: Props) {
+  const team = useCurrentTeam();
+
+  if (team.domainsManagedByEnv) {
+    return <EnvManagedDomains domains={team.domainsManagedByEnv} />;
+  }
+
+  return <EditableDomains onSuccess={onSuccess} />;
 }
 
 const Remove = styled("div")`

--- a/server/env.ts
+++ b/server/env.ts
@@ -366,6 +366,22 @@ export class Environment {
   public ALLOWED_DOMAINS =
     environment.ALLOWED_DOMAINS ?? environment.GOOGLE_ALLOWED_DOMAINS;
 
+  /**
+   * Returns the parsed list of allowed domains from the ALLOWED_DOMAINS
+   * environment variable, or undefined if the variable is not set.
+   *
+   * @returns the parsed allowed domains, or undefined.
+   */
+  public getAllowedDomains(): string[] | undefined {
+    if (!this.ALLOWED_DOMAINS) {
+      return undefined;
+    }
+    const domains = this.ALLOWED_DOMAINS.split(",")
+      .map((d) => d.trim().toLowerCase())
+      .filter(Boolean);
+    return domains.length > 0 ? domains : undefined;
+  }
+
   // Third-party services
 
   /**

--- a/server/models/Team.ts
+++ b/server/models/Team.ts
@@ -318,11 +318,26 @@ class Team extends ParanoidModel<
   };
 
   /**
+   * Returns the effective list of allowed domains for this team, consulting
+   * the environment variable first and falling back to database records.
+   *
+   * @returns the list of allowed domain names.
+   */
+  public async getEffectiveAllowedDomains(): Promise<string[]> {
+    const envDomains = env.getAllowedDomains();
+    if (envDomains) {
+      return envDomains;
+    }
+    const dbDomains = (await this.$get("allowedDomains")) || [];
+    return dbDomains.map((d: TeamDomain) => d.name);
+  }
+
+  /**
    * Find whether the passed domain can be used to sign-in to this team. Note
    * that this method always returns true if no domain restrictions are set.
    *
-   * @param domainOrEmail The domain or email to check
-   * @returns True if the domain is allowed to sign-in to this team
+   * @param domainOrEmail the domain or email to check.
+   * @returns true if the domain is allowed to sign-in to this team.
    */
   public isDomainAllowed = async function (
     this: Team,
@@ -334,18 +349,8 @@ class Team extends ParanoidModel<
       domain = parsed.domain;
     }
 
-    if (env.ALLOWED_DOMAINS) {
-      const envDomains = env.ALLOWED_DOMAINS.split(",")
-        .map((d) => d.trim().toLowerCase())
-        .filter(Boolean);
-      return envDomains.length === 0 || envDomains.includes(domain);
-    }
-
-    const allowedDomains = (await this.$get("allowedDomains")) || [];
-    return (
-      allowedDomains.length === 0 ||
-      allowedDomains.map((d: TeamDomain) => d.name).includes(domain)
-    );
+    const allowed = await this.getEffectiveAllowedDomains();
+    return allowed.length === 0 || allowed.includes(domain);
   };
 
   // associations

--- a/server/presenters/team.ts
+++ b/server/presenters/team.ts
@@ -19,12 +19,8 @@ export default function presentTeam(team: Team) {
     url: team.url,
     defaultUserRole: team.defaultUserRole,
     inviteRequired: team.inviteRequired,
-    allowedDomains: env.ALLOWED_DOMAINS
-      ? env.ALLOWED_DOMAINS.split(",")
-          .map((d) => d.trim().toLowerCase())
-          .filter(Boolean)
-      : team.allowedDomains?.map((d) => d.name),
-    domainsManagedByEnv: !!env.ALLOWED_DOMAINS,
+    allowedDomains: team.allowedDomains?.map((d) => d.name),
+    domainsManagedByEnv: env.getAllowedDomains(),
     preferences: team.preferences,
   };
 }

--- a/server/routes/api/teams/teams.ts
+++ b/server/routes/api/teams/teams.ts
@@ -29,7 +29,8 @@ const handleTeamUpdate = async (ctx: APIContext<T.TeamsUpdateSchemaReq>) => {
   });
   authorize(user, "update", team);
 
-  if (env.ALLOWED_DOMAINS && ctx.input.body.allowedDomains !== undefined) {
+  const envDomains = env.getAllowedDomains();
+  if (envDomains && ctx.input.body.allowedDomains !== undefined) {
     throw ValidationError(
       "Allowed domains are managed by the ALLOWED_DOMAINS environment variable"
     );

--- a/shared/i18n/locales/cs_CZ/translation.json
+++ b/shared/i18n/locales/cs_CZ/translation.json
@@ -1092,6 +1092,7 @@
   "Are you sure you want to disconnect the <em>{{ service }}</em> integration?": "Opravdu chcete odpojit integraci <em>{{ service }}</em>?",
   "This will stop sending analytics events to the configured instance.": "Tímto zastavíte odesílání analytických událostí do nastavené instance.",
   "Allowed domains": "Povolené domény",
+  "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.": "Povolené domény jsou spravovány proměnnou prostředí ALLOWED_DOMAINS.",
   "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.": "Domény, které mají povoleno vytvářet účty přes SSO. Změna se nedotkne stávajících účtů.",
   "Remove domain": "Odstranit doménu",
   "Add a domain": "Přidat doménu",

--- a/shared/i18n/locales/da_DK/translation.json
+++ b/shared/i18n/locales/da_DK/translation.json
@@ -1092,6 +1092,7 @@
   "Are you sure you want to disconnect the <em>{{ service }}</em> integration?": "Are you sure you want to disconnect the <em>{{ service }}</em> integration?",
   "This will stop sending analytics events to the configured instance.": "This will stop sending analytics events to the configured instance.",
   "Allowed domains": "Allowed domains",
+  "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.": "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.",
   "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.": "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.",
   "Remove domain": "Remove domain",
   "Add a domain": "Add a domain",

--- a/shared/i18n/locales/de_DE/translation.json
+++ b/shared/i18n/locales/de_DE/translation.json
@@ -1092,6 +1092,7 @@
   "Are you sure you want to disconnect the <em>{{ service }}</em> integration?": "Sind Sie sicher, dass Sie die <em>{{ service }}</em> Integration trennen möchten?",
   "This will stop sending analytics events to the configured instance.": "Dies stoppt das Senden von Analyseereignissen an die konfigurierte Instanz.",
   "Allowed domains": "Erlaubte Domains",
+  "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.": "Die erlaubten Domains werden über die Umgebungsvariable ALLOWED_DOMAINS verwaltet.",
   "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.": "Die Domänen, die mit SSO neue Konten erstellen dürfen. Das Ändern dieser Einstellung wirkt sich nicht auf bestehende Benutzerkonten aus.",
   "Remove domain": "Domäne entfernen",
   "Add a domain": "Eine Domäne hinzufügen",

--- a/shared/i18n/locales/en_GB/translation.json
+++ b/shared/i18n/locales/en_GB/translation.json
@@ -1092,6 +1092,7 @@
   "Are you sure you want to disconnect the <em>{{ service }}</em> integration?": "Are you sure you want to disconnect the <em>{{ service }}</em> integration?",
   "This will stop sending analytics events to the configured instance.": "This will stop sending analytics events to the configured instance.",
   "Allowed domains": "Allowed domains",
+  "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.": "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.",
   "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.": "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.",
   "Remove domain": "Remove domain",
   "Add a domain": "Add a domain",

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -1098,7 +1098,6 @@
   "This will stop sending analytics events to the configured instance.": "This will stop sending analytics events to the configured instance.",
   "Allowed domains": "Allowed domains",
   "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.": "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.",
-  "No domains configured": "No domains configured",
   "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.": "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.",
   "Remove domain": "Remove domain",
   "Add a domain": "Add a domain",

--- a/shared/i18n/locales/es_ES/translation.json
+++ b/shared/i18n/locales/es_ES/translation.json
@@ -1092,6 +1092,7 @@
   "Are you sure you want to disconnect the <em>{{ service }}</em> integration?": "¿Estás seguro de que quieres desconectar la integración <em>{{ service }}</em>?",
   "This will stop sending analytics events to the configured instance.": "Esto dejará de enviar eventos analíticos a la instancia configurada.",
   "Allowed domains": "Dominios permitidos",
+  "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.": "Los dominios permitidos se gestionan mediante la variable de entorno ALLOWED_DOMAINS.",
   "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.": "Los dominios que deberían poder crear nuevas cuentas usando SSO. Cambiar esta configuración no afecta a las cuentas de usuario existentes.",
   "Remove domain": "Eliminar dominio",
   "Add a domain": "Añadir un dominio",

--- a/shared/i18n/locales/fa_IR/translation.json
+++ b/shared/i18n/locales/fa_IR/translation.json
@@ -1092,6 +1092,7 @@
   "Are you sure you want to disconnect the <em>{{ service }}</em> integration?": "آیا مطمئن هستید که می‌خواهید یکپارچه‌سازی <em>{{ service }}</em> را قطع کنید؟",
   "This will stop sending analytics events to the configured instance.": "با این کار، ارسال رویدادهای تحلیلی به نمونهٔ پیکربندی‌شده متوقف می‌شود.",
   "Allowed domains": "دامنه‌های مجاز",
+  "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.": "دامنه‌های مجاز توسط متغیر محیطی ALLOWED_DOMAINS مدیریت می‌شوند.",
   "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.": "دامنه‌هایی که باید اجازه ایجاد حساب‌های جدید با استفاده از SSO را داشته باشند. تغییر این تنظیمات بر حساب‌های کاربری موجود تأثیری نخواهد داشت.",
   "Remove domain": "حذف دامنه",
   "Add a domain": "افزودن دامنه",

--- a/shared/i18n/locales/fr_FR/translation.json
+++ b/shared/i18n/locales/fr_FR/translation.json
@@ -1092,6 +1092,7 @@
   "Are you sure you want to disconnect the <em>{{ service }}</em> integration?": "Êtes-vous sûr de vouloir déconnecter l'intégration <em>{{ service }}</em>?",
   "This will stop sending analytics events to the configured instance.": "Ceci arrêtera d'envoyer des événements de statistiques à l'instance configurée.",
   "Allowed domains": "Domaines autorisés",
+  "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.": "Les domaines autorisés sont gérés par la variable d\u0027environnement ALLOWED_DOMAINS.",
   "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.": "Domaines autorisés à créer de nouveaux comptes en utilisant le SSO. La modification de ce paramètre n'affecte pas les comptes d'utilisateurs existants.",
   "Remove domain": "Supprimer le domaine",
   "Add a domain": "Ajouter un domaine",

--- a/shared/i18n/locales/he_IL/translation.json
+++ b/shared/i18n/locales/he_IL/translation.json
@@ -1092,6 +1092,7 @@
   "Are you sure you want to disconnect the <em>{{ service }}</em> integration?": "Are you sure you want to disconnect the <em>{{ service }}</em> integration?",
   "This will stop sending analytics events to the configured instance.": "This will stop sending analytics events to the configured instance.",
   "Allowed domains": "Allowed domains",
+  "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.": "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.",
   "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.": "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.",
   "Remove domain": "Remove domain",
   "Add a domain": "Add a domain",

--- a/shared/i18n/locales/hu_HU/translation.json
+++ b/shared/i18n/locales/hu_HU/translation.json
@@ -1092,6 +1092,7 @@
   "Are you sure you want to disconnect the <em>{{ service }}</em> integration?": "Biztos vagy benne, hogy le akarod választani a {{ service }} integrációt?",
   "This will stop sending analytics events to the configured instance.": "Ez megállítja az analitikai események küldését a beállított fogadónak.",
   "Allowed domains": "Allowed domains",
+  "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.": "Az engedélyezett domainek az ALLOWED_DOMAINS környezeti változóval kezelhetők.",
   "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.": "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.",
   "Remove domain": "Remove domain",
   "Add a domain": "Add a domain",

--- a/shared/i18n/locales/id_ID/translation.json
+++ b/shared/i18n/locales/id_ID/translation.json
@@ -1092,6 +1092,7 @@
   "Are you sure you want to disconnect the <em>{{ service }}</em> integration?": "Are you sure you want to disconnect the <em>{{ service }}</em> integration?",
   "This will stop sending analytics events to the configured instance.": "This will stop sending analytics events to the configured instance.",
   "Allowed domains": "Domain yang diizinkan",
+  "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.": "Domain yang diizinkan dikelola oleh variabel lingkungan ALLOWED_DOMAINS.",
   "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.": "Domain yang seharusnya diizinkan untuk membuat akun baru menggunakan SSO. Mengubah setelan ini tidak memengaruhi akun pengguna yang ada.",
   "Remove domain": "Hapus domain",
   "Add a domain": "Tambahkan domain",

--- a/shared/i18n/locales/it_IT/translation.json
+++ b/shared/i18n/locales/it_IT/translation.json
@@ -1092,6 +1092,7 @@
   "Are you sure you want to disconnect the <em>{{ service }}</em> integration?": "Sei sicuro di voler disconnettere l'integrazione con <em>{{ service }}</em>?",
   "This will stop sending analytics events to the configured instance.": "Ciò interromperà l'invio di eventi di analytics all'istanza configurata.",
   "Allowed domains": "Domini consentiti",
+  "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.": "I domini consentiti sono gestiti dalla variabile d\u0027ambiente ALLOWED_DOMAINS.",
   "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.": "I domini che dovrebbero essere autorizzati a creare nuovi account utilizzando SSO. La modifica di questa impostazione non influisce sugli utenti esistenti.",
   "Remove domain": "Rimuovi dominio",
   "Add a domain": "Aggiungi un dominio",

--- a/shared/i18n/locales/ja_JP/translation.json
+++ b/shared/i18n/locales/ja_JP/translation.json
@@ -1092,6 +1092,7 @@
   "Are you sure you want to disconnect the <em>{{ service }}</em> integration?": "Are you sure you want to disconnect the <em>{{ service }}</em> integration?",
   "This will stop sending analytics events to the configured instance.": "This will stop sending analytics events to the configured instance.",
   "Allowed domains": "許可されているドメイン",
+  "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.": "許可されているドメインは ALLOWED_DOMAINS 環境変数で管理されています。",
   "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.": "SSO を使用して新しいアカウントを作成できるドメイン。この設定を変更しても、既存のユーザーには影響しません。",
   "Remove domain": "ドメインを削除",
   "Add a domain": "ドメインを追加",

--- a/shared/i18n/locales/ko_KR/translation.json
+++ b/shared/i18n/locales/ko_KR/translation.json
@@ -1092,6 +1092,7 @@
   "Are you sure you want to disconnect the <em>{{ service }}</em> integration?": "서비스 <em>{{ service }}</em>와 통합을 해제하시겠습니까?",
   "This will stop sending analytics events to the configured instance.": "이렇게 하면 구성된 인스턴스로 분석 이벤트가 전송되지 않습니다.",
   "Allowed domains": "허용된 도메인",
+  "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.": "허용된 도메인은 ALLOWED_DOMAINS 환경 변수로 관리됩니다.",
   "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.": "SSO를 사용하여 새 계정을 만들 수 있도록 허용해야 하는 도메인입니다. 이 설정을 변경해도 기존 사용자 계정에는 영향을 미치지 않습니다.",
   "Remove domain": "도메인 삭제",
   "Add a domain": "도메인 추가",

--- a/shared/i18n/locales/nb_NO/translation.json
+++ b/shared/i18n/locales/nb_NO/translation.json
@@ -1092,6 +1092,7 @@
   "Are you sure you want to disconnect the <em>{{ service }}</em> integration?": "Er du sikker på at du vil koble fra <em>{{ service }}</em>-integrasjonen?",
   "This will stop sending analytics events to the configured instance.": "Dette vil slutte å sende analytiske hendelser til den konfigurerte instansen.",
   "Allowed domains": "Tillatte domener",
+  "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.": "Tillatte domener administreres av miljøvariabelen ALLOWED_DOMAINS.",
   "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.": "Domenene som skal tillates å opprette nye kontoer ved bruk av SSO. Å endre denne innstillingen påvirker ikke eksisterende brukerkontoer.",
   "Remove domain": "Fjern domene",
   "Add a domain": "Legg til et domene",

--- a/shared/i18n/locales/nl_NL/translation.json
+++ b/shared/i18n/locales/nl_NL/translation.json
@@ -1092,6 +1092,7 @@
   "Are you sure you want to disconnect the <em>{{ service }}</em> integration?": "Weet je zeker dat je de koppeling met <em>{{ service }}</em> wilt verbreken?",
   "This will stop sending analytics events to the configured instance.": "Hiermee stopt het verzenden van analytics-gebeurtenissen naar de geconfigureerde instantie.",
   "Allowed domains": "Toegestane domeinen",
+  "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.": "Toegestane domeinen worden beheerd door de ALLOWED_DOMAINS omgevingsvariabele.",
   "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.": "De domeinen die moeten kunnen worden toegestaan om nieuwe accounts met behulp van SSO te maken. Het wijzigen van deze instelling heeft geen invloed op bestaande gebruikersaccounts.",
   "Remove domain": "Domein verwijderen",
   "Add a domain": "Voeg domein toe",

--- a/shared/i18n/locales/pl_PL/translation.json
+++ b/shared/i18n/locales/pl_PL/translation.json
@@ -1092,6 +1092,7 @@
   "Are you sure you want to disconnect the <em>{{ service }}</em> integration?": "Czy na pewno chcesz odłączyć integrację <em>{{ service }}</em>?",
   "This will stop sending analytics events to the configured instance.": "To zatrzyma wysyłanie zdarzeń analitycznych do skonfigurowanej instancji.",
   "Allowed domains": "Dozwolone domeny",
+  "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.": "Dozwolone domeny są zarządzane przez zmienną środowiskową ALLOWED_DOMAINS.",
   "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.": "Domeny, które powinny być dozwolone do tworzenia nowych kont przy użyciu SSO. Zmiana tego ustawienia nie wpływa na istniejące konta użytkowników.",
   "Remove domain": "Usuń domenę",
   "Add a domain": "Dodaj domenę",

--- a/shared/i18n/locales/pt_BR/translation.json
+++ b/shared/i18n/locales/pt_BR/translation.json
@@ -1092,6 +1092,7 @@
   "Are you sure you want to disconnect the <em>{{ service }}</em> integration?": "Você realmente deseja desconectar a integração <em>{{ service }}</em>?",
   "This will stop sending analytics events to the configured instance.": "This will stop sending analytics events to the configured instance.",
   "Allowed domains": "Domínios permitidos",
+  "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.": "Os domínios permitidos são gerenciados pela variável de ambiente ALLOWED_DOMAINS.",
   "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.": "Os domínios que devem ser autorizados a criar novas contas usando SSO. Alterar esta configuração não afeta as contas de usuários existentes.",
   "Remove domain": "Remover domínio",
   "Add a domain": "Adicionar um domínio",

--- a/shared/i18n/locales/pt_PT/translation.json
+++ b/shared/i18n/locales/pt_PT/translation.json
@@ -1092,6 +1092,7 @@
   "Are you sure you want to disconnect the <em>{{ service }}</em> integration?": "Are you sure you want to disconnect the <em>{{ service }}</em> integration?",
   "This will stop sending analytics events to the configured instance.": "This will stop sending analytics events to the configured instance.",
   "Allowed domains": "Domínios permitidos",
+  "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.": "Os domínios permitidos são geridos pela variável de ambiente ALLOWED_DOMAINS.",
   "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.": "Os domínios que devem ser autorizados a criar contas usando SSO. Alterar esta configuração não afeta as contas de utilizador existentes.",
   "Remove domain": "Remover o domínio",
   "Add a domain": "Adicionar um domínio",

--- a/shared/i18n/locales/ro_RO/translation.json
+++ b/shared/i18n/locales/ro_RO/translation.json
@@ -1092,6 +1092,7 @@
   "Are you sure you want to disconnect the <em>{{ service }}</em> integration?": "Are you sure you want to disconnect the <em>{{ service }}</em> integration?",
   "This will stop sending analytics events to the configured instance.": "This will stop sending analytics events to the configured instance.",
   "Allowed domains": "Allowed domains",
+  "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.": "Domeniile permise sunt gestionate prin variabila de mediu ALLOWED_DOMAINS.",
   "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.": "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.",
   "Remove domain": "Remove domain",
   "Add a domain": "Add a domain",

--- a/shared/i18n/locales/sv_SE/translation.json
+++ b/shared/i18n/locales/sv_SE/translation.json
@@ -1092,6 +1092,7 @@
   "Are you sure you want to disconnect the <em>{{ service }}</em> integration?": "Är du säker på att du vill koppla från <em>{{ service }}</em>-integrationen?",
   "This will stop sending analytics events to the configured instance.": "This will stop sending analytics events to the configured instance.",
   "Allowed domains": "Tillåtna domäner",
+  "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.": "Tillåtna domäner hanteras av miljövariabeln ALLOWED_DOMAINS.",
   "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.": "De domäner som bör tillåtas att skapa nya konton med SSO. Ändra denna inställning påverkar inte befintliga användarkonton.",
   "Remove domain": "Ta bort domän",
   "Add a domain": "Lägg till en domän",

--- a/shared/i18n/locales/th_TH/translation.json
+++ b/shared/i18n/locales/th_TH/translation.json
@@ -1092,6 +1092,7 @@
   "Are you sure you want to disconnect the <em>{{ service }}</em> integration?": "Are you sure you want to disconnect the <em>{{ service }}</em> integration?",
   "This will stop sending analytics events to the configured instance.": "This will stop sending analytics events to the configured instance.",
   "Allowed domains": "Allowed domains",
+  "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.": "โดเมนที่อนุญาตถูกจัดการโดยตัวแปรสภาพแวดล้อม ALLOWED_DOMAINS",
   "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.": "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.",
   "Remove domain": "Remove domain",
   "Add a domain": "Add a domain",

--- a/shared/i18n/locales/tr_TR/translation.json
+++ b/shared/i18n/locales/tr_TR/translation.json
@@ -1092,6 +1092,7 @@
   "Are you sure you want to disconnect the <em>{{ service }}</em> integration?": "<em>{{ service }}</em> entegrasyonunun bağlantısını kesmek istediğinizden emin misiniz?",
   "This will stop sending analytics events to the configured instance.": "Bu, yapılandırılan örneğe analitik olayları göndermeyi durduracaktır.",
   "Allowed domains": "İzin verilen alan adları",
+  "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.": "İzin verilen alan adları ALLOWED_DOMAINS ortam değişkeni tarafından yönetilir.",
   "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.": "SSO kullanarak yeni hesap oluşturmasına izin verilmesi gereken alan adları. Bu ayarın değiştirilmesi mevcut kullanıcı hesaplarını etkilemez.",
   "Remove domain": "Alan adını kaldır",
   "Add a domain": "Bir alan adı ekle",

--- a/shared/i18n/locales/uk_UA/translation.json
+++ b/shared/i18n/locales/uk_UA/translation.json
@@ -1092,6 +1092,7 @@
   "Are you sure you want to disconnect the <em>{{ service }}</em> integration?": "Are you sure you want to disconnect the <em>{{ service }}</em> integration?",
   "This will stop sending analytics events to the configured instance.": "This will stop sending analytics events to the configured instance.",
   "Allowed domains": "Дозволені домени",
+  "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.": "Дозволені домени керуються змінною середовища ALLOWED_DOMAINS.",
   "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.": "Домени, яким має бути дозволено створювати нові облікові записи за допомогою системи єдиного входу. Зміна цього параметра не впливає на наявні облікові записи користувачів.",
   "Remove domain": "Видалити домен",
   "Add a domain": "Додати домен",

--- a/shared/i18n/locales/vi_VN/translation.json
+++ b/shared/i18n/locales/vi_VN/translation.json
@@ -1092,6 +1092,7 @@
   "Are you sure you want to disconnect the <em>{{ service }}</em> integration?": "Are you sure you want to disconnect the <em>{{ service }}</em> integration?",
   "This will stop sending analytics events to the configured instance.": "This will stop sending analytics events to the configured instance.",
   "Allowed domains": "Các tên miền cho phép",
+  "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.": "Các tên miền cho phép được quản lý bởi biến môi trường ALLOWED_DOMAINS.",
   "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.": "Các miền được phép tạo tài khoản mới bằng SSO. Việc thay đổi cài đặt này không ảnh hưởng đến các tài khoản người dùng hiện có.",
   "Remove domain": "Xóa tên miền",
   "Add a domain": "Thêm tên miền",

--- a/shared/i18n/locales/zh_CN/translation.json
+++ b/shared/i18n/locales/zh_CN/translation.json
@@ -1092,6 +1092,7 @@
   "Are you sure you want to disconnect the <em>{{ service }}</em> integration?": "您确定要移除与 <em>{{ service }}</em> 的集成吗？",
   "This will stop sending analytics events to the configured instance.": "这将停止向配置实例发送分析事件。",
   "Allowed domains": "允许的域",
+  "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.": "允许的域由 ALLOWED_DOMAINS 环境变量管理。",
   "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.": "应该允许使用 SSO 创建新帐户的域。更改此设置不会影响现有用户帐户。",
   "Remove domain": "删除域",
   "Add a domain": "添加域",

--- a/shared/i18n/locales/zh_TW/translation.json
+++ b/shared/i18n/locales/zh_TW/translation.json
@@ -1092,6 +1092,7 @@
   "Are you sure you want to disconnect the <em>{{ service }}</em> integration?": "Are you sure you want to disconnect the <em>{{ service }}</em> integration?",
   "This will stop sending analytics events to the configured instance.": "This will stop sending analytics events to the configured instance.",
   "Allowed domains": "域名白名單",
+  "Allowed domains are managed by the ALLOWED_DOMAINS environment variable.": "允許的網域由 ALLOWED_DOMAINS 環境變數管理。",
   "The domains which should be allowed to create new accounts using SSO. Changing this setting does not affect existing user accounts.": "應該要可以使用SSO建立新帳號的網域。更改這個並不會影響現有的帳號。",
   "Remove domain": "移除網域",
   "Add a domain": "添加網域",


### PR DESCRIPTION
 ## Summary
`ALLOWED_DOMAINS` environment variable was used only in the migration and not in the subsequent flows - without any warning to the admin hence creating a confusion.
 - When `ALLOWED_DOMAINS` is set, the settings UI shows the configured domains as read-only and blocks API updates to prevent conflicts
 - Falls back to the existing database-managed domains when the env var is not set

 ## Changes
 - **`server/env.ts`** — Added `getAllowedDomains()` helper to parse the comma-separated `ALLOWED_DOMAINS` env var
 - **`server/models/Team.ts`** — Added `getEffectiveAllowedDomains()` that checks env var first, then falls back to DB; refactored `isDomainAllowed` to use it
 - **`server/presenters/team.ts`** — Exposes `domainsManagedByEnv` in the team API response so the client knows when domains are env-managed
 - **`server/routes/api/teams/teams.ts`** — Rejects `allowedDomains` updates when the env var is set, returning a validation error
 - **`app/models/Team.ts`** — Added `domainsManagedByEnv` observable field
 - **`app/scenes/Settings/components/DomainManagement.tsx`** — Shows a read-only view of env-managed domains instead of the editable form
 - **`shared/i18n/locales/*/translation.json`** — Added translations for the env-managed domains message across all 27 locales