### PR TITLE
chore: Catch other types of client aborted error

### DIFF
--- a/server/onerror.ts
+++ b/server/onerror.ts
@@ -26,6 +26,11 @@ export default function onerror(app: Koa) {
       if (err.internalCode === 1002) {
         err = ClientClosedRequestError();
       }
+    } else if (
+      err.code === "HPE_INVALID_EOF_STATE" ||
+      err.code === "ECONNRESET"
+    ) {
+      err = ClientClosedRequestError();
     }
 
     // Push only errors explicitly marked for Sentry reporting.

--- a/server/onerror.ts
+++ b/server/onerror.ts
@@ -28,7 +28,8 @@ export default function onerror(app: Koa) {
       }
     } else if (
       err.code === "HPE_INVALID_EOF_STATE" ||
-      err.code === "ECONNRESET"
+      err.code === "ECONNRESET" ||
+      err.code === "EPIPE"
     ) {
       err = ClientClosedRequestError();
     }


### PR DESCRIPTION
Return `499` rather than `500` to the client in two more common connection disconnect scenarios