### PR TITLE
fix: should change `lastModifiedById` when republishing doc

### DIFF
--- a/server/commands/documentUpdater.test.ts
+++ b/server/commands/documentUpdater.test.ts
@@ -31,6 +31,25 @@ describe("documentUpdater", () => {
     expect(event!.documentId).toEqual(document.id);
   });
 
+  it("should change lastModifiedById when republishing an already published document", async () => {
+    const user = await buildUser();
+    let document = await buildDocument({
+      teamId: user.teamId,
+    });
+    const originalCreatorId = document.createdById;
+
+    document = await withAPIContext(user, (ctx) =>
+      documentUpdater(ctx, {
+        text: "Changed",
+        publish: true,
+        document,
+      })
+    );
+
+    expect(originalCreatorId).not.toEqual(user.id);
+    expect(document.lastModifiedById).toEqual(user.id);
+  });
+
   it("should not change lastModifiedById or generate event if nothing changed", async () => {
     const user = await buildUser();
     let document = await buildDocument({

--- a/server/commands/documentUpdater.test.ts
+++ b/server/commands/documentUpdater.test.ts
@@ -33,10 +33,11 @@ describe("documentUpdater", () => {
 
   it("should change lastModifiedById when republishing an already published document", async () => {
     const user = await buildUser();
+    const creator = await buildUser({ teamId: user.teamId });
     let document = await buildDocument({
       teamId: user.teamId,
+      userId: creator.id,
     });
-    const originalCreatorId = document.createdById;
 
     document = await withAPIContext(user, (ctx) =>
       documentUpdater(ctx, {
@@ -46,7 +47,7 @@ describe("documentUpdater", () => {
       })
     );
 
-    expect(originalCreatorId).not.toEqual(user.id);
+    expect(document.createdById).toEqual(creator.id);
     expect(document.lastModifiedById).toEqual(user.id);
   });
 

--- a/server/models/Document.ts
+++ b/server/models/Document.ts
@@ -1009,6 +1009,9 @@ class Document extends ArchivableModel<
     const { user } = ctx.state.auth;
     const { transaction } = ctx.state;
 
+    this.lastModifiedById = user.id;
+    this.updatedBy = user;
+
     // If the document is already published then calling publish should act like
     // a regular save
     if (this.publishedAt) {
@@ -1056,8 +1059,6 @@ class Document extends ArchivableModel<
       );
     }
 
-    this.lastModifiedById = user.id;
-    this.updatedBy = user;
     this.publishedAt = new Date();
 
     if (event) {


### PR DESCRIPTION
closes #12220 