### PR TITLE
fix: Re-render Mermaid diagrams in light theme for print

### DIFF
--- a/app/actions/definitions/documents.tsx
+++ b/app/actions/definitions/documents.tsx
@@ -954,7 +954,12 @@ export const printDocument = createAction({
   icon: <PrintIcon />,
   visible: ({ activeDocumentId }) => !!(activeDocumentId && window.print),
   perform: () => {
-    setTimeout(window.print, 0);
+    // Kick off the Mermaid light re-render before the print dialog opens —
+    // its async render won't finish in time if we wait for beforeprint.
+    window.dispatchEvent(
+      new CustomEvent("theme-changed", { detail: { isDark: false } })
+    );
+    setTimeout(window.print, 250);
   },
 });
 

--- a/app/actions/definitions/documents.tsx
+++ b/app/actions/definitions/documents.tsx
@@ -954,12 +954,7 @@ export const printDocument = createAction({
   icon: <PrintIcon />,
   visible: ({ activeDocumentId }) => !!(activeDocumentId && window.print),
   perform: () => {
-    // Kick off the Mermaid light re-render before the print dialog opens —
-    // its async render won't finish in time if we wait for beforeprint.
-    window.dispatchEvent(
-      new CustomEvent("theme-changed", { detail: { isDark: false } })
-    );
-    setTimeout(window.print, 250);
+    setTimeout(window.print, 0);
   },
 });
 

--- a/app/components/Theme.tsx
+++ b/app/components/Theme.tsx
@@ -31,6 +31,32 @@ const Theme: React.FC = ({ children }: Props) => {
     );
   }, [ui.resolvedTheme]);
 
+  // Mermaid SVGs are baked at render time with theme colors, so CSS overrides
+  // can't lighten them for print — re-emit theme-changed to force a re-render.
+  React.useEffect(() => {
+    const handleBeforePrint = () => {
+      window.dispatchEvent(
+        new CustomEvent("theme-changed", { detail: { isDark: false } })
+      );
+    };
+
+    const handleAfterPrint = () => {
+      window.dispatchEvent(
+        new CustomEvent("theme-changed", {
+          detail: { isDark: ui.resolvedTheme === "dark" },
+        })
+      );
+    };
+
+    window.addEventListener("beforeprint", handleBeforePrint);
+    window.addEventListener("afterprint", handleAfterPrint);
+
+    return () => {
+      window.removeEventListener("beforeprint", handleBeforePrint);
+      window.removeEventListener("afterprint", handleAfterPrint);
+    };
+  }, [ui]);
+
   return (
     <DirectionProvider dir={direction}>
       <ThemeProvider theme={theme}>

--- a/app/components/Theme.tsx
+++ b/app/components/Theme.tsx
@@ -31,31 +31,25 @@ const Theme: React.FC = ({ children }: Props) => {
     );
   }, [ui.resolvedTheme]);
 
-  // Mermaid SVGs are baked at render time with theme colors, so CSS overrides
-  // can't lighten them for print — re-emit theme-changed to force a re-render.
+  // Some editor elements such as Mermaid diagrams rely on theme-changed event
+  // to render the correct color.
+  // Listen on the print media query, which fires consistently for both the
+  // print dialog and print preview.
   React.useEffect(() => {
-    const handleBeforePrint = () => {
-      window.dispatchEvent(
-        new CustomEvent("theme-changed", { detail: { isDark: false } })
-      );
-    };
-
-    const handleAfterPrint = () => {
+    const mediaQuery = window.matchMedia("print");
+    const handleChange = (event: MediaQueryListEvent) => {
       window.dispatchEvent(
         new CustomEvent("theme-changed", {
-          detail: { isDark: ui.resolvedTheme === "dark" },
+          detail: {
+            isDark: event.matches ? false : ui.resolvedTheme === "dark",
+          },
         })
       );
     };
 
-    window.addEventListener("beforeprint", handleBeforePrint);
-    window.addEventListener("afterprint", handleAfterPrint);
-
-    return () => {
-      window.removeEventListener("beforeprint", handleBeforePrint);
-      window.removeEventListener("afterprint", handleAfterPrint);
-    };
-  }, [ui]);
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, [ui.resolvedTheme]);
 
   return (
     <DirectionProvider dir={direction}>


### PR DESCRIPTION
Mermaid diagrams are rendered as SVG with theme-specific colors baked in, so when printing from dark mode the dark backgrounds carry through onto white paper.

closes #12313