### PR TITLE
feat: Support Azure managed identity for SSO authentication

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -162,6 +162,17 @@ GOOGLE_CLIENT_SECRET=
 # DOCS: https://docs.getoutline.com/s/hosting/doc/microsoft-entra-UVz6jsIOcv
 AZURE_CLIENT_ID=
 AZURE_CLIENT_SECRET=
+
+# When running on Azure Container Apps, App Service, or VMs with a managed
+# identity, set this to true to authenticate with Azure AD using the managed
+# identity instead of a client secret. Requires a federated identity credential
+# on the Entra app registration.
+# AZURE_USE_MANAGED_IDENTITY=true
+
+# Client ID of a user-assigned managed identity. Only required when using
+# a user-assigned identity; omit for system-assigned identities.
+# AZURE_MANAGED_IDENTITY_CLIENT_ID=
+
 AZURE_RESOURCE_APP_ID=
 
 # Discord sign-in provider
@@ -288,3 +299,4 @@ DEBUG=http
 # Configure lowest severity level for server logs. Should be one of
 # error, warn, info, http, verbose, debug, or silly
 LOG_LEVEL=info
+

--- a/package.json
+++ b/package.json
@@ -272,7 +272,8 @@
     "y-protocols": "^1.0.7",
     "yauzl": "^3.2.1",
     "yjs": "^13.6.30",
-    "zod": "^4.2.1"
+    "zod": "^4.2.1",
+    "@azure/identity": "^4.13.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.28.6",

--- a/plugins/azure/server/auth/azure.ts
+++ b/plugins/azure/server/auth/azure.ts
@@ -22,14 +22,30 @@ import config from "../../plugin.json";
 import env from "../env";
 import { createContext } from "@server/context";
 
+import {
+  getClientAssertion,
+  initializeManagedIdentityAuth,
+} from "./managedIdentityAuth";
+
 const router = new Router();
 const scopes: string[] = [];
 
-if (env.AZURE_CLIENT_ID && env.AZURE_CLIENT_SECRET) {
+const hasCredentials =
+  env.AZURE_CLIENT_ID &&
+  (env.AZURE_CLIENT_SECRET || env.AZURE_USE_MANAGED_IDENTITY);
+
+if (hasCredentials) {
+  void initializeManagedIdentityAuth();
+
+  // When using managed identity, provide a placeholder secret. The actual
+  // authentication is handled via client_assertion in the token exchange,
+  // injected by the custom tokenParams override below.
+  const effectiveSecret = env.AZURE_CLIENT_SECRET ?? "managed-identity";
+
   const strategy = new AzureStrategy(
     {
-      clientID: env.AZURE_CLIENT_ID,
-      clientSecret: env.AZURE_CLIENT_SECRET,
+      clientID: env.AZURE_CLIENT_ID!,
+      clientSecret: effectiveSecret,
       callbackURL: `${env.URL}/auth/azure.callback`,
       useCommonEndpoint: env.AZURE_TENANT_ID ? false : true,
       tenant: env.AZURE_TENANT_ID ? env.AZURE_TENANT_ID : undefined,
@@ -140,6 +156,42 @@ if (env.AZURE_CLIENT_ID && env.AZURE_CLIENT_SECRET) {
       }
     }
   );
+
+  // When using managed identity, override tokenParams to inject
+  // client_assertion instead of client_secret for the token exchange.
+  if (env.AZURE_USE_MANAGED_IDENTITY) {
+    const originalTokenParams = strategy.tokenParams.bind(strategy);
+    strategy.tokenParams = function (options: Record<string, string>) {
+      const assertion = getClientAssertion();
+      if (!assertion) {
+        throw new Error(
+          "Azure managed identity authentication is enabled, but no client " +
+            "assertion is available for the token exchange. Check that the " +
+            "managed identity endpoint is reachable."
+        );
+      }
+
+      const params = originalTokenParams(options);
+      params.client_assertion = assertion;
+      params.client_assertion_type =
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+      return params;
+    };
+
+    // passport-oauth2 sends client_secret in the token request by default.
+    // When using managed identity we authenticate via client_assertion
+    // instead, so we must clear the placeholder secret to prevent it from
+    // being sent alongside the assertion. The _oauth2 property is an
+    // internal detail of passport-oauth2@1.x (oauth2 npm package); if the
+    // library changes its internals this will need updating.
+    // @ts-expect-error accessing private _oauth2 property
+    const oauth2 = strategy._oauth2;
+    if (oauth2) {
+      // @ts-expect-error clearing protected _clientSecret
+      oauth2._clientSecret = "";
+    }
+  }
+
   passport.use(strategy);
   router.get(
     config.id,

--- a/plugins/azure/server/auth/managedIdentityAuth.ts
+++ b/plugins/azure/server/auth/managedIdentityAuth.ts
@@ -1,0 +1,98 @@
+import Logger from "@server/logging/Logger";
+import env from "../env";
+
+/**
+ * Lazily imports @azure/identity to avoid loading the module when managed
+ * identity is not enabled. The dependency is listed in package.json but
+ * only required at runtime when AZURE_USE_MANAGED_IDENTITY=true.
+ */
+async function getManagedIdentityCredential() {
+  const { ManagedIdentityCredential } = await import("@azure/identity");
+  return env.AZURE_MANAGED_IDENTITY_CLIENT_ID
+    ? new ManagedIdentityCredential({
+        clientId: env.AZURE_MANAGED_IDENTITY_CLIENT_ID,
+      })
+    : new ManagedIdentityCredential();
+}
+
+/**
+ * Audience for Azure AD token exchange when using federated identity
+ * credentials.
+ *
+ * @see https://learn.microsoft.com/en-us/entra/identity-platform/certificate-credentials
+ */
+const TOKEN_EXCHANGE_AUDIENCE = "api://AzureADTokenExchange";
+
+let cachedAssertion: string | undefined;
+let cachedExpiresAt = 0;
+let refreshPromise: Promise<void> | undefined;
+
+/**
+ * Gets a client assertion token from the managed identity for use as a
+ * client_assertion in the OAuth2 token exchange. The managed identity must be
+ * configured as a federated identity credential on the Azure AD app
+ * registration.
+ *
+ * @returns the client assertion JWT, or undefined if not available.
+ */
+export function getClientAssertion(): string | undefined {
+  const now = Date.now();
+
+  if (cachedAssertion && now < cachedExpiresAt - 60_000) {
+    return cachedAssertion;
+  }
+
+  // Clear expired assertion so callers see undefined rather than stale token
+  if (cachedAssertion) {
+    cachedAssertion = undefined;
+    cachedExpiresAt = 0;
+  }
+
+  if (!refreshPromise) {
+    refreshPromise = refreshAssertion().finally(() => {
+      refreshPromise = undefined;
+    });
+  }
+  return cachedAssertion;
+}
+
+/**
+ * Pre-fetches the managed identity token so it is ready for the first auth
+ * request. Call at module initialization time.
+ *
+ * @returns a promise that resolves when the token is ready.
+ */
+export async function initializeManagedIdentityAuth(): Promise<void> {
+  if (!env.AZURE_USE_MANAGED_IDENTITY) {
+    return;
+  }
+
+  Logger.info(
+    "lifecycle",
+    "Initializing Azure managed identity authentication"
+  );
+
+  await refreshAssertion();
+
+  if (cachedAssertion) {
+    Logger.info(
+      "lifecycle",
+      `Azure managed identity token acquired (${cachedAssertion.length} chars)`
+    );
+  } else {
+    Logger.error(
+      "Failed to acquire managed identity token. Azure AD SSO will not work.",
+      new Error("No assertion returned from managed identity endpoint")
+    );
+  }
+}
+
+async function refreshAssertion(): Promise<void> {
+  const credential = await getManagedIdentityCredential();
+  const token = await credential.getToken(TOKEN_EXCHANGE_AUDIENCE);
+
+  if (token) {
+    cachedAssertion = token.token;
+    cachedExpiresAt = token.expiresOnTimestamp;
+  }
+}

--- a/plugins/azure/server/azure.ts
+++ b/plugins/azure/server/azure.ts
@@ -17,9 +17,12 @@ export default class AzureClient extends OAuthClient {
 
   constructor() {
     invariant(env.AZURE_CLIENT_ID, "AZURE_CLIENT_ID is required");
-    invariant(env.AZURE_CLIENT_SECRET, "AZURE_CLIENT_SECRET is required");
+    invariant(
+      env.AZURE_CLIENT_SECRET || env.AZURE_USE_MANAGED_IDENTITY,
+      "Either AZURE_CLIENT_SECRET or AZURE_USE_MANAGED_IDENTITY is required"
+    );
 
-    super(env.AZURE_CLIENT_ID, env.AZURE_CLIENT_SECRET);
+    super(env.AZURE_CLIENT_ID, env.AZURE_CLIENT_SECRET ?? "managed-identity");
   }
 
   async rotateToken(

--- a/plugins/azure/server/env.ts
+++ b/plugins/azure/server/env.ts
@@ -8,13 +8,36 @@ class AzurePluginEnvironment extends Environment {
    * Azure OAuth2 client credentials. To enable authentication with Azure.
    */
   @IsOptional()
-  @CannotUseWithout("AZURE_CLIENT_SECRET")
   public AZURE_CLIENT_ID = this.toOptionalString(environment.AZURE_CLIENT_ID);
 
   @IsOptional()
   @CannotUseWithout("AZURE_CLIENT_ID")
   public AZURE_CLIENT_SECRET = this.toOptionalString(
     environment.AZURE_CLIENT_SECRET
+  );
+
+  /**
+   * When true, uses the hosting platform's managed identity to authenticate
+   * with Azure AD instead of a client secret. Requires a federated identity
+   * credential configured on the Entra app registration trusting the managed
+   * identity. This eliminates the need to store and rotate client secrets.
+   *
+   * @see https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation
+   */
+  @IsOptional()
+  @CannotUseWithout("AZURE_CLIENT_ID")
+  public AZURE_USE_MANAGED_IDENTITY = this.toBoolean(
+    environment.AZURE_USE_MANAGED_IDENTITY ?? "false"
+  );
+
+  /**
+   * Client ID of a user-assigned managed identity. Only required when using
+   * a user-assigned identity; omit for system-assigned identities.
+   */
+  @IsOptional()
+  @CannotUseWithout("AZURE_USE_MANAGED_IDENTITY")
+  public AZURE_MANAGED_IDENTITY_CLIENT_ID = this.toOptionalString(
+    environment.AZURE_MANAGED_IDENTITY_CLIENT_ID
   );
 
   @IsOptional()

--- a/plugins/azure/server/index.ts
+++ b/plugins/azure/server/index.ts
@@ -3,7 +3,9 @@ import config from "../plugin.json";
 import router from "./auth/azure";
 import env from "./env";
 
-const enabled = !!env.AZURE_CLIENT_ID && !!env.AZURE_CLIENT_SECRET;
+const enabled =
+  !!env.AZURE_CLIENT_ID &&
+  (!!env.AZURE_CLIENT_SECRET || env.AZURE_USE_MANAGED_IDENTITY);
 
 if (enabled) {
   PluginManager.add({


### PR DESCRIPTION
Adds support for using Azure managed identity (federated identity credentials) instead of a client secret for the Azure AD OAuth2 flow.

When AZURE_USE_MANAGED_IDENTITY=true, the plugin acquires a token from the hosting platform's managed identity endpoint and uses it as a client_assertion in the OAuth2 token exchange. This eliminates the need to generate, store, and rotate client secrets.

This is useful when self-hosting Outline on Azure Container Apps, App Service, or VMs with managed identities configured. The managed identity must be set up as a federated identity credential on the Entra app registration.

New environment variables:
- AZURE_USE_MANAGED_IDENTITY: Enable managed identity auth (default: false)
- AZURE_MANAGED_IDENTITY_CLIENT_ID: Optional, for user-assigned identities