### PR TITLE
chore: Clear lodash _.template injection advisory from audit ignore list

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -12,4 +12,3 @@ npmPreapprovedPackages:
 npmAuditIgnoreAdvisories:
   - "1113517" # GHSA-mw96-cpmx-2vgc rollup <2.80.0 path traversal (workbox-build, build-time)
   - "1113686" # GHSA-5c6j-r48x-rmvq serialize-javascript RCE (@rollup/plugin-terser, build-time)
-  - "1115805" # GHSA-r5fr-rjxr-66jc lodash-es _.template injection (mermaid; not exposed to user-controlled template keys)

--- a/package.json
+++ b/package.json
@@ -407,7 +407,15 @@
     "picomatch@npm:^2.2.3": "^2.3.2",
     "picomatch@npm:^2.3.1": "^2.3.2",
     "picomatch@npm:^4.0.2": "^4.0.4",
-    "picomatch@npm:^4.0.3": "^4.0.4"
+    "picomatch@npm:^4.0.3": "^4.0.4",
+    "lodash@npm:4.17.21": "^4.18.1",
+    "lodash@npm:^4.17.11": "^4.18.1",
+    "lodash@npm:^4.17.20": "^4.18.1",
+    "lodash@npm:^4.17.21": "^4.18.1",
+    "lodash@npm:^4.17.23": "^4.18.1",
+    "lodash-es@npm:4.17.23": "^4.18.1",
+    "lodash-es@npm:^4.17.21": "^4.18.1",
+    "lodash-es@npm:^4.17.23": "^4.18.1"
   },
   "version": "1.7.0",
   "packageManager": "yarn@4.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15292,10 +15292,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash-es@npm:4.17.23, lodash-es@npm:^4.17.21, lodash-es@npm:^4.17.23":
-  version: 4.17.23
-  resolution: "lodash-es@npm:4.17.23"
-  checksum: 10c0/3150fb6660c14c7a6b5f23bd11597d884b140c0e862a17fdb415aaa5ef7741523182904a6b7929f04e5f60a11edb5a79499eb448734381c99ffb3c4734beeddd
+"lodash-es@npm:^4.18.1":
+  version: 4.18.1
+  resolution: "lodash-es@npm:4.18.1"
+  checksum: 10c0/35d4dcf87ef07f8d090f409447575800108057e360b445f590d0d25d09e3d1e33a163d2fc100d4d072b0f901d5e2fc533cd7c4bfd8eeb38a06abec693823c8b8
   languageName: node
   linkType: hard
 
@@ -15432,14 +15432,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.21":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
-  languageName: node
-  linkType: hard
-
-"lodash@npm:^4.17.11, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.23":
+"lodash@npm:^4.18.1":
   version: 4.18.1
   resolution: "lodash@npm:4.18.1"
   checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27


### PR DESCRIPTION
## Summary
- Pins `lodash` and `lodash-es` to `^4.18.1` via resolutions in `package.json` so transitive deps (mermaid, @relative-ci/agent) pick up the patched versions.
- Drops advisory `1115805` (GHSA-r5fr-rjxr-66jc — lodash `_.template` code injection) from the `npmAuditIgnoreAdvisories` list in `.yarnrc.yml`.

## Test plan
- [ ] `yarn npm audit --severity high --recursive --environment production` reports no suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)