### PR TITLE
test: Fix flaky comments.list ordering assertion

### DIFF
--- a/server/routes/api/comments/comments.test.ts
+++ b/server/routes/api/comments/comments.test.ts
@@ -187,10 +187,12 @@ describe("#comments.list", () => {
     const comment = await buildComment({
       userId: user.id,
       documentId: document.id,
+      createdAt: new Date(Date.now() - 1000),
     });
     await buildResolvedComment(user, {
       userId: user.id,
       documentId: document.id,
+      createdAt: new Date(),
     });
     const res = await server.post("/api/comments.list", {
       body: {


### PR DESCRIPTION
## Summary
- Two comments built back-to-back in the `comments.list` test could share a millisecond-precision `createdAt`, leaving the DESC-ordered result non-deterministic and occasionally failing the `body.data[1].id` assertion.
- Pass explicit `createdAt` values to both `buildComment` and `buildResolvedComment` so ordering is stable.

## Test plan
- [ ] `yarn test server/routes/api/comments/comments.test.ts`