### PR TITLE
fix: Search highlights not rendering in Firefox

### DIFF
--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -405,12 +405,12 @@ const diffStyle = (props: Props) => css`
 `;
 
 const findAndReplaceStyle = () => css`
-  ::highlight(search-results) {
+  & ::highlight(search-results) {
     background-color: rgba(255, 213, 0, 0.25);
     color: inherit;
   }
 
-  ::highlight(search-results-current) {
+  & ::highlight(search-results-current) {
     background-color: rgba(255, 213, 0, 0.75);
     color: inherit;
   }


### PR DESCRIPTION
## Summary

`@emotion/stylis` (used by styled-components 5.x) compiles top-level `::highlight(name)` rules inside a styled component as a *compound* selector `.parent::highlight(name)` rather than `.parent ::highlight(name)`. That only matches highlights on the editor container element itself, not its descendants which actually contain the text. Chrome applies these leniently, but Firefox 140+ correctly requires the originating element to contain the highlighted text — so highlights silently failed to render. Prefixing with `&` forces a descendant combinator and matches the descendant text-bearing elements.

Closes #12270