### PR TITLE
fix: Catch failures in image upload

### DIFF
--- a/shared/editor/plugins/UploadPlugin.ts
+++ b/shared/editor/plugins/UploadPlugin.ts
@@ -95,6 +95,9 @@ export class UploadPlugin extends Plugin {
                     ],
                     options
                   );
+                })
+                .catch(() => {
+                  // Silently handle fetch failures (e.g. CORS, network errors)
                 });
             }
 


### PR DESCRIPTION
Added a `.catch()` to the fetch(imageSrc) call in the drop handler. This silently swallows fetch failures (CORS, network errors, etc.) instead of letting them propagate as uncaught errors.