### PR TITLE
fix: Remove archived document from sidebar immediately

### DIFF
--- a/app/stores/DocumentsStore.ts
+++ b/app/stores/DocumentsStore.ts
@@ -618,7 +618,7 @@ export default class DocumentsStore extends Store<Document> {
     });
     const collection = this.getCollectionForDocument(document);
     if (collection) {
-      await collection.refresh();
+      collection.removeDocument(document.id);
     }
   };
 


### PR DESCRIPTION
## Summary
- When archiving a document, proactively remove it from the sidebar collection tree using `collection.removeDocument()` instead of calling `collection.refresh()` which required a second network request
- This is the same method the websocket handler uses, so the behavior is consistent
- Eliminates a redundant API call and removes the visual delay where the document lingered in the sidebar until the refresh completed

## Test plan
- [ ] Archive a document and verify it disappears from the sidebar immediately
- [ ] Verify archived document no longer appears in collection navigation
- [ ] Verify other users still see the removal via websocket events

🤖 Generated with [Claude Code](https://claude.com/claude-code)