### PR TITLE
Only preconnect to S3 if it's being used

### DIFF
--- a/server/utils/prefetchTags.tsx
+++ b/server/utils/prefetchTags.tsx
@@ -6,22 +6,24 @@ import readManifestFile from "./readManifestFile";
 
 const prefetchTags = [];
 
-if (env.AWS_S3_ACCELERATE_URL) {
-  prefetchTags.push(
-    <link
-      rel="preconnect"
-      href={env.AWS_S3_ACCELERATE_URL}
-      key={env.AWS_S3_ACCELERATE_URL}
-    />
-  );
-} else if (env.AWS_S3_UPLOAD_BUCKET_URL) {
-  prefetchTags.push(
-    <link
-      rel="preconnect"
-      href={env.AWS_S3_UPLOAD_BUCKET_URL}
-      key={env.AWS_S3_UPLOAD_BUCKET_URL}
-    />
-  );
+if (env.FILE_STORAGE === "s3") {
+  if (env.AWS_S3_ACCELERATE_URL) {
+    prefetchTags.push(
+      <link
+        rel="preconnect"
+        href={env.AWS_S3_ACCELERATE_URL}
+        key={env.AWS_S3_ACCELERATE_URL}
+      />
+    );
+  } else if (env.AWS_S3_UPLOAD_BUCKET_URL) {
+    prefetchTags.push(
+      <link
+        rel="preconnect"
+        href={env.AWS_S3_UPLOAD_BUCKET_URL}
+        key={env.AWS_S3_UPLOAD_BUCKET_URL}
+      />
+    );
+  }
 }
 if (env.CDN_URL) {
   prefetchTags.push(


### PR DESCRIPTION
The `.env.sample` includes some [placeholder S3 config](https://github.com/outline/outline/blob/571463710e6d14d48ca71fc98fc547edd8293f23/.env.sample#L114-L121), which should only be used if `LOCAL_STORAGE` is set to `s3`, not `local`.

Currently this results in a spurious preconnect:

```<link rel="preconnect" href="http://s3:4569" data-reactroot=""/>```

It's hard to verify this because it doesn't show up in the network tab, but it should be possible to see the DNS request.