### PR TITLE
fix: Skip auto-closing PRs with "pinned" label

### DIFF
--- a/.github/workflows/auto-close-prs.yml
+++ b/.github/workflows/auto-close-prs.yml
@@ -31,6 +31,12 @@ jobs:
 
               if (prAge < TWO_WEEKS) continue;
 
+              const hasSkipLabel = pr.labels.some(label =>
+                label.name === 'pinned'
+              );
+
+              if (hasSkipLabel) continue;
+
               const comments = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,


### PR DESCRIPTION
## Summary

- Adds a label check to the auto-close unsigned PRs workflow so that PRs with the `pinned` label are not automatically closed after 14 days without CLA acceptance.
- The check runs before fetching comments, avoiding unnecessary API calls for pinned PRs.

## Test plan

- [ ] Add the `pinned` label to an open PR that hasn't signed the CLA and verify it is not closed by the workflow
- [ ] Verify PRs without the label continue to be closed as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)