### PR TITLE
chore: resolve unbound-method warnings in NotionConverter

### DIFF
--- a/plugins/notion/server/utils/NotionConverter.ts
+++ b/plugins/notion/server/utils/NotionConverter.ts
@@ -279,7 +279,7 @@ export class NotionConverter {
     };
   }
 
-  private static rich_text(item: RichTextItemResponse) {
+  private static rich_text = (item: RichTextItemResponse) => {
     const annotationToMark: Record<
       keyof RichTextItemResponse["annotations"],
       string
@@ -386,11 +386,10 @@ export class NotionConverter {
     }
 
     return undefined;
-  }
+  };
 
-  private static rich_text_to_plaintext(item: RichTextItemResponse) {
-    return item.plain_text;
-  }
+  private static rich_text_to_plaintext = (item: RichTextItemResponse) =>
+    item.plain_text;
 
   private static divider(_: DividerBlockObjectResponse) {
     return {


### PR DESCRIPTION
## Summary
- Convert \`rich_text\` and \`rich_text_to_plaintext\` from static methods to static arrow-function fields so they can be passed as \`map\` callbacks without tripping the \`unbound-method\` lint
- Neither method accesses \`this\`, so behavior is unchanged; this clears 15 warnings in \`NotionConverter.ts\`

## Test plan
- [x] yarn lint shows zero unbound-method warnings in plugins/notion
- [x] yarn tsc passes
- [x] yarn test plugins/notion/server/utils/NotionConverter.test.ts passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)