### PR TITLE
fix: Shared doc should respect 'Show last modified' option when logged in

### DIFF
--- a/app/scenes/Document/components/Editor.tsx
+++ b/app/scenes/Document/components/Editor.tsx
@@ -70,7 +70,7 @@ function DocumentEditor(props: Props, ref: React.RefObject<any>) {
   const team = useCurrentTeam({ rejectOnEmpty: false });
   const sidebarContext = useLocationSidebarContext();
   const params = useQuery();
-  const { shareId } = useShare();
+  const { shareId, showLastUpdated } = useShare();
   const {
     document,
     onChangeTitle,
@@ -212,7 +212,7 @@ function DocumentEditor(props: Props, ref: React.RefObject<any>) {
         placeholder={t("Untitled")}
       />
       {shareId ? (
-        document.updatedAt ? (
+        showLastUpdated && document.updatedAt ? (
           <SharedMeta type="tertiary">
             {t("Last updated")} <Time dateTime={document.updatedAt} addSuffix />
           </SharedMeta>

--- a/app/scenes/Shared/Collection.tsx
+++ b/app/scenes/Shared/Collection.tsx
@@ -29,7 +29,7 @@ type Props = {
 
 function SharedCollection({ collection }: Props) {
   const { t } = useTranslation();
-  const { shareId } = useShare();
+  const { shareId, showLastUpdated } = useShare();
   const can = usePolicy(collection);
   const isMobile = useMobile();
 
@@ -77,7 +77,7 @@ function SharedCollection({ collection }: Props) {
             </IconTitleWrapper>
             {collection.name}
           </CollectionHeading>
-          {!!shareId && !!collection.updatedAt ? (
+          {!!shareId && showLastUpdated && !!collection.updatedAt ? (
             <SharedMeta type="tertiary">
               {t("Last updated")}{" "}
               <Time dateTime={collection.updatedAt} addSuffix />

--- a/app/scenes/Shared/index.tsx
+++ b/app/scenes/Shared/index.tsx
@@ -251,6 +251,7 @@ function SharedScene() {
         shareId,
         sharedTree: share.tree,
         allowSubscriptions: share.allowSubscriptions,
+        showLastUpdated: share.showLastUpdated,
       }}
     >
       <Helmet>

--- a/shared/hooks/useShare.ts
+++ b/shared/hooks/useShare.ts
@@ -5,6 +5,7 @@ type ShareContextType = {
   shareId?: string;
   sharedTree?: NavigationNode;
   allowSubscriptions?: boolean;
+  showLastUpdated?: boolean;
 };
 
 export const ShareContext = React.createContext<ShareContextType>({});


### PR DESCRIPTION
With a logged in session you always saw this date, even when the option is disabled - which is confusing.