### PR TITLE
fix: Handle missing team in OAuth authorize page during initial load

### DIFF
--- a/app/scenes/Login/OAuthAuthorize.tsx
+++ b/app/scenes/Login/OAuthAuthorize.tsx
@@ -76,7 +76,7 @@ function inputScopes(scope?: string): string[] {
  * and allows the user to either authorize or cancel the request.
  */
 function Authorize() {
-  const team = useCurrentTeam();
+  const team = useCurrentTeam({ rejectOnEmpty: false });
   const params = useQuery();
   const { t } = useTranslation();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -177,7 +177,7 @@ function Authorize() {
     );
   }
 
-  if (!response) {
+  if (!response || !team) {
     return <LoadingIndicator />;
   }
 


### PR DESCRIPTION
The Authorize component called useCurrentTeam() which throws an invariant error if the team hasn't loaded yet. During the MCP OAuth flow on first login, the MobX stores may not have hydrated, causing the page to crash with 'Invariant Violation: team required'.

Change useCurrentTeam() to useCurrentTeam({ rejectOnEmpty: false }) and show a loading indicator while the team is still loading, matching the existing pattern for waiting on the OAuth client response.