### PR TITLE
feat: Allow geo:, maps:, and magnet: link protocols

### DIFF
--- a/shared/utils/urls.test.ts
+++ b/shared/utils/urls.test.ts
@@ -165,20 +165,25 @@ describe("sanitizeUrl", () => {
       expect(urlsUtils.sanitizeUrl("fax:0123456789")).toEqual("fax:0123456789");
       expect(urlsUtils.sanitizeUrl("sms:0123456789")).toEqual("sms:0123456789");
     });
-    it("should return the url as it's if it's geo:", () => {
+    it("should return the url unchanged if it's geo:", () => {
       expect(urlsUtils.sanitizeUrl("geo:37.786971,-122.399677")).toEqual(
         "geo:37.786971,-122.399677"
       );
     });
-    it("should return the url as it's if it's maps:", () => {
+    it("should return the url unchanged if it's maps:", () => {
       expect(urlsUtils.sanitizeUrl("maps:?q=Eiffel+Tower")).toEqual(
         "maps:?q=Eiffel+Tower"
       );
     });
-    it("should return the url as it's if it's magnet:", () => {
+    it("should return the url unchanged if it's magnet:", () => {
       expect(
         urlsUtils.sanitizeUrl("magnet:?xt=urn:btih:abc123&dn=file")
       ).toEqual("magnet:?xt=urn:btih:abc123&dn=file");
+    });
+    it("should handle uppercase scheme", () => {
+      expect(urlsUtils.sanitizeUrl("GEO:37.786971,-122.399677")).toEqual(
+        "GEO:37.786971,-122.399677"
+      );
     });
     it("should return the url as it's if it's a special protocol", () => {
       expect(urlsUtils.sanitizeUrl("mqtt://getoutline.com")).toEqual(

--- a/shared/utils/urls.test.ts
+++ b/shared/utils/urls.test.ts
@@ -165,6 +165,21 @@ describe("sanitizeUrl", () => {
       expect(urlsUtils.sanitizeUrl("fax:0123456789")).toEqual("fax:0123456789");
       expect(urlsUtils.sanitizeUrl("sms:0123456789")).toEqual("sms:0123456789");
     });
+    it("should return the url as it's if it's geo:", () => {
+      expect(urlsUtils.sanitizeUrl("geo:37.786971,-122.399677")).toEqual(
+        "geo:37.786971,-122.399677"
+      );
+    });
+    it("should return the url as it's if it's maps:", () => {
+      expect(urlsUtils.sanitizeUrl("maps:?q=Eiffel+Tower")).toEqual(
+        "maps:?q=Eiffel+Tower"
+      );
+    });
+    it("should return the url as it's if it's magnet:", () => {
+      expect(
+        urlsUtils.sanitizeUrl("magnet:?xt=urn:btih:abc123&dn=file")
+      ).toEqual("magnet:?xt=urn:btih:abc123&dn=file");
+    });
     it("should return the url as it's if it's a special protocol", () => {
       expect(urlsUtils.sanitizeUrl("mqtt://getoutline.com")).toEqual(
         "mqtt://getoutline.com"

--- a/shared/utils/urls.ts
+++ b/shared/utils/urls.ts
@@ -198,7 +198,10 @@ export function sanitizeUrl(url: string | null | undefined) {
     !url.startsWith("mailto:") &&
     !url.startsWith("sms:") &&
     !url.startsWith("fax:") &&
-    !url.startsWith("tel:")
+    !url.startsWith("tel:") &&
+    !url.startsWith("geo:") &&
+    !url.startsWith("maps:") &&
+    !url.startsWith("magnet:")
   ) {
     return `https://${url}`;
   }

--- a/shared/utils/urls.ts
+++ b/shared/utils/urls.ts
@@ -191,17 +191,22 @@ export function sanitizeUrl(url: string | null | undefined) {
     return undefined;
   }
 
+  const allowedSchemes = [
+    "mailto:",
+    "sms:",
+    "fax:",
+    "tel:",
+    "geo:",
+    "maps:",
+    "magnet:",
+  ];
+  const lower = url.toLowerCase();
+
   if (
     !isUrl(url, { requireHostname: false }) &&
     !url.startsWith("/") &&
     !url.startsWith("#") &&
-    !url.startsWith("mailto:") &&
-    !url.startsWith("sms:") &&
-    !url.startsWith("fax:") &&
-    !url.startsWith("tel:") &&
-    !url.startsWith("geo:") &&
-    !url.startsWith("maps:") &&
-    !url.startsWith("magnet:")
+    !allowedSchemes.some((scheme) => lower.startsWith(scheme))
   ) {
     return `https://${url}`;
   }


### PR DESCRIPTION
Adds `geo:`, `maps:`, and `magnet:` to the allowlist of URI schemes in `sanitizeUrl`, so editor links using them are preserved rather than mangled into `https://geo:...`. Covers geographic location links (RFC 5870), Apple Maps deep links, and torrent magnet links.

closes #12147