### PR TITLE
fix: "Did not find anchor as previous sibling of heading" error

### DIFF
--- a/shared/editor/nodes/Heading.ts
+++ b/shared/editor/nodes/Heading.ts
@@ -142,19 +142,29 @@ export default class Heading extends Node {
   };
 
   handleCopyLink = (event: MouseEvent) => {
-    // this is unfortunate but appears to be the best way to grab the anchor
-    // as it's added directly to the dom by a decoration.
-    const anchor =
-      event.currentTarget instanceof HTMLButtonElement &&
-      (event.currentTarget.parentNode?.parentNode
-        ?.previousSibling as HTMLElement);
-
-    if (
-      !anchor ||
-      !anchor.className.includes(EditorStyleHelper.headingPositionAnchor)
-    ) {
-      throw new Error("Did not find anchor as previous sibling of heading");
+    if (!(event.currentTarget instanceof HTMLButtonElement)) {
+      return;
     }
+
+    const heading = event.currentTarget.closest(".heading-content");
+    if (!heading) {
+      return;
+    }
+
+    // Search previous siblings for the anchor element, as other elements
+    // (e.g. multiplayer cursors) may be inserted between the anchor and heading.
+    let anchor = heading.previousElementSibling;
+    while (
+      anchor &&
+      !anchor.className?.includes(EditorStyleHelper.headingPositionAnchor)
+    ) {
+      anchor = anchor.previousElementSibling;
+    }
+
+    if (!anchor) {
+      return;
+    }
+
     const hash = `#${anchor.id}`;
 
     // the existing url might contain a hash already, lets make sure to remove


### PR DESCRIPTION
The fix replaces the fragile DOM traversal `parentNode.parentNode.previousSibling` with a more resilient approach.