### PR TITLE
fix: prevent crash when printing with right sidebar open

### DIFF
--- a/app/components/Sidebar/Aside.tsx
+++ b/app/components/Sidebar/Aside.tsx
@@ -7,6 +7,7 @@ import { depths, s } from "@shared/styles";
 import ErrorBoundary from "~/components/ErrorBoundary";
 import Flex from "~/components/Flex";
 import ResizeBorder from "~/components/Sidebar/components/ResizeBorder";
+import useMediaQuery from "~/hooks/useMediaQuery";
 import useStores from "~/hooks/useStores";
 import useWindowScrollbarWidth from "~/hooks/useWindowScrollbarWidth";
 import { sidebarAppearDuration } from "~/styles/animations";
@@ -22,6 +23,7 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
 function Aside({ children, border, className, skipInitialAnimation }: Props) {
   const theme = useTheme();
   const { ui } = useStores();
+  const isPrinting = useMediaQuery("print");
   const [isResizing, setResizing] = React.useState(false);
   const maxWidth = theme.sidebarMaxWidth;
   const minWidth = theme.sidebarMinWidth + 16; // padding
@@ -112,7 +114,7 @@ function Aside({ children, border, className, skipInitialAnimation }: Props) {
       aria-label="Aside"
     >
       <Position style={style} column>
-        <ErrorBoundary>{children}</ErrorBoundary>
+        {!isPrinting && <ErrorBoundary>{children}</ErrorBoundary>}
         <ResizeBorder
           onMouseDown={handleMouseDown}
           onDoubleClick={handleReset}
@@ -153,6 +155,10 @@ const Sidebar = styled(m.div)<{
   ${breakpoint("tablet")`
     position: relative;
   `}
+
+  @media print {
+    display: none;
+  }
 `;
 
 export default observer(Aside);

--- a/app/hooks/useMediaQuery.ts
+++ b/app/hooks/useMediaQuery.ts
@@ -7,23 +7,28 @@ import { useState, useEffect } from "react";
  * @returns boolean indicating whether the media query matches
  */
 export default function useMediaQuery(query: string): boolean {
-  const [matches, setMatches] = useState<boolean>(false);
+  const [matches, setMatches] = useState<boolean>(
+    () => typeof window !== "undefined" && !!window.matchMedia?.(query)?.matches
+  );
 
   useEffect(() => {
-    if (window.matchMedia) {
-      const media = window.matchMedia(query);
-      if (media.matches !== matches) {
-        setMatches(media.matches);
-      }
-      const listener = () => {
-        setMatches(media.matches);
-      };
-      media.addListener(listener);
-      return () => media.removeListener(listener);
+    if (!window.matchMedia) {
+      return undefined;
     }
+    const media = window.matchMedia(query);
+    setMatches(media.matches);
 
-    return undefined;
-  }, [matches, query]);
+    let timeoutId: ReturnType<typeof setTimeout>;
+    const listener = () => {
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => setMatches(media.matches), 0);
+    };
+    media.addEventListener("change", listener);
+    return () => {
+      clearTimeout(timeoutId);
+      media.removeEventListener("change", listener);
+    };
+  }, [query]);
 
   return matches;
 }


### PR DESCRIPTION
## Summary
- Added `isPrinting` check using `useMediaQuery("print")` to conditionally unmount the aside sidebar's children during print, preventing a crash when the comments or history panel is open while printing
- When `window.print()` is triggered with the aside sidebar open, the browser's `matchMedia("print")` change event fires and React's microtask scheduler invalidates pending callbacks in child components (`ResizeObserver` in `Scrollable`, `useMeasure` in `ResizingHeightContainer`), resulting in an `ErrorBoundary` error: "The provided callback is no longer runnable"
- Also refactored `useMediaQuery` to defer state updates via `setTimeout(0)` to avoid microtask conflicts during print transitions — this fix is consistent with the existing `useMediaQuery("print")` pattern used in `PageScroll.tsx` and `useBuildTheme.ts`, and the `@media print { display: none }` CSS rule matches the left sidebar's print-hiding approach in `Sidebar.tsx`

## Test plan
- [x] Verified printing with comments sidebar open no longer crashes
- [x] Verified printing with history sidebar open no longer crashes
- [x] Verified normal printing (no sidebar open) still works
- [x] Confirmed responsive behavior unchanged (`useMobile` hook still works)
- [x] Confirmed no regressions in `useBuildTheme` print detection