### PR TITLE
fix: Reduce noise from XHR upload network errors

### DIFF
--- a/app/utils/files.ts
+++ b/app/utils/files.ts
@@ -85,9 +85,24 @@ export const uploadFile = async (
       }
     });
     xhr.addEventListener("error", () => {
+      const extra = {
+        status: xhr.status,
+        statusText: xhr.statusText,
+        contentType: file.type,
+        size: file.size,
+      };
+
+      // Status 0 means the request never reached the server (network drop,
+      // CORS, abort) — log as a warning rather than an unhelpful "Error: 0".
+      if (xhr.status === 0) {
+        Logger.warn("File upload failed before response", extra);
+        return;
+      }
+
       Logger.error(
         "File upload failed",
-        new Error(`${xhr.status} ${xhr.statusText}`)
+        new Error(`${xhr.status} ${xhr.statusText}`),
+        extra
       );
     });
     xhr.addEventListener("loadend", () => {


### PR DESCRIPTION
## Summary
Network-level upload failures (`xhr.status === 0` — network drop, CORS, abort) were reporting to Sentry as unactionable `Error: "0"` entries. These now log as warnings, while genuine server errors continue to report as errors and include useful context (`status`, `statusText`, `contentType`, `size`).

## Test plan
- [ ] Trigger an upload while offline — should log a warning, not an error
- [ ] Simulate a 5xx upload response — should still report to Sentry with extra context

🤖 Generated with [Claude Code](https://claude.com/claude-code)