### PR TITLE
fix: Resolve console warnings for rtl DOM attribute and untracked MobX read

### DIFF
--- a/app/components/ActionButton.tsx
+++ b/app/components/ActionButton.tsx
@@ -1,4 +1,5 @@
 /* oxlint-disable react/prop-types */
+import { observer } from "mobx-react";
 import * as React from "react";
 import type { Props as TooltipProps } from "~/components/Tooltip";
 import Tooltip from "~/components/Tooltip";
@@ -85,4 +86,4 @@ const ActionButton = React.forwardRef<HTMLButtonElement, Props>(
   }
 );
 
-export default ActionButton;
+export default observer(ActionButton);

--- a/app/scenes/Document/components/DocumentMeta.tsx
+++ b/app/scenes/Document/components/DocumentMeta.tsx
@@ -28,7 +28,7 @@ type Props = {
   rtl?: boolean;
 };
 
-function TitleDocumentMeta({ to, document, revision, ...rest }: Props) {
+function TitleDocumentMeta({ to, document, revision, rtl, ...rest }: Props) {
   const { views, comments, ui } = useStores();
   const { t } = useTranslation();
   const sidebarContext = useLocationSidebarContext();
@@ -50,6 +50,7 @@ function TitleDocumentMeta({ to, document, revision, ...rest }: Props) {
       revision={revision}
       to={to}
       replace
+      $rtl={rtl}
       {...rest}
     >
       {commentingEnabled && can.comment && (
@@ -113,8 +114,8 @@ const InsightsButton = styled(NudeButton)`
   }
 `;
 
-export const Meta = styled(DocumentMeta)<{ rtl?: boolean }>`
-  justify-content: ${(props) => (props.rtl ? "flex-end" : "flex-start")};
+export const Meta = styled(DocumentMeta)<{ $rtl?: boolean }>`
+  justify-content: ${(props) => (props.$rtl ? "flex-end" : "flex-start")};
   margin: -12px 0 2em 0;
   font-size: 14px;
   position: relative;

--- a/app/scenes/Document/components/RevisionViewer.tsx
+++ b/app/scenes/Document/components/RevisionViewer.tsx
@@ -92,7 +92,7 @@ function RevisionViewer(props: Props, ref: React.Ref<TEditor>) {
         document={document}
         revision={revision}
         to={documentPath(document)}
-        rtl={revision.rtl}
+        $rtl={revision.rtl}
       />
       <Editor
         key={compareToRevisionId}


### PR DESCRIPTION
## Summary
- Use a transient `$rtl` prop on the document `Meta` styled component so it isn't forwarded to the underlying DOM element (silences the `Received false for a non-boolean attribute rtl` warning).
- Wrap `ActionButton` in `observer` so action `visible` checks that read MobX computed values (e.g. policy abilities) execute inside a reactive context, fixing the `Computed value … is being read outside a reactive context` warning.

## Test plan
- [ ] Open a document and verify no React `rtl` attribute warning appears in the console
- [ ] Open the comments sidebar and verify no MobX `flattenedAbilities` warning appears
- [ ] Verify RTL document layout still renders meta right-aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)