### PR TITLE
chore: Clear picomatch ReDoS advisories from audit ignore list

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -12,6 +12,4 @@ npmPreapprovedPackages:
 npmAuditIgnoreAdvisories:
   - "1113517" # GHSA-mw96-cpmx-2vgc rollup <2.80.0 path traversal (workbox-build, build-time)
   - "1113686" # GHSA-5c6j-r48x-rmvq serialize-javascript RCE (@rollup/plugin-terser, build-time)
-  - "1115552" # GHSA-c2c7-rcm5-vvqj picomatch ReDoS (babel-plugin-styled-components, dotenvx CLI)
-  - "1115554" # GHSA-c2c7-rcm5-vvqj picomatch ReDoS (babel-plugin-styled-components, dotenvx CLI)
   - "1115805" # GHSA-r5fr-rjxr-66jc lodash-es _.template injection (mermaid; not exposed to user-controlled template keys)

--- a/package.json
+++ b/package.json
@@ -400,7 +400,14 @@
     "minimatch@npm:9.0.1": "9.0.9",
     "minimatch@npm:^9.0.4": "^9.0.9",
     "brace-expansion@npm:^1.1.7": "^1.1.13",
-    "brace-expansion@npm:^2.0.1": "^2.0.3"
+    "brace-expansion@npm:^2.0.1": "^2.0.3",
+    "picomatch@npm:^2.0.4": "^2.3.2",
+    "picomatch@npm:^2.2.1": "^2.3.2",
+    "picomatch@npm:^2.2.2": "^2.3.2",
+    "picomatch@npm:^2.2.3": "^2.3.2",
+    "picomatch@npm:^2.3.1": "^2.3.2",
+    "picomatch@npm:^4.0.2": "^4.0.4",
+    "picomatch@npm:^4.0.3": "^4.0.4"
   },
   "version": "1.7.0",
   "packageManager": "yarn@4.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17516,17 +17516,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.2.2, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
-  version: 2.3.1
-  resolution: "picomatch@npm:2.3.1"
-  checksum: 10c0/26c02b8d06f03206fc2ab8d16f19960f2ff9e81a658f831ecb656d8f17d9edc799e8364b1f4a7873e89d9702dff96204be0fa26fe4181f6843f040f819dac4be
+"picomatch@npm:^2.3.2":
+  version: 2.3.2
+  resolution: "picomatch@npm:2.3.2"
+  checksum: 10c0/a554d1709e59be97d1acb9eaedbbc700a5c03dbd4579807baed95100b00420bc729335440ef15004ae2378984e2487a7c1cebd743cfdb72b6fa9ab69223c0d61
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.2, picomatch@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "picomatch@npm:4.0.3"
-  checksum: 10c0/9582c951e95eebee5434f59e426cddd228a7b97a0161a375aed4be244bd3fe8e3a31b846808ea14ef2c8a2527a6eeab7b3946a67d5979e81694654f939473ae2
+"picomatch@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "picomatch@npm:4.0.4"
+  checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Pin `picomatch` to `^2.3.2` / `^4.0.4` via `resolutions` so transitive deps (babel-plugin-styled-components, @dotenvx/dotenvx, etc.) pick up the patched versions.
- Drop the now-obsolete picomatch advisory IDs from `.yarnrc.yml`.

## Test plan
- [x] `yarn install` succeeds
- [x] `yarn npm audit --recursive --severity moderate` no longer reports picomatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)