### PR TITLE
fix: Integrations list missing when language is not English

### DIFF
--- a/app/scenes/Settings/Integrations.tsx
+++ b/app/scenes/Settings/Integrations.tsx
@@ -27,7 +27,7 @@ function Integrations() {
   const groupedItems = groupBy(
     items.filter(
       (item) =>
-        item.group === "Integrations" &&
+        item.group === t("Integrations") &&
         item.enabled &&
         item.path !== settingsPath("integrations") &&
         item.name.toLowerCase().includes(query.toLowerCase())


### PR DESCRIPTION
## Summary
- The Integrations settings page filtered items by comparing `item.group` against the hardcoded English string `"Integrations"` instead of using the translated `t("Integrations")`.
- When the app language was set to anything other than English, the group values were translated but the filter was not, so no integrations appeared on the page.
- Fixed by using `t("Integrations")` in the filter comparison to match the translated group name.

closes #11907