### PR TITLE
feature: Add dark mode option to landing page

### DIFF
--- a/app/components/ThemeToggle.tsx
+++ b/app/components/ThemeToggle.tsx
@@ -1,0 +1,46 @@
+import { observer } from "mobx-react";
+import { MoonIcon, SunIcon } from "outline-icons";
+import { useTranslation } from "react-i18next";
+import Button from "~/components/Button";
+import Tooltip from "~/components/Tooltip";
+import useStores from "~/hooks/useStores";
+import { Theme } from "~/stores/UiStore";
+
+export default observer(function ThemeToggle() {
+  const { t } = useTranslation();
+  const { ui } = useStores();
+  const { resolvedTheme, themeOverride } = ui;
+
+  if (themeOverride) {
+    return null;
+  }
+
+  const handleToggle = () => {
+    const newTheme =
+      resolvedTheme === "light" ? Theme.Dark : Theme.Light;
+    ui.setTheme(newTheme);
+  };
+
+  return (
+    <Tooltip
+      content={
+        resolvedTheme === "light"
+          ? t("Switch to dark")
+          : t("Switch to light")
+      }
+      placement="bottom"
+    >
+      <Button
+        icon={resolvedTheme === "light" ? <SunIcon /> : <MoonIcon />}
+        onClick={handleToggle}
+        aria-label={
+          resolvedTheme === "light"
+            ? t("Switch to dark")
+            : t("Switch to light")
+        }
+        neutral
+        borderOnHover
+      />
+    </Tooltip>
+  );
+});

--- a/app/scenes/Login/Login.tsx
+++ b/app/scenes/Login/Login.tsx
@@ -14,6 +14,7 @@ import type { Config } from "~/stores/AuthStore";
 import { AvatarSize } from "~/components/Avatar";
 import ButtonLarge from "~/components/ButtonLarge";
 import ChangeLanguage from "~/components/ChangeLanguage";
+import ThemeToggle from "~/components/ThemeToggle";
 import Flex from "~/components/Flex";
 import Heading from "~/components/Heading";
 import OutlineIcon from "~/components/Icons/OutlineIcon";
@@ -121,6 +122,7 @@ function Login({ children, onBack }: Props) {
       <Background>
         <BackButton onBack={onBack} />
         <ChangeLanguage locale={detectLanguage()} />
+        <ThemeToggle />
         <Centered>
           <PageTitle title={t("Login")} />
           <Heading centered>{t("Error")}</Heading>
@@ -153,6 +155,7 @@ function Login({ children, onBack }: Props) {
       <Background>
         <BackButton onBack={onBack} config={config} />
         <ChangeLanguage locale={detectLanguage()} />
+        <ThemeToggle />
         <Centered>
           <PageTitle title={t("Custom domain setup")} />
           <Heading centered>{t("Almost there")}…</Heading>
@@ -171,6 +174,7 @@ function Login({ children, onBack }: Props) {
       <Background>
         <BackButton onBack={onBack} config={config} />
         <ChangeLanguage locale={detectLanguage()} />
+        <ThemeToggle />
 
         <Centered as="form" onSubmit={handleGoSubdomain}>
           <Heading centered>{t("Choose workspace")}</Heading>
@@ -221,6 +225,7 @@ function Login({ children, onBack }: Props) {
     return (
       <Background>
         <BackButton onBack={onBack} config={config} />
+        <ThemeToggle />
         <Centered>
           <PageTitle title={t("Check your email")} />
           <CheckEmailIcon size={38} />
@@ -286,6 +291,7 @@ function Login({ children, onBack }: Props) {
     <Background>
       <BackButton onBack={onBack} config={config} />
       <ChangeLanguage locale={detectLanguage()} />
+      <ThemeToggle />
 
       <Centered gap={12}>
         <PageTitle


### PR DESCRIPTION
## Add Dark Mode Toggle to Login Page

Add a theme toggle button on the login page so users can switch between light and dark modes. The choice is saved and remembered.

### What Changed
- New `ThemeToggle` component with sun/moon icon
- Added toggle to all login screens

Thank You!