### PR TITLE
feat: Show toggle theme shortcut in keyboard shortcuts modal

### DIFF
--- a/app/scenes/KeyboardShortcuts.tsx
+++ b/app/scenes/KeyboardShortcuts.tsx
@@ -91,6 +91,15 @@ function KeyboardShortcuts({ defaultQuery = "" }: Props) {
           {
             shortcut: (
               <>
+                <Key symbol>{metaDisplay}</Key> + <Key symbol>⇧</Key> +{" "}
+                <Key>l</Key>
+              </>
+            ),
+            label: t("Toggle theme"),
+          },
+          {
+            shortcut: (
+              <>
                 <Key symbol>{metaDisplay}</Key> + <Key>f</Key>
               </>
             ),


### PR DESCRIPTION
Adds the existing Cmd/Ctrl+Shift+L toggle theme shortcut to the keyboard shortcuts modal so it's discoverable. The action and key binding were already wired up — only the listing in the Navigation section was missing.