### PR TITLE
feat: Add recent documents menu on desktop

### DIFF
--- a/app/actions/definitions/documents.tsx
+++ b/app/actions/definitions/documents.tsx
@@ -128,7 +128,7 @@ export const openDocument = createActionWithChildren({
             color={item.color ?? undefined}
           />
         ) : (
-          <DocumentIcon />
+          <DocumentIcon outline={item.isDraft} />
         ),
         section: DocumentSection,
         to: item.url,

--- a/app/components/CommandBar/useRecentDocumentActions.tsx
+++ b/app/components/CommandBar/useRecentDocumentActions.tsx
@@ -26,7 +26,7 @@ const useRecentDocumentActions = (count = 6) => {
                 color={item.color ?? undefined}
               />
             ) : (
-              <DocumentIcon />
+              <DocumentIcon outline={item.isDraft} />
             ),
             to: documentPath(item),
           })

--- a/app/components/Sidebar/components/HistoryNavigation.tsx
+++ b/app/components/Sidebar/components/HistoryNavigation.tsx
@@ -77,7 +77,7 @@ function HistoryNavigation(props: React.ComponentProps<typeof Flex>) {
       <Tooltip content={t("History")}>
         <DropdownMenu
           action={menuAction}
-          ariaLabel={t("Recently viewed")}
+          ariaLabel={t("History")}
           onOpen={handleOpen}
         >
           <NudeButton aria-label={t("History")}>

--- a/app/components/Sidebar/components/HistoryNavigation.tsx
+++ b/app/components/Sidebar/components/HistoryNavigation.tsx
@@ -1,18 +1,43 @@
-import { ArrowIcon } from "outline-icons";
+import { ArrowIcon, ClockIcon } from "outline-icons";
+import { observer } from "mobx-react";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { s } from "@shared/styles";
+import { createActionGroup } from "~/actions";
+import { DropdownMenu } from "~/components/Menu/DropdownMenu";
 import Flex from "~/components/Flex";
 import NudeButton from "~/components/NudeButton";
 import Tooltip from "~/components/Tooltip";
+import useRecentDocumentActions from "~/components/CommandBar/useRecentDocumentActions";
+import { useMenuAction } from "~/hooks/useMenuAction";
+import useStores from "~/hooks/useStores";
 import Desktop from "~/utils/Desktop";
+
+const RECENT_DOCUMENTS_LIMIT = 10;
 
 function HistoryNavigation(props: React.ComponentProps<typeof Flex>) {
   const { t } = useTranslation();
+  const { documents } = useStores();
   const [canGoBack, setCanGoBack] = React.useState(false);
   const [canGoForward, setCanGoForward] = React.useState(false);
   const [supported, setSupported] = React.useState(false);
+
+  const recentActions = useRecentDocumentActions(RECENT_DOCUMENTS_LIMIT);
+  const menuActions = React.useMemo(
+    () => [
+      createActionGroup({
+        name: t("Recent"),
+        actions: recentActions,
+      }),
+    ],
+    [t, recentActions]
+  );
+  const menuAction = useMenuAction(menuActions);
+
+  const handleOpen = React.useCallback(() => {
+    void documents.fetchRecentlyViewed({ limit: RECENT_DOCUMENTS_LIMIT });
+  }, [documents]);
 
   React.useEffect(() => {
     if (!(Desktop.bridge && "onNavigationStateChanged" in Desktop.bridge)) {
@@ -31,7 +56,7 @@ function HistoryNavigation(props: React.ComponentProps<typeof Flex>) {
 
   return (
     <Navigation gap={4} {...props}>
-      <Tooltip content={t("Go back")}>
+      <Tooltip content={t("Go back")} disabled={!canGoBack}>
         <NudeButton
           aria-label={t("Go back")}
           disabled={!canGoBack}
@@ -40,7 +65,7 @@ function HistoryNavigation(props: React.ComponentProps<typeof Flex>) {
           <Back $enabled={canGoBack} />
         </NudeButton>
       </Tooltip>
-      <Tooltip content={t("Go forward")}>
+      <Tooltip content={t("Go forward")} disabled={!canGoForward}>
         <NudeButton
           aria-label={t("Go forward")}
           disabled={!canGoForward}
@@ -48,6 +73,17 @@ function HistoryNavigation(props: React.ComponentProps<typeof Flex>) {
         >
           <Forward $enabled={canGoForward} />
         </NudeButton>
+      </Tooltip>
+      <Tooltip content={t("History")}>
+        <DropdownMenu
+          action={menuAction}
+          ariaLabel={t("Recently viewed")}
+          onOpen={handleOpen}
+        >
+          <NudeButton aria-label={t("History")}>
+            <StyledClockIcon />
+          </NudeButton>
+        </DropdownMenu>
       </Tooltip>
     </Navigation>
   );
@@ -79,4 +115,16 @@ const Back = styled(Forward)`
   flex-shrink: 0;
 `;
 
-export default HistoryNavigation;
+const StyledClockIcon = styled(ClockIcon)`
+  color: ${s("textTertiary")};
+  opacity: 0.5;
+  transition: color 100ms ease-in-out;
+
+  &:active,
+  &:hover,
+  [data-state="open"] & {
+    opacity: 1;
+  }
+`;
+
+export default observer(HistoryNavigation);

--- a/app/components/primitives/components/Menu.tsx
+++ b/app/components/primitives/components/Menu.tsx
@@ -129,6 +129,7 @@ export const MenuHeader = styled.h3`
   color: ${s("sidebarText")};
   letter-spacing: 0.04em;
   margin: 1em 12px 0.5em;
+  user-select: none;
 `;
 
 export const MenuDisclosure = styled(ExpandedIcon)`

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -508,6 +508,7 @@
   "Expand": "Expand",
   "Document not supported – try Markdown, Plain text, HTML, or Word": "Document not supported – try Markdown, Plain text, HTML, or Word",
   "Import files": "Import files",
+  "Recent": "Recent",
   "Go back": "Go back",
   "Go forward": "Go forward",
   "Could not load shared documents": "Could not load shared documents",


### PR DESCRIPTION
It adds a useful shortcut menu to the top left of the app, allowing you to navigate to recent documents without going to home or cmdk