### PR TITLE
fix: Checklist toggle overlapping content in table cells

### DIFF
--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -1544,6 +1544,11 @@ ol li {
   opacity: 1;
 }
 
+td .${EditorStyleHelper.checklistCompletedToggle},
+th .${EditorStyleHelper.checklistCompletedToggle} {
+  top: -32px;
+}
+
 .${EditorStyleHelper.checklistWrapper}.${EditorStyleHelper.checklistCompletedHidden} ul.checkbox_list > li.checked {
   display: none;
 }


### PR DESCRIPTION
Moves the "Hide completed" checklist toggle button higher (`top: -32px`) when inside table cells (`td`/`th`) so it doesn't overlap the checklist content in narrow containers.

closes #11983