### PR TITLE
fix: Silence expected `ResourceLockedError` during `Redlock` retries

### DIFF
--- a/server/utils/MutexLock.ts
+++ b/server/utils/MutexLock.ts
@@ -1,5 +1,6 @@
 import Redlock, {
   ExecutionError,
+  ResourceLockedError,
   type Lock,
   type RedlockAbortSignal,
 } from "redlock";
@@ -27,7 +28,10 @@ export class MutexLock {
         retryDelay: 1000,
       });
       this.redlock.on("error", (err) => {
-        if (err instanceof ExecutionError) {
+        if (err instanceof ResourceLockedError) {
+          // Expected during lock contention retries, not an error.
+          return;
+        } else if (err instanceof ExecutionError) {
           Logger.warn("Failed to extend Redlock lock", {
             message: err.message,
           });


### PR DESCRIPTION
`ResourceLockedError` is emitted on every retry attempt during lock contention but was not handled, causing it to be logged as an unexpected error and reported to Sentry (OUTLINE-CLOUD-CAW).

Fixes OUTLINE-CLOUD-CAW