### PR TITLE
fix: API keys with global read scope not being saved correctly

### DIFF
--- a/server/middlewares/authentication.test.ts
+++ b/server/middlewares/authentication.test.ts
@@ -97,6 +97,62 @@ describe("Authentication middleware", () => {
       );
       expect(state.auth.user.id).toEqual(user.id);
     });
+    it("should authenticate with global read scope on read endpoints", async () => {
+      const state = {} as DefaultState;
+      const user = await buildUser();
+      const authMiddleware = auth();
+      const key = await buildApiKey({
+        userId: user.id,
+        scope: [Scope.Read],
+      });
+
+      await authMiddleware(
+        {
+          originalUrl: "/api/auth.info",
+          // @ts-expect-error mock request
+          request: {
+            url: "/auth.info",
+            get: jest.fn(() => `Bearer ${key.value}`),
+          },
+          state,
+          cache: {},
+        },
+        jest.fn()
+      );
+      expect(state.auth.user.id).toEqual(user.id);
+    });
+
+    it("should return 403 authorization error when scope does not match", async () => {
+      const state = {} as DefaultState;
+      const user = await buildUser();
+      const authMiddleware = auth();
+      const key = await buildApiKey({
+        userId: user.id,
+        scope: [Scope.Read],
+      });
+
+      try {
+        await authMiddleware(
+          {
+            originalUrl: "/api/documents.create",
+            // @ts-expect-error mock request
+            request: {
+              url: "/documents.create",
+              get: jest.fn(() => `Bearer ${key.value}`),
+            },
+            state,
+            cache: {},
+          },
+          jest.fn()
+        );
+        throw new Error("Expected error to be thrown");
+      } catch (e) {
+        expect(e.status).toBe(403);
+        expect(e.id).toBe("authorization_error");
+        expect(e.message).toContain("does not have access to this resource");
+      }
+    });
+
     it("should return error with invalid API key", async () => {
       const state = {} as DefaultState;
       const authMiddleware = auth();

--- a/server/middlewares/authentication.ts
+++ b/server/middlewares/authentication.ts
@@ -177,7 +177,7 @@ async function validateAuthentication(
       throw AuthenticationError("Access token is expired");
     }
     if (!authentication.canAccess(ctx.originalUrl)) {
-      throw AuthenticationError(
+      throw AuthorizationError(
         "Access token does not have access to this resource"
       );
     }
@@ -220,9 +220,7 @@ async function validateAuthentication(
     }
 
     if (!apiKey.canAccess(ctx.originalUrl)) {
-      throw AuthenticationError(
-        "API key does not have access to this resource"
-      );
+      throw AuthorizationError("API key does not have access to this resource");
     }
 
     user = await User.findByPk(apiKey.userId, {

--- a/server/routes/api/apiKeys/apiKeys.test.ts
+++ b/server/routes/api/apiKeys/apiKeys.test.ts
@@ -53,6 +53,8 @@ describe("#apiKeys.create", () => {
           "*.info",
           "users.*",
           "collections:read",
+          "read",
+          "write",
         ],
       },
     });
@@ -66,6 +68,8 @@ describe("#apiKeys.create", () => {
       "/api/*.info",
       "/api/users.*",
       "collections:read",
+      "read",
+      "write",
     ]);
   });
 

--- a/server/routes/api/apiKeys/apiKeys.ts
+++ b/server/routes/api/apiKeys/apiKeys.ts
@@ -1,6 +1,6 @@
 import Router from "koa-router";
 import { Op, Sequelize, type WhereOptions } from "sequelize";
-import { UserRole } from "@shared/types";
+import { Scope, UserRole } from "@shared/types";
 import auth from "@server/middlewares/authentication";
 import { transaction } from "@server/middlewares/transaction";
 import validate from "@server/middlewares/validate";
@@ -33,7 +33,9 @@ router.post(
       userId: user.id,
       expiresAt,
       scope: scope?.map((s) =>
-        s.startsWith("/api/") || s.includes(":")
+        s.startsWith("/api/") ||
+        s.includes(":") ||
+        Object.values(Scope).includes(s as Scope)
           ? s
           : `/api/${s.replace(/^\//, "")}`
       ),

--- a/server/routes/api/apiKeys/apiKeys.ts
+++ b/server/routes/api/apiKeys/apiKeys.ts
@@ -14,6 +14,8 @@ import * as T from "./schema";
 
 const router = new Router();
 
+const globalScopes = new Set<string>(Object.values(Scope));
+
 router.post(
   "apiKeys.create",
   auth({
@@ -33,9 +35,7 @@ router.post(
       userId: user.id,
       expiresAt,
       scope: scope?.map((s) =>
-        s.startsWith("/api/") ||
-        s.includes(":") ||
-        Object.values(Scope).includes(s as Scope)
+        s.startsWith("/api/") || s.includes(":") || globalScopes.has(s)
           ? s
           : `/api/${s.replace(/^\//, "")}`
       ),


### PR DESCRIPTION
closes #12222 