### PR TITLE
fix: Scrollbar flash in new collection modal

### DIFF
--- a/app/components/Collapsible.tsx
+++ b/app/components/Collapsible.tsx
@@ -64,7 +64,7 @@ const StyledTrigger = styled(RadixCollapsible.Trigger)`
   padding: 0 0 8px 0;
   cursor: var(--pointer);
   color: ${s("textTertiary")};
-  font-size: 14pxte
+  font-size: 14px;
 
   &:hover {
     color: ${s("textSecondary")};

--- a/app/components/Collection/CollectionForm.tsx
+++ b/app/components/Collection/CollectionForm.tsx
@@ -25,6 +25,7 @@ import useCurrentTeam from "~/hooks/useCurrentTeam";
 import useStores from "~/hooks/useStores";
 import { EmptySelectValue } from "~/types";
 import { HStack } from "../primitives/HStack";
+import { useDialogContext } from "~/components/DialogContext";
 
 const IconPicker = createLazyComponent(() => import("~/components/IconPicker"));
 
@@ -67,6 +68,7 @@ export const CollectionForm = observer(function CollectionForm_({
 }) {
   const team = useCurrentTeam();
   const { t } = useTranslation();
+  const dialog = useDialogContext();
 
   const [hasOpenedIconPicker, setHasOpenedIconPicker] = useBoolean(false);
 
@@ -278,7 +280,12 @@ export const CollectionForm = observer(function CollectionForm_({
       {collection ? (
         options
       ) : (
-        <Collapsible label={t("Advanced options")}>{options}</Collapsible>
+        <Collapsible
+          label={t("Advanced options")}
+          onOpenChange={() => dialog.setAnimating(true)}
+        >
+          {options}
+        </Collapsible>
       )}
 
       <HStack justify="flex-end">

--- a/app/components/DialogContext.tsx
+++ b/app/components/DialogContext.tsx
@@ -1,0 +1,32 @@
+import { createContext, useContext, useMemo, useState } from "react";
+
+export type DialogContext = {
+  animating: boolean;
+  setAnimating: (isAnimating: boolean) => void;
+};
+
+/**
+ * Context for the dialogs (Guide/Modal) being rendered.
+ * This helps control the dialog's behavior from within any nested component.
+ */
+const DialogContext = createContext<DialogContext>({
+  animating: false,
+  setAnimating: () => {},
+});
+
+export function DialogProvider({ children }: { children: React.ReactNode }) {
+  const [animating, setAnimating] = useState(false);
+  const ctx = useMemo<DialogContext>(
+    () => ({
+      animating,
+      setAnimating,
+    }),
+    [animating]
+  );
+
+  return (
+    <DialogContext.Provider value={ctx}>{children}</DialogContext.Provider>
+  );
+}
+
+export const useDialogContext = () => useContext(DialogContext);

--- a/app/components/Dialogs.tsx
+++ b/app/components/Dialogs.tsx
@@ -2,6 +2,7 @@ import { observer } from "mobx-react";
 import { Suspense } from "react";
 import useStores from "~/hooks/useStores";
 import lazyWithRetry from "~/utils/lazyWithRetry";
+import { DialogProvider } from "./DialogContext";
 
 const Guide = lazyWithRetry(() => import("~/components/Guide"));
 const Modal = lazyWithRetry(() => import("~/components/Modal"));
@@ -12,33 +13,35 @@ function Dialogs() {
   const modals = [...modalStack];
 
   return (
-    <Suspense fallback={null}>
-      {guide ? (
-        <Guide
-          isOpen={guide.isOpen}
-          onRequestClose={dialogs.closeGuide}
-          title={guide.title}
-        >
-          {guide.content}
-        </Guide>
-      ) : undefined}
-      {modals.map(([id, modal]) => (
-        <Modal
-          key={id}
-          isOpen={modal.isOpen}
-          onRequestClose={() => {
-            modal.onClose?.();
-            dialogs.closeModal(id);
-          }}
-          title={modal.title}
-          style={modal.style}
-          width={modal.width}
-          height={modal.height}
-        >
-          {modal.content}
-        </Modal>
-      ))}
-    </Suspense>
+    <DialogProvider>
+      <Suspense fallback={null}>
+        {guide ? (
+          <Guide
+            isOpen={guide.isOpen}
+            onRequestClose={dialogs.closeGuide}
+            title={guide.title}
+          >
+            {guide.content}
+          </Guide>
+        ) : undefined}
+        {modals.map(([id, modal]) => (
+          <Modal
+            key={id}
+            isOpen={modal.isOpen}
+            onRequestClose={() => {
+              modal.onClose?.();
+              dialogs.closeModal(id);
+            }}
+            title={modal.title}
+            style={modal.style}
+            width={modal.width}
+            height={modal.height}
+          >
+            {modal.content}
+          </Modal>
+        ))}
+      </Suspense>
+    </DialogProvider>
   );
 }
 

--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -43,23 +43,25 @@ const Modal: React.FC<Props> = ({
   const { t } = useTranslation();
   const dialog = useDialogContext();
 
+  const onClose = React.useCallback(() => {
+    dialog.setAnimating(false); // Reset
+    onRequestClose();
+  }, [dialog, onRequestClose]);
+
   if (!isOpen && !wasOpen) {
     return null;
   }
 
   return (
-    <Dialog.Root
-      open={isOpen}
-      onOpenChange={(open) => !open && onRequestClose()}
-    >
+    <Dialog.Root open={isOpen} onOpenChange={(open) => !open && onClose()}>
       <Dialog.Portal>
         <StyledOverlay />
         <Dialog.Title asChild>
           <VisuallyHidden.Root>{title}</VisuallyHidden.Root>
         </Dialog.Title>
         <StyledContent
-          onEscapeKeyDown={onRequestClose}
-          onPointerDownOutside={onRequestClose}
+          onEscapeKeyDown={onClose}
+          onPointerDownOutside={onClose}
           aria-describedby={undefined}
         >
           {isMobile ? (
@@ -74,10 +76,10 @@ const Modal: React.FC<Props> = ({
                   <ErrorBoundary>{children}</ErrorBoundary>
                 </Centered>
               </MobileContent>
-              <Close onClick={onRequestClose}>
+              <Close onClick={onClose}>
                 <CloseIcon size={32} />
               </Close>
-              <Back onClick={onRequestClose}>
+              <Back onClick={onClose}>
                 <BackIcon size={32} />
                 <Text>{t("Back")} </Text>
               </Back>
@@ -102,7 +104,7 @@ const Modal: React.FC<Props> = ({
                 <Header>
                   {title && <Text size="large">{title}</Text>}
                   <Tooltip content={t("Close")} shortcut="Esc">
-                    <NudeButton onClick={onRequestClose}>
+                    <NudeButton onClick={onClose}>
                       <CloseIcon />
                     </NudeButton>
                   </Tooltip>

--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -17,6 +17,7 @@ import Desktop from "~/utils/Desktop";
 import ErrorBoundary from "./ErrorBoundary";
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import Tooltip from "./Tooltip";
+import { useDialogContext } from "~/components/DialogContext";
 
 type Props = {
   children?: React.ReactNode;
@@ -40,6 +41,7 @@ const Modal: React.FC<Props> = ({
   const wasOpen = usePrevious(isOpen);
   const isMobile = useMobile();
   const { t } = useTranslation();
+  const dialog = useDialogContext();
 
   if (!isOpen && !wasOpen) {
     return null;
@@ -89,7 +91,12 @@ const Modal: React.FC<Props> = ({
                 column
                 reverse
               >
-                <DesktopContent style={style} topShadow>
+                <DesktopContent
+                  style={style}
+                  topShadow
+                  overflow={dialog.animating ? "hidden" : undefined}
+                  onAnimationEnd={() => dialog.setAnimating(false)}
+                >
                   <ErrorBoundary component="div">{children}</ErrorBoundary>
                 </DesktopContent>
                 <Header>


### PR DESCRIPTION
Noticed scrollbar flash when advanced-options is animating in new collections form.

### Before
https://github.com/user-attachments/assets/9da26c22-299d-4c01-a617-5c6a0edb6c52

### After
https://github.com/user-attachments/assets/e66a6263-ff8f-4bea-98ec-b6de461234b3

