### PR TITLE
fix: Return to empty search on 'Search' sidebar click

### DIFF
--- a/app/components/Sidebar/App.tsx
+++ b/app/components/Sidebar/App.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useCallback, useMemo } from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import { useTranslation } from "react-i18next";
+import { useHistory, useLocation } from "react-router-dom";
 import styled from "styled-components";
 import { metaDisplay } from "@shared/utils/keyboard";
 import Scrollable from "~/components/Scrollable";
@@ -37,6 +38,17 @@ function AppSidebar() {
   const team = useCurrentTeam();
   const user = useCurrentUser();
   const can = usePolicy(team);
+  const history = useHistory();
+  const location = useLocation();
+
+  const handleSearchClick = useCallback(() => {
+    if (
+      location.pathname.startsWith("/search") &&
+      (location.search || location.pathname !== "/search")
+    ) {
+      history.push(searchPath());
+    }
+  }, [history, location.pathname, location.search]);
 
   useEffect(() => {
     void collections.fetchAll();
@@ -106,6 +118,7 @@ function AppSidebar() {
                 icon={<SearchIcon />}
                 label={t("Search")}
                 exact={false}
+                onClick={handleSearchClick}
               />
               {can.createDocument && <DraftsLink />}
             </Section>

--- a/app/components/Sidebar/App.tsx
+++ b/app/components/Sidebar/App.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState, useCallback, useMemo } from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import { useTranslation } from "react-i18next";
-import { useHistory, useLocation } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 import styled from "styled-components";
 import { metaDisplay } from "@shared/utils/keyboard";
 import Scrollable from "~/components/Scrollable";
@@ -39,16 +39,14 @@ function AppSidebar() {
   const user = useCurrentUser();
   const can = usePolicy(team);
   const history = useHistory();
-  const location = useLocation();
 
   const handleSearchClick = useCallback(() => {
-    if (
-      location.pathname.startsWith("/search") &&
-      (location.search || location.pathname !== "/search")
-    ) {
-      history.push(searchPath());
+    const basePath = searchPath();
+    const { pathname, search } = history.location;
+    if (pathname.startsWith(basePath) && (search || pathname !== basePath)) {
+      history.push(basePath);
     }
-  }, [history, location.pathname, location.search]);
+  }, [history]);
 
   useEffect(() => {
     void collections.fetchAll();


### PR DESCRIPTION
Currently, when you're on a search page with an active query and you click it in the sidebar, nothing happens.