### PR TITLE
fix: Cannot access property `pos`

### DIFF
--- a/shared/editor/nodes/TableHeader.ts
+++ b/shared/editor/nodes/TableHeader.ts
@@ -4,7 +4,7 @@ import type { EditorState } from "prosemirror-state";
 import { Plugin, PluginKey } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 import { DecorationSet, Decoration } from "prosemirror-view";
-import { moveTableColumn, TableMap } from "prosemirror-tables";
+import { isInTable, moveTableColumn, TableMap } from "prosemirror-tables";
 import { addColumnBefore, selectColumn } from "../commands/table";
 import { getCellAttrs, setCellAttrs } from "../lib/table";
 import {
@@ -125,16 +125,19 @@ function setupColumnDragTracking(
     document.removeEventListener("mouseup", handleMouseUp);
 
     document.body.classList.remove(EditorStyleHelper.tableDragging);
-    clearDragState();
 
-    if (isDragging && currentToIndex !== fromIndex) {
-      moveTableColumn({ from: fromIndex, to: currentToIndex })(
+    if (isDragging && currentToIndex !== fromIndex && isInTable(view.state)) {
+      const moved = moveTableColumn({ from: fromIndex, to: currentToIndex })(
         view.state,
         view.dispatch
       );
-      // Select the column at its new position
-      selectColumn(currentToIndex)(view.state, view.dispatch);
+      if (moved) {
+        // Select the column at its new position
+        selectColumn(currentToIndex)(view.state, view.dispatch);
+      }
     }
+
+    clearDragState();
   };
 
   document.addEventListener("mousemove", handleMouseMove);

--- a/shared/editor/nodes/TableRow.ts
+++ b/shared/editor/nodes/TableRow.ts
@@ -118,9 +118,8 @@ function setupRowDragTracking(
     document.removeEventListener("mouseup", handleMouseUp);
 
     document.body.classList.remove(EditorStyleHelper.tableDragging);
-    clearDragState();
 
-    if (isDragging && currentToIndex !== fromIndex) {
+    if (isDragging && currentToIndex !== fromIndex && isInTable(view.state)) {
       moveTableRow({ from: fromIndex, to: currentToIndex })(
         view.state,
         view.dispatch
@@ -128,6 +127,8 @@ function setupRowDragTracking(
       // Select the row at its new position
       selectRow(currentToIndex)(view.state, view.dispatch);
     }
+
+    clearDragState();
   };
 
   document.addEventListener("mousemove", handleMouseMove);

--- a/shared/editor/nodes/TableRow.ts
+++ b/shared/editor/nodes/TableRow.ts
@@ -120,12 +120,14 @@ function setupRowDragTracking(
     document.body.classList.remove(EditorStyleHelper.tableDragging);
 
     if (isDragging && currentToIndex !== fromIndex && isInTable(view.state)) {
-      moveTableRow({ from: fromIndex, to: currentToIndex })(
+      const moved = moveTableRow({ from: fromIndex, to: currentToIndex })(
         view.state,
         view.dispatch
       );
-      // Select the row at its new position
-      selectRow(currentToIndex)(view.state, view.dispatch);
+      if (moved) {
+        // Select the row at its new position
+        selectRow(currentToIndex)(view.state, view.dispatch);
+      }
     }
 
     clearDragState();


### PR DESCRIPTION
Root cause: `clearDragState()` dispatches a transaction that updates view.state before `moveTableRow` reads it. The moveTableRow function in `prosemirror-tables` uses `state.selection.from` to find the table, and after the intervening transaction, the selection state could become invalid for table operations — causing `getSelectionRangeInRow` to operate on an empty array and crash accessing .pos on undefined.