### PR TITLE
fix: Handling for top-level node in `getCurrentBlock`

### DIFF
--- a/shared/editor/queries/getCurrentBlock.ts
+++ b/shared/editor/queries/getCurrentBlock.ts
@@ -12,13 +12,10 @@ export function getCurrentBlock(
   const { $head } = state.selection;
 
   // Walk up the tree to find the first block node
-  for (let d = $head.depth; d >= 0; d--) {
+  for (let d = $head.depth; d > 0; d--) {
     const node = $head.node(d);
-    const pos = $head.before(d);
-
-    if (node.isBlock && d > 0) {
-      // Don't return the document itself
-      return [node, pos];
+    if (node.isBlock) {
+      return [node, $head.before(d)];
     }
   }
 


### PR DESCRIPTION
Handles `RangeError: There is no position before the top-level node`

Changed the loop bound from `d >= 0` to `d > 0` — the document node at depth `0` should never be returned anyway, so there’s no reason to visit it