### PR TITLE
fix: Stale collaborator IDs

### DIFF
--- a/server/commands/revisionCreator.test.ts
+++ b/server/commands/revisionCreator.test.ts
@@ -14,6 +14,7 @@ describe("revisionCreator", () => {
     const revision = await revisionCreator({
       document,
       user,
+      collaboratorIds: [user.id],
       event: {
         name: "documents.update",
         authType: AuthenticationType.APP,

--- a/server/commands/revisionCreator.ts
+++ b/server/commands/revisionCreator.ts
@@ -1,34 +1,31 @@
 import { createContext } from "@server/context";
-import type { User } from "@server/models";
-import { Document, Revision } from "@server/models";
+import type { User , Document} from "@server/models";
+import { Revision } from "@server/models";
 import { sequelize } from "@server/storage/database";
-import Redis from "@server/storage/redis";
 import type { DocumentEvent, RevisionEvent } from "@server/types";
 
 export default async function revisionCreator({
   event,
   document,
+  collaboratorIds,
   user,
 }: {
   event: DocumentEvent | RevisionEvent;
   document: Document;
+  collaboratorIds: string[];
   user: User;
 }) {
-  return sequelize.transaction(async (transaction) => {
-    // Get collaborator IDs since last revision was written.
-    const key = Document.getCollaboratorKey(document.id);
-    const collaboratorIds = await Redis.defaultClient.smembers(key);
-    await Redis.defaultClient.del(key);
-
-    return await Revision.createFromDocument(
-      createContext({
-        user,
-        authType: event.authType,
-        ip: event.ip,
-        transaction,
-      }),
-      document,
-      collaboratorIds
-    );
-  });
+  return sequelize.transaction(
+    async (transaction) =>
+      await Revision.createFromDocument(
+        createContext({
+          user,
+          authType: event.authType,
+          ip: event.ip,
+          transaction,
+        }),
+        document,
+        collaboratorIds
+      )
+  );
 }

--- a/server/queues/processors/RevisionsProcessor.ts
+++ b/server/queues/processors/RevisionsProcessor.ts
@@ -1,4 +1,5 @@
 import isEqual from "fast-deep-equal";
+import Redis from "@server/storage/redis";
 import revisionCreator from "@server/commands/revisionCreator";
 import { Revision, Document, User } from "@server/models";
 import type { DocumentEvent, RevisionEvent, Event } from "@server/types";
@@ -20,6 +21,11 @@ export default class RevisionsProcessor extends BaseProcessor {
         if (event.name === "documents.update" && !event.data?.done) {
           return;
         }
+
+        // Get collaborator IDs since last revision was written.
+        const key = Document.getCollaboratorKey(event.documentId);
+        const collaboratorIds = await Redis.defaultClient.smembers(key);
+        await Redis.defaultClient.del(key);
 
         const document = await Document.findByPk(event.documentId, {
           paranoid: false,
@@ -43,9 +49,11 @@ export default class RevisionsProcessor extends BaseProcessor {
           paranoid: false,
           rejectOnEmpty: true,
         });
+
         await revisionCreator({
           event,
           user,
+          collaboratorIds,
           document,
         });
         break;


### PR DESCRIPTION
Fixes an issue where stale collaborator IDs could build up in Redis set if release is not created due to early return

closes #11732