### PR TITLE
feat: Allow comparing any two revisions in document history

### DIFF
--- a/app/scenes/Document/components/DataLoader.tsx
+++ b/app/scenes/Document/components/DataLoader.tsx
@@ -111,25 +111,38 @@ function DataLoader({ match, children }: Props) {
     void fetchDocument();
   }, [ui, documents, missingPolicy, documentSlug]);
 
-  React.useEffect(() => {
-    async function fetchRevision() {
-      if (!revisionId) {
-        return;
-      }
+  const fetchRevisionById = React.useCallback(
+    async (id: string, onError: (err: Error) => void) => {
       try {
-        if (revisionId === "latest") {
+        if (id === "latest") {
           if (document?.id) {
             await revisions.fetchLatest(document.id);
           }
         } else {
-          await revisions.fetch(revisionId);
+          await revisions.fetch(id);
         }
       } catch (err) {
-        setError(err);
+        onError(err as Error);
       }
+    },
+    [revisions, document?.id]
+  );
+
+  React.useEffect(() => {
+    if (revisionId) {
+      void fetchRevisionById(revisionId, setError);
     }
-    void fetchRevision();
-  }, [revisions, revisionId, document?.id]);
+  }, [fetchRevisionById, revisionId]);
+
+  const compareTo = query.get("compareTo");
+
+  React.useEffect(() => {
+    if (compareTo) {
+      void fetchRevisionById(compareTo, (err) =>
+        Logger.error("Failed to fetch compareTo revision", err)
+      );
+    }
+  }, [fetchRevisionById, compareTo]);
 
   React.useEffect(() => {
     async function fetchViews() {

--- a/app/scenes/Document/components/History.tsx
+++ b/app/scenes/Document/components/History.tsx
@@ -1,4 +1,6 @@
+import { format as formatDate } from "date-fns";
 import isEqual from "fast-deep-equal";
+import { dateLocale } from "@shared/utils/date";
 import orderBy from "lodash/orderBy";
 import { observer } from "mobx-react";
 import * as React from "react";
@@ -9,11 +11,14 @@ import { Pagination } from "@shared/constants";
 import { RevisionHelper } from "@shared/utils/RevisionHelper";
 import Revision from "~/models/Revision";
 import Empty from "~/components/Empty";
+import { InputSelect, type Option } from "~/components/InputSelect";
 import PaginatedEventList from "~/components/PaginatedEventList";
 import useKeyDown from "~/hooks/useKeyDown";
 import { useLocationSidebarContext } from "~/hooks/useLocationSidebarContext";
+import useQuery from "~/hooks/useQuery";
 import useStores from "~/hooks/useStores";
-import { documentPath } from "~/utils/routeHelpers";
+import useUserLocale from "~/hooks/useUserLocale";
+import { documentPath, matchDocumentHistory } from "~/utils/routeHelpers";
 import Sidebar from "./SidebarLayout";
 import useMobile from "~/hooks/useMobile";
 import Switch from "~/components/Switch";
@@ -21,6 +26,8 @@ import Text from "@shared/components/Text";
 import usePersistedState from "~/hooks/usePersistedState";
 import Scrollable from "~/components/Scrollable";
 import Flex from "@shared/components/Flex";
+
+const COMPARE_TO_PREVIOUS = "previous";
 
 const DocumentEvents = [
   "documents.publish",
@@ -38,12 +45,20 @@ function History() {
   const { events, documents, revisions } = useStores();
   const { t } = useTranslation();
   const match = useRouteMatch<{ documentSlug: string }>();
+  const historyMatch = useRouteMatch<{ revisionId?: string }>({
+    path: matchDocumentHistory,
+  });
   const history = useHistory();
+  const query = useQuery();
   const sidebarContext = useLocationSidebarContext();
   const document = documents.get(match.params.documentSlug);
   const [revisionsOffset, setRevisionsOffset] = React.useState(0);
   const [eventsOffset, setEventsOffset] = React.useState(0);
   const isMobile = useMobile();
+  const userLocale = useUserLocale();
+  const [compareTo, setCompareTo] = React.useState(
+    () => query.get("compareTo") ?? COMPARE_TO_PREVIOUS
+  );
 
   const [defaultShowChanges, setDefaultShowChanges] =
     usePersistedState<boolean>("history-show-changes", true);
@@ -80,9 +95,37 @@ function History() {
     (checked: boolean) => {
       setShowChanges(checked);
       setDefaultShowChanges(checked);
-      updateLocation({ changes: checked ? "true" : null });
+      if (checked) {
+        updateLocation({ changes: "true" });
+      } else {
+        setCompareTo(COMPARE_TO_PREVIOUS);
+        updateLocation({ changes: null, compareTo: null });
+      }
     },
-    [history]
+    [updateLocation]
+  );
+
+  const selectedRevisionId = historyMatch?.params.revisionId;
+
+  // Reset "Compare to" when the user clicks a different revision in the list,
+  // but not on initial mount (which would break deep links with ?compareTo=…)
+  const prevSelectedRef = React.useRef(selectedRevisionId);
+  React.useEffect(() => {
+    if (prevSelectedRef.current !== selectedRevisionId) {
+      prevSelectedRef.current = selectedRevisionId;
+      setCompareTo(COMPARE_TO_PREVIOUS);
+      updateLocation({ compareTo: null });
+    }
+  }, [selectedRevisionId, updateLocation]);
+
+  const handleCompareToChange = React.useCallback(
+    (value: string) => {
+      setCompareTo(value);
+      updateLocation({
+        compareTo: value === COMPARE_TO_PREVIOUS ? null : value,
+      });
+    },
+    [updateLocation]
   );
 
   // Ensure that the URL parameter is in sync with the persisted state on mount
@@ -178,6 +221,47 @@ function History() {
     return merged;
   }, [revisions, document, revisionEvents, nonRevisionEvents]);
 
+  const compareOptions = React.useMemo((): Option[] => {
+    const revisionItems = items.filter(
+      (item): item is Revision => item instanceof Revision
+    );
+
+    const locale = dateLocale(userLocale);
+    const resolvedSelectedId =
+      selectedRevisionId === "latest" && document
+        ? RevisionHelper.latestId(document.id)
+        : selectedRevisionId;
+
+    const options: Option[] = [
+      { type: "item", label: t("Previous revision"), value: COMPARE_TO_PREVIOUS },
+    ];
+
+    for (const rev of revisionItems) {
+      if (rev.id === resolvedSelectedId) {
+        continue;
+      }
+
+      const dateLabel = formatDate(
+        new Date(rev.createdAt),
+        "MMM do, h:mm a",
+        { locale }
+      );
+      const collaboratorName =
+        rev.collaborators?.[0]?.name ?? rev.createdBy?.name;
+
+      options.push({
+        type: "item",
+        label: dateLabel,
+        value: rev.id,
+        description: collaboratorName
+          ? t("{{ userName }} edited", { userName: collaboratorName })
+          : undefined,
+      });
+    }
+
+    return options;
+  }, [items, selectedRevisionId, document, userLocale, t]);
+
   const onCloseHistory = React.useCallback(() => {
     if (isMobile) {
       // Allow closing the history drawer on mobile to view revision content
@@ -205,6 +289,17 @@ function History() {
             onChange={handleShowChangesToggle}
           />
         </Text>
+        {showChanges && (
+          <CompareToWrapper>
+            <InputSelect
+              options={compareOptions}
+              value={compareTo}
+              onChange={handleCompareToChange}
+              label={t("Compare to")}
+              short
+            />
+          </CompareToWrapper>
+        )}
       </Content>
       <Scrollable hiddenScrollbars topShadow>
         {document ? (
@@ -242,6 +337,10 @@ const Content = styled.div`
   border-radius: 8px;
   padding: 8px 8px 0;
   flex-shrink: 0;
+`;
+
+const CompareToWrapper = styled.div`
+  padding: 4px 0 8px;
 `;
 
 export default observer(History);

--- a/app/scenes/Document/components/History.tsx
+++ b/app/scenes/Document/components/History.tsx
@@ -236,6 +236,8 @@ function History() {
       { type: "item", label: t("Previous revision"), value: COMPARE_TO_PREVIOUS },
     ];
 
+    const latestId = document ? RevisionHelper.latestId(document.id) : undefined;
+
     for (const rev of revisionItems) {
       if (rev.id === resolvedSelectedId) {
         continue;
@@ -252,9 +254,9 @@ function History() {
       options.push({
         type: "item",
         label: dateLabel,
-        value: rev.id,
+        value: rev.id === latestId ? "latest" : rev.id,
         description: collaboratorName
-          ? t("{{ userName }} edited", { userName: collaboratorName })
+          ? t("{{userName}} edited", { userName: collaboratorName })
           : undefined,
       });
     }

--- a/app/scenes/Document/components/RevisionViewer.tsx
+++ b/app/scenes/Document/components/RevisionViewer.tsx
@@ -58,7 +58,9 @@ function RevisionViewer(props: Props, ref: React.Ref<TEditor>) {
     ? revisions.get(compareToRevisionId)
     : undefined;
 
-  const comparisonData = (compareToRevision ?? revision.before)?.data;
+  const comparisonData = compareToRevisionId
+    ? compareToRevision?.data
+    : revision.before?.data;
 
   /**
    * Create editor extensions with the Diff extension configured to render

--- a/app/scenes/Document/components/RevisionViewer.tsx
+++ b/app/scenes/Document/components/RevisionViewer.tsx
@@ -93,6 +93,7 @@ function RevisionViewer(props: Props, ref: React.Ref<TEditor>) {
         rtl={revision.rtl}
       />
       <Editor
+        key={compareToRevisionId}
         ref={ref}
         defaultValue={revision.data}
         extensions={extensions}

--- a/app/scenes/Document/components/RevisionViewer.tsx
+++ b/app/scenes/Document/components/RevisionViewer.tsx
@@ -45,16 +45,18 @@ function RevisionViewer(props: Props, ref: React.Ref<TEditor>) {
   const showChanges = props.showChanges ?? query.has("changes");
   const compareToParam = query.get("compareTo");
 
-  const compareToRevision = React.useMemo(() => {
+  const compareToRevisionId = React.useMemo(() => {
     if (!compareToParam) {
       return undefined;
     }
-    const resolvedId =
-      compareToParam === "latest"
-        ? RevisionHelper.latestId(revision.documentId)
-        : compareToParam;
-    return revisions.get(resolvedId);
-  }, [compareToParam, revision.documentId, revisions]);
+    return compareToParam === "latest"
+      ? RevisionHelper.latestId(revision.documentId)
+      : compareToParam;
+  }, [compareToParam, revision.documentId]);
+
+  const compareToRevision = compareToRevisionId
+    ? revisions.get(compareToRevisionId)
+    : undefined;
 
   const comparisonData = (compareToRevision ?? revision.before)?.data;
 

--- a/app/scenes/Document/components/RevisionViewer.tsx
+++ b/app/scenes/Document/components/RevisionViewer.tsx
@@ -11,7 +11,9 @@ import DocumentTitle from "./DocumentTitle";
 import Editor from "~/components/Editor";
 import { richExtensions, withComments } from "@shared/editor/nodes";
 import Diff from "@shared/editor/extensions/Diff";
+import { RevisionHelper } from "@shared/utils/RevisionHelper";
 import useQuery from "~/hooks/useQuery";
+import useStores from "~/hooks/useStores";
 import { type Editor as TEditor } from "~/editor";
 import { ChangesetHelper } from "@shared/editor/lib/ChangesetHelper";
 
@@ -38,8 +40,23 @@ type Props = Omit<EditorProps, "extensions"> & {
  */
 function RevisionViewer(props: Props, ref: React.Ref<TEditor>) {
   const { document, children, revision } = props;
+  const { revisions } = useStores();
   const query = useQuery();
   const showChanges = props.showChanges ?? query.has("changes");
+  const compareToParam = query.get("compareTo");
+
+  const compareToRevision = React.useMemo(() => {
+    if (!compareToParam) {
+      return undefined;
+    }
+    const resolvedId =
+      compareToParam === "latest"
+        ? RevisionHelper.latestId(revision.documentId)
+        : compareToParam;
+    return revisions.get(resolvedId);
+  }, [compareToParam, revision.documentId, revisions]);
+
+  const comparisonData = (compareToRevision ?? revision.before)?.data;
 
   /**
    * Create editor extensions with the Diff extension configured to render
@@ -48,7 +65,7 @@ function RevisionViewer(props: Props, ref: React.Ref<TEditor>) {
   const extensions = React.useMemo(() => {
     const changeset = ChangesetHelper.getChangeset(
       revision.data,
-      revision.before?.data
+      comparisonData
     );
     return [
       ...withComments(richExtensions),
@@ -56,7 +73,7 @@ function RevisionViewer(props: Props, ref: React.Ref<TEditor>) {
         ? [new Diff({ changes: changeset?.changes })]
         : []),
     ];
-  }, [revision.data, showChanges]);
+  }, [revision.data, comparisonData, showChanges]);
 
   return (
     <Flex auto column>


### PR DESCRIPTION
Discussed in \#11981

When "Highlight changes" is enabled in the history sidebar, this adds a "Compare to" dropdown that lets you pick any revision to diff against, not just the immediately previous one. Defaults to "Previous revision" so existing behavior is unchanged.

The selected comparison target is stored in a `compareTo` query parameter, so you can share or bookmark a specific comparison (e.g. `?changes=true&compareTo=<revisionId>`). DataLoader handles fetching the comparison revision if it's not already loaded.

No API or server changes, everything is client-side. The dropdown reuses the existing InputSelect component and resets when you navigate to a different revision in the list.