### PR TITLE
fix: Race condition when editing title while doc is saving

### DIFF
--- a/app/components/ContentEditable.tsx
+++ b/app/components/ContentEditable.tsx
@@ -128,7 +128,14 @@ const ContentEditable = React.forwardRef(function ContentEditable_(
 
   React.useEffect(() => {
     if (contentRef.current && value !== contentRef.current.textContent) {
-      setInnerValue(value);
+      if (document.activeElement === contentRef.current) {
+        // Don't reset content while the user is actively editing. Update
+        // lastValue so that the next input or blur event will push the
+        // current DOM text back to the model via onChange.
+        lastValue.current = value;
+      } else {
+        setInnerValue(value);
+      }
     }
   }, [value, contentRef]);
 


### PR DESCRIPTION
On a slow connection or if `documents.update` call hangs when editing title it's possible for the input to be reset to a previous value. No longer~