### PR TITLE
Add support for client_secret_basic authentication method in OIDC

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -179,6 +179,11 @@ OIDC_AUTH_URI=
 OIDC_TOKEN_URI=
 OIDC_USERINFO_URI=
 OIDC_LOGOUT_URI=
+# The authentication method to use when making requests to the token endpoint.
+# Supported values: "client_secret_basic" or "client_secret_post".
+# If not set, will be automatically determined from OIDC discovery response,
+# or default to "client_secret_post".
+OIDC_TOKEN_ENDPOINT_AUTH_METHOD=
 
 # Specify which claims to derive user information from
 # Supports any valid JSON path with the JWT payload

--- a/.env.test
+++ b/.env.test
@@ -26,6 +26,7 @@ OIDC_CLIENT_SECRET=client-secret
 OIDC_AUTH_URI=http://localhost/authorize
 OIDC_TOKEN_URI=http://localhost/token
 OIDC_USERINFO_URI=http://localhost/userinfo
+OIDC_TOKEN_ENDPOINT_AUTH_METHOD=
 
 IFRAMELY_API_KEY=123
 

--- a/plugins/oidc/server/auth/OIDCStrategy.ts
+++ b/plugins/oidc/server/auth/OIDCStrategy.ts
@@ -1,17 +1,38 @@
 import { HttpsProxyAgent } from "https-proxy-agent";
 import type OAuth2Strategy from "passport-oauth2";
 import { Strategy } from "passport-oauth2";
+import fetch from "@server/utils/fetch";
+import Logger from "@server/logging/Logger";
+
+export interface OIDCStrategyOptions
+  extends OAuth2Strategy.StrategyOptionsWithRequest {
+  /**
+   * Authentication method for the token endpoint.
+   * - "client_secret_post": Send client_id and client_secret in the request body (default)
+   * - "client_secret_basic": Send credentials via HTTP Basic Auth header
+   */
+  authMethod?: "client_secret_basic" | "client_secret_post";
+}
 
 export class OIDCStrategy extends Strategy {
+  private authMethod: "client_secret_basic" | "client_secret_post";
+
   constructor(
-    options: OAuth2Strategy.StrategyOptionsWithRequest,
+    options: OIDCStrategyOptions,
     verify: OAuth2Strategy.VerifyFunctionWithRequest
   ) {
     super(options, verify);
 
+    this.authMethod = options.authMethod || "client_secret_post";
+
     if (process.env.https_proxy) {
       const httpsProxyAgent = new HttpsProxyAgent(process.env.https_proxy);
       this._oauth2.setAgent(httpsProxyAgent);
+    }
+
+    // Override the getOAuthAccessToken method to support client_secret_basic
+    if (this.authMethod === "client_secret_basic") {
+      this._overrideGetOAuthAccessToken(options);
     }
   }
 
@@ -24,6 +45,71 @@ export class OIDCStrategy extends Strategy {
     return {
       ...options.originalQuery,
       ...super.authorizationParams?.(options),
+    };
+  }
+
+  /**
+   * Override the OAuth2 getOAuthAccessToken method to use HTTP Basic Auth
+   */
+  private _overrideGetOAuthAccessToken(
+    options: OIDCStrategyOptions
+  ): void {
+    const clientId = options.clientID;
+    const clientSecret = options.clientSecret!;
+    const tokenURL = options.tokenURL;
+
+    // @ts-expect-error Overriding internal OAuth2 method to support client_secret_basic
+    this._oauth2.getOAuthAccessToken = async function (
+      code: string,
+      params: any,
+      callback: Function
+    ) {
+      try {
+        const body = new URLSearchParams({
+          grant_type: "authorization_code",
+          code: code,
+          redirect_uri: params.redirect_uri,
+        });
+
+        const credentials = Buffer.from(
+          `${clientId}:${clientSecret}`
+        ).toString("base64");
+
+        Logger.debug("plugins", "Requesting token with client_secret_basic", {
+          tokenURL,
+        });
+
+        const response = await fetch(tokenURL, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            Authorization: `Basic ${credentials}`,
+          },
+          body: body.toString(),
+          allowPrivateIPAddress: true,
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          Logger.error("Token request failed", {
+            status: response.status,
+            error: errorText,
+          });
+          return callback(new Error(`Token request failed: ${response.status}`));
+        }
+
+        const data = await response.json();
+
+        callback(
+          null,
+          data.access_token,
+          data.refresh_token,
+          data
+        );
+      } catch (error) {
+        Logger.error("Token request error", error);
+        callback(error);
+      }
     };
   }
 }

--- a/plugins/oidc/server/auth/oidc.ts
+++ b/plugins/oidc/server/auth/oidc.ts
@@ -23,13 +23,55 @@ const hasIssuerConfig = !!(
   env.OIDC_ISSUER_URL
 );
 
+/**
+ * Determine the authentication method based on environment variable and discovery response
+ */
+function determineAuthMethod(
+  discoveryAuthMethods?: string[]
+): "client_secret_basic" | "client_secret_post" {
+  // Environment variable override
+  if (env.OIDC_TOKEN_ENDPOINT_AUTH_METHOD) {
+    const method = env.OIDC_TOKEN_ENDPOINT_AUTH_METHOD;
+    if (method === "client_secret_basic" || method === "client_secret_post") {
+      Logger.debug("plugins", "Using authentication method from environment", {
+        authMethod: method,
+      });
+      return method;
+    }
+    Logger.warn("Invalid Environment variable OIDC_TOKEN_ENDPOINT_AUTH_METHOD, using default", {
+      provided: method,
+      valid: ["client_secret_basic", "client_secret_post"]
+    });
+  }
+
+  // Discovery response
+  if (discoveryAuthMethods && discoveryAuthMethods.length > 0) {
+    // Prefer client_secret_basic if supported, otherwise use client_secret_post
+    if (discoveryAuthMethods.includes("client_secret_basic")) {
+      Logger.debug("plugins", "Using client_secret_basic from discovery");
+      return "client_secret_basic";
+    }
+    if (discoveryAuthMethods.includes("client_secret_post")) {
+      Logger.debug("plugins", "Using client_secret_post from discovery");
+      return "client_secret_post";
+    }
+  }
+
+  // Default use client_secret_post
+  Logger.debug("plugins", "Using default authentication method: client_secret_post");
+  return "client_secret_post";
+}
+
 if (hasManualConfig) {
   // Mount endpoints immediately with manual configuration
+  const authMethod = determineAuthMethod();
+
   createOIDCRouter(router, {
     authorizationURL: env.OIDC_AUTH_URI!,
     tokenURL: env.OIDC_TOKEN_URI!,
     userInfoURL: env.OIDC_USERINFO_URI!,
     logoutURL: env.OIDC_LOGOUT_URI,
+    authMethod: authMethod,
   });
   Logger.info("plugins", "OIDC endpoints mounted with manual configuration");
 } else if (hasIssuerConfig) {
@@ -45,6 +87,11 @@ if (hasManualConfig) {
       env.OIDC_TOKEN_URI = oidcConfig.token_endpoint;
       env.OIDC_USERINFO_URI = oidcConfig.userinfo_endpoint;
 
+      // Determine authentication method from discovery or environment
+      const authMethod = determineAuthMethod(
+        oidcConfig.token_endpoint_auth_methods_supported
+      );
+
       // Mount endpoints into the existing router
       createOIDCRouter(router, {
         authorizationURL: oidcConfig.authorization_endpoint,
@@ -52,6 +99,7 @@ if (hasManualConfig) {
         userInfoURL: oidcConfig.userinfo_endpoint,
         logoutURL: oidcConfig.end_session_endpoint,
         pkce: oidcConfig.code_challenge_methods_supported?.includes("S256"),
+        authMethod: authMethod,
       });
 
       Logger.info("plugins", "OIDC endpoints mounted after discovery", {
@@ -59,6 +107,7 @@ if (hasManualConfig) {
         authorization_endpoint: oidcConfig.authorization_endpoint,
         token_endpoint: oidcConfig.token_endpoint,
         userinfo_endpoint: oidcConfig.userinfo_endpoint,
+        authMethod: authMethod,
       });
 
       return router;

--- a/plugins/oidc/server/auth/oidcRouter.ts
+++ b/plugins/oidc/server/auth/oidcRouter.ts
@@ -34,6 +34,7 @@ export interface OIDCEndpoints {
   userInfoURL: string;
   logoutURL?: string;
   pkce?: boolean;
+  authMethod?: "client_secret_basic" | "client_secret_post";
 }
 
 /**
@@ -60,6 +61,7 @@ export function createOIDCRouter(
         store: new StateStore(endpoints.pkce),
         state: true,
         pkce: endpoints.pkce ?? false,
+        authMethod: endpoints.authMethod,
       },
       // OpenID Connect standard profile claims can be found in the official
       // specification.

--- a/plugins/oidc/server/env.ts
+++ b/plugins/oidc/server/env.ts
@@ -105,6 +105,17 @@ class OIDCPluginEnvironment extends Environment {
     allow_underscores: true,
   })
   public OIDC_LOGOUT_URI = this.toOptionalString(environment.OIDC_LOGOUT_URI);
+
+  /**
+   * The authentication method to use when making requests to the token endpoint.
+   * Supported values: "client_secret_basic" or "client_secret_post".
+   * If not set, will be automatically determined from OIDC discovery response,
+   * or default to "client_secret_post".
+   */
+  @IsOptional()
+  public OIDC_TOKEN_ENDPOINT_AUTH_METHOD = this.toOptionalString(
+    environment.OIDC_TOKEN_ENDPOINT_AUTH_METHOD
+  );
 }
 
 export default new OIDCPluginEnvironment();

--- a/plugins/oidc/server/oidcDiscovery.ts
+++ b/plugins/oidc/server/oidcDiscovery.ts
@@ -13,6 +13,7 @@ export interface OIDCConfiguration {
   response_types_supported?: string[];
   grant_types_supported?: string[];
   code_challenge_methods_supported?: string[];
+  token_endpoint_auth_methods_supported?: string[];
 }
 
 /**

--- a/server/utils/oauth.ts
+++ b/server/utils/oauth.ts
@@ -5,6 +5,7 @@ import fetch from "./fetch";
 export default abstract class OAuthClient {
   private clientId: string;
   private clientSecret: string;
+  protected authMethod?: "client_secret_basic" | "client_secret_post";
 
   protected endpoints = {
     authorize: "",
@@ -63,18 +64,35 @@ export default abstract class OAuthClient {
     try {
       Logger.debug("utils", "Rotating token", { endpoint });
 
+      const body = new URLSearchParams({
+        refresh_token: refreshToken,
+        grant_type: "refresh_token",
+      });
+
+      // Determine authentication method
+      const useBasicAuth = this.authMethod === "client_secret_basic";
+
+      const headers: Record<string, string> = {
+        "Content-Type": "application/x-www-form-urlencoded",
+      };
+
+      if (useBasicAuth) {
+        // Use HTTP Basic Auth
+        const credentials = Buffer.from(
+          `${this.clientId}:${this.clientSecret}`
+        ).toString("base64");
+        headers["Authorization"] = `Basic ${credentials}`;
+      } else {
+        // Use client_secret_post (default)
+        body.append("client_id", this.clientId);
+        body.append("client_secret", this.clientSecret);
+      }
+
       response = await fetch(endpoint, {
         method: "POST",
         allowPrivateIPAddress: true,
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
-        },
-        body: new URLSearchParams({
-          client_id: this.clientId,
-          client_secret: this.clientSecret,
-          refresh_token: refreshToken,
-          grant_type: "refresh_token",
-        }),
+        headers,
+        body: body,
       });
       data = await response.json();
     } catch (err) {


### PR DESCRIPTION
# Add support for `client_secret_basic` authentication method in OIDC

## Problem

Some OIDC provider may require client_secret_basic authentication method. Currently, Outline only supports client_secret_post, which sends client credentials in the request body, making it impossible to authenticate without modifying the code.

## Solution

This PR adds support for the client_secret_basic authentication method:

### 1. OIDC Discovery Integration
- Added `token_endpoint_auth_methods_supported` field to OIDC configuration
- Automatically detects supported authentication methods from the provider's discovery endpoint

### 2. Configuration Options
- New environment variable: `OIDC_TOKEN_ENDPOINT_AUTH_METHOD`
- Accepts values: `client_secret_basic` or `client_secret_post`(default)

### 3. HTTP Basic Auth Implementation
- Modified `OIDCStrategy` to support HTTP Basic Auth header for token requests by overriding `_oauth2.getOAuthAccessToken` method
- Updated `OAuthClient.rotateToken` to use HTTP Basic Auth when refreshing tokens

## Configuration

The cat authentication method can be configured in three ways:

### Option 1: Environment Variable
```bash
OIDC_TOKEN_ENDPOINT_AUTH_METHOD=client_secret_basic
```

### Option 2: Automatic Discovery
```bash
OIDC_ISSUER_URL=https://your-provider.com
# Will automatically detect supported methods from /.well-known/openid-configuration
```

### Option 3: Manual Configuration
```bash
OIDC_AUTH_URI=https://provider.com/oauth/authorize
OIDC_TOKEN_URI=https://provider.com/oauth/token
OIDC_USERINFO_URI=https://provider.com/oauth/userinfo
OIDC_TOKEN_ENDPOINT_AUTH_METHOD=client_secret_basic
```

## Testing

Tested with:
- yarn test