### PR TITLE
fix: Remove user id from toggle storage key

### DIFF
--- a/shared/editor/nodes/ToggleBlock.ts
+++ b/shared/editor/nodes/ToggleBlock.ts
@@ -92,8 +92,6 @@ export default class ToggleBlock extends Node {
   }
 
   get plugins() {
-    const userId = this.editor.props.userId;
-
     // Assign IDs and auto-fold empty
     const plugin = new Plugin({
       appendTransaction: (transactions, _oldState, newState) => {
@@ -120,7 +118,7 @@ export default class ToggleBlock extends Node {
             const id = v4();
             tr!.setNodeAttribute(block.pos, "id", id);
             // Set unfolded for the user who created the toggle
-            Storage.set(`${id}:${userId}`, { fold: false });
+            Storage.set(id, { fold: false });
           });
         }
 
@@ -190,7 +188,7 @@ export default class ToggleBlock extends Node {
             currentBlocks.forEach((block) => {
               const id = block.node.attrs.id as string;
               if (!pluginState.foldedIds.has(id)) {
-                const stored = Storage.get(`${id}:${userId}`);
+                const stored = Storage.get(id);
                 // Default to folded if no stored state (new block from sync)
                 if (stored?.fold !== false) {
                   newFoldedIds.add(id);
@@ -214,7 +212,7 @@ export default class ToggleBlock extends Node {
               const node = newState.doc.nodeAt(action.at);
               if (node?.attrs.id) {
                 newFoldedIds.add(node.attrs.id);
-                Storage.set(`${node.attrs.id}:${userId}`, { fold: true });
+                Storage.set(node.attrs.id, { fold: true });
               }
               break;
             }
@@ -223,7 +221,7 @@ export default class ToggleBlock extends Node {
               const node = newState.doc.nodeAt(action.at);
               if (node?.attrs.id) {
                 newFoldedIds.delete(node.attrs.id);
-                Storage.set(`${node.attrs.id}:${userId}`, { fold: false });
+                Storage.set(node.attrs.id, { fold: false });
               }
               break;
             }
@@ -246,8 +244,7 @@ export default class ToggleBlock extends Node {
               view,
               getPos,
               decorations,
-              innerDecorations,
-              this.editor.props
+              innerDecorations
             ),
         },
       },
@@ -432,7 +429,7 @@ export default class ToggleBlock extends Node {
         if (!wrapping) {
           return false;
         }
-        Storage.set(`${id}:${this.editor.props.userId}`, { fold: false });
+        Storage.set(id, { fold: false });
         const tr = state.tr.wrap(range!, wrapping);
         dispatch?.(tr);
         return true;
@@ -446,7 +443,7 @@ export default class ToggleBlock extends Node {
           return false;
         }
 
-        Storage.set(`${id}:${this.editor.props.userId}`, { fold: false });
+        Storage.set(id, { fold: false });
         const tr = state.tr.wrap(range!, wrapping);
         dispatch?.(
           tr.insert(
@@ -476,19 +473,18 @@ export default class ToggleBlock extends Node {
   private initFoldedIds(state: EditorState) {
     const pluginState = toggleFoldPluginKey.getState(state);
     const foldedIds = new Set<string>(pluginState?.foldedIds);
-    const userId = this.editor.props.userId;
     findBlockNodes(state.doc, true)
       .filter((b) => b.node.type.name === this.name && b.node.attrs.id)
       .forEach((block) => {
         const id = block.node.attrs.id as string;
-        const stored = Storage.get(`${id}:${userId}`);
+        const stored = Storage.get(id);
         // Default to folded if no stored state
         if (stored?.fold !== false) {
           foldedIds.add(id);
         }
         // Ensure storage has a value
         if (stored === null || stored === undefined) {
-          Storage.set(`${id}:${userId}`, { fold: true });
+          Storage.set(id, { fold: true });
         }
       });
 

--- a/shared/editor/nodes/ToggleBlock.ts
+++ b/shared/editor/nodes/ToggleBlock.ts
@@ -61,6 +61,9 @@ export const toggleFoldPluginKey = new PluginKey<ToggleFoldState>("toggleFold");
 /** Plugin key for toggle block fold/unfold events. */
 export const toggleEventPluginKey = new PluginKey("toggleBlockEvent");
 
+/** Build the localStorage key used to persist a toggle block's fold state. */
+export const toggleStorageKey = (id: string) => `toggle:${id}`;
+
 export default class ToggleBlock extends Node {
   get name() {
     return "container_toggle";
@@ -110,15 +113,14 @@ export default class ToggleBlock extends Node {
 
         let tr: Transaction | null = null;
 
-        // Assign IDs to blocks that need them and set fold state for creator
+        // Assign IDs to blocks that need them and default to unfolded in this browser
         const blocksNeedingIds = toggleBlocks.filter((b) => !b.node.attrs.id);
         if (blocksNeedingIds.length > 0) {
           tr = newState.tr;
           blocksNeedingIds.forEach((block) => {
             const id = v4();
             tr!.setNodeAttribute(block.pos, "id", id);
-            // Set unfolded for the user who created the toggle
-            Storage.set(id, { fold: false });
+            Storage.set(toggleStorageKey(id), { fold: false });
           });
         }
 
@@ -188,7 +190,7 @@ export default class ToggleBlock extends Node {
             currentBlocks.forEach((block) => {
               const id = block.node.attrs.id as string;
               if (!pluginState.foldedIds.has(id)) {
-                const stored = Storage.get(id);
+                const stored = Storage.get(toggleStorageKey(id));
                 // Default to folded if no stored state (new block from sync)
                 if (stored?.fold !== false) {
                   newFoldedIds.add(id);
@@ -212,7 +214,7 @@ export default class ToggleBlock extends Node {
               const node = newState.doc.nodeAt(action.at);
               if (node?.attrs.id) {
                 newFoldedIds.add(node.attrs.id);
-                Storage.set(node.attrs.id, { fold: true });
+                Storage.set(toggleStorageKey(node.attrs.id), { fold: true });
               }
               break;
             }
@@ -221,7 +223,7 @@ export default class ToggleBlock extends Node {
               const node = newState.doc.nodeAt(action.at);
               if (node?.attrs.id) {
                 newFoldedIds.delete(node.attrs.id);
-                Storage.set(node.attrs.id, { fold: false });
+                Storage.set(toggleStorageKey(node.attrs.id), { fold: false });
               }
               break;
             }
@@ -429,7 +431,7 @@ export default class ToggleBlock extends Node {
         if (!wrapping) {
           return false;
         }
-        Storage.set(id, { fold: false });
+        Storage.set(toggleStorageKey(id), { fold: false });
         const tr = state.tr.wrap(range!, wrapping);
         dispatch?.(tr);
         return true;
@@ -443,7 +445,7 @@ export default class ToggleBlock extends Node {
           return false;
         }
 
-        Storage.set(id, { fold: false });
+        Storage.set(toggleStorageKey(id), { fold: false });
         const tr = state.tr.wrap(range!, wrapping);
         dispatch?.(
           tr.insert(
@@ -477,14 +479,14 @@ export default class ToggleBlock extends Node {
       .filter((b) => b.node.type.name === this.name && b.node.attrs.id)
       .forEach((block) => {
         const id = block.node.attrs.id as string;
-        const stored = Storage.get(id);
+        const stored = Storage.get(toggleStorageKey(id));
         // Default to folded if no stored state
         if (stored?.fold !== false) {
           foldedIds.add(id);
         }
         // Ensure storage has a value
         if (stored === null || stored === undefined) {
-          Storage.set(id, { fold: true });
+          Storage.set(toggleStorageKey(id), { fold: true });
         }
       });
 

--- a/shared/editor/nodes/ToggleBlockView.ts
+++ b/shared/editor/nodes/ToggleBlockView.ts
@@ -6,6 +6,7 @@ import {
   Action,
   toggleEventPluginKey,
   toggleFoldPluginKey,
+  toggleStorageKey,
 } from "./ToggleBlock";
 
 /**
@@ -121,7 +122,7 @@ export class ToggleBlockView implements NodeView {
 
   private broadcastFoldState(event: StorageEvent) {
     if (
-      event.key !== this.node.attrs.id ||
+      event.key !== toggleStorageKey(this.node.attrs.id) ||
       !event.newValue ||
       !event.oldValue
     ) {

--- a/shared/editor/nodes/ToggleBlockView.ts
+++ b/shared/editor/nodes/ToggleBlockView.ts
@@ -18,7 +18,6 @@ export class ToggleBlockView implements NodeView {
   private node: ProsemirrorNode;
   private view: EditorView;
   private getPos: () => number | undefined;
-  private editorProps: Record<string, unknown>;
   private boundBroadcastFoldState: (event: StorageEvent) => void;
 
   constructor(
@@ -26,13 +25,11 @@ export class ToggleBlockView implements NodeView {
     view: EditorView,
     getPos: () => number | undefined,
     decorations: readonly Decoration[],
-    _innerDecorations: DecorationSource,
-    editorProps: Record<string, unknown>
+    _innerDecorations: DecorationSource
   ) {
     this.node = node;
     this.view = view;
     this.getPos = getPos;
-    this.editorProps = editorProps;
 
     // Create DOM structure
     this.dom = document.createElement("div");
@@ -123,8 +120,11 @@ export class ToggleBlockView implements NodeView {
   };
 
   private broadcastFoldState(event: StorageEvent) {
-    const key = `${this.node.attrs.id}:${this.editorProps.userId}`;
-    if (event.key !== key || !event.newValue || !event.oldValue) {
+    if (
+      event.key !== this.node.attrs.id ||
+      !event.newValue ||
+      !event.oldValue
+    ) {
       return;
     }
 


### PR DESCRIPTION
In usage the user id was often `undefined` leading to multiple storage keys for the same toggle