### PR TITLE
feat(mcp): add fullWidth parameter to create_document and update_document tools

### DIFF
--- a/server/tools/documents.ts
+++ b/server/tools/documents.ts
@@ -300,6 +300,12 @@ export function documentTools(server: McpServer, scopes: string[]) {
             .describe(
               "Whether to publish the document. Defaults to true. Set to false to create as a draft."
             ),
+          fullWidth: z
+            .boolean()
+            .optional()
+            .describe(
+              "Whether the document should occupy full width of the screen. Defaults to false."
+            ),
         },
       },
       withTracing("create_document", async (input, context) => {
@@ -340,6 +346,7 @@ export function documentTools(server: McpServer, scopes: string[]) {
             parentDocumentId: parentDocumentId,
             publish: input.publish !== false,
             collectionId: collection?.id,
+            fullWidth: input.fullWidth,
           });
 
           const [{ text, ...attributes }, breadcrumb] = await Promise.all([
@@ -555,6 +562,12 @@ export function documentTools(server: McpServer, scopes: string[]) {
             .optional()
             .describe(
               "Set to true to publish a draft document, or false to convert a published document back to a draft."
+            ),
+          fullWidth: z
+            .boolean()
+            .optional()
+            .describe(
+              "Whether the document should occupy full width of the screen."
             ),
         },
       },


### PR DESCRIPTION
## Summary

The `fullWidth` boolean field is already persisted on the `Document` model and supported in the REST API schemas (`DocumentsCreateSchema`, `DocumentsUpdateSchema`), but the built-in MCP server did not expose it in the `create_document` or `update_document` tool schemas.

## Changes

- Added `fullWidth` as an optional `z.boolean()` parameter to the `create_document` MCP tool schema
- Added `fullWidth` as an optional `z.boolean()` parameter to the `update_document` MCP tool schema
- Passed `input.fullWidth` through to `documentCreator` in the create handler
- `documentUpdater` already receives the full `input` object, so `fullWidth` flows through automatically

## Testing

- Backend commands (`documentCreator`, `documentUpdater`) already accept and correctly handle `fullWidth`
- No schema or model changes required — purely an MCP tool layer addition
- Verified that `documentCreator` passes `fullWidth` to the document model (with template fallback: `fullWidth ?? template?.fullWidth`)

## Use case

MCP clients (AI agents, integrations) currently have no way to set full-width mode on documents. This is a supported feature in the UI and REST API that should also be available via MCP.

Resolves https://github.com/outline/outline/issues/12339