### PR TITLE
fix: Ignore Outlook SafeLink crawler errors in Sentry

### DIFF
--- a/app/utils/sentry.ts
+++ b/app/utils/sentry.ts
@@ -43,6 +43,7 @@ export function initSentry(history: History) {
       "Failed to fetch dynamically imported module",
       "ResizeObserver loop completed with undelivered notifications",
       "ResizeObserver loop limit exceeded",
+      "Object Not Found Matching Id",
       "file://",
       "chrome-extension://",
     ],


### PR DESCRIPTION
Filters out the well-known `Object Not Found Matching Id:N, MethodName:update, ParamCount:N` promise rejection noise in Sentry. This error originates from Microsoft Outlook's SafeLink crawler (and similar bots) injecting scripts into pages — it is not originating from Outline's code and has no user impact.