### PR TITLE
chore: Stagger cron cleanup tasks

### DIFF
--- a/server/queues/tasks/base/CronTask.test.ts
+++ b/server/queues/tasks/base/CronTask.test.ts
@@ -1,4 +1,5 @@
 import { Op } from "sequelize";
+import { Minute } from "@shared/utils/time";
 import type { PartitionInfo } from "./CronTask";
 import { CronTask, TaskInterval } from "./CronTask";
 
@@ -27,6 +28,71 @@ describe("CronTask", () => {
 
   beforeEach(() => {
     task = new TestTask();
+  });
+
+  describe("getStaggerDelay", () => {
+    it("should return a deterministic delay for the same task name", () => {
+      const delay1 = CronTask.getStaggerDelay("TaskA", TaskInterval.Hour);
+      const delay2 = CronTask.getStaggerDelay("TaskA", TaskInterval.Hour);
+      expect(delay1).toBe(delay2);
+    });
+
+    it("should return different delays for different task names", () => {
+      const delayA = CronTask.getStaggerDelay(
+        "CleanupDeletedDocumentsTask",
+        TaskInterval.Hour
+      );
+      const delayB = CronTask.getStaggerDelay(
+        "CleanupOldEventsTask",
+        TaskInterval.Hour
+      );
+      expect(delayA).not.toBe(delayB);
+    });
+
+    it("should stay within the hourly stagger window (10 minutes)", () => {
+      const names = [
+        "CleanupDeletedDocumentsTask",
+        "CleanupOldEventsTask",
+        "CleanupOldNotificationsTask",
+        "CleanupDeletedTeamsTask",
+        "CleanupExpiredAttachmentsTask",
+        "CleanupExpiredFileOperationsTask",
+      ];
+      for (const name of names) {
+        const delay = CronTask.getStaggerDelay(name, TaskInterval.Hour);
+        expect(delay).toBeGreaterThanOrEqual(0);
+        expect(delay).toBeLessThan(10 * Minute.ms);
+      }
+    });
+
+    it("should stay within the daily stagger window (30 minutes)", () => {
+      const names = [
+        "CleanupOAuthAuthorizationCodeTask",
+        "CleanupDynamicOAuthClientsTask",
+        "CleanupOldImportsTask",
+      ];
+      for (const name of names) {
+        const delay = CronTask.getStaggerDelay(name, TaskInterval.Day);
+        expect(delay).toBeGreaterThanOrEqual(0);
+        expect(delay).toBeLessThan(30 * Minute.ms);
+      }
+    });
+
+    it("should distribute delays across the window for real task names", () => {
+      const names = [
+        "CleanupDeletedDocumentsTask",
+        "CleanupOldEventsTask",
+        "CleanupOldNotificationsTask",
+        "CleanupDeletedTeamsTask",
+        "CleanupExpiredAttachmentsTask",
+        "CleanupExpiredFileOperationsTask",
+      ];
+      const delays = names.map((name) =>
+        CronTask.getStaggerDelay(name, TaskInterval.Hour)
+      );
+      const unique = new Set(delays);
+      expect(unique.size).toBe(delays.length);
+    });
   });
 
   describe("getPartitionWhereClause", () => {

--- a/server/queues/tasks/base/CronTask.ts
+++ b/server/queues/tasks/base/CronTask.ts
@@ -73,8 +73,8 @@ export abstract class CronTask extends BaseTask<Props> {
 
   /**
    * Compute a deterministic delay for a task based on its name and interval.
-   * Different tasks get different offsets within the stagger window for their
-   * interval, preventing concurrent heavy database operations.
+   * Different tasks are likely to get different offsets within the stagger
+   * window for their interval, reducing concurrent heavy database operations.
    *
    * @param taskName the name of the task class.
    * @param interval the task interval used to select the stagger window.

--- a/server/queues/tasks/base/CronTask.ts
+++ b/server/queues/tasks/base/CronTask.ts
@@ -1,11 +1,21 @@
 import type { WhereOptions } from "sequelize";
 import { Op } from "sequelize";
+import { Minute } from "@shared/utils/time";
 import { BaseTask } from "./BaseTask";
 
 export enum TaskInterval {
   Day = "daily",
   Hour = "hourly",
 }
+
+/**
+ * Stagger windows per interval to spread task start times and prevent
+ * concurrent heavy database operations from saturating PostgreSQL.
+ */
+const staggerWindows: Record<TaskInterval, number> = {
+  [TaskInterval.Hour]: 10 * Minute.ms,
+  [TaskInterval.Day]: 30 * Minute.ms,
+};
 
 export type TaskSchedule = {
   /** The interval at which to run this task */
@@ -60,6 +70,27 @@ export type Props = {
 export abstract class CronTask extends BaseTask<Props> {
   /** The schedule configuration for this cron task */
   public abstract get cron(): TaskSchedule;
+
+  /**
+   * Compute a deterministic delay for a task based on its name and interval.
+   * Different tasks get different offsets within the stagger window for their
+   * interval, preventing concurrent heavy database operations.
+   *
+   * @param taskName the name of the task class.
+   * @param interval the task interval used to select the stagger window.
+   * @returns a delay in milliseconds.
+   */
+  public static getStaggerDelay(
+    taskName: string,
+    interval: TaskInterval
+  ): number {
+    const windowMs = staggerWindows[interval];
+    let hash = 0;
+    for (let i = 0; i < taskName.length; i++) {
+      hash = ((hash << 5) - hash + taskName.charCodeAt(i)) | 0;
+    }
+    return Math.abs(hash) % windowMs;
+  }
 
   /**
    * Optimized partitioning method for UUID primary keys using range-based distribution.

--- a/server/routes/api/cron/cron.ts
+++ b/server/routes/api/cron/cron.ts
@@ -48,13 +48,18 @@ const cronHandler = async (ctx: APIContext<T.CronSchemaReq>) => {
         period === TaskInterval.Day);
 
     if (shouldSchedule) {
+      // Stagger different tasks so they don't all hit the database at once
+      const taskDelay = CronTask.getStaggerDelay(name, cronConfig.interval);
+
       if (partitionWindow && partitionWindow > 0) {
         // Split the task into partitions to spread work across time window
         // by dividing the partitionWindow into minutes and scheduling a delayed
-        // task for each minute.
+        // task for each minute. The taskDelay offsets the entire partition
+        // window so different tasks don't overlap.
         const partitions = Math.ceil(partitionWindow / Minute.ms);
         for (let i = 0; i < partitions; i++) {
-          const delay = Math.floor((partitionWindow / partitions) * i);
+          const delay =
+            taskDelay + Math.floor((partitionWindow / partitions) * i);
           const partition = {
             partitionIndex: i,
             partitionCount: partitions,
@@ -70,13 +75,16 @@ const cronHandler = async (ctx: APIContext<T.CronSchemaReq>) => {
           await taskInstance.schedule({ limit, partition }, { delay });
         }
       } else {
-        await taskInstance.schedule({
-          limit,
-          partition: {
-            partitionIndex: 0,
-            partitionCount: 1,
+        await taskInstance.schedule(
+          {
+            limit,
+            partition: {
+              partitionIndex: 0,
+              partitionCount: 1,
+            },
           },
-        });
+          { delay: taskDelay }
+        );
       }
     }
   }


### PR DESCRIPTION
Adds a deterministic stagger to tasks triggered from cron so that heavy cleanup tasks do not always hit the database at the same moment.