### PR TITLE
Copy fullWidth property when duplicating documents

### DIFF
--- a/server/commands/documentDuplicator.test.ts
+++ b/server/commands/documentDuplicator.test.ts
@@ -200,4 +200,64 @@ describe("documentDuplicator", () => {
     );
     expect(duplicatedChild?.sourceMetadata?.fileName).toEqual("child.md");
   });
+
+  it("should copy fullWidth property when duplicating document", async () => {
+    const user = await buildUser();
+    const original = await buildDocument({
+      userId: user.id,
+      teamId: user.teamId,
+      fullWidth: true,
+    });
+
+    const response = await withAPIContext(user, (ctx) =>
+      documentDuplicator(ctx, {
+        document: original,
+        collection: original.collection,
+      })
+    );
+
+    expect(response).toHaveLength(1);
+    expect(response[0].fullWidth).toBe(true);
+  });
+
+  it("should copy fullWidth property to child documents when duplicating recursively", async () => {
+    const user = await buildUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+
+    const original = await buildDocument({
+      userId: user.id,
+      teamId: user.teamId,
+      fullWidth: true,
+      collectionId: collection.id,
+    });
+
+    const childDocument = await buildDocument({
+      userId: user.id,
+      teamId: user.teamId,
+      parentDocumentId: original.id,
+      fullWidth: true,
+      collectionId: collection.id,
+    });
+
+    const response = await withAPIContext(user, (ctx) =>
+      documentDuplicator(ctx, {
+        document: original,
+        collection: original.collection,
+        recursive: true,
+      })
+    );
+
+    expect(response).toHaveLength(2);
+
+    // Check parent document
+    const duplicatedParent = response.find((doc) => !doc.parentDocumentId);
+    expect(duplicatedParent?.fullWidth).toBe(true);
+
+    // Check child document
+    const duplicatedChild = response.find((doc) => doc.parentDocumentId);
+    expect(duplicatedChild?.fullWidth).toBe(true);
+  });
 });

--- a/server/commands/documentDuplicator.test.ts
+++ b/server/commands/documentDuplicator.test.ts
@@ -234,7 +234,7 @@ describe("documentDuplicator", () => {
       collectionId: collection.id,
     });
 
-    const childDocument = await buildDocument({
+    await buildDocument({
       userId: user.id,
       teamId: user.teamId,
       parentDocumentId: original.id,

--- a/server/commands/documentDuplicator.ts
+++ b/server/commands/documentDuplicator.ts
@@ -35,6 +35,7 @@ export default async function documentDuplicator(
     parentDocumentId,
     icon: document.icon,
     color: document.color,
+    fullWidth: document.fullWidth,
     title: title ?? document.title,
     content: ProsemirrorHelper.removeMarks(
       DocumentHelper.toProsemirror(document),
@@ -85,6 +86,7 @@ export default async function documentDuplicator(
         parentDocumentId: duplicatedDocument.id,
         icon: childDocument.icon,
         color: childDocument.color,
+        fullWidth: childDocument.fullWidth,
         title: childDocument.title,
         content: ProsemirrorHelper.removeMarks(
           DocumentHelper.toProsemirror(childDocument),

--- a/server/routes/api/documents/documents.test.ts
+++ b/server/routes/api/documents/documents.test.ts
@@ -5661,27 +5661,6 @@ describe("#documents.duplicate", () => {
     expect(body.data.documents[0].fullWidth).toBe(true);
   });
 
-  it("should duplicate a document with fullWidth=false property", async () => {
-    const user = await buildUser();
-    const document = await buildDocument({
-      userId: user.id,
-      teamId: user.teamId,
-      fullWidth: false,
-    });
-
-    const res = await server.post("/api/documents.duplicate", {
-      body: {
-        token: user.getJwtToken(),
-        id: document.id,
-      },
-    });
-    const body = await res.json();
-
-    expect(res.status).toEqual(200);
-    expect(body.data.documents).toHaveLength(1);
-    expect(body.data.documents[0].fullWidth).toBe(false);
-  });
-
   it("should duplicate child documents with fullWidth property when recursive=true", async () => {
     const user = await buildUser();
     const collection = await buildCollection({
@@ -5701,9 +5680,6 @@ describe("#documents.duplicate", () => {
       parentDocumentId: parent.id,
       fullWidth: true,
     });
-
-    await collection.addDocumentToStructure(parent);
-    await collection.addDocumentToStructure(child);
 
     const res = await server.post("/api/documents.duplicate", {
       body: {

--- a/server/routes/api/documents/documents.test.ts
+++ b/server/routes/api/documents/documents.test.ts
@@ -5673,7 +5673,7 @@ describe("#documents.duplicate", () => {
       collectionId: collection.id,
       fullWidth: true,
     });
-    const child = await buildDocument({
+    await buildDocument({
       userId: user.id,
       teamId: user.teamId,
       collectionId: collection.id,

--- a/server/routes/api/documents/documents.test.ts
+++ b/server/routes/api/documents/documents.test.ts
@@ -5634,6 +5634,94 @@ describe("#documents.memberships", () => {
   });
 });
 
+describe("#documents.duplicate", () => {
+  it("should require authentication", async () => {
+    const res = await server.post("/api/documents.duplicate");
+    const body = await res.json();
+    expect(res.status).toEqual(401);
+  });
+
+  it("should duplicate a document with fullWidth property", async () => {
+    const user = await buildUser();
+    const document = await buildDocument({
+      userId: user.id,
+      teamId: user.teamId,
+      fullWidth: true,
+    });
+
+    const res = await server.post("/api/documents.duplicate", {
+      body: {
+        token: user.getJwtToken(),
+        id: document.id,
+      },
+    });
+    const body = await res.json();
+
+    expect(res.status).toEqual(200);
+    expect(body.data.documents).toHaveLength(1);
+    expect(body.data.documents[0].fullWidth).toBe(true);
+  });
+
+  it("should duplicate a document with fullWidth=false property", async () => {
+    const user = await buildUser();
+    const document = await buildDocument({
+      userId: user.id,
+      teamId: user.teamId,
+      fullWidth: false,
+    });
+
+    const res = await server.post("/api/documents.duplicate", {
+      body: {
+        token: user.getJwtToken(),
+        id: document.id,
+      },
+    });
+    const body = await res.json();
+
+    expect(res.status).toEqual(200);
+    expect(body.data.documents).toHaveLength(1);
+    expect(body.data.documents[0].fullWidth).toBe(false);
+  });
+
+  it("should duplicate child documents with fullWidth property when recursive=true", async () => {
+    const user = await buildUser();
+    const collection = await buildCollection({
+      userId: user.id,
+      teamId: user.teamId,
+    });
+    const parent = await buildDocument({
+      userId: user.id,
+      teamId: user.teamId,
+      collectionId: collection.id,
+      fullWidth: true,
+    });
+    const child = await buildDocument({
+      userId: user.id,
+      teamId: user.teamId,
+      collectionId: collection.id,
+      parentDocumentId: parent.id,
+      fullWidth: true,
+    });
+
+    await collection.addDocumentToStructure(parent);
+    await collection.addDocumentToStructure(child);
+
+    const res = await server.post("/api/documents.duplicate", {
+      body: {
+        token: user.getJwtToken(),
+        id: parent.id,
+        recursive: true,
+      },
+    });
+    const body = await res.json();
+
+    expect(res.status).toEqual(200);
+    expect(body.data.documents).toHaveLength(2);
+    expect(body.data.documents[0].fullWidth).toBe(true);
+    expect(body.data.documents[1].fullWidth).toBe(true);
+  });
+});
+
 describe("#documents.empty_trash", () => {
   it("should require authentication", async () => {
     const res = await server.post("/api/documents.empty_trash");

--- a/server/routes/api/documents/documents.test.ts
+++ b/server/routes/api/documents/documents.test.ts
@@ -5637,7 +5637,6 @@ describe("#documents.memberships", () => {
 describe("#documents.duplicate", () => {
   it("should require authentication", async () => {
     const res = await server.post("/api/documents.duplicate");
-    const body = await res.json();
     expect(res.status).toEqual(401);
   });
 


### PR DESCRIPTION
The `fullWidth` property was not being copied when documents were duplicated, causing duplicates to lose this setting.

## Changes

- **documentDuplicator.ts**: Pass `fullWidth` property when creating duplicated documents and their children
- **documentDuplicator.test.ts**: Add tests verifying `fullWidth` is copied for both single and recursive duplication
- **documents.test.ts**: Add API integration tests for the `documents.duplicate` endpoint

The fix follows the existing pattern used for `icon` and `color` properties:

```typescript
const duplicated = await documentCreator(ctx, {
  parentDocumentId,
  icon: document.icon,
  color: document.color,
  fullWidth: document.fullWidth,  // Added
  title: title ?? document.title,
  // ...
});
```