### PR TITLE
feat: support S3 PUT method

### DIFF
--- a/app/utils/files.ts
+++ b/app/utils/files.ts
@@ -62,19 +62,13 @@ export const uploadFile = async (
   invariant(response, "Response should be available");
   const data = response.data;
   const attachment = data.attachment;
-  const formData = new FormData();
-
-  for (const key in data.form) {
-    formData.append(key, data.form[key]);
-  }
-
-  // @ts-expect-error ts-migrate(2339) FIXME: Property 'blob' does not exist on type 'File | Blo... Remove this comment to see the full error message
-  if (file.blob) {
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'file' does not exist on type 'File | Blo... Remove this comment to see the full error message
-    formData.append("file", file.file);
-  } else {
-    formData.append("file", file);
-  }
+  const uploadMethod = data.uploadMethod ?? "POST";
+  const uploadBody =
+    // @ts-expect-error ts-migrate(2339) FIXME: Property 'blob' does not exist on type 'File | Blo... Remove this comment to see the full error message
+    file.blob
+      ? // @ts-expect-error ts-migrate(2339) FIXME: Property 'file' does not exist on type 'File | Blo... Remove this comment to see the full error message
+        file.file
+      : file;
 
   // Using XMLHttpRequest instead of fetch because fetch doesn't support progress
   const xhr = new XMLHttpRequest();
@@ -105,7 +99,23 @@ export const uploadFile = async (
       xhr.withCredentials = !requiresPreflightRequest;
     }
 
-    xhr.open("POST", data.uploadUrl, true);
+    xhr.open(uploadMethod, data.uploadUrl, true);
+
+    if (uploadMethod === "PUT") {
+      for (const [key, value] of Object.entries(
+        (data.headers ?? {}) as Record<string, string>
+      )) {
+        xhr.setRequestHeader(key, value);
+      }
+      xhr.send(uploadBody);
+      return;
+    }
+
+    const formData = new FormData();
+    for (const key in data.form) {
+      formData.append(key, data.form[key]);
+    }
+    formData.append("file", uploadBody);
     xhr.send(formData);
   });
 

--- a/server/env.ts
+++ b/server/env.ts
@@ -629,6 +629,14 @@ export class Environment {
   public AWS_S3_ACL = environment.AWS_S3_ACL ?? "private";
 
   /**
+   * Upload method for S3-compatible storage providers.
+   * Defaults to POST for compatibility with existing S3 setups.
+   */
+  @IsOptional()
+  @IsIn(["post", "put"])
+  public AWS_S3_UPLOAD_METHOD = environment.AWS_S3_UPLOAD_METHOD ?? "post";
+
+  /**
    * Which file storage system to use
    */
   @IsIn(["local", "s3"])

--- a/server/routes/api/attachments/attachments.ts
+++ b/server/routes/api/attachments/attachments.ts
@@ -145,15 +145,17 @@ router.post(
       maxUploadSize,
       contentType
     );
+    const uploadMethod = presignedPost.method ?? "POST";
+    const uploadUrl = presignedPost.url || FileStorage.getUploadUrl();
+    const form = uploadMethod === "POST" ? presignedPost.fields : {};
+    const headers = uploadMethod === "PUT" ? presignedPost.fields : {};
 
     ctx.body = {
       data: {
-        uploadUrl: FileStorage.getUploadUrl(),
-        form: {
-          "Cache-Control": "max-age=31557600",
-          "Content-Type": contentType,
-          ...presignedPost.fields,
-        },
+        uploadMethod,
+        uploadUrl,
+        form,
+        headers,
         attachment: {
           ...presentAttachment(attachment),
           url: attachment.redirectUrl,

--- a/server/storage/files/BaseStorage.test.ts
+++ b/server/storage/files/BaseStorage.test.ts
@@ -1,5 +1,7 @@
 import BaseStorage from "./BaseStorage";
+import type { PresignedUpload } from "./BaseStorage";
 import env from "@server/env";
+import type { AppContext } from "@server/types";
 
 /**
  * Mock implementation of BaseStorage for testing purposes.
@@ -12,8 +14,18 @@ class MockStorage extends BaseStorage {
     acl?: string;
   }> = [];
 
-  async getPresignedPost() {
-    return {};
+  public async getPresignedPost(
+    _ctx: AppContext,
+    key: string,
+    _acl: string,
+    _maxUploadSize: number,
+    _contentType: string
+  ): Promise<PresignedUpload> {
+    return {
+      method: "PUT",
+      url: this.getUrlForKey(key),
+      fields: {},
+    };
   }
 
   async getFileStream() {

--- a/server/storage/files/BaseStorage.ts
+++ b/server/storage/files/BaseStorage.ts
@@ -1,6 +1,5 @@
 import type { Blob } from "node:buffer";
 import type { Readable } from "node:stream";
-import type { PresignedPost } from "@aws-sdk/s3-presigned-post";
 import omit from "lodash/omit";
 import FileHelper from "@shared/editor/lib/FileHelper";
 import { isBase64Url, isInternalUrl } from "@shared/utils/urls";
@@ -10,6 +9,12 @@ import Logger from "@server/logging/Logger";
 import type { RequestInit } from "@server/utils/fetch";
 import fetch, { chromeUserAgent } from "@server/utils/fetch";
 import type { AppContext } from "@server/types";
+
+export interface PresignedUpload {
+  method: "POST" | "PUT";
+  url: string;
+  fields: Record<string, string>;
+}
 
 export default abstract class BaseStorage {
   /** The default number of seconds until a signed URL expires. */
@@ -22,14 +27,14 @@ export default abstract class BaseStorage {
   public static maxSignedUrlExpires = Week.seconds;
 
   /**
-   * Returns a presigned post for uploading files to the storage provider.
+   * Returns a presigned upload for uploading files to the storage provider.
    *
    * @param ctx The request context
    * @param key The path to store the file at
    * @param acl The ACL to use
    * @param maxUploadSize The maximum upload size in bytes
    * @param contentType The content type of the file
-   * @returns The presigned post object to use on the client (TODO: Abstract away from S3)
+   * @returns The presigned upload object to use on the client.
    */
   public abstract getPresignedPost(
     ctx: AppContext,
@@ -37,7 +42,7 @@ export default abstract class BaseStorage {
     acl: string,
     maxUploadSize: number,
     contentType: string
-  ): Promise<Partial<PresignedPost>>;
+  ): Promise<PresignedUpload>;
 
   /**
    * Returns a promise that resolves with a stream for reading a file from the storage provider.

--- a/server/storage/files/LocalStorage.ts
+++ b/server/storage/files/LocalStorage.ts
@@ -2,7 +2,6 @@ import { Blob } from "node:buffer";
 import { mkdir, unlink, rmdir } from "node:fs/promises";
 import path from "node:path";
 import { Readable } from "node:stream";
-import type { PresignedPost } from "@aws-sdk/s3-presigned-post";
 import fs from "fs-extra";
 import invariant from "invariant";
 import JWT from "jsonwebtoken";
@@ -11,6 +10,7 @@ import env from "@server/env";
 import { InternalError, ValidationError } from "@server/errors";
 import Logger from "@server/logging/Logger";
 import BaseStorage from "./BaseStorage";
+import type { PresignedUpload } from "./BaseStorage";
 import { CSRF } from "@shared/constants";
 import type { AppContext } from "@server/types";
 
@@ -21,8 +21,9 @@ export default class LocalStorage extends BaseStorage {
     acl: string,
     maxUploadSize: number,
     contentType = "image"
-  ): Promise<Partial<PresignedPost>> {
+  ): Promise<PresignedUpload> {
     return Promise.resolve({
+      method: "POST",
       url: this.getUrlForKey(key),
       fields: {
         key,

--- a/server/storage/files/S3Storage.test.ts
+++ b/server/storage/files/S3Storage.test.ts
@@ -1,7 +1,75 @@
+import { createPresignedPost } from "@aws-sdk/s3-presigned-post";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { Week, Day } from "@shared/utils/time";
+import env from "@server/env";
 import BaseStorage from "./BaseStorage";
+import S3Storage from "./S3Storage";
 
 describe("S3Storage", () => {
+  describe("getPresignedPost upload method", () => {
+    const mockedCreatePresignedPost = jest.mocked(createPresignedPost);
+    const mockedGetSignedUrl = jest.mocked(getSignedUrl);
+    const defaultUploadMethod = env.AWS_S3_UPLOAD_METHOD;
+
+    beforeEach(() => {
+      jest.resetAllMocks();
+      env.AWS_S3_UPLOAD_BUCKET_NAME = "test-bucket";
+      env.AWS_S3_UPLOAD_BUCKET_URL = "https://s3.eu-west-1.amazonaws.com";
+      env.AWS_S3_ACL = "private";
+    });
+
+    afterEach(() => {
+      env.AWS_S3_UPLOAD_METHOD = defaultUploadMethod;
+    });
+
+    it("should default to post upload method", async () => {
+      mockedCreatePresignedPost.mockResolvedValue({
+        url: "https://upload.example.com",
+        fields: {
+          key: "test-key",
+        },
+      });
+      delete process.env.AWS_S3_UPLOAD_METHOD;
+      env.AWS_S3_UPLOAD_METHOD = "post";
+
+      const storage = new S3Storage();
+      const result = await storage.getPresignedPost(
+        {} as never,
+        "test-key",
+        "private",
+        1024,
+        "image/png"
+      );
+
+      expect(result.method).toBe("POST");
+      expect(mockedCreatePresignedPost).toHaveBeenCalledTimes(1);
+      expect(mockedGetSignedUrl).not.toHaveBeenCalled();
+    });
+
+    it("should use put upload method when configured", async () => {
+      mockedGetSignedUrl.mockResolvedValue("https://signed-put.example.com");
+      env.AWS_S3_UPLOAD_METHOD = "put";
+
+      const storage = new S3Storage();
+      const result = await storage.getPresignedPost(
+        {} as never,
+        "test-key",
+        "private",
+        1024,
+        "image/png"
+      );
+
+      expect(result.method).toBe("PUT");
+      expect(result.url).toBe("https://signed-put.example.com");
+      expect(result.fields).toMatchObject({
+        "Content-Type": "image/png",
+        "Cache-Control": "max-age=31557600",
+      });
+      expect(mockedGetSignedUrl).toHaveBeenCalledTimes(1);
+      expect(mockedCreatePresignedPost).not.toHaveBeenCalled();
+    });
+  });
+
   describe("getSignedUrl expiration limits", () => {
     it("should define maximum expiration as 7 days for AWS S3 Signature V4", () => {
       // AWS S3 Signature V4 presigned URLs have a maximum expiration of 7 days

--- a/server/storage/files/S3Storage.ts
+++ b/server/storage/files/S3Storage.ts
@@ -7,6 +7,7 @@ import {
   GetObjectCommand,
   HeadObjectCommand,
   CopyObjectCommand,
+  PutObjectCommand,
 } from "@aws-sdk/client-s3";
 import { Upload } from "@aws-sdk/lib-storage";
 import "@aws-sdk/signature-v4-crt"; // https://github.com/aws/aws-sdk-js-v3#functionality-requiring-aws-common-runtime-crt
@@ -20,6 +21,7 @@ import tmp from "tmp";
 import env from "@server/env";
 import Logger from "@server/logging/Logger";
 import BaseStorage from "./BaseStorage";
+import type { PresignedUpload } from "./BaseStorage";
 import type { AppContext } from "@server/types";
 
 export default class S3Storage extends BaseStorage {
@@ -27,7 +29,7 @@ export default class S3Storage extends BaseStorage {
     super();
 
     this.client = new S3Client({
-      bucketEndpoint: env.AWS_S3_ACCELERATE_URL ? true : false,
+      bucketEndpoint: this.shouldUseBucketEndpoint(),
       forcePathStyle: env.AWS_S3_FORCE_PATH_STYLE,
       region: env.AWS_REGION,
       endpoint: this.getEndpoint(),
@@ -40,24 +42,65 @@ export default class S3Storage extends BaseStorage {
     _acl: string,
     maxUploadSize: number,
     contentType = "image"
-  ) {
-    const params: PresignedPostOptions = {
-      Bucket: env.AWS_S3_UPLOAD_BUCKET_NAME as string,
-      Key: key,
-      Conditions: compact([
-        ["content-length-range", 0, maxUploadSize],
-        ["starts-with", "$Content-Type", contentType],
-        ["starts-with", "$Cache-Control", ""],
-      ]),
-      Fields: {
-        "Content-Disposition": this.getContentDisposition(contentType),
-        key,
-        ...(env.AWS_S3_ACL && { ACL: env.AWS_S3_ACL as ObjectCannedACL }),
-      },
-      Expires: 3600,
+  ): Promise<PresignedUpload> {
+    if (maxUploadSize <= 0) {
+      throw new Error("maxUploadSize must be greater than 0");
+    }
+
+    if (env.AWS_S3_UPLOAD_METHOD === "post") {
+      const params: PresignedPostOptions = {
+        Bucket: this.getBucket(),
+        Key: key,
+        Conditions: compact([
+          ["content-length-range", 0, maxUploadSize],
+          ["starts-with", "$Content-Type", contentType],
+          ["starts-with", "$Cache-Control", ""],
+        ]),
+        Fields: {
+          "Content-Disposition": this.getContentDisposition(contentType),
+          key,
+          ...(env.AWS_S3_ACL && { ACL: env.AWS_S3_ACL as ObjectCannedACL }),
+        },
+        Expires: 3600,
+      };
+      const result = await createPresignedPost(this.client, params);
+
+      return {
+        method: "POST",
+        url: result.url,
+        fields: result.fields,
+      };
+    }
+
+    const contentDisposition = this.getContentDisposition(contentType);
+    const headers: Record<string, string> = {
+      "Cache-Control": "max-age=31557600",
+      "Content-Disposition": contentDisposition,
+      "Content-Type": contentType,
     };
 
-    return createPresignedPost(this.client, params);
+    if (env.AWS_S3_ACL) {
+      headers["x-amz-acl"] = env.AWS_S3_ACL;
+    }
+
+    const putObjectCommand = new PutObjectCommand({
+      ...(env.AWS_S3_ACL && { ACL: env.AWS_S3_ACL as ObjectCannedACL }),
+      Bucket: this.getBucket(),
+      Key: key,
+      ContentType: contentType,
+      CacheControl: headers["Cache-Control"],
+      ContentDisposition: contentDisposition,
+    });
+
+    const url = await getSignedUrl(this.client, putObjectCommand, {
+      expiresIn: 3600,
+    });
+
+    return {
+      method: "PUT",
+      url,
+      fields: headers,
+    };
   }
 
   private getPublicEndpoint(isServerUpload?: boolean) {
@@ -266,7 +309,11 @@ export default class S3Storage extends BaseStorage {
     // checking for the bucket name in the endpoint url.
     if (env.AWS_S3_UPLOAD_BUCKET_NAME) {
       const url = new URL(env.AWS_S3_UPLOAD_BUCKET_URL);
-      if (url.hostname.startsWith(env.AWS_S3_UPLOAD_BUCKET_NAME + ".")) {
+      const isVirtualHost =
+        url.hostname.startsWith(env.AWS_S3_UPLOAD_BUCKET_NAME + ".") &&
+        this.isAwsHostname(url.hostname);
+
+      if (isVirtualHost) {
         Logger.warn(
           "AWS_S3_UPLOAD_BUCKET_URL contains the bucket name, this configuration combination will always point to AWS.\nRename your bucket or hostname if not using AWS S3.\nSee: https://github.com/outline/outline/issues/8025"
         );
@@ -278,6 +325,23 @@ export default class S3Storage extends BaseStorage {
   }
 
   private getBucket() {
-    return env.AWS_S3_ACCELERATE_URL || env.AWS_S3_UPLOAD_BUCKET_NAME || "";
+    return env.AWS_S3_UPLOAD_BUCKET_NAME || "";
+  }
+
+  private shouldUseBucketEndpoint() {
+    if (env.AWS_S3_ACCELERATE_URL) {
+      return true;
+    }
+
+    if (!env.AWS_S3_UPLOAD_BUCKET_NAME || !env.AWS_S3_UPLOAD_BUCKET_URL) {
+      return false;
+    }
+
+    const url = new URL(env.AWS_S3_UPLOAD_BUCKET_URL);
+    return url.hostname.startsWith(`${env.AWS_S3_UPLOAD_BUCKET_NAME}.`);
+  }
+
+  private isAwsHostname(hostname: string) {
+    return hostname === "amazonaws.com" || hostname.endsWith(".amazonaws.com");
   }
 }

--- a/server/test/setup.ts
+++ b/server/test/setup.ts
@@ -18,6 +18,9 @@ jest.mock("@aws-sdk/client-s3", () => ({
   })),
   DeleteObjectCommand: jest.fn(),
   GetObjectCommand: jest.fn(),
+  HeadObjectCommand: jest.fn(),
+  CopyObjectCommand: jest.fn(),
+  PutObjectCommand: jest.fn(),
   ObjectCannedACL: {},
 }));
 

--- a/server/tools/attachments.ts
+++ b/server/tools/attachments.ts
@@ -24,7 +24,7 @@ export function attachmentTools(server: McpServer, scopes: string[]) {
       {
         title: "Create attachment upload",
         description:
-          "Requests a pre-signed upload URL. Use the returned uploadUrl and form fields to upload a file directly via a multipart POST request (e.g. with curl). The returned attachment URL is returned for use in documents.",
+          "Requests a pre-signed upload URL. Depending on storage, upload using either multipart POST form fields or PUT with request headers. The returned attachment URL is returned for use in documents.",
         annotations: {
           idempotentHint: false,
           readOnlyHint: false,
@@ -79,22 +79,27 @@ export function attachmentTools(server: McpServer, scopes: string[]) {
               contentType
             );
 
-            const uploadUrl = FileStorage.getUploadUrl();
-            const form = {
-              "Cache-Control": "max-age=31557600",
-              "Content-Type": contentType,
-              ...presignedPost.fields,
-            };
+            const uploadMethod = presignedPost.method ?? "POST";
+            const uploadUrl = presignedPost.url || FileStorage.getUploadUrl();
+            const form = uploadMethod === "POST" ? presignedPost.fields : {};
+            const headers =
+              uploadMethod === "PUT" ? presignedPost.fields : {};
 
             // Build a ready-to-use curl command for the MCP client
-            const formArgs = Object.entries(form)
-              .map(([k, v]) => `-F '${k}=${v}'`)
-              .join(" ");
-            const curlCommand = `curl -X POST ${formArgs} -F 'file=@/path/to/file' '${uploadUrl}'`;
+            const curlCommand =
+              uploadMethod === "PUT"
+                ? `curl -X PUT ${Object.entries(headers)
+                    .map(([k, v]) => `-H '${k}: ${v}'`)
+                    .join(" ")} --upload-file '/path/to/file' '${uploadUrl}'`
+                : `curl -X POST ${Object.entries(form)
+                    .map(([k, v]) => `-F '${k}=${v}'`)
+                    .join(" ")} -F 'file=@/path/to/file' '${uploadUrl}'`;
 
             return success({
+              uploadMethod,
               uploadUrl,
               form,
+              headers,
               maxUploadSize,
               curlCommand,
               attachment: {


### PR DESCRIPTION
Related discussion: https://github.com/outline/outline/discussions/4480#discussioncomment-16485894

## Summary
- Added support for configurable S3 upload method via AWS_S3_UPLOAD_METHOD with allowed values post|put, defaulting to post to preserve existing AWS behavior.
- Implemented PUT presigned upload path in S3Storage for S3-compatible providers (e.g. R2), while retaining existing presigned POST flow for standard S3 by default.
- Improved endpoint handling for S3-compatible virtual-host setups and avoided AWS-specific virtual-host warning behavior for non-AWS hosts.

## Config
- New env var: AWS_S3_UPLOAD_METHOD
  - post (default): existing presigned multipart POST flow
  - put: presigned PUT URL + headers flow

## Test
- [x] Verify no linter/type errors on touched files
- [x] Run yarn test server/storage/files/S3Storage.test.ts
- [ ] Verify AWS_S3_UPLOAD_METHOD=post returns POST upload metadata and uses createPresignedPost
- [ ] Verify AWS_S3_UPLOAD_METHOD=put returns PUT upload metadata and uses getSignedUrl with PutObjectCommand
