### PR TITLE
fix: Auto-hide TOC when window shrinks below mobile breakpoint

### DIFF
--- a/app/scenes/Document/components/Header.tsx
+++ b/app/scenes/Document/components/Header.tsx
@@ -125,6 +125,12 @@ function DocumentHeader({
   const showContents =
     ui.tocVisible === true || (isShare && ui.tocVisible !== false);
 
+  useEffect(() => {
+    if (isMobile && showContents) {
+      ui.set({ tocVisible: false });
+    }
+  }, [isMobile, showContents, ui]);
+
   const toc = (
     <Tooltip
       content={


### PR DESCRIPTION
Without this logic the TOC button changes function from a toggle to a menu, leaving no option to hide the TOC sidebar itself.