### PR TITLE
fix: Shift-Tab on list item inside toggle block outdents entire block

### DIFF
--- a/shared/editor/commands/toggleBlock.ts
+++ b/shared/editor/commands/toggleBlock.ts
@@ -348,6 +348,11 @@ export const liftAllChildBlocksOfNodeAfter: Command = (state, dispatch) => {
 };
 
 export const dedentBlocks: Command = (state, dispatch) => {
+  // If inside a list, allow the list's Shift-Tab handler to handle outdentation instead.
+  if (isInList(state)) {
+    return false;
+  }
+
   const { $from } = state.selection;
 
   const isToggle = isToggleBlock(state);


### PR DESCRIPTION
## Summary
- Mirrors the v1.7.0 Tab fix in `dedentBlocks`: when the selection is inside a list, return early so the list's Shift-Tab handler (`liftListItem`) outdents the list item instead of the toggle block lifting itself out of its parent.

## Test plan
- [ ] Create a toggle block with a nested list containing two items
- [ ] Tab on the second list item to indent it
- [ ] Press Shift-Tab and confirm only the list item is outdented (the toggle block stays put)
- [ ] Confirm Shift-Tab still dedents toggle blocks themselves when the cursor is not in a list

🤖 Generated with [Claude Code](https://claude.com/claude-code)