### PR TITLE
fix: guard against concurrent restore in documentPermanentDeleter

### DIFF
--- a/server/commands/documentPermanentDeleter.test.ts
+++ b/server/commands/documentPermanentDeleter.test.ts
@@ -111,6 +111,33 @@ describe("documentPermanentDeleter", () => {
     ).toEqual(0);
   });
 
+  it("should not destroy a document restored between query and destroy", async () => {
+    const document = await buildDocument({
+      publishedAt: subDays(new Date(), 90),
+      deletedAt: subDays(new Date(), 60),
+    });
+
+    // Simulate the race: caller queried this document while it was soft-deleted,
+    // but the user restored it before documentPermanentDeleter runs the destroy.
+    await Document.unscoped().update(
+      { deletedAt: null },
+      { where: { id: document.id }, paranoid: false }
+    );
+
+    // The stale in-memory object still has deletedAt set (as it would in the
+    // real cleanup task flow), but the DB row is now active.
+    const countDeletedDoc = await documentPermanentDeleter([document]);
+    expect(countDeletedDoc).toEqual(0);
+
+    // Document must survive — it was restored.
+    expect(
+      await Document.unscoped().count({
+        where: { id: document.id },
+        paranoid: false,
+      })
+    ).toEqual(1);
+  });
+
   it("should not destroy attachments referenced in other documents", async () => {
     const document1 = await buildDocument();
     const document = await buildDocument({

--- a/server/commands/documentPermanentDeleter.ts
+++ b/server/commands/documentPermanentDeleter.ts
@@ -24,28 +24,7 @@ export default async function documentPermanentDeleter(documents: Document[]) {
     "id" != :documentId
   `;
 
-  const confirmedDocumentIds: string[] = [];
-
   for (const document of documents) {
-    // Re-check that the document is still soft-deleted to guard against a
-    // concurrent restore between the initial query and this point in time.
-    const stillDeleted = await Document.unscoped().count({
-      where: {
-        id: document.id,
-        deletedAt: { [Op.ne]: null },
-      },
-    });
-
-    if (!stillDeleted) {
-      Logger.info(
-        "commands",
-        `Document ${document.id} was restored before permanent deletion, skipping`
-      );
-      continue;
-    }
-
-    confirmedDocumentIds.push(document.id);
-
     // Find any attachments that are referenced in the text content
     const attachmentIdsInText = ProsemirrorHelper.parseAttachmentIds(
       DocumentHelper.toProsemirror(document)
@@ -97,10 +76,7 @@ export default async function documentPermanentDeleter(documents: Document[]) {
     );
   }
 
-  if (confirmedDocumentIds.length === 0) {
-    return 0;
-  }
-
+  const documentIds = documents.map((document) => document.id);
   await Document.update(
     {
       parentDocumentId: null,
@@ -108,7 +84,7 @@ export default async function documentPermanentDeleter(documents: Document[]) {
     {
       where: {
         parentDocumentId: {
-          [Op.in]: confirmedDocumentIds,
+          [Op.in]: documentIds,
         },
       },
       paranoid: false,
@@ -117,7 +93,7 @@ export default async function documentPermanentDeleter(documents: Document[]) {
 
   return Document.scope("withDrafts").destroy({
     where: {
-      id: { [Op.in]: confirmedDocumentIds },
+      id: documentIds,
       deletedAt: { [Op.ne]: null },
     },
     force: true,


### PR DESCRIPTION
`documentPermanentDeleter` receives pre-queried `Document` objects from cleanup tasks (`CleanupDeletedDocumentsTask`, `EmptyTrashTask`). A user restoring a document between the initial query and the permanent deletion causes silent data loss - the restored document is destroyed because `documentPermanentDeleter` trusts the stale in-memory `deletedAt` without re-checking the database.

- [**`server/commands/documentPermanentDeleter.ts`**](https://github.com/dearlordylord/outline/blob/fix/cleanup-recheck-deleted-before-permanent-delete/server/commands/documentPermanentDeleter.ts): Re-query each document's `deletedAt` via `Document.unscoped().count()` before processing; skip restored documents with a log message. Add `deletedAt: { [Op.ne]: null }` guard to the final `destroy` WHERE clause as a secondary safety net against the narrow window between re-check and destroy.