### PR TITLE
Add title guidance for MCP

### DIFF
--- a/server/routes/mcp/index.ts
+++ b/server/routes/mcp/index.ts
@@ -23,7 +23,9 @@ import { version } from "../../../package.json";
 const app = new Koa();
 const router = new Router();
 
-const defaultInstructions = `Document and collection markdown support @mentions using the syntax: @[Display Name](mention://user/userId). For example: @[John Doe](mention://user/c9a1b2e3-...). Use the list_users tool to find user IDs.`;
+const defaultInstructions = `Document and collection markdown content must not begin with a top-level heading (H1) — the title is stored as a separate field, so set it via the title parameter and start the content with body text or a lower-level heading instead.
+
+Document and collection markdown support @mentions using the syntax: @[Display Name](mention://user/userId). For example: @[John Doe](mention://user/c9a1b2e3-...). Use the list_users tool to find user IDs.`;
 
 /**
  * Creates a fresh MCP server instance with tools filtered by the OAuth

--- a/server/routes/mcp/index.ts
+++ b/server/routes/mcp/index.ts
@@ -23,7 +23,7 @@ import { version } from "../../../package.json";
 const app = new Koa();
 const router = new Router();
 
-const defaultInstructions = `Document and collection markdown content must not begin with a top-level heading (H1) — the title is stored as a separate field, so set it via the title parameter and start the content with body text or a lower-level heading instead.
+const defaultInstructions = `Document markdown content must not begin with a top-level heading (H1) — the title is stored as a separate field, so set it via the title parameter and start the content with body text or a lower-level heading instead.
 
 Document and collection markdown support @mentions using the syntax: @[Display Name](mention://user/userId). For example: @[John Doe](mention://user/c9a1b2e3-...). Use the list_users tool to find user IDs.`;
 


### PR DESCRIPTION
Adds guidance to not use H1 as start of text for MCP clients.