### PR TITLE
fix: Guard against undefined boundsRef in MediaDimension

### DIFF
--- a/app/editor/components/MediaDimension.tsx
+++ b/app/editor/components/MediaDimension.tsx
@@ -68,7 +68,10 @@ export function MediaDimension() {
 
   const isOutsideBounds = useCallback(
     (type: "width" | "height", value: number) => {
-      const bounds = boundsRef.current!;
+      const bounds = boundsRef.current;
+      if (!bounds) {
+        return false;
+      }
       return value < bounds[type].min || value > bounds[type].max;
     },
     []
@@ -128,12 +131,12 @@ export function MediaDimension() {
         localWidthAsNumber &&
         isOutsideBounds("width", localWidthAsNumber)); // check width bounds here since 'onChange' error checker is debounced.
 
-    if (isUnchanged || isError) {
+    if (isUnchanged || isError || !boundsRef.current) {
       reset();
       return;
     }
 
-    const maxWidth = boundsRef.current!.width.max;
+    const maxWidth = boundsRef.current.width.max;
     // For images resized to the full width of the editor, natural width will be shown in the toolbar.
     // So, we constrain it here for computing aspect ratio.
     const constrainedWidth = Math.min(width, maxWidth);


### PR DESCRIPTION
## Summary
- Fixes `TypeError: Cannot read properties of undefined (reading 'width')` crash in the `MediaDimension` component
- `boundsRef.current` is lazily initialized during render only when the DOM ref is available, but `handleBlur` and `isOutsideBounds` could fire before bounds were computed
- Replaced unsafe `!` non-null assertions with proper guards that early-return/reset when bounds aren't ready

## Test plan
- [ ] Insert an image into a document, verify the width/height inputs in the toolbar work correctly
- [ ] Resize an image and confirm dimension changes apply
- [ ] Verify no crash occurs when blurring the dimension input before the component is fully mounted

🤖 Generated with [Claude Code](https://claude.com/claude-code)