### PR TITLE
Update comment about auth providers in .env.sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -129,9 +129,8 @@ FORCE_HTTPS=true
 # ––––––––––  AUTHENTICATION  ––––––––––
 # ––––––––––––––––––––––––––––––––––––––
 
-# Third party signin credentials, at least ONE OF EITHER Google, Slack,
-# Discord, or Microsoft is required for a working installation or you'll
-# have no sign-in options.
+# Third party signin credentials, at least ONE OF these is required for a 
+# working installation or you'll have no sign-in options.
 
 # Slack sign-in provider
 # DOCS: https://docs.getoutline.com/s/hosting/doc/slack-sgMujR8J9J


### PR DESCRIPTION
This comment is outdated now that there's more auth providers. It doesn't really add any value to list them all out.