### PR TITLE
chore: Remove url from error message to improve fingerprint matching

### DIFF
--- a/app/stores/UnfurlsStore.ts
+++ b/app/stores/UnfurlsStore.ts
@@ -87,7 +87,8 @@ class UnfurlsStore extends Store<Unfurl<any>> {
         data,
       } as Unfurl<UnfurlType>);
     } catch (err) {
-      Logger.warn(`Failed to unfurl url ${url}`, {
+      Logger.warn("Failed to unfurl url", {
+        url,
         message: err.message,
       });
       return;


### PR DESCRIPTION
Interpolation in error message prevented Sentry from correctly grouping these warnings.