### PR TITLE
feat: support self-hosted Grist embeds

### DIFF
--- a/plugins/grist/client/Icon.tsx
+++ b/plugins/grist/client/Icon.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+
+type Props = {
+  size?: number;
+  fill?: string;
+};
+
+export default function Icon({ size = 24 }: Props) {
+  const imageSize = Math.round(size * 0.75);
+
+  return (
+    <span
+      style={{
+        width: size,
+        height: size,
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <img
+        src="/images/grist.png"
+        alt="Grist"
+        width={imageSize}
+        height={imageSize}
+        style={{ borderRadius: 2, display: "block" }}
+      />
+    </span>
+  );
+}

--- a/plugins/grist/client/Settings.tsx
+++ b/plugins/grist/client/Settings.tsx
@@ -1,0 +1,132 @@
+import find from "lodash/find";
+import { observer } from "mobx-react";
+import * as React from "react";
+import { useForm } from "react-hook-form";
+import { useTranslation, Trans } from "react-i18next";
+import { toast } from "sonner";
+import { IntegrationType, IntegrationService } from "@shared/types";
+import type Integration from "~/models/Integration";
+import { IntegrationScene } from "~/scenes/Settings/components/IntegrationScene";
+import SettingRow from "~/scenes/Settings/components/SettingRow";
+import Button from "~/components/Button";
+import Heading from "~/components/Heading";
+import Input from "~/components/Input";
+import Text from "~/components/Text";
+import Flex from "~/components/Flex";
+import styled from "styled-components";
+import useStores from "~/hooks/useStores";
+import { disconnectIntegrationFactory } from "~/actions/definitions/integrations";
+import Icon from "./Icon";
+
+type FormData = {
+  url: string;
+};
+
+function Grist() {
+  const { integrations } = useStores();
+  const { t } = useTranslation();
+
+  const integration = find(integrations.orderedData, {
+    type: IntegrationType.Embed,
+    service: IntegrationService.Grist,
+  }) as Integration<IntegrationType.Embed> | undefined;
+
+  const url = integration?.settings.url;
+
+  const {
+    register,
+    reset,
+    handleSubmit: formHandleSubmit,
+    formState,
+  } = useForm<FormData>({
+    mode: "all",
+    defaultValues: {
+      url,
+    },
+  });
+
+  React.useEffect(() => {
+    reset({
+      url,
+    });
+  }, [reset, url]);
+
+  const handleSubmit = React.useCallback(
+    async (data: FormData) => {
+      try {
+        await integrations.save({
+          id: integration?.id,
+          type: IntegrationType.Embed,
+          service: IntegrationService.Grist,
+          settings: {
+            url: data.url,
+          } as Integration<IntegrationType.Embed>["settings"],
+        });
+
+        toast.success(t("Settings saved"));
+      } catch (err) {
+        toast.error(err.message);
+      }
+    },
+    [integrations, integration, t]
+  );
+
+  return (
+    <IntegrationScene title="Grist" icon={<Icon />}>
+      <Heading>Grist</Heading>
+
+      <Text as="p" type="secondary">
+        <Trans>
+          Configure a custom Grist installation URL to use your own self-hosted
+          instance for embedding spreadsheets in your documents.
+        </Trans>
+      </Text>
+      <form onSubmit={formHandleSubmit(handleSubmit)}>
+        <SettingRow
+          label={t("Installation URL")}
+          name="url"
+          description={t(
+            "The URL of your Grist installation. Leave empty to use the cloud hosted getgrist.com"
+          )}
+          border={false}
+        >
+          <Input
+            placeholder="https://grist.example.com"
+            {...register("url", { required: false })}
+          />
+        </SettingRow>
+
+        <Actions reverse justify="end" gap={8}>
+          <StyledSubmit
+            type="submit"
+            disabled={
+              !formState.isDirty || !formState.isValid || formState.isSubmitting
+            }
+          >
+            {formState.isSubmitting ? `${t("Saving")}…` : t("Save")}
+          </StyledSubmit>
+
+          <Button
+            action={disconnectIntegrationFactory(integration)}
+            disabled={formState.isSubmitting}
+            neutral
+            hideIcon
+            hideOnActionDisabled
+          >
+            {t("Disconnect")}
+          </Button>
+        </Actions>
+      </form>
+    </IntegrationScene>
+  );
+}
+
+const Actions = styled(Flex)`
+  margin-top: 8px;
+`;
+
+const StyledSubmit = styled(Button)`
+  width: 80px;
+`;
+
+export default observer(Grist);

--- a/plugins/grist/client/index.tsx
+++ b/plugins/grist/client/index.tsx
@@ -1,0 +1,20 @@
+import { UserRole } from "@shared/types";
+import { createLazyComponent } from "~/components/LazyLoad";
+import { Hook, PluginManager } from "~/utils/PluginManager";
+import config from "../plugin.json";
+import Icon from "./Icon";
+
+PluginManager.add([
+  {
+    ...config,
+    type: Hook.Settings,
+    value: {
+      group: "Integrations",
+      icon: Icon,
+      description:
+        "Configure a custom Grist installation URL to use your own self-hosted instance for embedding spreadsheets in your documents.",
+      component: createLazyComponent(() => import("./Settings")),
+      enabled: (_, user) => user.role === UserRole.Admin,
+    },
+  },
+]);

--- a/plugins/grist/plugin.json
+++ b/plugins/grist/plugin.json
@@ -1,0 +1,6 @@
+{
+  "id": "grist",
+  "name": "Grist",
+  "priority": 46,
+  "description": "Configure a custom Grist installation URL for embedding spreadsheets."
+}

--- a/shared/editor/embeds/index.tsx
+++ b/shared/editor/embeds/index.tsx
@@ -110,6 +110,8 @@ export class EmbedDescriptor {
     this.attrs = options.attrs;
     this.visible = options.visible;
     this.component = options.component;
+    this.settings = options.settings;
+    this.disabled = options.disabled;
   }
 
   matcher(url: string): false | RegExpMatchArray {

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -1497,6 +1497,8 @@
   "Add a Google Analytics 4 measurement ID to send document views and analytics from the workspace to your own Google Analytics account.": "Add a Google Analytics 4 measurement ID to send document views and analytics from the workspace to your own Google Analytics account.",
   "Measurement ID": "Measurement ID",
   "Create a \"Web\" stream in your Google Analytics admin dashboard and copy the measurement ID from the generated code snippet to install.": "Create a \"Web\" stream in your Google Analytics admin dashboard and copy the measurement ID from the generated code snippet to install.",
+  "Configure a custom Grist installation URL to use your own self-hosted instance for embedding spreadsheets in your documents.": "Configure a custom Grist installation URL to use your own self-hosted instance for embedding spreadsheets in your documents.",
+  "The URL of your Grist installation. Leave empty to use the cloud hosted getgrist.com": "The URL of your Grist installation. Leave empty to use the cloud hosted getgrist.com",
   "Whoops, you need to accept the permissions in Linear to connect {{appName}} to your workspace. Try again?": "Whoops, you need to accept the permissions in Linear to connect {{appName}} to your workspace. Try again?",
   "Enable previews of Linear issues in documents by connecting a Linear workspace to {{appName}}.": "Enable previews of Linear issues in documents by connecting a Linear workspace to {{appName}}.",
   "Disconnecting will prevent previewing Linear links from this workspace in documents. Are you sure?": "Disconnecting will prevent previewing Linear links from this workspace in documents. Are you sure?",


### PR DESCRIPTION
## Summary
- add a Grist integration settings page so admins can configure a self-hosted Grist installation URL
- preserve embed integration settings when rebuilding embed descriptors so custom Grist domains match correctly in the editor
- use the Grist logo in the integrations page and add the new settings copy to translations

Related to #11862 

## Testing
- yarn build