### PR TITLE
feat: Accept Azure AD bearer tokens for API authentication

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -288,3 +288,4 @@ DEBUG=http
 # Configure lowest severity level for server logs. Should be one of
 # error, warn, info, http, verbose, debug, or silly
 LOG_LEVEL=info
+

--- a/package.json
+++ b/package.json
@@ -272,7 +272,8 @@
     "y-protocols": "^1.0.7",
     "yauzl": "^3.2.1",
     "yjs": "^13.6.30",
-    "zod": "^4.2.1"
+    "zod": "^4.2.1",
+    "jwks-rsa": "^3.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.28.6",

--- a/plugins/azure/server/auth/azureAdAuth.ts
+++ b/plugins/azure/server/auth/azureAdAuth.ts
@@ -1,0 +1,248 @@
+import jwt from "jsonwebtoken";
+import JwksRsa from "jwks-rsa";
+import { Team, User } from "@server/models";
+import Logger from "@server/logging/Logger";
+import env from "../env";
+
+/**
+ * Minimal OpenID metadata required to validate Microsoft Entra access tokens.
+ */
+interface OpenIdConfiguration {
+  jwks_uri: string;
+}
+
+const openIdConfigurations = new Map<string, Promise<OpenIdConfiguration>>();
+const jwksClients = new Map<string, JwksRsa.JwksClient>();
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * Returns the set of valid audiences for incoming bearer tokens.
+ *
+ * @returns an array of audience strings.
+ */
+function getValidAudiences(): string[] {
+  const audiences = new Set<string>();
+  const clientId = env.AZURE_CLIENT_ID;
+  const configuredAudiences = env.AZURE_API_AUDIENCES?.split(",")
+    .map((a) => a.trim())
+    .filter(Boolean);
+
+  if (clientId) {
+    audiences.add(clientId);
+    audiences.add(`api://${clientId}`);
+  }
+
+  configuredAudiences?.forEach((a) => audiences.add(a));
+  return [...audiences];
+}
+
+/**
+ * Returns valid issuer URLs for the given tenant.
+ *
+ * @param tenantId - the Azure AD tenant ID.
+ * @returns an array of issuer strings (v1 and v2 formats).
+ */
+function getValidIssuers(tenantId: string): string[] {
+  return [
+    `https://sts.windows.net/${tenantId}/`,
+    `https://login.microsoftonline.com/${tenantId}/v2.0`,
+  ];
+}
+
+function getMetadataAddress(tenantId: string, issuer: string) {
+  if (issuer.startsWith("https://login.microsoftonline.com/")) {
+    return `https://login.microsoftonline.com/${tenantId}/v2.0/.well-known/openid-configuration`;
+  }
+  return `https://login.microsoftonline.com/${tenantId}/.well-known/openid-configuration`;
+}
+
+function extractTenantIdFromIssuer(issuer: string): string | undefined {
+  if (issuer.startsWith("https://sts.windows.net/")) {
+    return issuer.replace("https://sts.windows.net/", "").replace(/\/$/, "");
+  }
+  if (issuer.startsWith("https://login.microsoftonline.com/")) {
+    return issuer
+      .replace("https://login.microsoftonline.com/", "")
+      .split("/")[0] || undefined;
+  }
+  return undefined;
+}
+
+async function getOpenIdConfiguration(
+  tenantId: string,
+  issuer: string
+): Promise<OpenIdConfiguration> {
+  const version = issuer.includes("/v2.0") ? "v2" : "v1";
+  const cacheKey = `${tenantId}:${version}`;
+  let promise = openIdConfigurations.get(cacheKey);
+
+  if (!promise) {
+    promise = (async () => {
+      const response = await fetch(getMetadataAddress(tenantId, issuer));
+      if (!response.ok) {
+        throw new Error(`metadata request failed with status ${response.status}`);
+      }
+      const data = (await response.json()) as unknown;
+      if (!isObject(data) || typeof data.jwks_uri !== "string") {
+        throw new Error("metadata response did not include a jwks_uri");
+      }
+      return { jwks_uri: data.jwks_uri };
+    })();
+    openIdConfigurations.set(cacheKey, promise);
+  }
+
+  try {
+    return await promise;
+  } catch (error) {
+    openIdConfigurations.delete(cacheKey);
+    throw error;
+  }
+}
+
+/**
+ * Returns a JWKS client for the given URI, creating one if needed.
+ *
+ * @param jwksUri - the URI of the JWKS document.
+ * @returns a JwksClient instance.
+ */
+function getJwksClient(jwksUri: string): JwksRsa.JwksClient {
+  let client = jwksClients.get(jwksUri);
+  if (!client) {
+    client = JwksRsa({
+      jwksUri,
+      cache: true,
+      cacheMaxAge: 86400000,
+      rateLimit: true,
+    });
+    jwksClients.set(jwksUri, client);
+  }
+  return client;
+}
+
+function getEmailClaim(payload: jwt.JwtPayload): string | undefined {
+  return [payload.email, payload.preferred_username, payload.upn].find(
+    (c): c is string => typeof c === "string"
+  );
+}
+
+/**
+ * Validates an Azure AD / Entra bearer token and returns the corresponding
+ * Outline user. The token must be issued for a configured audience and signed
+ * by the tenant's keys. The user is looked up by email and must already exist
+ * in Outline (created via SSO login).
+ *
+ * This enables SSO-based API access, allowing tools such as MCP servers and
+ * AI agents to authenticate with Outline using the user's Entra identity
+ * instead of a manually created API key.
+ *
+ * @param token - the raw JWT bearer token.
+ * @returns the authenticated user and scope, or null if the token is not valid.
+ */
+export async function validateAzureADToken(token: string): Promise<{
+  user: User;
+  scope: string[];
+} | null> {
+  const validAudiences = getValidAudiences();
+  const configuredTenantId = env.AZURE_TENANT_ID;
+
+  if (!env.AZURE_CLIENT_ID || !configuredTenantId || validAudiences.length === 0) {
+    return null;
+  }
+
+  if (!token.startsWith("eyJ")) {
+    return null;
+  }
+
+  const decoded = jwt.decode(token, { complete: true });
+  if (!decoded || typeof decoded === "string" || typeof decoded.payload === "string") {
+    return null;
+  }
+
+  const payload = decoded.payload;
+  const issuer = payload.iss;
+  if (
+    typeof issuer !== "string" ||
+    (!issuer.startsWith("https://login.microsoftonline.com/") &&
+      !issuer.startsWith("https://sts.windows.net/"))
+  ) {
+    return null;
+  }
+
+  const tenantId = extractTenantIdFromIssuer(issuer);
+  if (!tenantId || tenantId !== configuredTenantId) {
+    return null;
+  }
+
+  const kid =
+    isObject(decoded.header) && typeof decoded.header.kid === "string"
+      ? decoded.header.kid
+      : undefined;
+  if (!kid) {
+    return null;
+  }
+
+  let configuration: OpenIdConfiguration;
+  try {
+    configuration = await getOpenIdConfiguration(tenantId, issuer);
+  } catch (err) {
+    Logger.info(
+      "lifecycle",
+      `Azure AD metadata fetch failed: ${(err as Error).message}`
+    );
+    return null;
+  }
+
+  const client = getJwksClient(configuration.jwks_uri);
+  let signingKey: string;
+  try {
+    const key = await client.getSigningKey(kid);
+    signingKey = key.getPublicKey();
+  } catch (err) {
+    Logger.info(
+      "lifecycle",
+      `Azure AD JWKS key fetch failed: ${(err as Error).message}`
+    );
+    return null;
+  }
+
+  let verified: jwt.JwtPayload;
+  try {
+    const result = jwt.verify(token, signingKey, {
+      algorithms: ["RS256"],
+      audience: validAudiences,
+      issuer: getValidIssuers(tenantId),
+      clockTolerance: 300,
+    });
+    if (typeof result === "string") {
+      return null;
+    }
+    verified = result;
+  } catch (err) {
+    Logger.info(
+      "lifecycle",
+      `Azure AD JWT verification failed: ${(err as Error).message}`
+    );
+    return null;
+  }
+
+  const email = getEmailClaim(verified);
+  if (!email) {
+    Logger.info("lifecycle", "Azure AD JWT: no email claim found");
+    return null;
+  }
+
+  const user = await User.findOne({
+    where: { email: email.toLowerCase() },
+    include: [{ model: Team, as: "team", required: true }],
+  });
+
+  if (!user) {
+    Logger.info("lifecycle", `Azure AD JWT: user not found for email`);
+    return null;
+  }
+
+  return { user, scope: ["*"] };
+}

--- a/plugins/azure/server/env.ts
+++ b/plugins/azure/server/env.ts
@@ -22,6 +22,21 @@ class AzurePluginEnvironment extends Environment {
     this.toOptionalString(environment.AZURE_RESOURCE_APP_ID) ??
     "00000003-0000-0000-c000-000000000000";
 
+  /**
+   * Comma-separated list of valid audiences for Entra bearer tokens used to
+   * authenticate API requests. When set, the API accepts Azure AD access
+   * tokens as an alternative to Outline API keys, enabling SSO-based API
+   * access for tools like MCP servers and AI agents.
+   *
+   * If omitted, the Azure client ID and `api://<client-id>` are accepted
+   * by default when AZURE_CLIENT_ID and AZURE_TENANT_ID are configured.
+   */
+  @IsOptional()
+  @CannotUseWithout("AZURE_CLIENT_ID")
+  public AZURE_API_AUDIENCES = this.toOptionalString(
+    environment.AZURE_API_AUDIENCES
+  );
+
   @IsOptional()
   @CannotUseWithout("AZURE_CLIENT_ID")
   public AZURE_TENANT_ID = this.toOptionalString(environment.AZURE_TENANT_ID);

--- a/plugins/azure/server/index.ts
+++ b/plugins/azure/server/index.ts
@@ -1,6 +1,7 @@
 import { Hook, PluginManager } from "@server/utils/PluginManager";
 import config from "../plugin.json";
 import router from "./auth/azure";
+import { validateAzureADToken } from "./auth/azureAdAuth";
 import env from "./env";
 
 const enabled = !!env.AZURE_CLIENT_ID && !!env.AZURE_CLIENT_SECRET;
@@ -10,5 +11,16 @@ if (enabled) {
     ...config,
     type: Hook.AuthProvider,
     value: { router, id: config.id },
+  });
+}
+
+// Register bearer token validator when Azure AD tenant is configured.
+// This enables SSO-based API access for MCP servers and AI agents.
+if (env.AZURE_CLIENT_ID && env.AZURE_TENANT_ID) {
+  PluginManager.add({
+    ...config,
+    name: `${config.name}-token-validator`,
+    type: Hook.TokenValidator,
+    value: validateAzureADToken,
   });
 }

--- a/server/middlewares/authentication.ts
+++ b/server/middlewares/authentication.ts
@@ -2,6 +2,7 @@ import type { Next } from "koa";
 import capitalize from "lodash/capitalize";
 import type { UserRole } from "@shared/types";
 import { UserRoleHelper } from "@shared/utils/UserRoleHelper";
+import Logger from "@server/logging/Logger";
 import tracer, {
   addTags,
   getRootSpanFromRequestContext,
@@ -15,6 +16,7 @@ import {
   AuthorizationError,
   UserSuspendedError,
 } from "../errors";
+import { Hook, PluginManager } from "../utils/PluginManager";
 
 type AuthenticationOptions = {
   /** Role required to access the route. */
@@ -242,10 +244,29 @@ async function validateAuthentication(
     scope = apiKey.scope ?? ["*"];
     await apiKey.updateActiveAt();
   } else {
-    type = AuthenticationType.APP;
-    const result = await getUserForJWT(token);
-    user = result.user;
-    service = result.service;
+    // Try plugin-registered token validators (e.g. Azure AD bearer tokens)
+    // before falling back to Outline's native JWT. This enables SSO-based
+    // API access for tools like MCP servers and AI agents.
+    const validators = PluginManager.getHooks(Hook.TokenValidator);
+    let pluginResult: { user: User; scope: string[] } | null = null;
+
+    for (const validator of validators) {
+      pluginResult = await validator.value(token).catch(() => null);
+      if (pluginResult) {
+        break;
+      }
+    }
+
+    if (pluginResult) {
+      type = AuthenticationType.API;
+      user = pluginResult.user;
+      scope = pluginResult.scope;
+    } else {
+      type = AuthenticationType.APP;
+      const result = await getUserForJWT(token);
+      user = result.user;
+      service = result.service;
+    }
   }
 
   if (user.isSuspended) {

--- a/server/utils/PluginManager.ts
+++ b/server/utils/PluginManager.ts
@@ -9,6 +9,7 @@ import Logger from "@server/logging/Logger";
 import type BaseProcessor from "@server/queues/processors/BaseProcessor";
 import type { BaseTask } from "@server/queues/tasks/base/BaseTask";
 import type { UnfurlSignature, UninstallSignature } from "@server/types";
+import type { User } from "@server/models";
 import type { BaseIssueProvider } from "./BaseIssueProvider";
 import type { GroupSyncProvider } from "./GroupSyncProvider";
 import type { BaseSearchProvider } from "./BaseSearchProvider";
@@ -32,10 +33,20 @@ export enum Hook {
   Processor = "processor",
   SearchProvider = "searchProvider",
   Task = "task",
+  TokenValidator = "tokenValidator",
   UnfurlProvider = "unfurl",
   Uninstall = "uninstall",
   GroupSyncProvider = "groupSyncProvider",
 }
+
+/**
+ * A function that validates a bearer token and returns the authenticated user,
+ * or null if the token is not recognized by this validator.
+ */
+export type TokenValidatorFn = (token: string) => Promise<{
+  user: User;
+  scope: string[];
+} | null>;
 
 /**
  * A map of plugin types to their values, for example an API plugin would have a value of type
@@ -49,6 +60,7 @@ type PluginValueMap = {
   [Hook.Processor]: typeof BaseProcessor;
   [Hook.SearchProvider]: BaseSearchProvider;
   [Hook.Task]: typeof BaseTask<any>;
+  [Hook.TokenValidator]: TokenValidatorFn;
   [Hook.Uninstall]: UninstallSignature;
   [Hook.UnfurlProvider]: { unfurl: UnfurlSignature; cacheExpiry: number };
   [Hook.GroupSyncProvider]: { id: string; provider: GroupSyncProvider };


### PR DESCRIPTION
Adds support for authenticating Outline API requests with Azure AD / Entra bearer tokens, as an alternative to Outline API keys. This enables SSO-based API access for MCP servers, AI agents, and other tools that already have the user's Entra identity.

When configured, the authentication middleware tries plugin-registered token validators before falling back to Outline's native JWT. The Azure plugin registers a validator that verifies the token's signature against Azure AD's JWKS endpoint, validates the audience and issuer, and maps the token's email claim to an existing Outline user.

This is particularly useful for Outline's built-in MCP server support, where tools like GitHub Copilot CLI can authenticate using the user's existing Entra SSO session without needing a manually created API key.

Architecture:
- New TokenValidator plugin hook in PluginManager, allowing any auth plugin to contribute bearer token validation
- Azure plugin registers its validator when AZURE_TENANT_ID is configured
- Authentication middleware iterates registered validators before JWT
- No changes to existing API key or session authentication

New environment variable:
- AZURE_API_AUDIENCES: Optional comma-separated list of valid token audiences (defaults to the Azure client ID)