### PR TITLE
fix: Update mention search query during IME compositionupdate

### DIFF
--- a/shared/editor/plugins/SuggestionsMenuPlugin.ts
+++ b/shared/editor/plugins/SuggestionsMenuPlugin.ts
@@ -27,6 +27,37 @@ export class SuggestionsMenuPlugin extends Plugin {
   ) {
     super({
       props: {
+        handleDOMEvents: {
+          // IME composition (e.g. Korean, Japanese, Chinese) fires compositionupdate
+          // as each character is being built up. ProseMirror's view.composing flag
+          // blocks the normal handleKeyDown path, so we handle it separately here.
+          compositionupdate: (view) => {
+            setTimeout(() => {
+              const { pos: fromPos } = view.state.selection.$from;
+              const state = view.state;
+              const $from = state.doc.resolve(fromPos);
+              if ($from.parent.type.spec.code) {
+                return;
+              }
+              const textBefore = $from.parent.textBetween(
+                Math.max(0, $from.parentOffset - MAX_MATCH),
+                $from.parentOffset,
+                undefined,
+                "\ufffc"
+              );
+              const match = openRegex.exec(textBefore);
+              action(() => {
+                if (match) {
+                  if (match[0].length <= 2) {
+                    extensionState.open = true;
+                  }
+                  extensionState.query = match[1];
+                }
+              })();
+            });
+            return false;
+          },
+        },
         handleKeyDown: (view, event) => {
           // Prosemirror input rules are not triggered on backspace, however
           // we need them to be evaluted for the filter trigger to work


### PR DESCRIPTION
#11943 Added a `compositionupdate` DOM event handler in `SuggestionsMenuPlugin.ts`. This event fires on every keystroke during IME composition, allowing us to read the current text from the ProseMirror document and update the search query in real-time — bypassing the `view.composing` guard that was intended only for other purposes.

A `setTimeout` is used (consistent with the existing `handleKeyDown` pattern) to let ProseMirror sync the document before reading `textBefore`.

https://github.com/user-attachments/assets/b3e0ccd7-0a92-4fd1-8bc2-b1f1da336be4

my reference: https://developer.mozilla.org/en-US/docs/Web/API/Element/compositionupdate_event

---

**Notes for reviewers**

I'm a first-time contributor and not fully familiar with the testing setup for this project. If there are existing tests that should be updated, or if a new test case is needed for this fix, I'd appreciate any guidance on how to proceed.

Happy to make any changes based on your feedback!

_Assisted by Claude_