### PR TITLE
feat: Add `delete_document` and `delete_collection` MCP tools

### DIFF
--- a/server/models/Collection.test.ts
+++ b/server/models/Collection.test.ts
@@ -8,6 +8,7 @@ import {
   buildTeam,
   buildDocument,
 } from "@server/test/factories";
+import { withAPIContext } from "@server/test/support";
 import Collection from "./Collection";
 import Document from "./Document";
 
@@ -547,5 +548,61 @@ describe("#setIndex", () => {
     });
     expect(anotherCollection.index).not.toBeNull();
     expect(anotherCollection.index).not.toEqual(collection.index);
+  });
+});
+
+describe("#archiveWithCtx", () => {
+  it("should archive the collection and its non-archived documents", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const collection = await buildCollection({ teamId: team.id });
+    const document = await buildDocument({
+      collectionId: collection.id,
+      teamId: team.id,
+      publishedAt: new Date(),
+    });
+    const alreadyArchived = await buildDocument({
+      collectionId: collection.id,
+      teamId: team.id,
+      publishedAt: new Date(),
+      archivedAt: new Date("2024-01-01"),
+    });
+
+    await withAPIContext(user, (ctx) => collection.archiveWithCtx(ctx));
+
+    await Promise.all([
+      collection.reload(),
+      document.reload(),
+      alreadyArchived.reload(),
+    ]);
+
+    expect(collection.archivedAt).not.toBeNull();
+    expect(collection.archivedById).toBe(user.id);
+    expect(document.archivedAt).not.toBeNull();
+    expect(document.archivedAt?.getTime()).toBe(
+      collection.archivedAt!.getTime()
+    );
+    expect(document.lastModifiedById).toBe(user.id);
+    // Previously-archived documents keep their original archivedAt timestamp.
+    expect(alreadyArchived.archivedAt?.getTime()).toBe(
+      new Date("2024-01-01").getTime()
+    );
+  });
+
+  it("should leave documents in other collections untouched", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const collection = await buildCollection({ teamId: team.id });
+    const otherCollection = await buildCollection({ teamId: team.id });
+    const otherDocument = await buildDocument({
+      collectionId: otherCollection.id,
+      teamId: team.id,
+      publishedAt: new Date(),
+    });
+
+    await withAPIContext(user, (ctx) => collection.archiveWithCtx(ctx));
+
+    await otherDocument.reload();
+    expect(otherDocument.archivedAt).toBeNull();
   });
 });

--- a/server/models/Collection.ts
+++ b/server/models/Collection.ts
@@ -772,6 +772,42 @@ class Collection extends ParanoidModel<
     };
   };
 
+  /**
+   * Archives the collection and all of its non-archived documents. The
+   * collection's `archivedAt` and `archivedBy` are set to now and the acting
+   * user respectively, and child documents inherit the same `archivedAt`.
+   *
+   * @param ctx - the API context, including the acting user and optional transaction.
+   * @returns the updated collection.
+   */
+  archiveWithCtx = async (ctx: APIContext) => {
+    const { transaction } = ctx.state;
+    const { user } = ctx.state.auth;
+
+    this.archivedAt = new Date();
+    this.archivedById = user.id;
+    this.archivedBy = user;
+
+    await this.saveWithCtx(ctx, undefined, { name: "archive" });
+
+    await Document.update(
+      {
+        lastModifiedById: user.id,
+        archivedAt: this.archivedAt,
+      },
+      {
+        where: {
+          teamId: this.teamId,
+          collectionId: this.id,
+          archivedAt: { [Op.is]: null },
+        },
+        transaction,
+      }
+    );
+
+    return this;
+  };
+
   deleteDocument = async function (document: Document, options?: FindOptions) {
     await this.removeDocumentInStructure(document, options);
 

--- a/server/models/Document.test.ts
+++ b/server/models/Document.test.ts
@@ -11,6 +11,7 @@ import {
   buildUser,
   buildGuestUser,
 } from "@server/test/factories";
+import { withAPIContext } from "@server/test/support";
 import UserMembership from "./UserMembership";
 
 beforeEach(() => {
@@ -39,11 +40,11 @@ paragraph 2`,
   });
 });
 
-describe("#delete", () => {
+describe("#destroyWithCtx", () => {
   test("should soft delete and set last modified", async () => {
     const document = await buildDocument();
     const user = await buildUser();
-    await document.delete(user);
+    await withAPIContext(user, (ctx) => document.destroyWithCtx(ctx));
 
     const newDocument = await Document.findByPk(document.id, {
       paranoid: false,
@@ -57,7 +58,7 @@ describe("#delete", () => {
       archivedAt: new Date(),
     });
     const user = await buildUser();
-    await document.delete(user);
+    await withAPIContext(user, (ctx) => document.destroyWithCtx(ctx));
     const newDocument = await Document.findByPk(document.id, {
       paranoid: false,
     });
@@ -80,7 +81,7 @@ describe("#delete", () => {
     });
     await collection.addDocumentToStructure(document, 0);
 
-    await document.delete(user);
+    await withAPIContext(user, (ctx) => document.destroyWithCtx(ctx));
     const [newDocument, newCollection] = await Promise.all([
       document.reload({ paranoid: false }),
       collection.reload(),
@@ -94,7 +95,7 @@ describe("#delete", () => {
   it("should delete draft without collection", async () => {
     const user = await buildUser();
     const document = await buildDraftDocument();
-    await document.delete(user);
+    await withAPIContext(user, (ctx) => document.destroyWithCtx(ctx));
     const deletedDocument = await Document.findByPk(document.id, {
       paranoid: false,
     });

--- a/server/models/Document.ts
+++ b/server/models/Document.ts
@@ -51,7 +51,6 @@ import slugify from "@shared/utils/slugify";
 import { DocumentValidation } from "@shared/validations";
 import { InvalidRequestError, ValidationError } from "@server/errors";
 import { generateUrlId } from "@server/utils/url";
-import { createContext } from "@server/context";
 import Collection from "./Collection";
 import FileOperation from "./FileOperation";
 import Group from "./Group";
@@ -73,7 +72,7 @@ import Length from "./validators/Length";
 import type { APIContext } from "@server/types";
 import { APIUpdateExtension } from "@server/collaboration/APIUpdateExtension";
 import { SkipChangeset } from "./decorators/Changeset";
-import type { HookContext } from "./base/Model";
+import type { EventOverrideOptions, HookContext } from "./base/Model";
 import Template from "./Template";
 
 export const DOCUMENT_VERSION = 2;
@@ -1217,36 +1216,36 @@ class Document extends ArchivableModel<
   };
 
   // Delete a document, archived or otherwise.
-  delete = (user: User) =>
-    this.sequelize.transaction(async (transaction: Transaction) => {
-      let deleted = false;
+  destroyWithCtx = async (
+    ctx: APIContext,
+    eventOpts?: EventOverrideOptions
+  ): Promise<void> => {
+    const { user } = ctx.state.auth;
+    const { transaction } = ctx.state;
+    let deleted = false;
 
-      if (this.collectionId) {
-        const collection = await Collection.findByPk(this.collectionId!, {
-          includeDocumentStructure: true,
-          transaction,
-          lock: transaction.LOCK.UPDATE,
-          paranoid: false,
-        });
-
-        if (!this.archivedAt || (this.archivedAt && collection?.archivedAt)) {
-          await collection?.deleteDocument(this, { transaction });
-          deleted = true;
-        }
-      }
-
-      if (!deleted) {
-        await this.destroy({
-          transaction,
-        });
-      }
-
-      this.lastModifiedById = user.id;
-      this.updatedBy = user;
-      return this.saveWithCtx(createContext({ user, transaction }), undefined, {
-        name: "delete",
+    if (this.collectionId) {
+      const collection = await Collection.findByPk(this.collectionId, {
+        includeDocumentStructure: true,
+        transaction,
+        lock: transaction?.LOCK.UPDATE,
+        paranoid: false,
       });
-    });
+
+      if (!this.archivedAt || (this.archivedAt && collection?.archivedAt)) {
+        await collection?.deleteDocument(this, { transaction });
+        deleted = true;
+      }
+    }
+
+    if (!deleted) {
+      await this.destroy({ transaction });
+    }
+
+    this.lastModifiedById = user.id;
+    this.updatedBy = user;
+    await this.saveWithCtx(ctx, undefined, { name: "delete", ...eventOpts });
+  };
 
   getTimestamp = () => Math.round(new Date(this.updatedAt).getTime() / 1000);
 

--- a/server/models/base/Model.ts
+++ b/server/models/base/Model.ts
@@ -27,7 +27,7 @@ import type { Replace, APIContext } from "@server/types";
 import { getChangesetSkipped } from "../decorators/Changeset";
 import { InternalError } from "@server/errors";
 
-type EventOverrideOptions = {
+export type EventOverrideOptions = {
   /** Override the default event name. */
   name?: string;
   /** Additional data to publish in the event. */

--- a/server/routes/api/collections/collections.ts
+++ b/server/routes/api/collections/collections.ts
@@ -853,31 +853,7 @@ router.post(
 
     authorize(user, "archive", collection);
 
-    collection.archivedAt = new Date();
-    collection.archivedById = user.id;
-    collection.archivedBy = user;
-
-    await collection.saveWithCtx(ctx, undefined, {
-      name: "archive",
-    });
-
-    // Archive all documents within the collection
-    await Document.update(
-      {
-        lastModifiedById: user.id,
-        archivedAt: collection.archivedAt,
-      },
-      {
-        where: {
-          teamId: collection.teamId,
-          collectionId: collection.id,
-          archivedAt: {
-            [Op.is]: null,
-          },
-        },
-        transaction,
-      }
-    );
+    await collection.archiveWithCtx(ctx);
 
     ctx.body = {
       data: await presentCollection(ctx, collection),

--- a/server/routes/api/documents/documents.test.ts
+++ b/server/routes/api/documents/documents.test.ts
@@ -2351,7 +2351,7 @@ describe("#documents.archived", () => {
       userId: user.id,
       teamId: user.teamId,
     });
-    await document.delete(user);
+    await withAPIContext(user, (ctx) => document.destroyWithCtx(ctx));
     const res = await server.post("/api/documents.archived", {
       body: {
         token: user.getJwtToken(),
@@ -2405,7 +2405,7 @@ describe("#documents.deleted", () => {
       userId: user.id,
       teamId: user.teamId,
     });
-    await document.delete(user);
+    await withAPIContext(user, (ctx) => document.destroyWithCtx(ctx));
     const res = await server.post("/api/documents.deleted", {
       body: {
         token: user.getJwtToken(),
@@ -2437,9 +2437,9 @@ describe("#documents.deleted", () => {
       collectionId: null,
     });
     await Promise.all([
-      document.delete(user),
-      draftDocument.delete(user),
-      otherUserDraft.delete(user2),
+      withAPIContext(user, (ctx) => document.destroyWithCtx(ctx)),
+      withAPIContext(user, (ctx) => draftDocument.destroyWithCtx(ctx)),
+      withAPIContext(user2, (ctx) => otherUserDraft.destroyWithCtx(ctx)),
     ]);
     const res = await server.post("/api/documents.deleted", {
       body: {
@@ -2460,7 +2460,7 @@ describe("#documents.deleted", () => {
       userId: admin.id,
       teamId: admin.teamId,
     });
-    await document.delete(admin);
+    await withAPIContext(admin, (ctx) => document.destroyWithCtx(ctx));
     const res = await server.post("/api/documents.deleted", {
       body: {
         token: admin.getJwtToken(),
@@ -2483,7 +2483,7 @@ describe("#documents.deleted", () => {
       teamId: user.teamId,
       collectionId: collection.id,
     });
-    await document.delete(user);
+    await withAPIContext(user, (ctx) => document.destroyWithCtx(ctx));
     const res = await server.post("/api/documents.deleted", {
       body: {
         token: user.getJwtToken(),
@@ -3056,7 +3056,7 @@ describe("#documents.restore", () => {
       collectionId: collection.id,
       teamId: team.id,
     });
-    await document.delete(user);
+    await withAPIContext(user, (ctx) => document.destroyWithCtx(ctx));
     await collection.destroy({ hooks: false });
 
     const res = await server.post("/api/documents.restore", {
@@ -3086,7 +3086,7 @@ describe("#documents.restore", () => {
       collectionId: collection.id,
       teamId: team.id,
     });
-    await document.delete(user);
+    await withAPIContext(user, (ctx) => document.destroyWithCtx(ctx));
     await collection.destroy({ hooks: false });
 
     const res = await server.post("/api/documents.restore", {
@@ -4618,7 +4618,7 @@ describe("#documents.unpublish", () => {
       userId: user.id,
       teamId: user.teamId,
     });
-    await document.delete(user);
+    await withAPIContext(user, (ctx) => document.destroyWithCtx(ctx));
     const res = await server.post("/api/documents.unpublish", {
       body: {
         token: user.getJwtToken(),

--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -1504,7 +1504,9 @@ router.post(
   "documents.delete",
   auth(),
   validate(T.DocumentsDeleteSchema),
+  transaction(),
   async (ctx: APIContext<T.DocumentsDeleteReq>) => {
+    const { transaction } = ctx.state;
     const { id, permanent } = ctx.input.body;
     const { user } = ctx.state.auth;
 
@@ -1512,6 +1514,7 @@ router.post(
       const document = await Document.findByPk(id, {
         userId: user.id,
         paranoid: false,
+        transaction,
       });
       authorize(user, "permanentDelete", document);
 
@@ -1527,11 +1530,12 @@ router.post(
     } else {
       const document = await Document.findByPk(id, {
         userId: user.id,
+        transaction,
       });
 
       authorize(user, "delete", document);
 
-      await document.delete(user);
+      await document.destroyWithCtx(ctx);
     }
 
     ctx.body = {

--- a/server/routes/api/shares/shares.test.ts
+++ b/server/routes/api/shares/shares.test.ts
@@ -12,7 +12,7 @@ import {
   buildTeam,
 } from "@server/test/factories";
 
-import { getTestServer } from "@server/test/support";
+import { getTestServer, withAPIContext } from "@server/test/support";
 
 const server = getTestServer();
 
@@ -166,7 +166,7 @@ describe("#shares.list", () => {
       teamId: user.teamId,
       userId: user.id,
     });
-    await document.delete(user);
+    await withAPIContext(user, (ctx) => document.destroyWithCtx(ctx));
     const res = await server.post("/api/shares.list", {
       body: {
         token: user.getJwtToken(),
@@ -1323,7 +1323,7 @@ describe("#shares.revoke", () => {
       teamId: user.teamId,
       userId: user.id,
     });
-    await document.delete(user);
+    await withAPIContext(user, (ctx) => document.destroyWithCtx(ctx));
     const res = await server.post("/api/shares.revoke", {
       body: {
         token: user.getJwtToken(),

--- a/server/tools/collections.ts
+++ b/server/tools/collections.ts
@@ -288,7 +288,7 @@ export function collectionTools(server: McpServer, scopes: string[]) {
       {
         title: "Delete collection",
         description:
-          "Deletes a collection by its ID. All documents within the collection will also be deleted. Set archive to true to archive the collection instead of deleting it.",
+          "Deletes a collection by its ID. Non-archived documents within the collection will also be deleted. Set archive to true to archive the collection instead of deleting it.",
         annotations: {
           idempotentHint: false,
           readOnlyHint: false,

--- a/server/tools/collections.ts
+++ b/server/tools/collections.ts
@@ -280,4 +280,53 @@ export function collectionTools(server: McpServer, scopes: string[]) {
       })
     );
   }
+
+  if (AuthenticationHelper.canAccess("collections.delete", scopes)) {
+    server.registerTool(
+      "delete_collection",
+      {
+        title: "Delete collection",
+        description:
+          "Deletes a collection by its ID. All documents within the collection will also be deleted. Set archive to true to archive the collection instead of deleting it.",
+        annotations: {
+          idempotentHint: false,
+          readOnlyHint: false,
+        },
+        inputSchema: {
+          id: z
+            .string()
+            .describe("The unique identifier of the collection to delete."),
+          archive: z
+            .boolean()
+            .optional()
+            .describe(
+              "Set to true to archive the collection instead of deleting it. All documents within the collection will also be archived."
+            ),
+        },
+      },
+      withTracing("delete_collection", async ({ id, archive }, context) => {
+        try {
+          const ctx = buildAPIContext(context);
+          const { user } = ctx.state.auth;
+
+          const collection = await Collection.findByPk(id, {
+            userId: user.id,
+            rejectOnEmpty: true,
+          });
+
+          if (archive) {
+            authorize(user, "archive", collection);
+            await collection.archiveWithCtx(ctx);
+          } else {
+            authorize(user, "delete", collection);
+            await collection.destroyWithCtx(ctx);
+          }
+
+          return success({ success: true });
+        } catch (message) {
+          return error(message);
+        }
+      })
+    );
+  }
 }

--- a/server/tools/collections.ts
+++ b/server/tools/collections.ts
@@ -3,6 +3,7 @@ import { Sequelize, Op, type WhereOptions } from "sequelize";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { CollectionPermission } from "@shared/types";
 import { Collection, Team } from "@server/models";
+import { sequelize } from "@server/storage/database";
 import { authorize } from "@server/policies";
 import { presentCollection } from "@server/presenters";
 import AuthenticationHelper from "@shared/helpers/AuthenticationHelper";
@@ -309,18 +310,24 @@ export function collectionTools(server: McpServer, scopes: string[]) {
           const ctx = buildAPIContext(context);
           const { user } = ctx.state.auth;
 
-          const collection = await Collection.findByPk(id, {
-            userId: user.id,
-            rejectOnEmpty: true,
-          });
+          await sequelize.transaction(async (transaction) => {
+            ctx.state.transaction = transaction;
+            ctx.context.transaction = transaction;
 
-          if (archive) {
-            authorize(user, "archive", collection);
-            await collection.archiveWithCtx(ctx);
-          } else {
-            authorize(user, "delete", collection);
-            await collection.destroyWithCtx(ctx);
-          }
+            const collection = await Collection.findByPk(id, {
+              userId: user.id,
+              rejectOnEmpty: true,
+              transaction,
+            });
+
+            if (archive) {
+              authorize(user, "archive", collection);
+              await collection.archiveWithCtx(ctx);
+            } else {
+              authorize(user, "delete", collection);
+              await collection.destroyWithCtx(ctx);
+            }
+          });
 
           return success({ success: true });
         } catch (message) {

--- a/server/tools/documents.ts
+++ b/server/tools/documents.ts
@@ -666,18 +666,24 @@ export function documentTools(server: McpServer, scopes: string[]) {
           const ctx = buildAPIContext(context);
           const { user } = ctx.state.auth;
 
-          const document = await Document.findByPk(id, {
-            userId: user.id,
-            rejectOnEmpty: true,
-          });
+          await sequelize.transaction(async (transaction) => {
+            ctx.state.transaction = transaction;
+            ctx.context.transaction = transaction;
 
-          if (archive) {
-            authorize(user, "archive", document);
-            await document.archiveWithCtx(ctx);
-          } else {
-            authorize(user, "delete", document);
-            await document.destroyWithCtx(ctx);
-          }
+            const document = await Document.findByPk(id, {
+              userId: user.id,
+              rejectOnEmpty: true,
+              transaction,
+            });
+
+            if (archive) {
+              authorize(user, "archive", document);
+              await document.archiveWithCtx(ctx);
+            } else {
+              authorize(user, "delete", document);
+              await document.destroyWithCtx(ctx);
+            }
+          });
 
           return success({ success: true });
         } catch (message) {

--- a/server/tools/documents.ts
+++ b/server/tools/documents.ts
@@ -637,4 +637,53 @@ export function documentTools(server: McpServer, scopes: string[]) {
       })
     );
   }
+
+  if (AuthenticationHelper.canAccess("documents.delete", scopes)) {
+    server.registerTool(
+      "delete_document",
+      {
+        title: "Delete document",
+        description:
+          "Deletes a document by its ID. The document is moved to the trash and can be restored later. Set archive to true to archive the document instead of deleting it.",
+        annotations: {
+          idempotentHint: false,
+          readOnlyHint: false,
+        },
+        inputSchema: {
+          id: z
+            .string()
+            .describe("The unique identifier of the document to delete."),
+          archive: z
+            .boolean()
+            .optional()
+            .describe(
+              "Set to true to archive the document instead of deleting it. Archived documents remain searchable in the archive view."
+            ),
+        },
+      },
+      withTracing("delete_document", async ({ id, archive }, context) => {
+        try {
+          const ctx = buildAPIContext(context);
+          const { user } = ctx.state.auth;
+
+          const document = await Document.findByPk(id, {
+            userId: user.id,
+            rejectOnEmpty: true,
+          });
+
+          if (archive) {
+            authorize(user, "archive", document);
+            await document.archiveWithCtx(ctx);
+          } else {
+            authorize(user, "delete", document);
+            await document.destroyWithCtx(ctx);
+          }
+
+          return success({ success: true });
+        } catch (message) {
+          return error(message);
+        }
+      })
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- Adds `delete_document` and `delete_collection` MCP tools, each supporting an `archive` flag to archive instead of delete.
- Refactors `Document#delete` into `destroyWithCtx` and extracts collection archive logic into `Collection#archiveWithCtx` so REST and MCP entry points share the same code paths.

## Test plan
- [ ] `yarn test server/models/Document.test.ts server/models/Collection.test.ts`
- [ ] Exercise `delete_document` and `delete_collection` MCP tools manually with and without `archive: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)