### PR TITLE
fix: Handle invalid post-login redirect path in Firefox

### DIFF
--- a/app/components/AuthenticatedLayout.tsx
+++ b/app/components/AuthenticatedLayout.tsx
@@ -11,6 +11,7 @@ import useKeyDown from "~/hooks/useKeyDown";
 import { usePostLoginPath } from "~/hooks/useLastVisitedPath";
 import usePolicy from "~/hooks/usePolicy";
 import useStores from "~/hooks/useStores";
+import Logger from "~/utils/Logger";
 import history from "~/utils/history";
 import { isModKey } from "@shared/utils/keyboard";
 import lazyWithRetry from "~/utils/lazyWithRetry";
@@ -18,6 +19,7 @@ import {
   searchPath,
   newDocumentPath,
   settingsPath,
+  homePath,
 } from "~/utils/routeHelpers";
 import { DocumentContextProvider } from "./DocumentContext";
 import Fade from "./Fade";
@@ -69,7 +71,15 @@ const AuthenticatedLayout: React.FC = ({ children }: Props) => {
   React.useEffect(() => {
     const postLoginPath = spendPostLoginPath();
     if (postLoginPath) {
-      history.replace(postLoginPath);
+      try {
+        history.replace(postLoginPath);
+      } catch (err) {
+        Logger.warn("Failed to navigate to post login path, falling back", {
+          path: postLoginPath,
+          error: err,
+        });
+        history.replace(homePath());
+      }
     }
   }, [spendPostLoginPath]);
 

--- a/app/utils/urls.test.ts
+++ b/app/utils/urls.test.ts
@@ -123,5 +123,13 @@ describe("decodeURIComponentSafe", () => {
       expect(isAllowedLoginRedirect("/s/share#public")).toBe(false);
       expect(isAllowedLoginRedirect("/#top")).toBe(false);
     });
+
+    test("should block protocol-relative paths", () => {
+      expect(isAllowedLoginRedirect("//home")).toBe(false);
+      expect(isAllowedLoginRedirect("//evil.com")).toBe(false);
+      expect(isAllowedLoginRedirect("//evil.com/path")).toBe(false);
+      expect(isAllowedLoginRedirect("/\\evil.com")).toBe(false);
+      expect(isAllowedLoginRedirect("//documents?foo=bar")).toBe(false);
+    });
   });
 });

--- a/app/utils/urls.ts
+++ b/app/utils/urls.ts
@@ -76,6 +76,13 @@ export function isLoopbackUri(uri: string | undefined): boolean {
  */
 export const isAllowedLoginRedirect = (input: string) => {
   const path = input.split("?")[0].split("#")[0];
+
+  // Reject protocol-relative or backslash-prefixed paths that browsers may
+  // interpret as navigations to a different origin.
+  if (path.startsWith("//") || path.startsWith("/\\")) {
+    return false;
+  }
+
   return (
     !["/", "/create", "/home", "/logout", "/desktop-redirect"].includes(path) &&
     !path.startsWith("/auth/") &&


### PR DESCRIPTION
## Summary

A protocol-relative path like `//home` stored as the post-login redirect caused `history.replace()` to throw a `DOMException` in Firefox, completely blocking login.

- Reject paths starting with `//` or `/\` in `isAllowedLoginRedirect` so they are never persisted as a redirect target.
- Wrap `history.replace(postLoginPath)` in `AuthenticatedLayout` with a try/catch that falls back to `/home` and logs a warning, protecting users who already have a bad value cached in cookies/sessionStorage.
- Added test coverage for the new validation.

## Test plan

- [x] `yarn test app/utils/urls.test.ts`
- [x] `yarn tsc`
- [x] `yarn lint`