### PR TITLE
chore: resolve lint warnings in oauth routes and BaseStorage

### DIFF
--- a/server/routes/oauth/index.ts
+++ b/server/routes/oauth/index.ts
@@ -53,8 +53,13 @@ router.post(
     authorize(user, "read", client);
 
     // Note: These objects are mutated by the OAuth2Server library
-    const request = new OAuth2Server.Request(ctx.request as any);
-    const response = new OAuth2Server.Response(ctx.response as any);
+    const request = new OAuth2Server.Request({
+      headers: ctx.request.headers as Record<string, string>,
+      method: ctx.request.method,
+      query: ctx.request.query as Record<string, string>,
+      body: ctx.request.body,
+    });
+    const response = new OAuth2Server.Response();
 
     const authorizationCode = await oauth.authorize(request, response, {
       // Require state to prevent CSRF attacks
@@ -113,8 +118,13 @@ router.post(
     }
 
     // Note: These objects are mutated by the OAuth2Server library
-    const request = new OAuth2Server.Request(ctx.request as any);
-    const response = new OAuth2Server.Response(ctx.response as any);
+    const request = new OAuth2Server.Request({
+      headers: ctx.request.headers as Record<string, string>,
+      method: ctx.request.method,
+      query: ctx.request.query as Record<string, string>,
+      body: ctx.request.body,
+    });
+    const response = new OAuth2Server.Response();
     const token = await oauth.token(request, response, {
       accessTokenLifetime: OAuthAuthentication.accessTokenLifetime,
       refreshTokenLifetime: OAuthAuthentication.refreshTokenLifetime,

--- a/server/storage/files/BaseStorage.ts
+++ b/server/storage/files/BaseStorage.ts
@@ -8,7 +8,7 @@ import { Week } from "@shared/utils/time";
 import env from "@server/env";
 import Logger from "@server/logging/Logger";
 import type { RequestInit } from "@server/utils/fetch";
-import fetch, { chromeUserAgent } from "@server/utils/fetch";
+import fetch, { chromeUserAgent, Headers } from "@server/utils/fetch";
 import type { AppContext } from "@server/types";
 
 export default abstract class BaseStorage {
@@ -189,10 +189,10 @@ export default abstract class BaseStorage {
       }
     } else {
       try {
-        const headers = {
-          "User-Agent": chromeUserAgent,
-          ...init?.headers,
-        };
+        const headers = new Headers(init?.headers);
+        if (!headers.has("User-Agent")) {
+          headers.set("User-Agent", chromeUserAgent);
+        }
         const initWithoutHeaders = omit(init, ["headers"]);
 
         const res = await fetch(url, {

--- a/server/utils/fetch.ts
+++ b/server/utils/fetch.ts
@@ -1,7 +1,11 @@
 /* oxlint-disable no-restricted-imports, react/rules-of-hooks */
 import type http from "node:http";
 import type https from "node:https";
-import nodeFetch, { type RequestInit, type Response } from "node-fetch";
+import nodeFetch, {
+  Headers,
+  type RequestInit,
+  type Response,
+} from "node-fetch";
 import { getProxyForUrl } from "proxy-from-env";
 import tunnelAgent, { type TunnelAgent } from "tunnel-agent";
 import { useAgent as useFilteringAgent } from "request-filtering-agent";
@@ -24,6 +28,7 @@ const DefaultOptions = {
 };
 
 export type { RequestInit } from "node-fetch";
+export { Headers };
 
 /**
  * Default user agent string for outgoing requests.


### PR DESCRIPTION
## Summary
- Replace `as any` casts in `server/routes/oauth/index.ts` when constructing `OAuth2Server.Request`/`Response` with explicit objects containing only the fields the library actually consumes (`headers`, `method`, `query`, `body`).
- Switch `BaseStorage.storeFromUrl` from a manual header object spread to a node-fetch `Headers` instance, avoiding the `no-misused-spread` warning that fires when `init.headers` is a `Headers`/array form.
- Re-export `Headers` from `@server/utils/fetch` so the no-restricted-imports rule still passes.

## Test plan
- [x] `yarn lint` clean for the touched files
- [x] `yarn tsc --noEmit`
- [x] `yarn test server/routes/oauth/` (39 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)