### PR TITLE
fix: Use configured URL domain for cookies when behind reverse proxy

### DIFF
--- a/shared/utils/domains.ts
+++ b/shared/utils/domains.ts
@@ -93,6 +93,14 @@ export function getCookieDomain(domain: string, isCloudHosted: boolean) {
     }
   }
 
+  // When behind a reverse proxy, the request hostname may differ from the
+  // configured public URL. Use the configured URL's domain so cookies are
+  // set for the domain the browser actually sees.
+  const baseDomain = getBaseDomain();
+  if (domain !== baseDomain) {
+    return baseDomain;
+  }
+
   return domain;
 }
 


### PR DESCRIPTION
When Outline runs behind a reverse proxy (e.g. Azure App Gateway, nginx) that forwards requests using a backend hostname different from the public URL, the request hostname seen by Koa differs from the domain the browser navigates to.

This caused cookies to be set on the backend hostname instead of the public domain, breaking authentication because the browser never sent the cookies back on subsequent requests to the public URL.

This fix falls back to the configured URL's domain (from the URL env variable) when the request hostname doesn't match, ensuring cookies are always set for the domain the browser sees.