### PR TITLE
fix: Add gap between search and actions in header

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -132,6 +132,7 @@ const Actions = styled(Flex)`
   min-width: auto;
   padding-inline: 8px 0;
   gap: 12px;
+  margin-inline-start: 8px;
 
   ${breakpoint("tablet")`
     position: unset;


### PR DESCRIPTION
## Summary
- On mobile the search input and "New doc" button were rendering with no visible gap between them. Adds an 8px `margin-inline-start` to the header `Actions` container so the two are visually separated.

## Test plan
- [ ] Verify on a mobile viewport that there is an 8px gap between the search field and the New doc button on Home / Drafts.
- [ ] Verify tablet/desktop header layouts are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/outline/codesmith/outline/pr/12214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->