### PR TITLE
fix: Show comment toolbar on read-only documents when user has comment permission

### DIFF
--- a/app/editor/components/SelectionToolbar.tsx
+++ b/app/editor/components/SelectionToolbar.tsx
@@ -264,7 +264,7 @@ export function SelectionToolbar(props: Props) {
   } else if (isDividerSelection) {
     items = getDividerMenuItems(state, readOnly, dictionary);
   } else if (readOnly) {
-    items = getReadOnlyMenuItems(state, !!canUpdate, dictionary);
+    items = getReadOnlyMenuItems(state, !!canUpdate, dictionary, !!canComment);
   } else if (isNoticeSelection && selection.empty) {
     items = getNoticeMenuItems(state, readOnly, dictionary);
     align = "end";

--- a/app/editor/menus/readOnly.tsx
+++ b/app/editor/menus/readOnly.tsx
@@ -7,14 +7,15 @@ import type { Dictionary } from "~/hooks/useDictionary";
 export default function readOnlyMenuItems(
   state: EditorState,
   canUpdate: boolean,
-  dictionary: Dictionary
+  dictionary: Dictionary,
+  canComment: boolean = false
 ): MenuItem[] {
   const { schema } = state;
   const isEmpty = state.selection.empty;
 
   return [
     {
-      visible: canUpdate && !isEmpty,
+      visible: (canUpdate || canComment) && !isEmpty,
       name: "comment",
       tooltip: dictionary.comment,
       label: dictionary.comment,


### PR DESCRIPTION
## Summary

Users with read-only access to a document — viewers, or members with a read-only collection grant — currently cannot reach the inline-comment toolbar, even though the backend already grants the `comment` permission to those roles separately from `update` (see `server/policies/document.ts`).

The read-only selection toolbar (`getReadOnlyMenuItems`) gates the Comment menu item solely on `canUpdate`. As a result the menu is built with its only entry hidden, the `SelectionToolbar` widget collapses to no items, and the floating toolbar never appears.

This PR threads the existing `canComment` prop (already destructured from `props` in `SelectionToolbar`) through to `readOnlyMenuItems` and makes the Comment entry visible when either `canUpdate` OR `canComment` is true.

Closes #7362

## What changed

- `app/editor/menus/readOnly.tsx` — `readOnlyMenuItems` accepts a fourth parameter `canComment: boolean = false`; visibility predicate becomes `(canUpdate || canComment) && !isEmpty`. Default keeps the existing signature backwards-compatible for any external caller.
- `app/editor/components/SelectionToolbar.tsx` — pass `!!canComment` through at the read-only call site.

That's the entire diff. No new permission, no new API surface, no new translation strings, no schema changes.

## Compat notes

- The default value on the new parameter (`false`) preserves the existing call signature; any external caller of `readOnlyMenuItems` that doesn't pass `canComment` continues to behave exactly as before.
- No new translation strings — the existing `dictionary.comment` is reused.
