### PR TITLE
fix: Resolve no-floating-promises lint errors

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -87,6 +87,7 @@
         "import/no-named-as-default": "off",
         "import/no-named-as-default-member": "off",
         "typescript/consistent-type-imports": "error",
+        "typescript/no-floating-promises": "error",
         "no-unused-vars": [
           "error",
           {

--- a/app/components/Reactions/Reaction.tsx
+++ b/app/components/Reactions/Reaction.tsx
@@ -49,13 +49,15 @@ const useTooltipContent = ({
   );
 
   // If the emoji is a custom emoji ID, we need to get its short name for display
-  if (isUUID(emoji)) {
-    emojis.fetch(emoji).then((ce) => {
-      if (ce) {
-        setTransformedEmoji(ce.shortName);
-      }
-    });
-  }
+  React.useEffect(() => {
+    if (isUUID(emoji)) {
+      void emojis.fetch(emoji).then((ce) => {
+        if (ce) {
+          setTransformedEmoji(ce.shortName);
+        }
+      });
+    }
+  }, [emoji, emojis]);
 
   if (!reactedUsers.length) {
     return;

--- a/app/components/Sidebar/Sidebar.tsx
+++ b/app/components/Sidebar/Sidebar.tsx
@@ -229,7 +229,7 @@ const Sidebar = React.forwardRef<HTMLDivElement, Props>(function Sidebar_(
   );
 
   const handleCloseSidebar = () => {
-    trigger("light");
+    void trigger("light");
     ui.toggleMobileSidebar();
   };
 

--- a/app/scenes/Collection/components/Overview.tsx
+++ b/app/scenes/Collection/components/Overview.tsx
@@ -50,7 +50,7 @@ function Overview({ collection, readOnly }: Props) {
 
   useEffect(
     () => () => {
-      handleSave.flush();
+      void handleSave.flush();
     },
     [handleSave]
   );

--- a/app/scenes/Collection/index.tsx
+++ b/app/scenes/Collection/index.tsx
@@ -364,7 +364,7 @@ const Content = styled.div`
 const RecentDocuments = observer(
   ({ collection, documents }: { collection: Collection; documents: any }) => {
     useEffect(() => {
-      collection.fetchDocuments();
+      void collection.fetchDocuments();
     }, [collection]);
 
     return (

--- a/app/scenes/Document/components/MultiplayerEditor.tsx
+++ b/app/scenes/Document/components/MultiplayerEditor.tsx
@@ -121,7 +121,7 @@ function MultiplayerEditor({ onSynced, ...props }: Props, ref: any) {
       provider.shouldConnect = false;
       retryCount.current++;
 
-      sleep(retryCount.current * 1000 - 1000).then(() =>
+      void sleep(retryCount.current * 1000 - 1000).then(() =>
         auth
           .fetchAuth()
           .then(() => {

--- a/server/collaboration/APIUpdateExtension.ts
+++ b/server/collaboration/APIUpdateExtension.ts
@@ -66,7 +66,7 @@ export class APIUpdateExtension implements Extension {
       });
 
       // Subscribe to the API update channel pattern
-      this.subscriber.psubscribe(`${CHANNEL_PREFIX}:*`, (err) => {
+      await this.subscriber.psubscribe(`${CHANNEL_PREFIX}:*`, (err) => {
         if (err) {
           Logger.error("Failed to subscribe to API update channel", err);
           return;

--- a/server/queues/tasks/ShareSubscriptionNotificationsTask.ts
+++ b/server/queues/tasks/ShareSubscriptionNotificationsTask.ts
@@ -73,7 +73,7 @@ export default class ShareSubscriptionNotificationsTask extends BaseTask<Revisio
           ? `${baseShareUrl.replace(/\/$/, "")}${document.path}`
           : baseShareUrl;
 
-      new ShareDocumentUpdatedEmail({
+      await new ShareDocumentUpdatedEmail({
         to: subscription.email,
         shareSubscriptionId: subscription.id,
         documentTitle: document.titleWithDefault,

--- a/server/routes/api/comments/comments.test.ts
+++ b/server/routes/api/comments/comments.test.ts
@@ -756,7 +756,7 @@ describe("#comments.create", () => {
     });
 
     expect(res.status).toEqual(200);
-    expect(res.json()).resolves.toMatchObject({
+    await expect(res.json()).resolves.toMatchObject({
       data: {
         data: {
           content: [

--- a/server/routes/api/shares/shares.ts
+++ b/server/routes/api/shares/shares.ts
@@ -540,7 +540,7 @@ router.post(
     const confirmUrl = ShareSubscriptionHelper.confirmUrl(subscription);
     const usePublicBranding =
       share.team?.getPreference(TeamPreference.PublicBranding) ?? false;
-    new ShareSubscriptionConfirmEmail({
+    await new ShareSubscriptionConfirmEmail({
       to: email,
       documentTitle: document?.titleWithDefault ?? "",
       confirmUrl,

--- a/shared/editor/nodes/Image.tsx
+++ b/shared/editor/nodes/Image.tsx
@@ -85,7 +85,7 @@ export const downloadImageNode = async (
     document.body.removeChild(link);
   } catch {
     if (cache !== "reload") {
-      downloadImageNode(node, "reload");
+      await downloadImageNode(node, "reload");
     } else {
       window.open(sanitizeUrl(node.attrs.src), "_blank");
     }


### PR DESCRIPTION
## Summary

Adds `await` or `void` to 10 floating promises flagged by `no-floating-promises`. Two were genuine bugs: a Jest assertion using `.resolves.toMatchObject(...)` was never awaited (so it could silently pass), and a custom-emoji fetch in `Reaction.tsx` was running directly in the render body and calling `setState` outside of an effect — moved into `useEffect`. The remaining changes await scheduled email tasks in request/queue handlers, await a Redis `psubscribe` inside `onConfigure`, await a recursive image-download retry, and `void` genuinely fire-and-forget calls in event handlers and effect cleanups.

## Test plan
- [x] `yarn lint` reports 0 errors
- [x] `yarn tsc` clean