### PR TITLE
fix: Guard IndexeddbPersistence for environments without indexedDB

### DIFF
--- a/app/scenes/Document/components/MultiplayerEditor.tsx
+++ b/app/scenes/Document/components/MultiplayerEditor.tsx
@@ -76,7 +76,15 @@ function MultiplayerEditor({ onSynced, ...props }: Props, ref: any) {
   useLayoutEffect(() => {
     const debug = env.ENVIRONMENT === "development";
     const name = `document.${documentId}`;
-    const localProvider = new IndexeddbPersistence(name, ydoc);
+    const localProvider =
+      typeof indexedDB !== "undefined"
+        ? new IndexeddbPersistence(name, ydoc)
+        : undefined;
+
+    if (!localProvider) {
+      setLocalSynced(true);
+    }
+
     const provider = new HocuspocusProvider({
       parameters: {
         editorVersion: EDITOR_VERSION,
@@ -156,7 +164,7 @@ function MultiplayerEditor({ onSynced, ...props }: Props, ref: any) {
     };
 
     provider.on("awarenessChange", showCursorNames);
-    localProvider.on("synced", () =>
+    localProvider?.on("synced", () =>
       // only set local storage to "synced" if it's loaded a non-empty doc
       setLocalSynced(!!ydoc.get("default")._start)
     );
@@ -195,7 +203,7 @@ function MultiplayerEditor({ onSynced, ...props }: Props, ref: any) {
           message: ev.message,
         })
       );
-      localProvider.on("synced", () =>
+      localProvider?.on("synced", () =>
         Logger.debug("collaboration", "local synced")
       );
     }

--- a/app/scenes/Document/components/MultiplayerEditor.tsx
+++ b/app/scenes/Document/components/MultiplayerEditor.tsx
@@ -61,6 +61,7 @@ function MultiplayerEditor({ onSynced, ...props }: Props, ref: any) {
   const [showCursorNames, setShowCursorNames] = useState(false);
   const [remoteProvider, setRemoteProvider] =
     useState<HocuspocusProvider | null>(null);
+  const [hasLocalPersistence, setHasLocalPersistence] = useState(true);
   const [isLocalSynced, setLocalSynced] = useState(false);
   const [isRemoteSynced, setRemoteSynced] = useState(false);
   const [ydoc] = useState(() => new Y.Doc());
@@ -82,7 +83,7 @@ function MultiplayerEditor({ onSynced, ...props }: Props, ref: any) {
         : undefined;
 
     if (!localProvider) {
-      setLocalSynced(true);
+      setHasLocalPersistence(false);
     }
 
     const provider = new HocuspocusProvider({
@@ -262,10 +263,10 @@ function MultiplayerEditor({ onSynced, ...props }: Props, ref: any) {
   }, [remoteProvider, user, ydoc, props.extensions]);
 
   useEffect(() => {
-    if (isLocalSynced && isRemoteSynced) {
+    if ((!hasLocalPersistence || isLocalSynced) && isRemoteSynced) {
       void onSynced?.();
     }
-  }, [onSynced, isLocalSynced, isRemoteSynced]);
+  }, [onSynced, hasLocalPersistence, isLocalSynced, isRemoteSynced]);
 
   // Disconnect the realtime connection while idle. `isIdle` also checks for
   // page visibility and will immediately disconnect when a tab is hidden.
@@ -314,7 +315,8 @@ function MultiplayerEditor({ onSynced, ...props }: Props, ref: any) {
 
   // while the collaborative document is loading, we render a version of the
   // document from the last text cache in read-only mode if we have it.
-  const showCache = !isLocalSynced && !isRemoteSynced;
+  const isLocalReady = !hasLocalPersistence || isLocalSynced;
+  const showCache = !isLocalReady && !isRemoteSynced;
 
   return (
     <>


### PR DESCRIPTION
## Summary

- Fixes a `ReferenceError: Can't find variable: indexedDB` crash in `MultiplayerEditor` when `indexedDB` is unavailable (e.g. certain mobile browsers, privacy-restricted contexts, or embedded webviews)
- Guards `IndexeddbPersistence` creation with a `typeof indexedDB !== "undefined"` check
- When `indexedDB` is unavailable, skips local persistence and marks local sync as complete so the editor falls back to remote-only sync without blocking

## Test plan

- [ ] Verify collaborative editing works normally in standard browsers
- [ ] Verify no crash in environments where `indexedDB` is undefined (e.g. simulate by overriding the global)
- [ ] Verify the editor loads and syncs via the remote provider when local persistence is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)