### PR TITLE
Feat: Add mentions syntax for create/update API

### DIFF
--- a/server/commands/documentCreator.ts
+++ b/server/commands/documentCreator.ts
@@ -5,6 +5,7 @@ import { Document } from "@server/models";
 import { DocumentHelper } from "@server/models/helpers/DocumentHelper";
 import { ProsemirrorHelper } from "@server/models/helpers/ProsemirrorHelper";
 import type { APIContext } from "@server/types";
+import importMentions from "@server/utils/importMentions";
 
 type Props = Optional<
   Pick<
@@ -107,6 +108,10 @@ export default async function documentCreator(
             )
         : ProsemirrorHelper.toProsemirror("").toJSON();
 
+  const contentWithReplacementsAndMentions = await importMentions({
+    content: contentWithReplacements,
+  });
+
   const document = Document.build({
     id,
     urlId,
@@ -128,7 +133,7 @@ export default async function documentCreator(
     icon: icon ?? templateDocument?.icon,
     color: color ?? templateDocument?.color,
     title: titleWithReplacements,
-    content: contentWithReplacements,
+    content: contentWithReplacementsAndMentions,
     state,
   });
 

--- a/server/commands/documentUpdater.ts
+++ b/server/commands/documentUpdater.ts
@@ -84,7 +84,7 @@ export default async function documentUpdater(
     document.insightsEnabled = insightsEnabled;
   }
   if (text !== undefined) {
-    document = DocumentHelper.applyMarkdownToDocument(
+    document = await DocumentHelper.applyMarkdownToDocument(
       document,
       await TextHelper.replaceImagesWithAttachments(ctx, text, user, {
         base64Only: true,

--- a/server/models/helpers/DocumentHelper.tsx
+++ b/server/models/helpers/DocumentHelper.tsx
@@ -19,6 +19,7 @@ import { Collection, Document, Revision } from "@server/models";
 import type { MentionAttrs } from "./ProsemirrorHelper";
 import { ProsemirrorHelper } from "./ProsemirrorHelper";
 import { TextHelper } from "./TextHelper";
+import { transformMentionsFragment } from "@server/utils/importMentions";
 
 type HTMLOptions = {
   /** Whether to include the document title in the generated HTML (defaults to true) */
@@ -475,7 +476,7 @@ export class DocumentHelper {
    * @param editMode The edit mode to use: "replace" (default), "append", or "prepend"
    * @returns The document
    */
-  static applyMarkdownToDocument(
+  static async applyMarkdownToDocument(
     document: Document,
     text: string,
     editMode: TextEditMode = TextEditMode.Replace
@@ -533,7 +534,9 @@ export class DocumentHelper {
         doc = existingDoc.copy(newDoc.content.append(existingDoc.content));
       }
     } else {
-      doc = parser.parse(text);
+      const content = parser.parse(text);
+      const node = await transformMentionsFragment(content);
+      doc = content.copy(node);
     }
 
     document.content = doc.toJSON();

--- a/server/utils/importMentions.ts
+++ b/server/utils/importMentions.ts
@@ -1,0 +1,80 @@
+import { Document } from "@server/models";
+import { ProsemirrorHelper } from "@server/models/helpers/ProsemirrorHelper";
+import {
+  MentionType,
+  ProsemirrorDoc,
+} from "@shared/types";
+import { Fragment, Node } from "prosemirror-model";
+import { schema } from "@server/editor";
+import { v4 as uuidv4 } from "uuid";
+
+/**
+ * Transform the mentions and attachments in ProseMirrorDoc to their internal references.
+ *
+ * @param content ProseMirrorDoc that represents collection (or) document content.
+ * @returns Updated ProseMirrorDoc.
+ */
+export default async function importMentions({
+  content,
+}: {
+  content: ProsemirrorDoc;
+}): Promise<ProsemirrorDoc> {
+  // special case when the doc content is empty.
+  if (!content.content.length) {
+    return content;
+  }
+
+  const doc = ProsemirrorHelper.toProsemirror(content);
+
+  return doc.copy(await transformMentionsFragment(doc.content)).toJSON();
+}
+
+async function transformMentionsFragment(fragment: Fragment|Node): Promise<Fragment> {
+  const transformImportedMentionNode = async (node: Node): Promise<Node> => {
+    const modelId = node.text && node.text.match(/mention:([a-f0-9\-]+)/)?.[1];
+
+    if (modelId) {
+      const doc = await Document.findOne({
+        where: {
+        id: modelId,
+        },
+      });
+      if (doc) {
+        const newNode =  schema.nodes.mention.create({
+          type: MentionType.Document,
+          modelId,
+          label: doc.titleWithDefault,
+          id: uuidv4(),
+          });
+        
+        return newNode;
+      }
+    }
+    console.log("documentCreator:updatedMentionsAndAttachments: doc not found", modelId);
+    return node;
+  };
+
+  const transformFragment = async (fragment: Fragment|Node): Promise<Fragment> => {
+    const nodePromises: Promise<Node>[] = [];
+
+    fragment.forEach((node) => {
+      if (node.type.name === "text" && node.text && node.text.search(/mention:[a-f0-9\-]+/) == 0) {
+        nodePromises.push(transformImportedMentionNode(node));
+      } else {
+        nodePromises.push(
+          transformFragment(node.content).then((transformedContent) =>
+            node.copy(transformedContent)
+          )
+        );
+      }
+    });
+
+    const nodes = await Promise.all(nodePromises);
+    return Fragment.fromArray(nodes);
+  };
+  return await transformFragment(fragment);
+}
+
+export {
+  transformMentionsFragment,
+};


### PR DESCRIPTION
This adds a support for including links to other documents in wiki when using API to create/update documents. Related #11894 
- reads mentions from markdown in format `<mention:DOCID>` that match DOCIDs in the system.