### PR TITLE
fix: Autofocus inside lazy-loaded modal and popover

### DIFF
--- a/app/components/Sharing/Collection/SharePopover.tsx
+++ b/app/components/Sharing/Collection/SharePopover.tsx
@@ -89,6 +89,13 @@ function SharePopover({
     }
   );
 
+  // Focus the search input to account for lazy-loading
+  React.useLayoutEffect(() => {
+    if (visible) {
+      searchInputRef.current?.focus();
+    }
+  }, [visible]);
+
   // Hide the picker when the popover is closed
   React.useEffect(() => {
     if (visible) {

--- a/app/components/Sharing/Collection/SharePopover.tsx
+++ b/app/components/Sharing/Collection/SharePopover.tsx
@@ -66,6 +66,7 @@ function SharePopover({
   const share = shares.getByCollectionId(collection.id);
   const prevPendingIds = usePrevious(pendingIds);
 
+  const wrapperRef = React.useRef<HTMLDivElement | null>(null);
   const suggestionsRef = React.useRef<HTMLDivElement | null>(null);
   const searchInputRef = React.useRef<HTMLInputElement | null>(null);
 
@@ -89,12 +90,14 @@ function SharePopover({
     }
   );
 
-  // Focus the search input to account for lazy-loading
+  // Move focus into the popover to account for lazy-loading
   React.useLayoutEffect(() => {
-    if (visible) {
-      searchInputRef.current?.focus();
+    if (!hasRendered) {
+      return;
     }
-  }, [visible]);
+
+    (searchInputRef.current ?? wrapperRef.current)?.focus();
+  }, [hasRendered]);
 
   // Hide the picker when the popover is closed
   React.useEffect(() => {
@@ -358,7 +361,7 @@ function SharePopover({
   );
 
   return (
-    <Wrapper>
+    <Wrapper ref={wrapperRef} tabIndex={-1}>
       {can.update && (
         <SearchInput
           ref={searchInputRef}

--- a/app/components/Sharing/Document/SharePopover.tsx
+++ b/app/components/Sharing/Document/SharePopover.tsx
@@ -91,6 +91,13 @@ function SharePopover({
     }
   );
 
+  // Focus the search input to account for lazy-loading
+  React.useLayoutEffect(() => {
+    if (visible) {
+      searchInputRef.current?.focus();
+    }
+  }, [visible]);
+
   React.useEffect(() => {
     if (visible) {
       if (externalLoading === undefined) {

--- a/app/components/Sharing/Document/SharePopover.tsx
+++ b/app/components/Sharing/Document/SharePopover.tsx
@@ -68,6 +68,7 @@ function SharePopover({
 
   const prevPendingIds = usePrevious(pendingIds);
 
+  const wrapperRef = React.useRef<HTMLDivElement | null>(null);
   const suggestionsRef = React.useRef<HTMLDivElement | null>(null);
   const searchInputRef = React.useRef<HTMLInputElement | null>(null);
 
@@ -91,12 +92,14 @@ function SharePopover({
     }
   );
 
-  // Focus the search input to account for lazy-loading
+  // Move focus into the popover to account for lazy-loading
   React.useLayoutEffect(() => {
-    if (visible) {
-      searchInputRef.current?.focus();
+    if (!hasRendered) {
+      return;
     }
-  }, [visible]);
+
+    (searchInputRef.current ?? wrapperRef.current)?.focus();
+  }, [hasRendered]);
 
   React.useEffect(() => {
     if (visible) {
@@ -365,7 +368,7 @@ function SharePopover({
   );
 
   return (
-    <Wrapper>
+    <Wrapper ref={wrapperRef} tabIndex={-1}>
       {can.manageUsers && (
         <SearchInput
           ref={searchInputRef}

--- a/app/scenes/Document/components/Insights.tsx
+++ b/app/scenes/Document/components/Insights.tsx
@@ -24,23 +24,19 @@ type Props = {
 
 function Insights({ document }: Props) {
   const { t } = useTranslation();
-  const hiddenRef = useRef<HTMLSpanElement | null>(null);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
   const selectedText = useTextSelection();
   const text = ProsemirrorHelper.toPlainText(document);
   const stats = useTextStats(text ?? "", selectedText);
   const formatNumber = useFormatNumber();
 
-  // Manually focus inside the modal to account for lazy-loading.
-  // Hidden span is needed since the only other focusable element is the close button.
+  // Move focus into the modal to account for lazy-loading
   useLayoutEffect(() => {
-    hiddenRef.current?.focus();
+    wrapperRef.current?.focus();
   }, []);
 
   return (
-    <div>
-      <VisuallyHidden>
-        <span ref={hiddenRef} tabIndex={0} />
-      </VisuallyHidden>
+    <div ref={wrapperRef} tabIndex={-1}>
       {document ? (
         <Flex
           column

--- a/app/scenes/Document/components/Insights.tsx
+++ b/app/scenes/Document/components/Insights.tsx
@@ -15,6 +15,8 @@ import { useTextStats } from "~/hooks/useTextStats";
 import type Document from "~/models/Document";
 import { useFormatNumber } from "~/hooks/useFormatNumber";
 import { ProsemirrorHelper } from "~/models/helpers/ProsemirrorHelper";
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
+import { useLayoutEffect, useRef } from "react";
 
 type Props = {
   document: Document;
@@ -22,13 +24,23 @@ type Props = {
 
 function Insights({ document }: Props) {
   const { t } = useTranslation();
+  const hiddenRef = useRef<HTMLSpanElement | null>(null);
   const selectedText = useTextSelection();
   const text = ProsemirrorHelper.toPlainText(document);
   const stats = useTextStats(text ?? "", selectedText);
   const formatNumber = useFormatNumber();
 
+  // Manually focus inside the modal to account for lazy-loading.
+  // Hidden span is needed since the only other focusable element is the close button.
+  useLayoutEffect(() => {
+    hiddenRef.current?.focus();
+  }, []);
+
   return (
     <div>
+      <VisuallyHidden>
+        <span ref={hiddenRef} tabIndex={0} />
+      </VisuallyHidden>
       {document ? (
         <Flex
           column

--- a/app/scenes/Document/components/Insights.tsx
+++ b/app/scenes/Document/components/Insights.tsx
@@ -15,7 +15,6 @@ import { useTextStats } from "~/hooks/useTextStats";
 import type Document from "~/models/Document";
 import { useFormatNumber } from "~/hooks/useFormatNumber";
 import { ProsemirrorHelper } from "~/models/helpers/ProsemirrorHelper";
-import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { useLayoutEffect, useRef } from "react";
 
 type Props = {


### PR DESCRIPTION
SharePopover & Insights are being lazy-loaded which prevents Radix's auto-focus from triggering.