### PR TITLE
chore(deps): Remove js-yaml resolution that no longer prevents downgrades

### DIFF
--- a/package.json
+++ b/package.json
@@ -381,7 +381,6 @@
     "@types/koa": "2.15.0",
     "prosemirror-transform": "1.10.5",
     "debug": "4.3.4",
-    "js-yaml": "^4.1.1",
     "prismjs": "1.30.0",
     "zod": "^4.3.6",
     "ajv@npm:~8.13.0": "^8.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13665,7 +13665,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.1.1":
+"js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1":
   version: 4.1.1
   resolution: "js-yaml@npm:4.1.1"
   dependencies:


### PR DESCRIPTION
## Summary

Audited each entry in the `resolutions` block of `package.json` against the criterion: a resolution is required only if some package depends on a lower version of the dependency *and* removing the resolution would result in that lower version being installed.

The only entry that no longer meets that criterion is `"js-yaml": "^4.1.1"`. Every consumer in the dep graph already requests `^4.1.0` or `^4.1.1`, both of which naturally resolve to `4.1.1`. Removing the resolution leaves the installed version unchanged — the only diff in `yarn.lock` is the descriptor list merging:

```diff
-"js-yaml@npm:^4.1.1":
+"js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1":
   version: 4.1.1
```

All other resolutions still pull their weight:

- **Prevent a lower version from being installed**: `prismjs` (~1.27.0 → 1.30.0), `zod` (^3.19.1 → ^4.3.6), `ajv@npm:~8.13.0`, `ip-address@npm:10.1.0`, `minimatch@npm:9.0.1`, `lodash@npm:4.17.21`, `lodash-es@npm:4.17.23`, `@types/markdown-it` (<14 → 14.1.2), and `debug` (also blocks `^2.2.0`/`^3.1.0` peers from pulling `2.6.9`/`3.2.7`).
- **Intentional dedupe pins** kept by #12304: `@types/react`, `@types/koa`, `prosemirror-transform`.
- **Compatibility pin** from #12307: `i18next-parser/i18next` (keeps the parser on the v23 line so plural keys are emitted in `compatibilityJSON v3` format expected by runtime i18next 22.5.1).

## Test plan

- [x] `yarn install --mode=update-lockfile` produces no version changes (only descriptor merge in `yarn.lock`).
- [ ] CI passes.

https://claude.ai/code/session_016igdKauoQ5NBsqiDADnovb

---
_Generated by [Claude Code](https://claude.ai/code/session_016igdKauoQ5NBsqiDADnovb)_