### PR TITLE
chore: Bump zod to 4.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -272,7 +272,7 @@
     "y-protocols": "^1.0.7",
     "yauzl": "^3.2.1",
     "yjs": "^13.6.30",
-    "zod": "^4.2.1"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@babel/cli": "^7.28.6",
@@ -385,7 +385,7 @@
     "qs": "6.14.1",
     "prismjs": "1.30.0",
     "cheerio": "1.0.0-rc.12",
-    "zod": "^4.2.1",
+    "zod": "^4.3.6",
     "socket.io-parser": "4.2.6",
     "@xmldom/xmldom": "^0.8.13",
     "fast-xml-parser": "5.5.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16900,7 +16900,7 @@ __metadata:
     y-protocols: "npm:^1.0.7"
     yauzl: "npm:^3.2.1"
     yjs: "npm:^13.6.30"
-    zod: "npm:^4.2.1"
+    zod: "npm:^4.3.6"
   languageName: unknown
   linkType: soft
 
@@ -22343,9 +22343,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^4.2.1":
-  version: 4.2.1
-  resolution: "zod@npm:4.2.1"
-  checksum: 10c0/ecb5219bddf76a42d092a843fb98ad4cb78f1e1077082772b03ef032ee5cbc80790a4051836b962d26fb4af854323bc784d628bd1b8d9898149eba7af21c5560
+"zod@npm:^4.3.6":
+  version: 4.3.6
+  resolution: "zod@npm:4.3.6"
+  checksum: 10c0/860d25a81ab41d33aa25f8d0d07b091a04acb426e605f396227a796e9e800c44723ed96d0f53a512b57be3d1520f45bf69c0cb3b378a232a00787a2609625307
   languageName: node
   linkType: hard


### PR DESCRIPTION
## Summary
- Bumps `zod` from `^4.2.1` to `^4.3.6` in both `dependencies` and `resolutions`.

## Test plan
- [ ] CI passes