### PR TITLE
fix: Present mode slide content not vertically centered

### DIFF
--- a/app/scenes/Document/components/PresentationMode.tsx
+++ b/app/scenes/Document/components/PresentationMode.tsx
@@ -460,6 +460,7 @@ const TopBar = styled.div<{ $idle: boolean }>`
   right: 0;
   z-index: 1;
   opacity: ${(props) => (props.$idle ? 0 : 1)};
+  pointer-events: ${(props) => (props.$idle ? "none" : "auto")};
   transition: opacity 300ms ease;
 `;
 


### PR DESCRIPTION
## Summary
- Make the presentation TopBar absolutely positioned so it doesn't consume 64px of vertical space in the flex column layout, which was shifting the slide content below the true viewport center.
- Remove the stale `- 48` height offset from the scale calculation, since the TopBar no longer reduces available flow space. The 80px padding on SlideArea already provides sufficient clearance.

## Test plan
- [ ] Open a document and enter present mode (⌘+Option+P)
- [ ] Verify the title slide and content slides appear vertically centered on screen
- [ ] Verify the navigation controls still appear at the top and function correctly
- [ ] Resize the window and verify content rescales properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)