### PR TITLE
Escape key clears search highlights in documents

### DIFF
--- a/app/editor/extensions/FindAndReplace.tsx
+++ b/app/editor/extensions/FindAndReplace.tsx
@@ -29,6 +29,29 @@ export default class FindAndReplaceExtension extends Extension {
     };
   }
 
+  keys(): Record<string, Command> {
+    return {
+      Escape: (state, dispatch) => {
+        if (!this.searchTerm) {
+          return false;
+        }
+
+        const params = new URLSearchParams(window.location.search);
+        if (params.has("q")) {
+          params.delete("q");
+          const search = params.toString();
+          window.history.replaceState(
+            window.history.state,
+            "",
+            window.location.pathname + (search ? `?${search}` : "")
+          );
+        }
+
+        return this.clear()(state, dispatch);
+      },
+    };
+  }
+
   public commands() {
     return {
       /**


### PR DESCRIPTION
## Summary

- When navigating to a document from search results, the search term is highlighted using the FindAndReplace extension, but since the popover isn't open there's no way to dismiss the highlights
- Adds an Escape key binding to the FindAndReplace extension that clears active search highlights
- Falls through to the default Escape behavior (blur editor) when no highlights are active

## Test plan

- [x] Search for a term and click a result to navigate to the document
- [x] Verify the search term is highlighted on the page
- [x] Press Escape and verify the highlights are cleared
- [x] Press Escape again and verify the editor blurs as before
- [ ] Open Find and Replace with Cmd+F, search, then close with Escape — verify highlights still clear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)