### PR TITLE
chore: resolve unbound-method lint warnings in tests

### DIFF
--- a/plugins/webhooks/server/processors/WebhookProcessor.test.ts
+++ b/plugins/webhooks/server/processors/WebhookProcessor.test.ts
@@ -5,9 +5,11 @@ import WebhookProcessor from "./WebhookProcessor";
 
 jest.mock("../tasks/DeliverWebhookTask");
 const ip = "127.0.0.1";
+const schedule = jest.fn();
 
 beforeEach(() => {
   jest.resetAllMocks();
+  DeliverWebhookTask.prototype.schedule = schedule;
 });
 
 describe("WebhookProcessor", () => {
@@ -29,12 +31,8 @@ describe("WebhookProcessor", () => {
 
     await processor.perform(event);
 
-    expect(
-      jest.mocked(DeliverWebhookTask.prototype.schedule)
-    ).toHaveBeenCalled();
-    expect(
-      jest.mocked(DeliverWebhookTask.prototype.schedule)
-    ).toHaveBeenCalledWith({
+    expect(schedule).toHaveBeenCalled();
+    expect(schedule).toHaveBeenCalledWith({
       event,
       subscriptionId: subscription.id,
     });
@@ -57,9 +55,7 @@ describe("WebhookProcessor", () => {
 
     await processor.perform(event);
 
-    expect(
-      jest.mocked(DeliverWebhookTask.prototype.schedule)
-    ).toHaveBeenCalledTimes(0);
+    expect(schedule).toHaveBeenCalledTimes(0);
   });
 
   it("it schedules a delivery for the event for each subscription", async () => {
@@ -85,21 +81,13 @@ describe("WebhookProcessor", () => {
 
     await processor.perform(event);
 
-    expect(
-      jest.mocked(DeliverWebhookTask.prototype.schedule)
-    ).toHaveBeenCalled();
-    expect(
-      jest.mocked(DeliverWebhookTask.prototype.schedule)
-    ).toHaveBeenCalledTimes(2);
-    expect(
-      jest.mocked(DeliverWebhookTask.prototype.schedule)
-    ).toHaveBeenCalledWith({
+    expect(schedule).toHaveBeenCalled();
+    expect(schedule).toHaveBeenCalledTimes(2);
+    expect(schedule).toHaveBeenCalledWith({
       event,
       subscriptionId: subscription.id,
     });
-    expect(
-      jest.mocked(DeliverWebhookTask.prototype.schedule)
-    ).toHaveBeenCalledWith({
+    expect(schedule).toHaveBeenCalledWith({
       event,
       subscriptionId: subscriptionTwo.id,
     });

--- a/server/commands/documentPermanentDeleter.test.ts
+++ b/server/commands/documentPermanentDeleter.test.ts
@@ -6,8 +6,11 @@ import documentPermanentDeleter from "./documentPermanentDeleter";
 
 jest.mock("@server/queues/tasks/DeleteAttachmentTask");
 
+const schedule = jest.fn();
+
 beforeEach(() => {
   jest.resetAllMocks();
+  DeleteAttachmentTask.prototype.schedule = schedule;
 });
 
 describe("documentPermanentDeleter", () => {
@@ -62,9 +65,7 @@ describe("documentPermanentDeleter", () => {
     await document.save();
     const countDeletedDoc = await documentPermanentDeleter([document]);
     expect(countDeletedDoc).toEqual(1);
-    expect(
-      jest.mocked(DeleteAttachmentTask.prototype.schedule)
-    ).toHaveBeenCalledTimes(2);
+    expect(schedule).toHaveBeenCalledTimes(2);
     expect(
       await Document.unscoped().count({
         where: {

--- a/server/middlewares/timeout.test.ts
+++ b/server/middlewares/timeout.test.ts
@@ -6,9 +6,10 @@ describe("Timeout middleware", () => {
     const originalTimeout = 10000;
     const newTimeout = 1800000; // 30 minutes
 
+    const setTimeout = jest.fn();
     const mockSocket = {
       timeout: originalTimeout,
-      setTimeout: jest.fn(),
+      setTimeout,
     } as unknown as Socket;
 
     const ctx = {
@@ -27,20 +28,21 @@ describe("Timeout middleware", () => {
     );
 
     // Should have set the new timeout
-    expect(mockSocket.setTimeout).toHaveBeenCalledWith(newTimeout);
+    expect(setTimeout).toHaveBeenCalledWith(newTimeout);
     // Should have called next
     expect(next).toHaveBeenCalled();
     // Should have restored the original timeout
-    expect(mockSocket.setTimeout).toHaveBeenCalledWith(originalTimeout);
+    expect(setTimeout).toHaveBeenCalledWith(originalTimeout);
   });
 
   it("should restore original timeout even if next throws", async () => {
     const originalTimeout = 10000;
     const newTimeout = 1800000; // 30 minutes
 
+    const setTimeout = jest.fn();
     const mockSocket = {
       timeout: originalTimeout,
-      setTimeout: jest.fn(),
+      setTimeout,
     } as unknown as Socket;
 
     const ctx = {
@@ -62,19 +64,20 @@ describe("Timeout middleware", () => {
     ).rejects.toThrow("Test error");
 
     // Should have set the new timeout
-    expect(mockSocket.setTimeout).toHaveBeenCalledWith(newTimeout);
+    expect(setTimeout).toHaveBeenCalledWith(newTimeout);
     // Should have called next
     expect(next).toHaveBeenCalled();
     // Should have restored the original timeout even after error
-    expect(mockSocket.setTimeout).toHaveBeenCalledWith(originalTimeout);
+    expect(setTimeout).toHaveBeenCalledWith(originalTimeout);
   });
 
   it("should handle undefined original timeout", async () => {
     const newTimeout = 1800000; // 30 minutes
 
+    const setTimeout = jest.fn();
     const mockSocket = {
       timeout: undefined,
-      setTimeout: jest.fn(),
+      setTimeout,
     } as unknown as Socket;
 
     const ctx = {
@@ -93,10 +96,10 @@ describe("Timeout middleware", () => {
     );
 
     // Should have set the new timeout
-    expect(mockSocket.setTimeout).toHaveBeenCalledWith(newTimeout);
+    expect(setTimeout).toHaveBeenCalledWith(newTimeout);
     // Should have called next
     expect(next).toHaveBeenCalled();
     // Should have restored timeout to 0 when original was undefined
-    expect(mockSocket.setTimeout).toHaveBeenCalledWith(0);
+    expect(setTimeout).toHaveBeenCalledWith(0);
   });
 });

--- a/server/models/Collection.test.ts
+++ b/server/models/Collection.test.ts
@@ -310,9 +310,9 @@ describe("#removeDocument", () => {
     const document = await buildDocument({ collectionId: collection.id });
     await collection.reload();
 
-    jest.spyOn(collection, "save");
+    const saveSpy = jest.spyOn(collection, "save");
     await collection.deleteDocument(document);
-    expect(collection.save).toHaveBeenCalled();
+    expect(saveSpy).toHaveBeenCalled();
   });
 
   it("should remove documents from root", async () => {


### PR DESCRIPTION
## Summary
- Capture jest mock references in local variables instead of asserting against unbound method references on mocked classes/instances
- Replace auto-mocked prototype methods with explicit `jest.fn()` assignments in `beforeEach` for `WebhookProcessor.test.ts` and `documentPermanentDeleter.test.ts`
- Capture `jest.spyOn()` return value in `Collection.test.ts` and assert against the spy

## Test plan
- [x] yarn lint shows zero unbound-method warnings in the four touched files
- [x] yarn test passes for all four touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)