### PR TITLE
Allow viewers to create and access API keys

### DIFF
--- a/server/policies/apiKey.ts
+++ b/server/policies/apiKey.ts
@@ -14,7 +14,6 @@ allow(User, "createApiKey", Team, (actor, team) =>
   and(
     isTeamModel(actor, team),
     isTeamMutable(actor),
-    !actor.isViewer,
     !actor.isGuest,
     !actor.isSuspended,
     actor.isAdmin ||

--- a/server/queues/tasks/CleanupDemotedUserTask.test.ts
+++ b/server/queues/tasks/CleanupDemotedUserTask.test.ts
@@ -33,7 +33,7 @@ describe("CleanupDemotedUserTask", () => {
 
     const task = new CleanupDemotedUserTask();
     await task.perform({ userId: user.id });
-    expect(await ApiKey.findByPk(apiKey.id)).toBeTruthy();
+    expect(await ApiKey.findByPk(apiKey.id)).not.toBeNull();
   });
 
   it("should retain api keys for member", async () => {

--- a/server/queues/tasks/CleanupDemotedUserTask.test.ts
+++ b/server/queues/tasks/CleanupDemotedUserTask.test.ts
@@ -25,7 +25,7 @@ describe("CleanupDemotedUserTask", () => {
     expect(await ApiKey.findByPk(apiKey.id)).toBeNull();
   });
 
-  it("should delete api keys for viewer", async () => {
+  it("should retain api keys for viewer", async () => {
     const user = await buildViewer();
     const apiKey = await buildApiKey({
       userId: user.id,
@@ -33,7 +33,7 @@ describe("CleanupDemotedUserTask", () => {
 
     const task = new CleanupDemotedUserTask();
     await task.perform({ userId: user.id });
-    expect(await ApiKey.findByPk(apiKey.id)).toBeNull();
+    expect(await ApiKey.findByPk(apiKey.id)).toBeTruthy();
   });
 
   it("should retain api keys for member", async () => {

--- a/server/routes/api/apiKeys/apiKeys.test.ts
+++ b/server/routes/api/apiKeys/apiKeys.test.ts
@@ -225,6 +225,22 @@ describe("#apiKeys.list", () => {
     expect(body.data.length).toEqual(0);
   });
 
+  it("should allow viewers to list their own api keys", async () => {
+    const viewer = await buildViewer();
+    await buildApiKey({ userId: viewer.id });
+
+    const res = await server.post("/api/apiKeys.list", {
+      body: {
+        token: viewer.getJwtToken(),
+        userId: viewer.id,
+      },
+    });
+    const body = await res.json();
+
+    expect(res.status).toEqual(200);
+    expect(body.data.length).toEqual(1);
+  });
+
   it("should require authentication", async () => {
     const res = await server.post("/api/apiKeys.list");
     expect(res.status).toEqual(401);
@@ -278,6 +294,20 @@ describe("#apiKeys.delete", () => {
     const res = await server.post("/api/apiKeys.delete", {
       body: {
         token: admin.getJwtToken(),
+        id: apiKey.id,
+      },
+    });
+
+    expect(res.status).toEqual(200);
+  });
+
+  it("should allow viewers to delete their own api key", async () => {
+    const viewer = await buildViewer();
+    const apiKey = await buildApiKey({ userId: viewer.id });
+
+    const res = await server.post("/api/apiKeys.delete", {
+      body: {
+        token: viewer.getJwtToken(),
         id: apiKey.id,
       },
     });

--- a/server/routes/api/apiKeys/apiKeys.test.ts
+++ b/server/routes/api/apiKeys/apiKeys.test.ts
@@ -1,4 +1,10 @@
-import { buildAdmin, buildApiKey, buildUser } from "@server/test/factories";
+import {
+  buildAdmin,
+  buildApiKey,
+  buildGuestUser,
+  buildUser,
+  buildViewer,
+} from "@server/test/factories";
 import { getTestServer } from "@server/test/support";
 
 const server = getTestServer();
@@ -71,6 +77,34 @@ describe("#apiKeys.create", () => {
       "read",
       "write",
     ]);
+  });
+
+  it("should allow viewers to create an api key", async () => {
+    const viewer = await buildViewer();
+
+    const res = await server.post("/api/apiKeys.create", {
+      body: {
+        token: viewer.getJwtToken(),
+        name: "My API Key",
+      },
+    });
+    const body = await res.json();
+
+    expect(res.status).toEqual(200);
+    expect(body.data.name).toEqual("My API Key");
+  });
+
+  it("should not allow guests to create an api key", async () => {
+    const guest = await buildGuestUser();
+
+    const res = await server.post("/api/apiKeys.create", {
+      body: {
+        token: guest.getJwtToken(),
+        name: "My API Key",
+      },
+    });
+
+    expect(res.status).toEqual(403);
   });
 
   it("should require authentication", async () => {

--- a/server/routes/api/apiKeys/apiKeys.ts
+++ b/server/routes/api/apiKeys/apiKeys.ts
@@ -1,6 +1,6 @@
 import Router from "koa-router";
 import { Op, Sequelize, type WhereOptions } from "sequelize";
-import { Scope, UserRole } from "@shared/types";
+import { Scope } from "@shared/types";
 import auth from "@server/middlewares/authentication";
 import { rateLimiter } from "@server/middlewares/rateLimiter";
 import { transaction } from "@server/middlewares/transaction";
@@ -22,7 +22,6 @@ router.post(
   "apiKeys.create",
   rateLimiter(RateLimiterStrategy.TwentyFivePerMinute),
   auth({
-    role: UserRole.Member,
     type: AuthenticationType.APP,
   }),
   validate(T.APIKeysCreateSchema),
@@ -54,7 +53,7 @@ router.post(
 
 router.post(
   "apiKeys.list",
-  auth({ role: UserRole.Member }),
+  auth(),
   pagination(),
   validate(T.APIKeysListSchema),
   async (ctx: APIContext<T.APIKeysListReq>) => {
@@ -123,7 +122,6 @@ router.post(
 router.post(
   "apiKeys.delete",
   auth({
-    role: UserRole.Member,
     type: AuthenticationType.APP,
   }),
   validate(T.APIKeysDeleteSchema),


### PR DESCRIPTION
Access is still guarded by view permissions and the "Members can create API keys" preference