### PR TITLE
fix(auth): Discord should not re-prompt authorization for existing grants

### DIFF
--- a/plugins/discord/server/auth/discord.ts
+++ b/plugins/discord/server/auth/discord.ts
@@ -51,7 +51,8 @@ if (env.DISCORD_CLIENT_ID && env.DISCORD_CLIENT_SECRET) {
         store: new StateStore(),
         state: true,
         callbackURL: `${env.URL}/auth/${config.id}.callback`,
-        authorizationURL: "https://discord.com/api/oauth2/authorize",
+        authorizationURL:
+          "https://discord.com/api/oauth2/authorize?prompt=none",
         tokenURL: "https://discord.com/api/oauth2/token",
         pkce: false,
       },
@@ -227,7 +228,6 @@ if (env.DISCORD_CLIENT_ID && env.DISCORD_CLIENT_SECRET) {
     config.id,
     passport.authenticate(config.id, {
       scope,
-      prompt: "consent",
     })
   );
   router.get(`${config.id}.callback`, passportMiddleware(config.id));


### PR DESCRIPTION
## Changes in this PR

- Adjusts the Discord OAuth2 flow to only prompt to authorize when the user hasn't previously consented, and/or additional permissions are requested. The new flow is as follows:
  - For first-time users picking the Discord OAuth2 choice, nothing will change. They will be prompted like normal.
  - For existing, already-previously-authorized users, it will redirect to Discord, but immediately redirect back to Outline to finish the OAuth2 flow.

## Related

- closes #11723
- closes #11725

## Notes to Reviewer

It does **not** look like `passport-oauth2` supports passing in arbitrary query parameters, like `passport-openidconnect` does. The solution I've chosen is to include the query parameter into the authorization URL, which gets merged with all other parameters that `passport-oauth2` supports.
  - There is 1 other viable solution using `passport-oauth2`, but it feels gross in comparison: https://github.com/jaredhanson/passport-oauth2/blob/master/test/oauth2.subclass.test.js#L10-L77
  - `passport-openidconnect` supports it in a few places. in `Strategy` options, `.authenticate()`, etc: https://github.com/search?q=repo%3Ajaredhanson%2Fpassport-openidconnect%20prompt&type=code

I've tested this myself, and the parameter is in fact included, and both new and existing authentication flows work as expected, as outlined above. If they were to add the support in the future, the way that `passport-oauth2` merges parameters, this should still work/shouldn't cause any issues.