### PR TITLE
fix: New shares do not include children

### DIFF
--- a/server/routes/api/shares/shares.test.ts
+++ b/server/routes/api/shares/shares.test.ts
@@ -324,6 +324,25 @@ describe("#shares.create", () => {
     expect(body.data.documentTitle).toBe(document.title);
   });
 
+  it("should set includeChildDocuments when creating a published share", async () => {
+    const user = await buildUser();
+    const document = await buildDocument({
+      userId: user.id,
+      teamId: user.teamId,
+    });
+    const res = await server.post("/api/shares.create", {
+      body: {
+        token: user.getJwtToken(),
+        documentId: document.id,
+        published: true,
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.data.published).toBe(true);
+    expect(body.data.includeChildDocuments).toBe(true);
+  });
+
   it("should accept allowIndexing and showLastUpdated parameters", async () => {
     const user = await buildUser();
     const document = await buildDocument({

--- a/server/routes/api/shares/shares.ts
+++ b/server/routes/api/shares/shares.ts
@@ -314,7 +314,7 @@ router.post(
       defaults: {
         userId: user.id,
         published,
-        includeChildDocuments,
+        includeChildDocuments: published || includeChildDocuments,
         allowIndexing,
         allowSubscriptions,
         showLastUpdated,


### PR DESCRIPTION
Regressed as part of https://github.com/outline/outline/pull/11950