### PR TITLE
Apply full width to print layout

### DIFF
--- a/app/scenes/Document/components/Document.tsx
+++ b/app/scenes/Document/components/Document.tsx
@@ -672,9 +672,8 @@ const Main = styled.div<MainProps>`
     max-width: ${({ fullWidth }: MainProps) =>
     fullWidth
       ? `100%`
-      : `calc(${EditorStyleHelper.documentWidth} + ${EditorStyleHelper.documentGutter}`
-  };
-    );
+      : `calc(${EditorStyleHelper.documentWidth} + ${EditorStyleHelper.documentGutter})`
+    };
   }
 `;
 


### PR DESCRIPTION
Enables the full width page option to also be applied to the print layout for that page.