### PR TITLE
chore: Increased default model creation rate limits from 10/m to 25/m

### DIFF
--- a/plugins/storage/server/api/files.ts
+++ b/plugins/storage/server/api/files.ts
@@ -29,7 +29,7 @@ const router = new Router();
 
 router.post(
   "files.create",
-  rateLimiter(RateLimiterStrategy.TenPerMinute),
+  rateLimiter(RateLimiterStrategy.TwentyFivePerMinute),
   auth(),
   validate(T.FilesCreateSchema),
   timeout(30 * 60 * 1000), // 30 minutes for large file uploads

--- a/server/routes/api/apiKeys/apiKeys.ts
+++ b/server/routes/api/apiKeys/apiKeys.ts
@@ -2,6 +2,7 @@ import Router from "koa-router";
 import { Op, Sequelize, type WhereOptions } from "sequelize";
 import { UserRole } from "@shared/types";
 import auth from "@server/middlewares/authentication";
+import { rateLimiter } from "@server/middlewares/rateLimiter";
 import { transaction } from "@server/middlewares/transaction";
 import validate from "@server/middlewares/validate";
 import { ApiKey, User } from "@server/models";
@@ -9,6 +10,7 @@ import { authorize, cannot } from "@server/policies";
 import { presentApiKey } from "@server/presenters";
 import type { APIContext } from "@server/types";
 import { AuthenticationType } from "@server/types";
+import { RateLimiterStrategy } from "@server/utils/RateLimiter";
 import pagination from "../middlewares/pagination";
 import * as T from "./schema";
 
@@ -16,6 +18,7 @@ const router = new Router();
 
 router.post(
   "apiKeys.create",
+  rateLimiter(RateLimiterStrategy.TwentyFivePerMinute),
   auth({
     role: UserRole.Member,
     type: AuthenticationType.APP,

--- a/server/routes/api/attachments/attachments.ts
+++ b/server/routes/api/attachments/attachments.ts
@@ -81,7 +81,7 @@ router.post(
 
 router.post(
   "attachments.create",
-  rateLimiter(RateLimiterStrategy.TenPerMinute),
+  rateLimiter(RateLimiterStrategy.TwentyFivePerMinute),
   auth(),
   validate(T.AttachmentsCreateSchema),
   transaction(),

--- a/server/routes/api/collections/collections.ts
+++ b/server/routes/api/collections/collections.ts
@@ -50,6 +50,7 @@ const router = new Router();
 
 router.post(
   "collections.create",
+  rateLimiter(RateLimiterStrategy.TwentyFivePerMinute),
   auth(),
   validate(T.CollectionsCreateSchema),
   transaction(),

--- a/server/routes/api/comments/comments.ts
+++ b/server/routes/api/comments/comments.ts
@@ -29,7 +29,7 @@ const router = new Router();
 
 router.post(
   "comments.create",
-  rateLimiter(RateLimiterStrategy.TenPerMinute),
+  rateLimiter(RateLimiterStrategy.TwentyFivePerMinute),
   auth(),
   feature(TeamPreference.Commenting),
   validate(T.CommentsCreateSchema),

--- a/server/routes/api/emojis/emojis.ts
+++ b/server/routes/api/emojis/emojis.ts
@@ -166,7 +166,7 @@ router.post(
 
 router.post(
   "emojis.create",
-  rateLimiter(RateLimiterStrategy.TenPerMinute),
+  rateLimiter(RateLimiterStrategy.TwentyFivePerMinute),
   auth(),
   validate(T.EmojisCreateSchema),
   transaction(),

--- a/server/routes/api/imports/imports.ts
+++ b/server/routes/api/imports/imports.ts
@@ -6,6 +6,7 @@ import { ImportState, UserRole } from "@shared/types";
 import { ImportValidation } from "@shared/validations";
 import { UnprocessableEntityError } from "@server/errors";
 import auth from "@server/middlewares/authentication";
+import { rateLimiter } from "@server/middlewares/rateLimiter";
 import { transaction } from "@server/middlewares/transaction";
 import validate from "@server/middlewares/validate";
 import { Integration } from "@server/models";
@@ -13,6 +14,7 @@ import Import from "@server/models/Import";
 import { authorize } from "@server/policies";
 import { presentImport, presentPolicies } from "@server/presenters";
 import type { APIContext } from "@server/types";
+import { RateLimiterStrategy } from "@server/utils/RateLimiter";
 import pagination from "../middlewares/pagination";
 import * as T from "./schema";
 
@@ -20,6 +22,7 @@ const router = new Router();
 
 router.post(
   "imports.create",
+  rateLimiter(RateLimiterStrategy.TwentyFivePerMinute),
   auth({ role: UserRole.Admin }),
   validate(T.ImportsCreateSchema),
   transaction(),

--- a/server/routes/api/integrations/integrations.ts
+++ b/server/routes/api/integrations/integrations.ts
@@ -3,12 +3,14 @@ import type { WhereOptions } from "sequelize";
 import { Op } from "sequelize";
 import { IntegrationType, UserRole } from "@shared/types";
 import auth from "@server/middlewares/authentication";
+import { rateLimiter } from "@server/middlewares/rateLimiter";
 import { transaction } from "@server/middlewares/transaction";
 import validate from "@server/middlewares/validate";
 import Integration from "@server/models/Integration";
 import { authorize } from "@server/policies";
 import { presentIntegration, presentPolicies } from "@server/presenters";
 import type { APIContext } from "@server/types";
+import { RateLimiterStrategy } from "@server/utils/RateLimiter";
 import pagination from "../middlewares/pagination";
 import * as T from "./schema";
 
@@ -68,6 +70,7 @@ router.post(
 
 router.post(
   "integrations.create",
+  rateLimiter(RateLimiterStrategy.TwentyFivePerMinute),
   auth({ role: UserRole.Admin }),
   validate(T.IntegrationsCreateSchema),
   transaction(),

--- a/server/routes/api/pins/pins.ts
+++ b/server/routes/api/pins/pins.ts
@@ -2,6 +2,7 @@ import Router from "koa-router";
 import { Sequelize, Op, Transaction } from "sequelize";
 import pinCreator from "@server/commands/pinCreator";
 import auth from "@server/middlewares/authentication";
+import { rateLimiter } from "@server/middlewares/rateLimiter";
 import { transaction } from "@server/middlewares/transaction";
 import validate from "@server/middlewares/validate";
 import { Collection, Document, Pin } from "@server/models";
@@ -12,6 +13,7 @@ import {
   presentPolicies,
 } from "@server/presenters";
 import type { APIContext } from "@server/types";
+import { RateLimiterStrategy } from "@server/utils/RateLimiter";
 import pagination from "../middlewares/pagination";
 import * as T from "./schema";
 
@@ -19,6 +21,7 @@ const router = new Router();
 
 router.post(
   "pins.create",
+  rateLimiter(RateLimiterStrategy.TwentyFivePerMinute),
   auth(),
   validate(T.PinsCreateSchema),
   transaction(),

--- a/server/routes/api/shares/shares.ts
+++ b/server/routes/api/shares/shares.ts
@@ -251,6 +251,7 @@ router.post(
 
 router.post(
   "shares.create",
+  rateLimiter(RateLimiterStrategy.TwentyFivePerMinute),
   auth(),
   validate(T.SharesCreateSchema),
   transaction(),

--- a/server/routes/api/stars/stars.ts
+++ b/server/routes/api/stars/stars.ts
@@ -2,6 +2,7 @@ import Router from "koa-router";
 import { Sequelize } from "sequelize";
 import starCreator from "@server/commands/starCreator";
 import auth from "@server/middlewares/authentication";
+import { rateLimiter } from "@server/middlewares/rateLimiter";
 import { transaction } from "@server/middlewares/transaction";
 import validate from "@server/middlewares/validate";
 import { Document, Star, Collection } from "@server/models";
@@ -13,6 +14,7 @@ import {
 } from "@server/presenters";
 import type { APIContext } from "@server/types";
 import { starIndexing } from "@server/utils/indexing";
+import { RateLimiterStrategy } from "@server/utils/RateLimiter";
 import pagination from "../middlewares/pagination";
 import * as T from "./schema";
 
@@ -20,6 +22,7 @@ const router = new Router();
 
 router.post(
   "stars.create",
+  rateLimiter(RateLimiterStrategy.TwentyFivePerMinute),
   auth(),
   validate(T.StarsCreateSchema),
   transaction(),

--- a/server/routes/api/subscriptions/subscriptions.ts
+++ b/server/routes/api/subscriptions/subscriptions.ts
@@ -114,6 +114,7 @@ router.post(
 
 router.post(
   "subscriptions.create",
+  rateLimiter(RateLimiterStrategy.TwentyFivePerMinute),
   auth(),
   validate(T.SubscriptionsCreateSchema),
   transaction(),

--- a/server/routes/api/teams/teams.ts
+++ b/server/routes/api/teams/teams.ts
@@ -43,7 +43,7 @@ const handleTeamUpdate = async (ctx: APIContext<T.TeamsUpdateSchemaReq>) => {
 
 router.post(
   "team.update",
-  rateLimiter(RateLimiterStrategy.TenPerMinute),
+  rateLimiter(RateLimiterStrategy.TwentyFivePerMinute),
   auth(),
   validate(T.TeamsUpdateSchema),
   transaction(),
@@ -52,7 +52,7 @@ router.post(
 
 router.post(
   "teams.update",
-  rateLimiter(RateLimiterStrategy.TenPerMinute),
+  rateLimiter(RateLimiterStrategy.TwentyFivePerMinute),
   auth(),
   validate(T.TeamsUpdateSchema),
   transaction(),


### PR DESCRIPTION
Mostly increases rate limits however where some middleware calls were missing rate limits actually end up reduced from previous behavior.

ref https://github.com/outline/outline/discussions/12224