### PR TITLE
fix: Breadcrumb item text disappearing when document has icon

### DIFF
--- a/app/components/Breadcrumb.tsx
+++ b/app/components/Breadcrumb.tsx
@@ -113,19 +113,15 @@ const Item = styled(Link)<{ $highlight: boolean; $withIcon: boolean }>`
   ${ellipsis()}
   ${undraggableOnDesktop()}
 
-  display: flex;
   flex-shrink: 1;
   min-width: 0;
   cursor: var(--pointer);
   color: ${s("text")};
   font-size: 15px;
   height: 24px;
+  line-height: 24px;
   font-weight: ${(props) => (props.$highlight ? "500" : "inherit")};
   margin-left: ${(props) => (props.$withIcon ? "4px" : "0")};
-
-  svg {
-    flex-shrink: 0;
-  }
 
   &:hover {
     text-decoration: underline;

--- a/app/components/DocumentBreadcrumb.tsx
+++ b/app/components/DocumentBreadcrumb.tsx
@@ -101,11 +101,16 @@ function DocumentBreadcrumb(
             <DocumentName
               documentId={node.id}
               collection={collection}
-              icon={node.icon}
-              color={node.color}
               title={title}
             />
           ),
+          icon: node.icon ? (
+            <StyledIcon
+              value={node.icon}
+              color={node.color}
+              initial={title.charAt(0).toUpperCase()}
+            />
+          ) : undefined,
           section: ActiveDocumentSection,
           to: {
             pathname: node.url,
@@ -197,14 +202,10 @@ const CollectionName = observer(function CollectionName_({
 const DocumentName = observer(function DocumentName_({
   documentId,
   collection,
-  icon,
-  color,
   title,
 }: {
   documentId: string;
   collection: Collection | undefined;
-  icon: string | undefined;
-  color: string | undefined;
   title: string;
 }) {
   const { t } = useTranslation();
@@ -212,21 +213,8 @@ const DocumentName = observer(function DocumentName_({
   const doc = documents.get(documentId);
   const menuAction = useDocumentMenuAction({ documentId });
 
-  const content = icon ? (
-    <>
-      <StyledIcon
-        value={icon}
-        color={color}
-        initial={title.charAt(0).toUpperCase()}
-      />{" "}
-      {title}
-    </>
-  ) : (
-    title
-  );
-
   if (!doc) {
-    return <>{content}</>;
+    return <>{title}</>;
   }
 
   return (
@@ -236,7 +224,7 @@ const DocumentName = observer(function DocumentName_({
       }}
     >
       <ContextMenu action={menuAction} ariaLabel={t("Document options")}>
-        <span>{content}</span>
+        <span>{title}</span>
       </ContextMenu>
     </ActionContextProvider>
   );


### PR DESCRIPTION
## Summary
- Fixes #11942 — breadcrumb document name text disappears when the document has an icon
- Moves document icons out of the ContextMenu trigger `<span>` and into the action's `icon` property, rendered as a sibling flex item outside the link — consistent with how collection icons already work
- Block-level icon elements (FontAwesome wrapper, custom emoji) inside the inline span were taking a full line and pushing text below the `overflow: hidden` clip
- Removes `display: flex` from breadcrumb `Item` so `text-overflow: ellipsis` works correctly for truncation

## Test plan
- [ ] Navigate to a document nested under a parent that has an icon (FontAwesome or emoji)
- [ ] Verify the parent document name text is visible in the breadcrumb alongside its icon
- [ ] Verify text truncation with ellipsis works when the breadcrumb is narrow
- [ ] Verify right-click context menu still works on breadcrumb items

🤖 Generated with [Claude Code](https://claude.com/claude-code)