### PR TITLE
chore: Remove stale Jest references from docs and comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ There is a web client which is fully responsive and works on mobile devices.
 - **`shared/`** - Shared TypeScript types, utilities, and editor components
 - **`plugins/`** - Plugin system for extending functionality
 - **`public/`** - Static assets served directly
-- **Various config files** - TypeScript, Vite, Jest, Prettier, Oxlint configurations
+- **Various config files** - TypeScript, Vite, Vitest, Prettier, Oxlint configurations
 
 Refer to /docs/ARCHITECTURE.md for detailed architecture documentation.
 
@@ -152,7 +152,7 @@ yarn sequelize migration:create --name=add-field-to-table
 
 ## Testing
 
-- Run tests with Jest:
+- Run tests with Vitest:
 
 ```bash
 # Run a specific test file (preferred)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ can be enabled for all categories by setting `DEBUG=*` or for specific categorie
 
 We aim to have sufficient test coverage for critical parts of the application and aren't aiming for 100% unit test coverage. All API endpoints and anything authentication related should be thoroughly tested.
 
-To add new tests, write your tests with [Jest](https://facebook.github.io/jest/) and add a file with `.test.ts` extension next to the tested code.
+To add new tests, write your tests with [Vitest](https://vitest.dev/) and add a file with `.test.ts` extension next to the tested code.
 
 ```shell
 # To run all tests
@@ -72,7 +72,7 @@ make watch
 ```
 
 Once the test database is created with `make test` you may individually run
-frontend and backend tests directly with jest:
+frontend and backend tests directly with vitest:
 
 ```shell
 # To run backend tests

--- a/server/models/decorators/Fix.ts
+++ b/server/models/decorators/Fix.ts
@@ -32,7 +32,7 @@ export default function Fix(target: any): void {
 
         Object.defineProperty(this, propertyKey, {
           get() {
-            // Safety check for Jest serialization - getDataValue may not be available
+            // Safety check for test serialization - getDataValue may not be available
             // during serialization for inter-process communication
             if (typeof this.getDataValue === "function") {
               return this.getDataValue(propertyKey);
@@ -41,7 +41,7 @@ export default function Fix(target: any): void {
             return this.dataValues?.[propertyKey];
           },
           set(value) {
-            // Safety check for Jest serialization - setDataValue may not be available
+            // Safety check for test serialization - setDataValue may not be available
             // during serialization for inter-process communication
             if (typeof this.setDataValue === "function") {
               this.setDataValue(propertyKey, value);

--- a/server/onerror.ts
+++ b/server/onerror.ts
@@ -98,7 +98,6 @@ export default function onerror(app: Koa) {
 function wrapInNativeError(err: any): Error {
   // When dealing with cross-globals a normal `instanceof` check doesn't work properly.
   // See https://github.com/koajs/koa/issues/1466
-  // We can probably remove it once jest fixes https://github.com/facebook/jest/issues/2549.
   const isNativeError =
     Object.prototype.toString.call(err) === "[object Error]" ||
     err instanceof Error;

--- a/server/storage/database.ts
+++ b/server/storage/database.ts
@@ -106,7 +106,7 @@ export function createDatabaseInstance(
     sequelizeStrictAttributes(instance);
 
     if (env.isTest) {
-      instance = monkeyPatchSequelizeErrorsForJest(instance);
+      instance = monkeyPatchSequelizeErrorsForTests(instance);
     }
 
     // Skip queries when the originating HTTP request socket has been destroyed
@@ -232,7 +232,7 @@ export function createMigrationRunner(
  * Fixed in Sequelize v7, but hasn't been back-ported to Sequelize v6.
  * See https://github.com/sequelize/sequelize/issues/14807#issuecomment-1854398131
  */
-export function monkeyPatchSequelizeErrorsForJest(instance: Sequelize) {
+export function monkeyPatchSequelizeErrorsForTests(instance: Sequelize) {
   const sequelizeVersion = (Sequelize as unknown as { version: string })
     .version;
   const major = sequelizeVersion.split(".").map(Number)[0];
@@ -251,7 +251,7 @@ export function monkeyPatchSequelizeErrorsForJest(instance: Sequelize) {
     try {
       return await origQueryFunc(...args);
     } catch (err) {
-      // Ensure error appears in Jest output, not swallowed by Sequelize internals
+      // Ensure error appears in test output, not swallowed by Sequelize internals
       const error = err as Error & { parent?: Error };
       Logger.error(error.message, error.parent ?? error);
       throw err;

--- a/server/test/setupMocks.ts
+++ b/server/test/setupMocks.ts
@@ -41,8 +41,7 @@ vi.mock("@server/utils/MutexLock");
 vi.mock("@aws-sdk/signature-v4-crt", () => ({}));
 
 // Auto-mock these modules using the corresponding files under server/__mocks__/.
-// In Jest, __mocks__ next to a `roots` directory is auto-applied; vitest
-// requires an explicit vi.mock() call to wire them up.
+// Vitest requires an explicit vi.mock() call to wire them up.
 vi.mock("bull", () => import("../__mocks__/bull"));
 vi.mock("dd-trace", async () => {
   const mod = await import("../__mocks__/dd-trace");

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -49,8 +49,7 @@ export default defineConfig({
   test: {
     globals: true,
     pool: "threads",
-    // Match Jest's default behavior — unhandled promise rejections are
-    // logged but don't fail tests on their own.
+    // Unhandled promise rejections are logged but don't fail tests on their own.
     dangerouslyIgnoreUnhandledErrors: true,
     projects: [
       {


### PR DESCRIPTION
## Summary
- Update `AGENTS.md` and `README.md` to reference Vitest instead of Jest
- Clean up Jest mentions in code comments (`vitest.config.ts`, `server/onerror.ts`, `server/test/setupMocks.ts`, `server/models/decorators/Fix.ts`, `server/storage/database.ts`)
- Rename `monkeyPatchSequelizeErrorsForJest` to `monkeyPatchSequelizeErrorsForTests`

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)