### PR TITLE
Tune collaborative undo grouping

### DIFF
--- a/app/editor/extensions/Multiplayer.ts
+++ b/app/editor/extensions/Multiplayer.ts
@@ -121,7 +121,9 @@ export default class Multiplayer extends Extension<MultiplayerOptions> {
         awarenessStateFilter,
         selectionBuilder,
       }),
-      yUndoPlugin(),
+      yUndoPlugin({
+        captureTimeout: 500,
+      }),
       new Plugin({
         props: {
           handleScrollToSelection: (view) => isRemoteTransaction(view.state.tr),


### PR DESCRIPTION
Adjusts the Yjs undo manager capture timeout used by the collaborative editor so separate typing and formatting actions are grouped less aggressively. This keeps undo and redo steps closer to the most recent editing action and makes redo restore the immediately undone change more predictably.

Verification: ran `git diff --check`; local TypeScript verification was not run because dependencies were not installed in the checkout.

Fixes #12351
