### PR TITLE
feat: Allow MCP to access signed attachment urls through `fetch` tool

### DIFF
--- a/server/routes/mcp/index.ts
+++ b/server/routes/mcp/index.ts
@@ -26,7 +26,9 @@ const router = new Router();
 
 const defaultInstructions = `Document markdown content must not begin with a top-level heading (H1) — the title is stored as a separate field, so set it via the title parameter and start the content with body text or a lower-level heading instead.
 
-Document and collection markdown support @mentions using the syntax: @[Display Name](mention://user/userId). For example: @[John Doe](mention://user/c9a1b2e3-...). Use the list_users tool to find user IDs.`;
+Document and collection markdown support @mentions using the syntax: @[Display Name](mention://user/userId). For example: @[John Doe](mention://user/c9a1b2e3-...). Use the "list_users" tool to find user IDs.
+
+Read images and attachments by passing the ID to the "fetch" tool, which will return a signed URL for download.`;
 
 /**
  * Creates a fresh MCP server instance with tools filtered by the OAuth

--- a/server/routes/mcp/index.ts
+++ b/server/routes/mcp/index.ts
@@ -28,7 +28,7 @@ const defaultInstructions = `Document markdown content must not begin with a top
 
 Document and collection markdown support @mentions using the syntax: @[Display Name](mention://user/userId). For example: @[John Doe](mention://user/c9a1b2e3-...). Use the "list_users" tool to find user IDs.
 
-Read images and attachments by passing the ID to the "fetch" tool, which will return a signed URL for download.`;
+Read images and attachments with the "fetch" tool by setting resource to "attachment" and passing either the attachment ID or an /api/attachments.redirect?id=... URL; the tool will return a signed URL for download.`;
 
 /**
  * Creates a fresh MCP server instance with tools filtered by the OAuth

--- a/server/tools/fetch.ts
+++ b/server/tools/fetch.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { type CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { Collection, Document, User } from "@server/models";
+import { Attachment, Collection, Document, User } from "@server/models";
 import { authorize, can } from "@server/policies";
 import {
   presentCollection,
@@ -32,8 +32,12 @@ const SELF_TOKENS = new Set(["self", "me", "current_user"]);
 function extractId(value: string): string {
   if (/^https?:\/\//.test(value)) {
     try {
-      const pathname = new URL(value).pathname;
-      const segments = pathname.split("/").filter(Boolean);
+      const url = new URL(value);
+      const queryId = url.searchParams.get("id");
+      if (queryId) {
+        return queryId;
+      }
+      const segments = url.pathname.split("/").filter(Boolean);
       return segments[segments.length - 1] ?? value;
     } catch {
       return value;
@@ -59,8 +63,17 @@ export function fetchTool(server: McpServer, scopes: string[]) {
     scopes
   );
   const canReadUsers = AuthenticationHelper.canAccess("users.info", scopes);
+  const canReadAttachments = AuthenticationHelper.canAccess(
+    "attachments.info",
+    scopes
+  );
 
-  if (!canReadDocuments && !canReadCollections && !canReadUsers) {
+  if (
+    !canReadDocuments &&
+    !canReadCollections &&
+    !canReadUsers &&
+    !canReadAttachments
+  ) {
     return;
   }
 
@@ -68,6 +81,7 @@ export function fetchTool(server: McpServer, scopes: string[]) {
     ...(canReadDocuments ? ["document"] : []),
     ...(canReadCollections ? ["collection"] : []),
     ...(canReadUsers ? ["user"] : []),
+    ...(canReadAttachments ? ["attachment"] : []),
   ] as [string, ...string[]];
 
   server.registerTool(
@@ -75,7 +89,7 @@ export function fetchTool(server: McpServer, scopes: string[]) {
     {
       title: "Fetch",
       description:
-        'Fetches a document, collection, or user by type and ID. When fetching a collection the response includes the full hierarchical document tree. For users, "current_user" can be used as the ID to get the authenticated user.',
+        'Fetches a document, collection, user, or attachment by type and ID. When fetching a collection the response includes the full hierarchical document tree. For users, "current_user" can be used as the ID to get the authenticated user. For attachments, the response includes a short-lived signed URL that can be used to download the file contents directly.',
       annotations: {
         idempotentHint: true,
         readOnlyHint: true,
@@ -159,6 +173,22 @@ export function fetchTool(server: McpServer, scopes: string[]) {
                 includeDetails: !!can(actor, "readDetails", user),
               })
             );
+          }
+
+          case "attachment": {
+            const attachment = await Attachment.findByPk(id, {
+              rejectOnEmpty: true,
+            });
+
+            authorize(actor, "read", attachment);
+
+            return success({
+              id: attachment.id,
+              name: attachment.name,
+              contentType: attachment.contentType,
+              size: attachment.size,
+              signedUrl: await attachment.signedUrl,
+            });
           }
 
           default:

--- a/server/tools/fetch.ts
+++ b/server/tools/fetch.ts
@@ -3,6 +3,7 @@ import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { type CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { Attachment, Collection, Document, User } from "@server/models";
 import { authorize, can } from "@server/policies";
+import { AuthorizationError } from "@server/errors";
 import {
   presentCollection,
   presentDocument,
@@ -180,7 +181,12 @@ export function fetchTool(server: McpServer, scopes: string[]) {
               rejectOnEmpty: true,
             });
 
-            authorize(actor, "read", attachment);
+            // Private attachments are accessible to any member of the workspace they
+            // belong to. This is intentional and not a permission bypass – attachments
+            // are owned by the workspace (team), not by individual documents or users.
+            if (attachment.teamId !== actor?.teamId) {
+              throw AuthorizationError();
+            }
 
             return success({
               id: attachment.id,


### PR DESCRIPTION
closes https://github.com/outline/outline/discussions/12314