### PR TITLE
fix: `action.ancestors` can be undefined

### DIFF
--- a/app/components/CommandBar/CommandBarItem.tsx
+++ b/app/components/CommandBar/CommandBarItem.tsx
@@ -30,8 +30,8 @@ function CommandBarItem(
 ) {
   const theme = useTheme();
   const ancestors = React.useMemo(() => {
-    if (!currentRootActionId) {
-      return action.ancestors;
+    if (!currentRootActionId || !action.ancestors) {
+      return action.ancestors ?? [];
     }
     const index = action.ancestors.findIndex(
       (ancestor) => ancestor.id === currentRootActionId


### PR DESCRIPTION
Fixes `TypeError: Cannot read properties of undefined (reading 'ancestors')` in `CommandBarItem`