### PR TITLE
fix: pass expires into /auth/redirect's accessToken JWT

### DIFF
--- a/server/routes/auth/index.test.ts
+++ b/server/routes/auth/index.test.ts
@@ -43,4 +43,32 @@ describe("auth/redirect", () => {
 
     expect(res.status).toEqual(401);
   });
+
+  it("should mint an accessToken JWT carrying an expiresAt claim", async () => {
+    const user = await buildUser();
+    const before = Date.now();
+
+    const res = await server.get(
+      `/auth/redirect?token=${user.getTransferToken()}`,
+      {
+        redirect: "manual",
+      }
+    );
+
+    expect(res.status).toEqual(302);
+
+    // Pull the `accessToken` cookie out of the Set-Cookie header(s).
+    const setCookie = res.headers.get("set-cookie") || "";
+    const match = setCookie.match(/accessToken=([^;,]+)/);
+    expect(match).not.toBeNull();
+    const jwt = match![1];
+
+    const payload = JSON.parse(
+      Buffer.from(jwt.split(".")[1], "base64url").toString()
+    );
+
+    expect(payload.expiresAt).toBeDefined();
+    const expiresMs = new Date(payload.expiresAt).getTime();
+    expect(expiresMs).toBeGreaterThan(before);
+  });
 });

--- a/server/routes/auth/index.ts
+++ b/server/routes/auth/index.ts
@@ -43,14 +43,16 @@ router.get(
       throw AuthenticationError("Cannot extend token");
     }
 
-    const jwtToken = user.getJwtToken(undefined, service);
+    // Bind JWT expiry to the cookie so the token validator enforces it.
+    const expires = addMonths(new Date(), 3);
+    const jwtToken = user.getJwtToken(expires, service);
 
     // ensure that the lastActiveAt on user is updated to prevent replay requests
     await user.updateActiveAt(ctx, true);
 
     ctx.cookies.set("accessToken", jwtToken, {
       sameSite: "lax",
-      expires: addMonths(new Date(), 3),
+      expires,
     });
     const [team, collection, view] = await Promise.all([
       Team.findByPk(user.teamId),


### PR DESCRIPTION
## Summary

`/auth/redirect` mints the new `accessToken` JWT via `user.getJwtToken(undefined, service)`, omitting the `expiresAt` payload claim. The validator at `server/utils/jwt.ts` skips its expiry check when that claim is missing, so the token is valid until the next `jwtSecret` rotation regardless of the cookie's `Max-Age`. If the token ever leaves the cookie (log capture, screenshot, browser history copy, etc.), it can be replayed indefinitely.

The two other call sites that mint this cookie (`server/middlewares/authentication.ts`, `server/utils/authentication.ts`) already pass `expires` into both `getJwtToken` and the cookie option. This PR brings the third path in line.

## Changes

- Compute `expires` once and pass it into both `getJwtToken(expires, service)` and the cookie's `expires` option.
- One-line comment at the call site noting why the binding matters.

## Testing

New test in `server/routes/auth/index.test.ts`: hits `/auth/redirect` with a transfer token, extracts the resulting `accessToken` cookie from `Set-Cookie`, decodes the JWT payload (`base64url`), and asserts `expiresAt` is set and future-dated. Guards against future regression to `getJwtToken(undefined, ...)`.

Existing tests (`should redirect to home`, `should redirect to first collection`, `should prevent token extension by rejecting JWT tokens`) all continue to pass.

## Before / after

| Scenario | Before | After |
|---|---|---|
| Cookie + JWT both held in browser | Token works for cookie's `Max-Age` | Same |
| Raw JWT exfiltrated (logs, history, screenshot) | Replayable indefinitely until `jwtSecret` rotation | Bounded by `expiresAt` (= cookie's `Max-Age`) |