### PR TITLE
fix: Parse bullet lists in table cells from markdown input

### DIFF
--- a/shared/editor/rules/tables.test.ts
+++ b/shared/editor/rules/tables.test.ts
@@ -1,0 +1,127 @@
+import markdownit from "markdown-it";
+import tablesRule from "./tables";
+
+describe("Tables Rule", () => {
+  const md = markdownit().use(tablesRule);
+
+  describe("bullet lists in table cells", () => {
+    it("should parse bullet list items separated by br tags", () => {
+      const result = md.parse(
+        "| Header |\n|---|\n| * Item 1<br>* Item 2<br>* Item 3 |",
+        {}
+      );
+
+      const bulletOpen = result.find((t) => t.type === "bullet_list_open");
+      expect(bulletOpen).toBeDefined();
+
+      const listItems = result.filter((t) => t.type === "list_item_open");
+      expect(listItems.length).toBe(3);
+    });
+
+    it("should parse a single bullet item", () => {
+      const result = md.parse("| Header |\n|---|\n| * Just one item |", {});
+
+      const bulletOpen = result.find((t) => t.type === "bullet_list_open");
+      expect(bulletOpen).toBeDefined();
+
+      const listItems = result.filter((t) => t.type === "list_item_open");
+      expect(listItems.length).toBe(1);
+    });
+
+    it("should not convert mixed content to bullet list", () => {
+      const result = md.parse(
+        "| Header |\n|---|\n| * Item 1<br>Not a bullet |",
+        {}
+      );
+
+      const bulletOpen = result.find((t) => t.type === "bullet_list_open");
+      expect(bulletOpen).toBeUndefined();
+    });
+
+    it("should handle dash markers", () => {
+      const result = md.parse(
+        "| Header |\n|---|\n| - Item 1<br>- Item 2 |",
+        {}
+      );
+
+      const bulletOpen = result.find((t) => t.type === "bullet_list_open");
+      expect(bulletOpen).toBeDefined();
+
+      const listItems = result.filter((t) => t.type === "list_item_open");
+      expect(listItems.length).toBe(2);
+    });
+
+    it("should handle plus markers", () => {
+      const result = md.parse(
+        "| Header |\n|---|\n| + Item 1<br>+ Item 2 |",
+        {}
+      );
+
+      const bulletOpen = result.find((t) => t.type === "bullet_list_open");
+      expect(bulletOpen).toBeDefined();
+
+      const listItems = result.filter((t) => t.type === "list_item_open");
+      expect(listItems.length).toBe(2);
+    });
+
+    it("should resolve inline markdown in bullet items", () => {
+      const result = md.parse(
+        "| Header |\n|---|\n| * Visit [Google](https://google.com)<br>* **Bold** item |",
+        {}
+      );
+
+      const bulletOpen = result.find((t) => t.type === "bullet_list_open");
+      expect(bulletOpen).toBeDefined();
+
+      // Inline markdown is parsed into children of inline tokens
+      const inlineTokens = result.filter(
+        (t) => t.type === "inline" && t.content !== "Header"
+      );
+      const allChildren = inlineTokens.flatMap((t) => t.children ?? []);
+
+      const linkOpen = allChildren.find((t) => t.type === "link_open");
+      expect(linkOpen).toBeDefined();
+
+      const strongOpen = allChildren.find((t) => t.type === "strong_open");
+      expect(strongOpen).toBeDefined();
+    });
+
+    it("should preserve inline text content of bullet items", () => {
+      const result = md.parse("| Header |\n|---|\n| * First<br>* Second |", {});
+
+      const inlineTokens = result.filter(
+        (t) => t.type === "inline" && t.content !== "Header"
+      );
+      expect(inlineTokens.length).toBe(2);
+      expect(inlineTokens[0].content).toBe("First");
+      expect(inlineTokens[1].content).toBe("Second");
+    });
+  });
+
+  describe("paragraph wrapping", () => {
+    it("should wrap plain text in paragraphs", () => {
+      const result = md.parse("| Header |\n|---|\n| Plain text |", {});
+
+      const paragraphOpen = result.filter((t) => t.type === "paragraph_open");
+      expect(paragraphOpen.length).toBeGreaterThanOrEqual(1);
+
+      const bulletOpen = result.find((t) => t.type === "bullet_list_open");
+      expect(bulletOpen).toBeUndefined();
+    });
+  });
+
+  describe("checkbox parsing", () => {
+    it("should still parse checkboxes in table cells", () => {
+      const result = md.parse(
+        "| Header |\n|---|\n| - [x] Done<br>- [ ] Pending |",
+        {}
+      );
+
+      const checkboxOpen = result.find((t) => t.type === "checkbox_list_open");
+      expect(checkboxOpen).toBeDefined();
+
+      const bulletOpen = result.find((t) => t.type === "bullet_list_open");
+      expect(bulletOpen).toBeUndefined();
+    });
+  });
+});

--- a/shared/editor/rules/tables.ts
+++ b/shared/editor/rules/tables.ts
@@ -1,10 +1,25 @@
 import type MarkdownIt from "markdown-it";
+import type { StateCore } from "markdown-it";
 
 const BREAK_REGEX = /(?<=^|[^\\])\\n/;
 const BR_TAG_REGEX = /<br\s*\/?>/gi;
 // Matches checkbox syntax with optional list prefix: "- [x] Task" or "[x] Task"
 // Stops at <br> or newline to handle multiple checkboxes in a cell
 const CHECKBOX_REGEX = /^(?:-\s*)?\[(X|\s|_|-)\]\s([^<\n]*)?/i;
+// Matches bullet list markers: *, -, or + followed by a space
+const BULLET_REGEX = /^[*\-+]\s(.*)/;
+
+/** Create an inline token with parsed inline content (links, bold, etc). */
+function makeInlineToken(state: StateCore, content: string) {
+  const inline = new state.Token("inline", "", 0);
+  inline.content = content;
+
+  // Parse inline markdown so links, bold, etc. are resolved
+  const parsed = state.md.parseInline(content, state.env);
+  inline.children = parsed[0]?.children ?? [];
+
+  return inline;
+}
 
 export default function markdownTables(md: MarkdownIt): void {
   // insert a new rule after the "inline" rules are parsed
@@ -134,15 +149,7 @@ export default function markdownTables(md: MarkdownIt): void {
             }
             newTokens.push(itemOpen);
             newTokens.push(new state.Token("paragraph_open", "p", 1));
-
-            // Create inline token for the label
-            const labelInline = new state.Token("inline", "", 0);
-            labelInline.content = item.label;
-            const textToken = new state.Token("text", "", 0);
-            textToken.content = item.label;
-            labelInline.children = [textToken];
-            newTokens.push(labelInline);
-
+            newTokens.push(makeInlineToken(state, item.label));
             newTokens.push(new state.Token("paragraph_close", "p", -1));
             newTokens.push(new state.Token("checkbox_item_close", "li", -1));
           }
@@ -153,16 +160,48 @@ export default function markdownTables(md: MarkdownIt): void {
           // Replace the inline token with our new structure
           tokens.splice(i + 1, closeIndex - i - 1, ...newTokens);
         } else {
-          // markdown-it table parser does not return paragraphs inside the cells
-          // but prosemirror requires them, so we add 'em in here.
-          // Insert closing token first (before closeIndex shifts)
-          tokens.splice(
-            closeIndex,
-            0,
-            new state.Token("paragraph_close", "p", -1)
-          );
-          // Then insert opening token
-          tokens.splice(i + 1, 0, new state.Token("paragraph_open", "p", 1));
+          // Check if the cell content looks like a bullet list
+          // (e.g. "* Item1 <br> * Item2" as serialized by the table serializer)
+          const nonEmptyParts = parts.filter((p) => p.trim());
+          const bulletItems: string[] = [];
+
+          for (const part of nonEmptyParts) {
+            const match = part.trim().match(BULLET_REGEX);
+            if (!match) {
+              bulletItems.length = 0;
+              break;
+            }
+            bulletItems.push(match[1]);
+          }
+
+          if (bulletItems.length > 0) {
+            const newTokens: InstanceType<typeof state.Token>[] = [];
+
+            newTokens.push(new state.Token("bullet_list_open", "ul", 1));
+
+            for (const text of bulletItems) {
+              newTokens.push(new state.Token("list_item_open", "li", 1));
+              newTokens.push(new state.Token("paragraph_open", "p", 1));
+              newTokens.push(makeInlineToken(state, text));
+              newTokens.push(new state.Token("paragraph_close", "p", -1));
+              newTokens.push(new state.Token("list_item_close", "li", -1));
+            }
+
+            newTokens.push(new state.Token("bullet_list_close", "ul", -1));
+
+            tokens.splice(i + 1, closeIndex - i - 1, ...newTokens);
+          } else {
+            // markdown-it table parser does not return paragraphs inside the cells
+            // but prosemirror requires them, so we add 'em in here.
+            // Insert closing token first (before closeIndex shifts)
+            tokens.splice(
+              closeIndex,
+              0,
+              new state.Token("paragraph_close", "p", -1)
+            );
+            // Then insert opening token
+            tokens.splice(i + 1, 0, new state.Token("paragraph_open", "p", 1));
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

The serializer outputs bullet lists in table cells as `* Item 1 <br> * Item 2`, but when this markdown is parsed back (e.g. via the API), the `*` markers become literal text instead of `bullet_list` nodes.

This adds bullet list detection to the table cell parsing rule, using the same approach already in place for checkbox lists.

Additionally, the existing checkbox parsing had a pre-existing issue where inline markdown (links, bold, etc.) in labels was stored as raw text instead of being parsed. For example, `[link](url)` would appear literally instead of rendering as a clickable link. This is fixed by extracting a shared `makeInlineToken` helper that uses `parseInline` to resolve inline formatting, benefiting both bullet items and checkbox labels.

## Changes

- Detect `* item <br> * item` patterns in table cells and emit `bullet_list` > `list_item` tokens
- Extract `makeInlineToken` helper that runs `parseInline` on content, so links and formatting are properly resolved
- Apply `makeInlineToken` to both bullet items and existing checkbox labels