### PR TITLE
chore: enable `typescript/restrict-template-expressions` lint rule

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -87,6 +87,7 @@
         "import/no-named-as-default": "off",
         "import/no-named-as-default-member": "off",
         "typescript/consistent-type-imports": "error",
+        "typescript/restrict-template-expressions": "error",
         "no-unused-vars": [
           "error",
           {

--- a/app/components/HoverPreview/Components.tsx
+++ b/app/components/HoverPreview/Components.tsx
@@ -88,6 +88,7 @@ export const CardContent = styled.div`
 
 // &:after — gradient mask for overflow text
 export const Card = styled.div<{ fadeOut?: boolean; $borderRadius?: string }>`
+  ${sharedVars}
   backdrop-filter: blur(10px);
   background: ${s("menuBackground")};
   padding: 16px;

--- a/app/components/HoverPreview/Components.tsx
+++ b/app/components/HoverPreview/Components.tsx
@@ -112,7 +112,6 @@ export const Card = styled.div<{ fadeOut?: boolean; $borderRadius?: string }>`
   ${(props) =>
     props.fadeOut !== false
       ? `&:after {
-          ${sharedVars}
           content: "";
           display: block;
           position: absolute;

--- a/app/components/Menu/transformer.tsx
+++ b/app/components/Menu/transformer.tsx
@@ -42,7 +42,7 @@ export function toMenuItems(items: MenuItem[]) {
       case "button":
         return (
           <MenuButton
-            key={`${item.type}-${item.title}-${index}`}
+            key={`${item.type}-${index}`}
             label={item.title as string}
             icon={icon}
             disabled={item.disabled}
@@ -57,7 +57,7 @@ export function toMenuItems(items: MenuItem[]) {
       case "route":
         return (
           <MenuInternalLink
-            key={`${item.type}-${item.title}-${index}`}
+            key={`${item.type}-${index}`}
             label={item.title as string}
             icon={icon}
             disabled={item.disabled}
@@ -69,7 +69,7 @@ export function toMenuItems(items: MenuItem[]) {
       case "link":
         return (
           <MenuExternalLink
-            key={`${item.type}-${item.title}-${index}`}
+            key={`${item.type}-${index}`}
             label={item.title as string}
             icon={icon}
             disabled={item.disabled}
@@ -95,7 +95,7 @@ export function toMenuItems(items: MenuItem[]) {
         };
 
         return (
-          <SubMenu key={`${item.type}-${item.title}-${index}`}>
+          <SubMenu key={`${item.type}-${index}`}>
             <SubMenuTrigger
               label={item.title as string}
               icon={icon}
@@ -121,7 +121,7 @@ export function toMenuItems(items: MenuItem[]) {
 
         return (
           <MenuGroup
-            key={`${item.type}-${item.title}-${index}`}
+            key={`${item.type}-${index}`}
             label={item.title as string}
             items={groupItems}
           />
@@ -171,7 +171,7 @@ export function toMobileMenuItems(
       case "button":
         return (
           <Components.MenuButton
-            key={`${item.type}-${item.title}-${index}`}
+            key={`${item.type}-${index}`}
             disabled={item.disabled}
             $dangerous={item.dangerous}
             onClick={(e) => {
@@ -192,7 +192,7 @@ export function toMobileMenuItems(
       case "route":
         return (
           <Components.MenuInternalLink
-            key={`${item.type}-${item.title}-${index}`}
+            key={`${item.type}-${index}`}
             to={item.to}
             disabled={item.disabled}
             onClick={closeMenu}
@@ -205,7 +205,7 @@ export function toMobileMenuItems(
       case "link":
         return (
           <Components.MenuExternalLink
-            key={`${item.type}-${item.title}-${index}`}
+            key={`${item.type}-${index}`}
             href={typeof item.href === "string" ? item.href : item.href.url}
             target={
               typeof item.href === "string" ? undefined : item.href.target
@@ -231,7 +231,7 @@ export function toMobileMenuItems(
 
         return (
           <Components.MenuButton
-            key={`${item.type}-${item.title}-${index}`}
+            key={`${item.type}-${index}`}
             disabled={item.disabled}
             onClick={() => {
               openSubmenu(item.title as string);
@@ -256,7 +256,7 @@ export function toMobileMenuItems(
         }
 
         return (
-          <div key={`${item.type}-${item.title}-${index}`}>
+          <div key={`${item.type}-${index}`}>
             <Components.MenuHeader>{item.title}</Components.MenuHeader>
             {groupItems}
           </div>

--- a/app/components/PageTitle.tsx
+++ b/app/components/PageTitle.tsx
@@ -1,12 +1,11 @@
 import { observer } from "mobx-react";
-import * as React from "react";
 import { Helmet } from "react-helmet-async";
 import env from "~/env";
 import useStores from "~/hooks/useStores";
 import { useTeamContext } from "./TeamContext";
 
 type Props = {
-  title: React.ReactNode;
+  title: string;
   favicon?: string;
 };
 

--- a/app/components/Scene.tsx
+++ b/app/components/Scene.tsx
@@ -34,7 +34,7 @@ const Scene: React.FC<Props> = ({
   wide,
 }: Props) => (
   <FillWidth>
-    <PageTitle title={textTitle || title} />
+    <PageTitle title={textTitle ?? (typeof title === "string" ? title : "")} />
     <Header
       hasSidebar
       title={

--- a/plugins/github/server/GitHubIssueProvider.ts
+++ b/plugins/github/server/GitHubIssueProvider.ts
@@ -116,7 +116,7 @@ export class GitHubIssueProvider extends BaseIssueProvider {
     const installation = await client.requestAppInstallation(installationId);
 
     const scopes = Object.entries(installation.data.permissions).map(
-      ([name, permission]) => `${name}:${permission}`
+      ([name, permission]) => `${name}:${String(permission)}`
     );
 
     await sequelize.transaction(async (transaction) => {

--- a/plugins/github/server/api/github.ts
+++ b/plugins/github/server/api/github.ts
@@ -64,7 +64,7 @@ router.get(
     }
 
     const scopes = Object.entries(installation.permissions).map(
-      ([name, permission]) => `${name}:${permission}`
+      ([name, permission]) => `${name}:${String(permission)}`
     );
 
     const authentication = await IntegrationAuthentication.create(

--- a/server/logging/Logger.ts
+++ b/server/logging/Logger.ts
@@ -60,8 +60,8 @@ class Logger {
               winston.format.printf(
                 ({ message, level, label, ...extra }) =>
                   `${level}: ${
-                    label ? styleText("bold", `[${label}] `) : ""
-                  }${message} ${isEmpty(extra) ? "" : JSON.stringify(extra)}`
+                    label ? styleText("bold", `[${String(label)}] `) : ""
+                  }${String(message)} ${isEmpty(extra) ? "" : JSON.stringify(extra)}`
               )
             ),
       })

--- a/server/middlewares/rateLimiter.ts
+++ b/server/middlewares/rateLimiter.ts
@@ -75,7 +75,7 @@ export function defaultRateLimiter() {
         ctx.set("RateLimit-Remaining", `${rateLimiterRes.remainingPoints}`);
         ctx.set(
           "RateLimit-Reset",
-          `${new Date(Date.now() + rateLimiterRes.msBeforeNext)}`
+          new Date(Date.now() + rateLimiterRes.msBeforeNext).toString()
         );
 
         Metrics.increment("rate_limit.exceeded", {

--- a/server/models/decorators/CounterCache.ts
+++ b/server/models/decorators/CounterCache.ts
@@ -36,9 +36,9 @@ export function CounterCache<
     setImmediate(() => {
       const recalculateCache =
         (offset: number) => async (model: InstanceType<T>) => {
-          const cacheKey = `${cacheKeyPrefix}:${
+          const cacheKey = `${cacheKeyPrefix}:${String(
             model[options.foreignKey as keyof typeof model]
-          }`;
+          )}`;
 
           const count = await modelClass.count({
             where: {

--- a/server/queues/queue.ts
+++ b/server/queues/queue.ts
@@ -31,7 +31,7 @@ export function createQueue(
           });
 
         default:
-          throw new Error(`Unexpected connection type: ${type}`);
+          throw new Error(`Unexpected connection type: ${String(type)}`);
       }
     },
     defaultJobOptions: {

--- a/server/storage/database.ts
+++ b/server/storage/database.ts
@@ -214,15 +214,15 @@ export function createMigrationRunner(
         Logger.info(
           "database",
           params.event === "migrating"
-            ? `Migrating ${params.name}…`
-            : `Migrated ${params.name} in ${params.durationSeconds}s`
+            ? `Migrating ${String(params.name)}…`
+            : `Migrated ${String(params.name)} in ${String(params.durationSeconds)}s`
         ),
       debug: (params) =>
         Logger.debug(
           "database",
           params.event === "migrating"
-            ? `Migrating ${params.name}…`
-            : `Migrated ${params.name} in ${params.durationSeconds}s`
+            ? `Migrating ${String(params.name)}…`
+            : `Migrated ${String(params.name)} in ${String(params.durationSeconds)}s`
         ),
     },
   });

--- a/shared/utils/rfc6902/patch.ts
+++ b/shared/utils/rfc6902/patch.ts
@@ -23,7 +23,7 @@ export class TestError extends Error {
     public actual: unknown,
     public expected: unknown
   ) {
-    super(`Test failed: ${actual} != ${expected}`);
+    super(`Test failed: ${String(actual)} != ${String(expected)}`);
     this.name = "TestError";
   }
 }


### PR DESCRIPTION
## Summary
- Enable the `typescript/restrict-template-expressions` lint rule
- Fix all 28 existing violations across `app/`, `server/`, `shared/`, and `plugins/`
- Most fixes are explicit `String(x)` coercion of values typed as `unknown`; a couple tighten the source type instead (e.g. `PageTitle`'s `title` prop is now `string`)

## Test plan
- [x] `yarn lint` clean
- [x] `yarn tsc` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)