### PR TITLE
chore: Add Redis PING healthcheck

### DIFF
--- a/server/env.ts
+++ b/server/env.ts
@@ -200,6 +200,26 @@ export class Environment {
   public REDIS_COLLABORATION_URL = environment.REDIS_COLLABORATION_URL;
 
   /**
+   * The interval in milliseconds between redis connection healthchecks. Each
+   * healthcheck issues a PING and forces a reconnect if it fails.
+   */
+  @IsNumber()
+  public REDIS_HEALTHCHECK_INTERVAL = parseInt(
+    environment.REDIS_HEALTHCHECK_INTERVAL || "30000",
+    10
+  );
+
+  /**
+   * The timeout in milliseconds for a redis healthcheck PING before the
+   * connection is considered stuck and forcibly reconnected.
+   */
+  @IsNumber()
+  public REDIS_HEALTHCHECK_TIMEOUT = parseInt(
+    environment.REDIS_HEALTHCHECK_TIMEOUT || "5000",
+    10
+  );
+
+  /**
    * The fully qualified, external facing domain name of the server.
    * If not set, will be derived from HEROKU_APP_NAME for Heroku deployments.
    */

--- a/server/env.ts
+++ b/server/env.ts
@@ -13,6 +13,7 @@ import {
   IsNumber,
   IsIn,
   IsBoolean,
+  Min,
 } from "class-validator";
 import uniq from "lodash/uniq";
 import { languages } from "@shared/i18n";
@@ -204,6 +205,7 @@ export class Environment {
    * healthcheck issues a PING and forces a reconnect if it fails.
    */
   @IsNumber()
+  @Min(1000)
   public REDIS_HEALTHCHECK_INTERVAL = parseInt(
     environment.REDIS_HEALTHCHECK_INTERVAL || "30000",
     10
@@ -214,6 +216,7 @@ export class Environment {
    * connection is considered stuck and forcibly reconnected.
    */
   @IsNumber()
+  @Min(100)
   public REDIS_HEALTHCHECK_TIMEOUT = parseInt(
     environment.REDIS_HEALTHCHECK_TIMEOUT || "5000",
     10

--- a/server/storage/redis.ts
+++ b/server/storage/redis.ts
@@ -85,20 +85,23 @@ export default class RedisAdapter extends Redis {
       if (this.status !== "ready") {
         return;
       }
-      Promise.race([
-        this.ping(),
-        new Promise((_, reject) =>
-          setTimeout(
-            () => reject(new Error("ping timeout")),
-            env.REDIS_HEALTHCHECK_TIMEOUT
-          )
-        ),
-      ]).catch((err) => {
-        Logger.warn(
-          `Redis healthcheck failed, forcing reconnect: ${err.message}`
+
+      let pingTimeout: NodeJS.Timeout;
+      const timeoutPromise = new Promise((_, reject) => {
+        pingTimeout = setTimeout(
+          () => reject(new Error("ping timeout")),
+          env.REDIS_HEALTHCHECK_TIMEOUT
         );
-        this.disconnect(true);
       });
+
+      Promise.race([this.ping(), timeoutPromise])
+        .catch((err) => {
+          Logger.warn("Redis healthcheck failed, forcing reconnect", {
+            error: err,
+          });
+          this.disconnect(true);
+        })
+        .finally(() => clearTimeout(pingTimeout));
     }, env.REDIS_HEALTHCHECK_INTERVAL);
 
     this.on("end", () => clearInterval(healthcheck));

--- a/server/storage/redis.ts
+++ b/server/storage/redis.ts
@@ -81,30 +81,36 @@ export default class RedisAdapter extends Redis {
       }
     });
 
-    const healthcheck = setInterval(() => {
-      if (this.status !== "ready") {
-        return;
-      }
+    // Skip the healthcheck on connections reserved for blocking or pub/sub
+    // operations (signalled via maxRetriesPerRequest: null). A PING issued on
+    // those connections queues behind the in-flight blocking command and would
+    // spuriously time out.
+    if (this.options.maxRetriesPerRequest !== null) {
+      const healthcheck = setInterval(() => {
+        if (this.status !== "ready") {
+          return;
+        }
 
-      let pingTimeout: NodeJS.Timeout;
-      const timeoutPromise = new Promise((_, reject) => {
-        pingTimeout = setTimeout(
-          () => reject(new Error("ping timeout")),
-          env.REDIS_HEALTHCHECK_TIMEOUT
-        );
-      });
+        let pingTimeout: NodeJS.Timeout;
+        const timeoutPromise = new Promise((_, reject) => {
+          pingTimeout = setTimeout(
+            () => reject(new Error("ping timeout")),
+            env.REDIS_HEALTHCHECK_TIMEOUT
+          );
+        });
 
-      Promise.race([this.ping(), timeoutPromise])
-        .catch((err) => {
-          Logger.warn("Redis healthcheck failed, forcing reconnect", {
-            error: err,
-          });
-          this.disconnect(true);
-        })
-        .finally(() => clearTimeout(pingTimeout));
-    }, env.REDIS_HEALTHCHECK_INTERVAL);
+        Promise.race([this.ping(), timeoutPromise])
+          .catch((err) => {
+            Logger.warn("Redis healthcheck failed, forcing reconnect", {
+              error: err,
+            });
+            this.disconnect(true);
+          })
+          .finally(() => clearTimeout(pingTimeout));
+      }, env.REDIS_HEALTHCHECK_INTERVAL);
 
-    this.on("end", () => clearInterval(healthcheck));
+      this.on("end", () => clearInterval(healthcheck));
+    }
   }
 
   private static client: RedisAdapter;

--- a/server/storage/redis.ts
+++ b/server/storage/redis.ts
@@ -80,6 +80,28 @@ export default class RedisAdapter extends Redis {
         Logger.error("Redis error", err);
       }
     });
+
+    const healthcheck = setInterval(() => {
+      if (this.status !== "ready") {
+        return;
+      }
+      Promise.race([
+        this.ping(),
+        new Promise((_, reject) =>
+          setTimeout(
+            () => reject(new Error("ping timeout")),
+            env.REDIS_HEALTHCHECK_TIMEOUT
+          )
+        ),
+      ]).catch((err) => {
+        Logger.warn(
+          `Redis healthcheck failed, forcing reconnect: ${err.message}`
+        );
+        this.disconnect(true);
+      });
+    }, env.REDIS_HEALTHCHECK_INTERVAL);
+
+    this.on("end", () => clearInterval(healthcheck));
   }
 
   private static client: RedisAdapter;


### PR DESCRIPTION
Improves recovery from Redis backend failover by implementing a ping and disconnect on failure mechanism in addition to the existing error types that will trigger a reconnect.