### PR TITLE
chore(test): Performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,15 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/install
-      - run: yarn test:${{ matrix.test-group }}
+      - name: Restore Jest transform cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/jest_runner
+          key: jest-${{ matrix.test-group }}-${{ hashFiles('.babelrc', '.jestconfig.json', 'yarn.lock', 'app/**/*.ts', 'app/**/*.tsx', 'shared/**/*.ts', 'shared/**/*.tsx') }}
+          restore-keys: |
+            jest-${{ matrix.test-group }}-${{ hashFiles('.babelrc', '.jestconfig.json', 'yarn.lock') }}-
+            jest-${{ matrix.test-group }}-
+      - run: yarn test:${{ matrix.test-group }} --cacheDirectory=/tmp/jest_runner
 
   test-server:
     needs: changes
@@ -110,9 +118,17 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/install
+      - name: Restore Jest transform cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/jest_runner
+          key: jest-server-${{ matrix.shard }}-${{ hashFiles('.babelrc', '.jestconfig.json', 'yarn.lock', 'server/**/*.ts', 'shared/**/*.ts', 'plugins/**/*.ts') }}
+          restore-keys: |
+            jest-server-${{ matrix.shard }}-${{ hashFiles('.babelrc', '.jestconfig.json', 'yarn.lock') }}-
+            jest-server-${{ matrix.shard }}-
       - run: yarn sequelize db:migrate
       - name: Run server tests
-        run: yarn test:server --maxWorkers=2 --shard=${{ matrix.shard }}/4
+        run: yarn test:server --maxWorkers=2 --shard=${{ matrix.shard }}/4 --cacheDirectory=/tmp/jest_runner
 
   bundle-size:
     needs: changes

--- a/server/test/setup.ts
+++ b/server/test/setup.ts
@@ -51,16 +51,6 @@ jest.mock("@aws-sdk/s3-request-presigner", () => ({
 // Initialize the database models
 require("@server/storage/database");
 
-// Import Redis after mocking
-const Redis = require("ioredis");
-
 beforeEach(() => {
   env.URL = sharedEnv.URL = "https://app.outline.dev";
-});
-
-afterEach(async () => {
-  // Create a new Redis instance for cleanup
-  const redis = new Redis();
-  await redis.flushall();
-  redis.disconnect();
 });


### PR DESCRIPTION
## Summary
- Removes the `afterEach` in `server/test/setup.ts` that created a fresh `ioredis-mock` client just to call `flushall` on it. Since the fresh client doesn't share state with clients held elsewhere in the test, this was effectively a no-op costing a few ms per test across thousands of tests.
- Adds cache for jest transform