### PR TITLE
chore: Add flags to `Team` model to match `User`

### DIFF
--- a/server/migrations/20260314000000-add-team-flags.js
+++ b/server/migrations/20260314000000-add-team-flags.js
@@ -1,0 +1,14 @@
+"use strict";
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.addColumn("teams", "flags", {
+      type: Sequelize.JSONB,
+      allowNull: true,
+    });
+  },
+
+  down: async (queryInterface) => {
+    return queryInterface.removeColumn("teams", "flags");
+  },
+};

--- a/server/models/Team.ts
+++ b/server/models/Team.ts
@@ -50,6 +50,13 @@ import Length from "./validators/Length";
 import NotContainsUrl from "./validators/NotContainsUrl";
 import { SkipChangeset } from "./decorators/Changeset";
 
+/**
+ * Flags that are available for setting on the team.
+ */
+export enum TeamFlag {
+  MarkedSafe = "markedSafe",
+}
+
 @Scopes(() => ({
   withDomains: {
     include: [{ model: TeamDomain }],
@@ -188,6 +195,9 @@ class Team extends ParanoidModel<
   @Column
   suspendedAt: Date | null;
 
+  @Column(DataType.JSONB)
+  flags: { [key in TeamFlag]?: number } | null;
+
   @IsDate
   @Column
   @SkipChangeset
@@ -281,6 +291,56 @@ class Team extends ParanoidModel<
     this.preferences?.[preference] ??
     TeamPreferenceDefaults[preference] ??
     false;
+
+  /**
+   * Team flags are for storing information on a team record that is not visible
+   * to the team members.
+   *
+   * @param flag The flag to set
+   * @param value Set the flag to true/false
+   * @returns The current team flags
+   */
+  public setFlag = (flag: TeamFlag, value = true) => {
+    if (!this.flags) {
+      this.flags = {};
+    }
+    const binary = value ? 1 : 0;
+    if (this.flags[flag] !== binary) {
+      this.flags = {
+        ...this.flags,
+        [flag]: binary,
+      };
+    }
+
+    return this.flags;
+  };
+
+  /**
+   * Returns the content of the given team flag.
+   *
+   * @param flag The flag to retrieve
+   * @returns The flag value
+   */
+  public getFlag = (flag: TeamFlag) => this.flags?.[flag] ?? 0;
+
+  /**
+   * Team flags are for storing information on a team record that is not visible
+   * to the team members.
+   *
+   * @param flag The flag to set
+   * @param value The amount to increment by, defaults to 1
+   * @returns The current team flags
+   */
+  public incrementFlag = (flag: TeamFlag, value = 1) => {
+    if (!this.flags) {
+      this.flags = {};
+    }
+    this.flags = {
+      ...this.flags,
+      [flag]: (this.flags[flag] ?? 0) + value,
+    };
+    return this.flags;
+  };
 
   /**
    * Updates the lastActiveAt timestamp to the current time.


### PR DESCRIPTION
For now this is only used upstream in cloud hosted fork, but is foundational – so included here.