### PR TITLE
fix: use local editor state for Copy as Markdown

### DIFF
--- a/app/actions/definitions/documents.tsx
+++ b/app/actions/definitions/documents.tsx
@@ -40,9 +40,7 @@ import Icon from "@shared/components/Icon";
 import type { NavigationNode } from "@shared/types";
 import { ExportContentType, TeamPreference } from "@shared/types";
 import { getEventFiles } from "@shared/utils/files";
-import { Week } from "@shared/utils/time";
 import type UserMembership from "~/models/UserMembership";
-import { client } from "~/utils/ApiClient";
 import DocumentDelete from "~/scenes/DocumentDelete";
 import DocumentPermanentDelete from "~/scenes/DocumentPermanentDelete";
 import DocumentPublish from "~/scenes/DocumentPublish";
@@ -714,11 +712,9 @@ export const copyDocumentAsMarkdown = createAction({
       ? stores.documents.get(activeDocumentId)
       : undefined;
     if (document) {
-      const res = await client.post("/documents.export", {
-        id: document.id,
-        signedUrls: Week.seconds, // 7 days (AWS S3 max for presigned URLs)
-      });
-      copy(res.data);
+      const { ProsemirrorHelper } =
+        await import("~/models/helpers/ProsemirrorHelper");
+      copy(ProsemirrorHelper.toMarkdown(document));
       toast.success(t("Markdown copied to clipboard"));
     }
   },


### PR DESCRIPTION
## Summary

Fixes #11491

- **"Copy as Markdown"** was fetching content from the server API (`/documents.export`), which only returns the last saved version. During active editing, unsaved changes were not included in the copied output.
- Changed the action to use `ProsemirrorHelper.toMarkdown(document)` instead, which reads directly from the local ProseMirror document data — always reflecting the current editor state.
- This makes the behavior consistent with **"Copy as text"**, which already uses `ProsemirrorHelper.toPlainText(document)` for the same reason.

## Root Cause

In `app/actions/definitions/documents.tsx`, the `copyDocumentAsMarkdown` action called:
```ts
const res = await client.post("/documents.export", {
  id: document.id,
  signedUrls: Week.seconds,
});
copy(res.data);
```
This round-trips to the server, which returns markdown from the **persisted** document state. Any unsaved local edits are lost.

## Fix

Replaced the server API call with the client-side ProseMirror serializer:
```ts
const { ProsemirrorHelper } = await import("~/models/helpers/ProsemirrorHelper");
copy(ProsemirrorHelper.toMarkdown(document));
```

This is the same pattern used by `copyDocumentAsPlainText`, ensuring both copy actions behave consistently.

## Test plan

- [ ] Open a document and start editing (add/delete some text)
- [ ] Without saving, use **Copy → Copy as Markdown** from the menu
- [ ] Paste into a text editor — should reflect the current unsaved content
- [ ] Verify that **Copy as text** still works as expected
- [ ] Verify that attachment image URLs in the markdown are absolute

🤖 Generated with [Claude Code](https://claude.com/claude-code)