### PR TITLE
fix: Allow connecting additional auth providers on custom domain

### DIFF
--- a/app/scenes/Login/Login.tsx
+++ b/app/scenes/Login/Login.tsx
@@ -40,8 +40,9 @@ import { BackButton } from "./components/BackButton";
 import { Background } from "./components/Background";
 import { Centered } from "./components/Centered";
 import { Notices } from "./components/Notices";
-import { getRedirectUrl, navigateToSubdomain } from "./urls";
+import { navigateToSubdomain } from "./urls";
 import lazyWithRetry from "~/utils/lazyWithRetry";
+import { getRedirectUrl } from "~/utils/urls";
 
 const WorkspaceSetup = lazyWithRetry(
   () => import("./components/WorkspaceSetup")

--- a/app/scenes/Login/components/AuthenticationProvider.tsx
+++ b/app/scenes/Login/components/AuthenticationProvider.tsx
@@ -11,7 +11,7 @@ import PluginIcon from "~/components/PluginIcon";
 import Tooltip from "~/components/Tooltip";
 import { client } from "~/utils/ApiClient";
 import Desktop from "~/utils/Desktop";
-import { getRedirectUrl } from "../urls";
+import { getRedirectUrl } from "~/utils/urls";
 import { CSRF } from "@shared/constants";
 import { getCookie } from "tiny-cookie";
 

--- a/app/scenes/Login/urls.ts
+++ b/app/scenes/Login/urls.ts
@@ -1,6 +1,3 @@
-import { Client } from "@shared/types";
-import { parseDomain } from "@shared/utils/domains";
-import env from "~/env";
 import Desktop from "~/utils/Desktop";
 
 function validateAndEncodeSubdomain(subdomain: string): string {
@@ -10,29 +7,6 @@ function validateAndEncodeSubdomain(subdomain: string): string {
     throw new Error("Invalid subdomain");
   }
   return `https://${encodedSubdomain}.getoutline.com`;
-}
-
-/**
- * If we're on a custom domain or a subdomain then the auth must point to the
- * apex (env.URL) for authentication so that the state cookie can be set and read.
- * We pass the host into the auth URL so that the server can redirect on error
- * and keep the user on the same page.
- *
- * @param authUrl The URL to redirect to after authentication
- */
-export function getRedirectUrl(authUrl: string) {
-  const { custom, teamSubdomain, host } = parseDomain(window.location.origin);
-  const url = new URL(env.URL);
-  url.pathname = authUrl;
-
-  if (custom || teamSubdomain) {
-    url.searchParams.set("host", host);
-  }
-  if (Desktop.isElectron()) {
-    url.searchParams.set("client", Client.Desktop);
-  }
-
-  return url.toString();
 }
 
 /**

--- a/app/scenes/Settings/Authentication.tsx
+++ b/app/scenes/Settings/Authentication.tsx
@@ -19,6 +19,7 @@ import useRequest from "~/hooks/useRequest";
 import useStores from "~/hooks/useStores";
 import SettingRow from "./components/SettingRow";
 import { setPostLoginPath } from "~/hooks/useLastVisitedPath";
+import { getRedirectUrl } from "~/utils/urls";
 import { settingsPath } from "~/utils/routeHelpers";
 import DomainManagement from "./components/DomainManagement";
 import Button from "~/components/Button";
@@ -97,7 +98,7 @@ function Authentication() {
 
   const handleConnectProvider = React.useCallback((name: string) => {
     setPostLoginPath(settingsPath("authentication"));
-    window.location.href = `/auth/${name}?host=${window.location.host}`;
+    window.location.href = getRedirectUrl(`/auth/${name}`);
   }, []);
 
   const handleToggleGroupSync = React.useCallback(

--- a/app/scenes/Settings/Authentication.tsx
+++ b/app/scenes/Settings/Authentication.tsx
@@ -19,7 +19,6 @@ import useRequest from "~/hooks/useRequest";
 import useStores from "~/hooks/useStores";
 import SettingRow from "./components/SettingRow";
 import { setPostLoginPath } from "~/hooks/useLastVisitedPath";
-import { getRedirectUrl } from "~/utils/urls";
 import { settingsPath } from "~/utils/routeHelpers";
 import DomainManagement from "./components/DomainManagement";
 import Button from "~/components/Button";
@@ -98,7 +97,7 @@ function Authentication() {
 
   const handleConnectProvider = React.useCallback((name: string) => {
     setPostLoginPath(settingsPath("authentication"));
-    window.location.href = getRedirectUrl(`/auth/${name}`);
+    window.location.href = `/auth/${name}?host=${window.location.host}`;
   }, []);
 
   const handleToggleGroupSync = React.useCallback(

--- a/app/utils/urls.ts
+++ b/app/utils/urls.ts
@@ -4,12 +4,13 @@ import env from "~/env";
 import Desktop from "~/utils/Desktop";
 
 /**
- * If we're on a custom domain or a subdomain then the auth must point to the
- * apex (env.URL) for authentication so that the state cookie can be set and read.
- * We pass the host into the auth URL so that the server can redirect on error
- * and keep the user on the same page.
+ * Builds an absolute auth redirect URL against the apex (env.URL). When the
+ * user is on a custom domain or team subdomain the auth flow must start on the
+ * apex so that the OAuth state cookie can be set and later read by the
+ * callback. The originating host is forwarded as a query param so the server
+ * can return the user to the same page on error or after sign-in.
  *
- * @param authUrl The URL to redirect to after authentication
+ * @param authUrl The auth endpoint path to redirect to (e.g. "/auth/google").
  */
 export function getRedirectUrl(authUrl: string) {
   const { custom, teamSubdomain, host } = parseDomain(window.location.origin);

--- a/app/utils/urls.ts
+++ b/app/utils/urls.ts
@@ -1,3 +1,31 @@
+import { Client } from "@shared/types";
+import { parseDomain } from "@shared/utils/domains";
+import env from "~/env";
+import Desktop from "~/utils/Desktop";
+
+/**
+ * If we're on a custom domain or a subdomain then the auth must point to the
+ * apex (env.URL) for authentication so that the state cookie can be set and read.
+ * We pass the host into the auth URL so that the server can redirect on error
+ * and keep the user on the same page.
+ *
+ * @param authUrl The URL to redirect to after authentication
+ */
+export function getRedirectUrl(authUrl: string) {
+  const { custom, teamSubdomain, host } = parseDomain(window.location.origin);
+  const url = new URL(env.URL);
+  url.pathname = authUrl;
+
+  if (custom || teamSubdomain) {
+    url.searchParams.set("host", host);
+  }
+  if (Desktop.isElectron()) {
+    url.searchParams.set("client", Client.Desktop);
+  }
+
+  return url.toString();
+}
+
 export function isHash(href: string) {
   if (href[0] === "#") {
     return true;

--- a/plugins/azure/server/auth/azure.ts
+++ b/plugins/azure/server/auth/azure.ts
@@ -17,6 +17,7 @@ import {
   getTeamFromContext,
   getClientFromOAuthState,
   getUserFromOAuthState,
+  startOAuthFlow,
 } from "@server/utils/passport";
 import config from "../../plugin.json";
 import env from "../env";
@@ -143,6 +144,7 @@ if (env.AZURE_CLIENT_ID && env.AZURE_CLIENT_SECRET) {
   passport.use(strategy);
   router.get(
     config.id,
+    startOAuthFlow,
     passport.authenticate(config.id, { prompt: "select_account" })
   );
   router.get(`${config.id}.callback`, passportMiddleware(config.id));

--- a/plugins/discord/server/auth/discord.ts
+++ b/plugins/discord/server/auth/discord.ts
@@ -24,6 +24,7 @@ import {
   getClientFromOAuthState,
   getUserFromOAuthState,
   request,
+  startOAuthFlow,
 } from "@server/utils/passport";
 import config from "../../plugin.json";
 import env from "../env";
@@ -226,6 +227,7 @@ if (env.DISCORD_CLIENT_ID && env.DISCORD_CLIENT_SECRET) {
 
   router.get(
     config.id,
+    startOAuthFlow,
     passport.authenticate(config.id, {
       scope,
     })

--- a/plugins/google/server/auth/google.ts
+++ b/plugins/google/server/auth/google.ts
@@ -19,6 +19,7 @@ import {
   getTeamFromContext,
   getClientFromOAuthState,
   getUserFromOAuthState,
+  startOAuthFlow,
 } from "@server/utils/passport";
 import config from "../../plugin.json";
 import env from "../env";
@@ -151,7 +152,7 @@ if (env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET) {
     )
   );
 
-  router.get(config.id, async (ctx, next) => {
+  router.get(config.id, startOAuthFlow, async (ctx, next) => {
     const team = await getTeamFromContext(ctx, {
       includeHostQueryParam: true,
     });

--- a/plugins/oidc/server/auth/oidcRouter.ts
+++ b/plugins/oidc/server/auth/oidcRouter.ts
@@ -22,6 +22,7 @@ import {
   getClientFromOAuthState,
   getUserFromOAuthState,
   request,
+  startOAuthFlow,
 } from "@server/utils/passport";
 import config from "../../plugin.json";
 import env from "../env";
@@ -227,7 +228,7 @@ export function createOIDCRouter(
     )
   );
 
-  router.get(config.id, passport.authenticate(config.id));
+  router.get(config.id, startOAuthFlow, passport.authenticate(config.id));
   router.get(`${config.id}.callback`, passportMiddleware(config.id));
   router.post(`${config.id}.callback`, passportMiddleware(config.id));
 }

--- a/plugins/slack/server/auth/slack.ts
+++ b/plugins/slack/server/auth/slack.ts
@@ -25,6 +25,7 @@ import {
   getTeamFromContext,
   getUserFromOAuthState,
   StateStore,
+  startOAuthFlow,
 } from "@server/utils/passport";
 import { parseEmail } from "@shared/utils/email";
 import env from "../env";
@@ -134,7 +135,7 @@ if (env.SLACK_CLIENT_ID && env.SLACK_CLIENT_SECRET) {
   strategy.name = providerName;
   passport.use(strategy);
 
-  router.get("slack", passport.authenticate(providerName));
+  router.get("slack", startOAuthFlow, passport.authenticate(providerName));
   router.get("slack.callback", passportMiddleware(providerName));
 
   router.get(

--- a/server/commands/accountProvisioner.ts
+++ b/server/commands/accountProvisioner.ts
@@ -99,7 +99,7 @@ async function accountProvisioner(
   const actor = ctx.state.auth?.user;
 
   // If the user is already logged in and is an admin of the team then we
-  // allow them to connect a new authentication provider
+  // allow them to connect a new authentication provider.
   if (actor && actor.teamId === teamParams.teamId && actor.isAdmin) {
     const team = actor.team;
     const authenticationProvider = await AuthenticationProvider.findOne({

--- a/server/middlewares/passport.ts
+++ b/server/middlewares/passport.ts
@@ -71,15 +71,17 @@ export default function createMiddleware(providerName: string) {
             // same domain or subdomain that they originated from (found in state).
 
             // get original host
-            const stateString = ctx.cookies.get("state");
+            const stateString =
+              typeof ctx.query.state === "string" ? ctx.query.state : undefined;
             const state = stateString ? parseState(stateString) : undefined;
+            const oauthState = ctx.state.oauthState ?? state;
 
             // form a URL object with the err.redirectPath and replace the host
             const reqProtocol =
-              state?.client === Client.Desktop ? "outline" : ctx.protocol;
+              oauthState?.client === Client.Desktop ? "outline" : ctx.protocol;
 
             const requestHost = await getValidatedHost(
-              state?.host ?? ctx.hostname
+              oauthState?.host ?? ctx.hostname
             );
             const url = new URL(
               env.isCloudHosted

--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -549,7 +549,7 @@ router.post(
     const { user } = ctx.state.auth;
     const apiVersion = getAPIVersion(ctx);
     const teamFromCtx = await getTeamFromContext(ctx, {
-      includeStateCookie: false,
+      includeOAuthState: false,
     });
 
     let document: Document | null;
@@ -1103,7 +1103,7 @@ router.post(
 
     if (shareId) {
       const teamFromCtx = await getTeamFromContext(ctx, {
-        includeStateCookie: false,
+        includeOAuthState: false,
       });
       const result = await loadPublicShare({
         id: shareId,

--- a/server/routes/api/emojis/emojis.ts
+++ b/server/routes/api/emojis/emojis.ts
@@ -85,7 +85,7 @@ router.get(
 
     if (shareId) {
       const teamFromCtx = await getTeamFromContext(ctx, {
-        includeStateCookie: false,
+        includeOAuthState: false,
       });
       const { share } = await loadPublicShare({
         id: shareId,

--- a/server/routes/api/shares/shares.ts
+++ b/server/routes/api/shares/shares.ts
@@ -56,7 +56,7 @@ router.post(
     const { id, collectionId, documentId } = ctx.input.body;
     const { user } = ctx.state.auth;
     const teamFromCtx = await getTeamFromContext(ctx, {
-      includeStateCookie: false,
+      includeOAuthState: false,
     });
 
     // only public link loads will send "id".
@@ -440,7 +440,7 @@ router.get(
   validate(T.SharesSitemapSchema),
   async (ctx: APIContext<T.SharesSitemapReq>) => {
     const { id } = ctx.input.query;
-    const team = await getTeamFromContext(ctx, { includeStateCookie: false });
+    const team = await getTeamFromContext(ctx, { includeOAuthState: false });
 
     const { share, sharedTree } = await loadPublicShare({
       id,
@@ -473,7 +473,7 @@ router.post(
 
     const { shareId, documentId, email } = ctx.input.body;
     const { transaction } = ctx.state;
-    const team = await getTeamFromContext(ctx, { includeStateCookie: false });
+    const team = await getTeamFromContext(ctx, { includeOAuthState: false });
 
     // Validate the share exists and is published
     const { share, document } = await loadPublicShare({

--- a/server/routes/api/urls/urls.ts
+++ b/server/routes/api/urls/urls.ts
@@ -55,7 +55,7 @@ router.post(
         let teamId: string | undefined = actor?.teamId;
         if (!teamId && !isUUID(shareId)) {
           const teamFromCtx = await getTeamFromContext(ctx, {
-            includeStateCookie: false,
+            includeOAuthState: false,
           });
           teamId = teamFromCtx?.id;
         }

--- a/server/routes/app.ts
+++ b/server/routes/app.ts
@@ -215,7 +215,7 @@ export const renderShare = async (ctx: Context, next: Next) => {
 
   let sharedTree;
   try {
-    team = await getTeamFromContext(ctx, { includeStateCookie: false });
+    team = await getTeamFromContext(ctx, { includeOAuthState: false });
     const result = await loadPublicShare({
       id: shareId,
       collectionId: collectionSlug,

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -124,7 +124,7 @@ router.get(
     const origin = env.isCloudHosted
       ? ctx.request.URL.origin
       : new URL(env.URL).origin;
-    const team = await getTeamFromContext(ctx, { includeStateCookie: false });
+    const team = await getTeamFromContext(ctx, { includeOAuthState: false });
     const mcpEnabled = team?.getPreference(TeamPreference.MCP) ?? true;
 
     ctx.body = {
@@ -151,7 +151,7 @@ router.get(
     "/.well-known/oauth-protected-resource/mcp",
   ],
   async (ctx) => {
-    const team = await getTeamFromContext(ctx, { includeStateCookie: false });
+    const team = await getTeamFromContext(ctx, { includeOAuthState: false });
     const mcpEnabled = team?.getPreference(TeamPreference.MCP) ?? true;
 
     if (!mcpEnabled) {

--- a/server/routes/oauth/index.ts
+++ b/server/routes/oauth/index.ts
@@ -194,7 +194,7 @@ router.post(
     } = ctx.input.body;
 
     const team = await getTeamFromContext(ctx, {
-      includeStateCookie: false,
+      includeOAuthState: false,
     });
     if (!team) {
       throw NotFoundError();

--- a/server/types.ts
+++ b/server/types.ts
@@ -14,6 +14,7 @@ import type {
 } from "@shared/types";
 import type { BaseSchema } from "@server/routes/api/schema";
 import type { AccountProvisionerResult } from "./commands/accountProvisioner";
+import type { OAuthIntent, OAuthState } from "./utils/oauthState";
 import type {
   AccessRequest,
   ApiKey,
@@ -77,6 +78,8 @@ export type AppState = {
   transaction: Transaction;
   pagination: Pagination;
   oauthClient?: OAuthClient;
+  oauthIntent?: OAuthIntent;
+  oauthState?: OAuthState;
 };
 
 export type AppContext = ParameterizedContext<AppState, DefaultContext>;

--- a/server/utils/oauthState.test.ts
+++ b/server/utils/oauthState.test.ts
@@ -1,0 +1,97 @@
+import { Client } from "@shared/types";
+import env from "@server/env";
+import {
+  hashOAuthStateNonce,
+  signOAuthIntent,
+  signOAuthState,
+  verifyOAuthIntent,
+  verifyOAuthState,
+} from "./oauthState";
+
+describe("oauthState", () => {
+  const originalSecretKey = env.SECRET_KEY;
+
+  afterEach(() => {
+    env.SECRET_KEY = originalSecretKey;
+  });
+
+  it("round-trips a signed OAuth intent", () => {
+    const token = signOAuthIntent({
+      host: "docs.example.com",
+      actorId: "user-id",
+      client: Client.Web,
+    });
+
+    const payload = verifyOAuthIntent(token);
+
+    expect(payload.host).toBe("docs.example.com");
+    expect(payload.actorId).toBe("user-id");
+    expect(payload.client).toBe(Client.Web);
+    expect(payload.type).toBe("oauth_intent");
+    expect(payload.exp).toBeGreaterThan(payload.iat);
+  });
+
+  it("round-trips a signed OAuth state", () => {
+    const token = signOAuthState({
+      host: "team.outline.dev",
+      actorId: "user-id",
+      client: Client.Desktop,
+      codeVerifier: "pkce-verifier",
+      nonceHash: hashOAuthStateNonce("csrf-nonce"),
+    });
+
+    const payload = verifyOAuthState(token);
+
+    expect(payload.host).toBe("team.outline.dev");
+    expect(payload.actorId).toBe("user-id");
+    expect(payload.client).toBe(Client.Desktop);
+    expect(payload.type).toBe("oauth_state");
+    expect(payload.codeVerifier).toBe("pkce-verifier");
+    expect(payload.nonceHash).toBe(hashOAuthStateNonce("csrf-nonce"));
+  });
+
+  it("rejects a signed OAuth state as an OAuth intent", () => {
+    const token = signOAuthState({
+      host: "team.outline.dev",
+      actorId: "user-id",
+      client: Client.Web,
+      nonceHash: hashOAuthStateNonce("csrf-nonce"),
+    });
+
+    expect(() => verifyOAuthIntent(token)).toThrow("Invalid OAuth intent");
+  });
+
+  it("rejects a signed OAuth intent as an OAuth state", () => {
+    const token = signOAuthIntent({
+      host: "docs.example.com",
+      actorId: "user-id",
+      client: Client.Web,
+    });
+
+    expect(() => verifyOAuthState(token)).toThrow("Invalid OAuth state");
+  });
+
+  it("rejects a tampered token", () => {
+    const token = signOAuthState({
+      host: "team.outline.dev",
+      client: Client.Web,
+      nonceHash: hashOAuthStateNonce("csrf-nonce"),
+    });
+    const tamperedToken = `${token}tampered`;
+
+    expect(() => verifyOAuthState(tamperedToken)).toThrow(
+      "Invalid OAuth state"
+    );
+  });
+
+  it("rejects tokens signed with another secret", () => {
+    const token = signOAuthIntent({
+      host: "docs.example.com",
+      client: Client.Web,
+    });
+
+    env.SECRET_KEY = "1".repeat(64);
+
+    expect(() => verifyOAuthIntent(token)).toThrow("Invalid OAuth state");
+  });
+});

--- a/server/utils/oauthState.test.ts
+++ b/server/utils/oauthState.test.ts
@@ -19,6 +19,7 @@ describe("oauthState", () => {
     const token = signOAuthIntent({
       host: "docs.example.com",
       actorId: "user-id",
+      actorSessionHash: "session-hash",
       client: Client.Web,
     });
 
@@ -26,6 +27,7 @@ describe("oauthState", () => {
 
     expect(payload.host).toBe("docs.example.com");
     expect(payload.actorId).toBe("user-id");
+    expect(payload.actorSessionHash).toBe("session-hash");
     expect(payload.client).toBe(Client.Web);
     expect(payload.type).toBe("oauth_intent");
     expect(payload.exp).toBeGreaterThan(payload.iat);
@@ -35,6 +37,7 @@ describe("oauthState", () => {
     const token = signOAuthState({
       host: "team.outline.dev",
       actorId: "user-id",
+      actorSessionHash: "session-hash",
       client: Client.Desktop,
       codeVerifier: "pkce-verifier",
       nonceHash: hashOAuthStateNonce("csrf-nonce"),
@@ -44,6 +47,7 @@ describe("oauthState", () => {
 
     expect(payload.host).toBe("team.outline.dev");
     expect(payload.actorId).toBe("user-id");
+    expect(payload.actorSessionHash).toBe("session-hash");
     expect(payload.client).toBe(Client.Desktop);
     expect(payload.type).toBe("oauth_state");
     expect(payload.codeVerifier).toBe("pkce-verifier");

--- a/server/utils/oauthState.ts
+++ b/server/utils/oauthState.ts
@@ -12,6 +12,7 @@ const StateType = "oauth_state";
 interface OAuthIntentInput {
   host: string;
   actorId?: string;
+  actorSessionHash?: string;
   client: Client;
 }
 
@@ -143,6 +144,7 @@ function isOAuthIntent(payload: JWT.JwtPayload): payload is OAuthIntent {
     typeof payload.host === "string" &&
     isClient(payload.client) &&
     isOptionalString(payload.actorId) &&
+    isOptionalString(payload.actorSessionHash) &&
     payload.nonceHash === undefined &&
     payload.codeVerifier === undefined &&
     typeof payload.iat === "number" &&
@@ -156,6 +158,7 @@ function isOAuthState(payload: JWT.JwtPayload): payload is OAuthState {
     typeof payload.host === "string" &&
     isClient(payload.client) &&
     isOptionalString(payload.actorId) &&
+    isOptionalString(payload.actorSessionHash) &&
     typeof payload.iat === "number" &&
     typeof payload.exp === "number" &&
     typeof payload.nonceHash === "string" &&

--- a/server/utils/oauthState.ts
+++ b/server/utils/oauthState.ts
@@ -1,0 +1,174 @@
+import JWT from "jsonwebtoken";
+import { Client } from "@shared/types";
+import env from "@server/env";
+import { OAuthStateMismatchError } from "@server/errors";
+import { hash } from "./crypto";
+
+const Algorithm = "HS256";
+const ExpiresInSeconds = 10 * 60;
+const IntentType = "oauth_intent";
+const StateType = "oauth_state";
+
+interface OAuthIntentInput {
+  host: string;
+  actorId?: string;
+  client: Client;
+}
+
+interface OAuthStateInput extends OAuthIntentInput {
+  codeVerifier?: string;
+  nonceHash: string;
+}
+
+interface OAuthIntentClaims extends OAuthIntentInput {
+  type: typeof IntentType;
+}
+
+interface OAuthStateClaims extends OAuthStateInput {
+  type: typeof StateType;
+}
+
+export interface OAuthIntent extends OAuthIntentClaims {
+  iat: number;
+  exp: number;
+}
+
+export interface OAuthState extends OAuthStateClaims {
+  iat: number;
+  exp: number;
+}
+
+/**
+ * Hashes an OAuth CSRF nonce for storage in signed OAuth state.
+ *
+ * @param nonce the nonce stored in the browser cookie.
+ * @returns the sha256 hash of the nonce.
+ */
+export function hashOAuthStateNonce(nonce: string): string {
+  return hash(nonce);
+}
+
+/**
+ * Creates a short-lived signed OAuth intent token.
+ *
+ * @param payload the intent values to sign.
+ * @returns the signed intent token.
+ */
+export function signOAuthIntent(payload: OAuthIntentInput): string {
+  return sign({
+    ...payload,
+    type: IntentType,
+  });
+}
+
+/**
+ * Verifies a signed OAuth intent token.
+ *
+ * @param token the token to verify.
+ * @returns the verified intent payload.
+ * @throws {OAuthStateMismatchError} if the token is missing, expired, invalid,
+ * or has an unexpected payload shape.
+ */
+export function verifyOAuthIntent(token: string): OAuthIntent {
+  const payload = verify(token);
+
+  if (!isOAuthIntent(payload)) {
+    throw OAuthStateMismatchError("Invalid OAuth intent");
+  }
+
+  return payload;
+}
+
+/**
+ * Creates a short-lived signed OAuth state token.
+ *
+ * @param payload the OAuth state values to sign.
+ * @returns the signed OAuth state token.
+ */
+export function signOAuthState(payload: OAuthStateInput): string {
+  return sign({
+    ...payload,
+    type: StateType,
+  });
+}
+
+/**
+ * Verifies a signed OAuth state token.
+ *
+ * @param token the token to verify.
+ * @returns the verified OAuth state payload.
+ * @throws {OAuthStateMismatchError} if the token is missing, expired, invalid,
+ * or has an unexpected payload shape.
+ */
+export function verifyOAuthState(token: string): OAuthState {
+  const payload = verify(token);
+
+  if (!isOAuthState(payload)) {
+    throw OAuthStateMismatchError("Invalid OAuth state");
+  }
+
+  return payload;
+}
+
+function sign(payload: OAuthIntentClaims | OAuthStateClaims): string {
+  return JWT.sign(payload, env.SECRET_KEY, {
+    algorithm: Algorithm,
+    expiresIn: ExpiresInSeconds,
+  });
+}
+
+function verify(token: string): JWT.JwtPayload {
+  try {
+    const payload = JWT.verify(token, env.SECRET_KEY, {
+      algorithms: [Algorithm],
+    });
+
+    if (typeof payload === "string") {
+      throw OAuthStateMismatchError("Invalid OAuth state");
+    }
+
+    return payload;
+  } catch (err) {
+    if (err instanceof Error && err.name === "TokenExpiredError") {
+      throw OAuthStateMismatchError("Expired OAuth state");
+    }
+
+    throw OAuthStateMismatchError("Invalid OAuth state");
+  }
+}
+
+function isOAuthIntent(payload: JWT.JwtPayload): payload is OAuthIntent {
+  return (
+    payload.type === IntentType &&
+    typeof payload.host === "string" &&
+    isClient(payload.client) &&
+    isOptionalString(payload.actorId) &&
+    payload.nonceHash === undefined &&
+    payload.codeVerifier === undefined &&
+    typeof payload.iat === "number" &&
+    typeof payload.exp === "number"
+  );
+}
+
+function isOAuthState(payload: JWT.JwtPayload): payload is OAuthState {
+  return (
+    payload.type === StateType &&
+    typeof payload.host === "string" &&
+    isClient(payload.client) &&
+    isOptionalString(payload.actorId) &&
+    typeof payload.iat === "number" &&
+    typeof payload.exp === "number" &&
+    typeof payload.nonceHash === "string" &&
+    isOptionalString(payload.codeVerifier)
+  );
+}
+
+function isClient(value: string | undefined): value is Client {
+  return value === Client.Desktop || value === Client.Web;
+}
+
+function isOptionalString(
+  value: string | undefined
+): value is string | undefined {
+  return value === undefined || typeof value === "string";
+}

--- a/server/utils/passport.ts
+++ b/server/utils/passport.ts
@@ -10,8 +10,9 @@ import { Client } from "@shared/types";
 import { getCookieDomain, parseDomain } from "@shared/utils/domains";
 import env from "@server/env";
 import { Team, User } from "@server/models";
+import Redis from "@server/storage/redis";
 import { InternalError, OAuthStateMismatchError } from "../errors";
-import { safeEqual } from "./crypto";
+import { hash, safeEqual } from "./crypto";
 import fetch from "./fetch";
 import { getUserForJWT } from "./jwt";
 import {
@@ -24,6 +25,8 @@ import {
 
 const FLOW_QUERY_PARAM = "flow";
 const OAUTH_CSRF_COOKIE = "oauth_csrf";
+const OAUTH_INTENT_PREFIX = "oauth:intent:";
+const OAUTH_INTENT_TTL_SECONDS = 10 * 60;
 
 /**
  * Middleware for OAuth start routes that bridges cookie scopes between custom
@@ -56,16 +59,15 @@ export async function startOAuthFlow(ctx: Context, next: Next) {
     const url = new URL(ctx.originalUrl, apex);
     const client = getClientFromInput(ctx);
     const actorId = await getOAuthActorId(ctx);
+    const flow = signOAuthIntent({
+      host: ctx.hostname,
+      actorId,
+      client,
+    });
 
     url.searchParams.delete(FLOW_QUERY_PARAM);
-    url.searchParams.set(
-      FLOW_QUERY_PARAM,
-      signOAuthIntent({
-        host: ctx.hostname,
-        actorId,
-        client,
-      })
-    );
+    url.searchParams.set(FLOW_QUERY_PARAM, flow);
+    await storeOAuthIntent(flow);
 
     return ctx.redirect(url.toString());
   }
@@ -73,7 +75,10 @@ export async function startOAuthFlow(ctx: Context, next: Next) {
   const flow = ctx.query[FLOW_QUERY_PARAM];
   if (onApex && typeof flow === "string" && flow) {
     try {
-      ctx.state.oauthIntent = verifyOAuthIntent(flow);
+      const intent = verifyOAuthIntent(flow);
+      if (await consumeOAuthIntent(flow)) {
+        ctx.state.oauthIntent = intent;
+      }
     } catch {
       // Invalid or expired intent — proceed without an actor.
       // The user can still complete the OAuth flow as a fresh sign-in.
@@ -334,6 +339,24 @@ async function getOAuthActorId(ctx: Context): Promise<string | undefined> {
   } catch {
     return undefined;
   }
+}
+
+async function storeOAuthIntent(token: string): Promise<void> {
+  await Redis.defaultClient.set(
+    getOAuthIntentKey(token),
+    "1",
+    "EX",
+    OAUTH_INTENT_TTL_SECONDS
+  );
+}
+
+async function consumeOAuthIntent(token: string): Promise<boolean> {
+  const result = await Redis.defaultClient.getdel(getOAuthIntentKey(token));
+  return result === "1";
+}
+
+function getOAuthIntentKey(token: string): string {
+  return `${OAUTH_INTENT_PREFIX}${hash(token)}`;
 }
 
 function getKoaContext(ctx: Context): Context {

--- a/server/utils/passport.ts
+++ b/server/utils/passport.ts
@@ -9,40 +9,39 @@ import type { Primitive } from "utility-types";
 import { Client } from "@shared/types";
 import { getCookieDomain, parseDomain } from "@shared/utils/domains";
 import env from "@server/env";
-import { Team } from "@server/models";
+import { Team, User } from "@server/models";
 import { InternalError, OAuthStateMismatchError } from "../errors";
 import { safeEqual } from "./crypto";
 import fetch from "./fetch";
-import { getJWTPayload, getUserForJWT } from "./jwt";
+import { getUserForJWT } from "./jwt";
+import {
+  hashOAuthStateNonce,
+  signOAuthIntent,
+  signOAuthState,
+  verifyOAuthIntent,
+  verifyOAuthState,
+} from "./oauthState";
 
-const TRANSFER_QUERY_PARAM = "_t";
-const ACTOR_STATE_KEY = "oauthActorAccessToken";
+const FLOW_QUERY_PARAM = "flow";
+const OAUTH_CSRF_COOKIE = "oauth_csrf";
 
 /**
  * Middleware for OAuth start routes that bridges cookie scopes between custom
  * team domains and the apex (env.URL) where the OAuth callback always lands.
  *
- * The OAuth `state` cookie must be set on the same eTLD+1 as the callback URL,
- * and the user's `accessToken` session cookie is host-scoped to the team
- * domain it was issued on. To make the "connect a new auth provider while
- * signed in" flow work from a custom domain (whose cookies aren't shared with
- * the apex):
+ * The OAuth callback always lands on the apex domain, while a user's
+ * `accessToken` session cookie may be host-scoped to a custom team domain. To
+ * make the "connect a new auth provider while signed in" flow work from a
+ * custom domain:
  *
- *   1. On a custom team domain — mint a single-use transfer token from the
- *      user's `accessToken` cookie and bounce to the apex with it in the
- *      query string. Any pre-existing `_t` in the URL is stripped so an
- *      attacker can't smuggle a token along the bounce.
- *   2. On the apex with a transfer token — exchange it, but only if the
- *      transfer's user belongs to the team that owns the host claimed in
- *      `?host=`. This binding prevents an attacker who controls one team from
- *      pinning their session into another visitor's OAuth flow. The actor's
- *      session is stashed on `ctx.state` (not in a cookie) so that
- *      `StateStore.store` can read it later in the same request — a cookie
- *      `set` here wouldn't be visible to `get` on the same request anyway.
+ *   1. On a custom team domain — create a short-lived signed intent containing
+ *      the original host and actor id, then bounce to the apex with it.
+ *   2. On the apex — verify the signed intent and stash it on `ctx.state` so
+ *      `StateStore.store` can fold it into the signed OAuth `state` parameter.
  *
- * Non-custom team subdomains skip the bounce because their `state` cookie is
- * already shared with the apex via the base domain. Self-hosted deployments
- * have a single domain and pass through.
+ * Non-custom team subdomains skip the bounce because their cookies are shared
+ * with the apex via the base domain. Self-hosted deployments have a single
+ * domain and pass through.
  */
 export async function startOAuthFlow(ctx: Context, next: Next) {
   if (!env.isCloudHosted) {
@@ -55,66 +54,38 @@ export async function startOAuthFlow(ctx: Context, next: Next) {
 
   if (isCustom && !onApex) {
     const url = new URL(ctx.originalUrl, apex);
-    if (!url.searchParams.has("host")) {
-      url.searchParams.set("host", ctx.hostname);
-    }
-    url.searchParams.delete(TRANSFER_QUERY_PARAM);
+    const client = getClientFromInput(ctx);
+    const actorId = await getOAuthActorId(ctx);
 
-    const accessToken = ctx.cookies.get("accessToken");
-    if (accessToken) {
-      try {
-        const { user } = await getUserForJWT(accessToken);
-        url.searchParams.set(TRANSFER_QUERY_PARAM, user.getTransferToken());
-      } catch {
-        // Stale or invalid session — proceed without; the user can still
-        // complete the OAuth flow as a fresh sign-in.
-      }
-    }
+    url.searchParams.delete(FLOW_QUERY_PARAM);
+    url.searchParams.set(
+      FLOW_QUERY_PARAM,
+      signOAuthIntent({
+        host: ctx.hostname,
+        actorId,
+        client,
+      })
+    );
 
     return ctx.redirect(url.toString());
   }
 
-  if (!onApex) {
-    return next();
-  }
-
-  const transfer = ctx.query[TRANSFER_QUERY_PARAM];
-  const host = typeof ctx.query.host === "string" ? ctx.query.host : undefined;
-  if (typeof transfer !== "string" || !transfer || !host) {
-    return next();
-  }
-
-  try {
-    // Only accept transfer tokens here, not long-lived session JWTs.
-    if (getJWTPayload(transfer).type !== "transfer") {
-      return next();
+  const flow = ctx.query[FLOW_QUERY_PARAM];
+  if (onApex && typeof flow === "string" && flow) {
+    try {
+      ctx.state.oauthIntent = verifyOAuthIntent(flow);
+    } catch {
+      // Invalid or expired intent — proceed without an actor.
+      // The user can still complete the OAuth flow as a fresh sign-in.
     }
-    const { user } = await getUserForJWT(transfer);
-    // Bind to the host claim: only honor the transfer when the user belongs
-    // to the team that owns the custom domain. Prevents an attacker who
-    // controls one team from pinning their session into another visitor's
-    // OAuth flow via a crafted link.
-    if (
-      user.team?.domain &&
-      user.team.domain.toLowerCase() === host.toLowerCase()
-    ) {
-      // Bump lastActiveAt so the just-used transfer token can't be replayed
-      // within its 1-min TTL.
-      await user.updateActiveAt(ctx, true);
-      ctx.state[ACTOR_STATE_KEY] = user.getJwtToken(addMinutes(new Date(), 10));
-    }
-  } catch {
-    // Invalid/expired transfer — proceed without.
   }
 
   return next();
 }
 
-function getOAuthActorAccessToken(ctx: Context): string | undefined {
-  const value = ctx.state?.[ACTOR_STATE_KEY];
-  return typeof value === "string" ? value : undefined;
-}
-
+/**
+ * Passport OAuth state store backed by signed state and a CSRF nonce cookie.
+ */
 export class StateStore {
   constructor(private pkce = false) {}
 
@@ -127,8 +98,8 @@ export class StateStore {
     _meta?: unknown,
     cb?: StateStoreStoreCallback
   ) => {
-    // token is a short lived one-time pad to prevent replay attacks
-    const token = crypto.randomBytes(8).toString("hex");
+    const context = getKoaContext(ctx);
+    const csrfNonce = crypto.randomBytes(16).toString("hex");
 
     // Note parameters are based on whether PKCE is in use or not, this is parameters
     // of how the underlying library is architected, see:
@@ -144,25 +115,31 @@ export class StateStore {
 
     // We expect host to be a team subdomain, custom domain, or apex domain
     // that is passed via query param from the auth provider component.
-    const clientInput = ctx.query.client?.toString();
-    const client = clientInput === Client.Desktop ? Client.Desktop : Client.Web;
-    const host = ctx.query.host?.toString() || parseDomain(ctx.hostname).host;
-    const accessToken =
-      getOAuthActorAccessToken(ctx) ?? ctx.cookies.get("accessToken");
-    const state = buildState({
+    const client =
+      context.state.oauthIntent?.client ?? getClientFromInput(context);
+    const host =
+      context.state.oauthIntent?.host ??
+      context.query.host?.toString() ??
+      parseDomain(context.hostname).host;
+    const actorId =
+      context.state.oauthIntent?.actorId ?? getAuthenticatedUserId(context);
+    const state = signOAuthState({
       host,
-      token,
+      actorId,
       client,
       codeVerifier,
-      accessToken,
+      nonceHash: hashOAuthStateNonce(csrfNonce),
     });
 
-    ctx.cookies.set(this.key, state, {
+    context.cookies.set(OAUTH_CSRF_COOKIE, csrfNonce, {
+      httpOnly: true,
+      sameSite: "lax",
+      secure: env.isProduction,
       expires: addMinutes(new Date(), 10),
-      domain: getCookieDomain(ctx.hostname, env.isCloudHosted),
+      domain: getCookieDomain(context.hostname, env.isCloudHosted),
     });
 
-    callback(null, token);
+    callback(null, state);
   };
 
   verify = (
@@ -170,34 +147,35 @@ export class StateStore {
     providedToken: string,
     callback: StateStoreVerifyCallback
   ) => {
-    const state = ctx.cookies.get(this.key);
-
-    if (!state) {
-      return callback(
-        OAuthStateMismatchError("No state was available after OAuth flow"),
-        false,
-        state
-      );
-    }
-
-    const { token, codeVerifier } = parseState(state);
-
-    // Destroy the one-time pad token and ensure it matches
-    ctx.cookies.set(this.key, "", {
+    const context = getKoaContext(ctx);
+    const csrfNonce = context.cookies.get(OAUTH_CSRF_COOKIE);
+    context.cookies.set(OAUTH_CSRF_COOKIE, "", {
+      httpOnly: true,
+      sameSite: "lax",
+      secure: env.isProduction,
       expires: subMinutes(new Date(), 1),
-      domain: getCookieDomain(ctx.hostname, env.isCloudHosted),
+      domain: getCookieDomain(context.hostname, env.isCloudHosted),
     });
 
-    if (!safeEqual(token, providedToken)) {
+    let state;
+    try {
+      state = verifyOAuthState(providedToken);
+    } catch (err) {
+      return callback(err, false, providedToken);
+    }
+
+    if (!safeEqual(hashOAuthStateNonce(csrfNonce ?? ""), state.nonceHash)) {
       return callback(
         OAuthStateMismatchError("Token in state mismatched"),
         false,
-        token
+        providedToken
       );
     }
 
+    context.state.oauthState = state;
+
     // @ts-expect-error Type in library is wrong
-    callback(null, codeVerifier ?? true, state);
+    callback(null, state.codeVerifier ?? true, providedToken);
   };
 }
 
@@ -225,34 +203,18 @@ export async function request(
   }
 }
 
-function buildState({
-  host,
-  token,
-  client,
-  codeVerifier,
-  accessToken,
-}: {
-  host: string;
-  token: string;
-  client?: Client;
-  codeVerifier?: string;
-  accessToken?: string;
-}) {
-  return [host, token, client, codeVerifier, accessToken].join("|");
-}
-
 /**
  * Parses the state string into its components.
  *
  * @param state The state string
- * @returns An object containing the parsed components
+ * @returns An object containing the parsed components, if valid.
  */
 export function parseState(state: string) {
-  const [host, token, client, rawCodeVerifier, rawAccessToken] =
-    state.split("|");
-  const codeVerifier = rawCodeVerifier ? rawCodeVerifier : undefined;
-  const accessToken = rawAccessToken ? rawAccessToken : undefined;
-  return { host, token, client, codeVerifier, accessToken };
+  try {
+    return verifyOAuthState(state);
+  } catch {
+    return undefined;
+  }
 }
 
 /**
@@ -263,8 +225,8 @@ export function parseState(state: string) {
  * @returns The client type, defaults to Client.Web
  */
 export function getClientFromOAuthState(ctx: Context): Client {
-  const state = ctx.cookies.get("state");
-  const client = state ? parseState(state).client : undefined;
+  const context = getKoaContext(ctx);
+  const client = context.state.oauthState?.client;
   return client === Client.Desktop ? Client.Desktop : Client.Web;
 }
 
@@ -276,36 +238,20 @@ export function getClientFromOAuthState(ctx: Context): Client {
  * @param ctx The Koa context
  * @returns The access token if available, otherwise undefined
  */
-export function getAccessTokenFromOAuthState(ctx: Context): string | undefined {
-  const state = ctx.cookies.get("state");
-  return state ? parseState(state).accessToken : undefined;
-}
-
-/**
- * Returns the user from the context if they are authenticated. This is used
- * to restore the session during the OAuth flow.
- *
- * @param ctx The Koa context
- * @returns The user if authenticated, otherwise undefined
- */
 export async function getUserFromOAuthState(ctx: Context) {
-  const token = getAccessTokenFromOAuthState(ctx);
-  if (!token) {
+  const context = getKoaContext(ctx);
+  const actorId = context.state.oauthState?.actorId;
+  if (!actorId) {
     return undefined;
   }
 
-  try {
-    const { user } = await getUserForJWT(token);
-    return user;
-  } catch (_err) {
-    return undefined;
-  }
+  return User.scope("withTeam").findByPk(actorId);
 }
 
 type TeamFromContextOptions = {
   /**
-   * Whether to consider the state cookie in the context when determining the team.
-   * If true, the state cookie will be parsed to determine the host and infer the team
+   * Whether to consider OAuth state in the context when determining the team.
+   * If true, OAuth state will be used to determine the host and infer the team
    * this should only be used in the authentication process.
    */
   includeStateCookie?: boolean;
@@ -327,16 +273,17 @@ export async function getTeamFromContext(
   ctx: Context,
   options: TeamFromContextOptions = { includeStateCookie: true }
 ) {
+  const context = getKoaContext(ctx);
   // "domain" is the domain the user came from when attempting auth
   // we use it to infer the team they intend on signing into
   const state = options.includeStateCookie
-    ? ctx.cookies.get("state")
+    ? (context.state.oauthState ?? context.state.oauthIntent)
     : undefined;
   const queryHost =
-    options.includeHostQueryParam && typeof ctx.query.host === "string"
-      ? ctx.query.host
+    options.includeHostQueryParam && typeof context.query.host === "string"
+      ? context.query.host
       : undefined;
-  const host = (state ? parseState(state).host : queryHost) || ctx.hostname;
+  const host = state?.host ?? queryHost ?? context.hostname;
   const domain = parseDomain(host);
 
   let team;
@@ -348,8 +295,8 @@ export async function getTeamFromContext(
         order: [["createdAt", "DESC"]],
       });
     }
-  } else if (ctx.state?.rootShare) {
-    team = await Team.findByPk(ctx.state.rootShare.teamId);
+  } else if (context.state?.rootShare) {
+    team = await Team.findByPk(context.state.rootShare.teamId);
   } else if (domain.custom) {
     team = await Team.findByDomain(domain.host);
   } else if (domain.teamSubdomain) {
@@ -357,4 +304,38 @@ export async function getTeamFromContext(
   }
 
   return team;
+}
+
+function getClientFromInput(ctx: Context): Client {
+  const clientInput = ctx.query.client?.toString();
+  return clientInput === Client.Desktop ? Client.Desktop : Client.Web;
+}
+
+function getAuthenticatedUserId(ctx: Context): string | undefined {
+  return ctx.state.auth && "user" in ctx.state.auth
+    ? ctx.state.auth.user?.id
+    : undefined;
+}
+
+async function getOAuthActorId(ctx: Context): Promise<string | undefined> {
+  const authenticatedUserId = getAuthenticatedUserId(ctx);
+  if (authenticatedUserId) {
+    return authenticatedUserId;
+  }
+
+  const accessToken = ctx.cookies.get("accessToken");
+  if (!accessToken) {
+    return undefined;
+  }
+
+  try {
+    const { user } = await getUserForJWT(accessToken);
+    return user.id;
+  } catch {
+    return undefined;
+  }
+}
+
+function getKoaContext(ctx: Context): Context {
+  return (ctx as Context & { ctx?: Context }).ctx ?? ctx;
 }

--- a/server/utils/passport.ts
+++ b/server/utils/passport.ts
@@ -42,9 +42,10 @@ const OAUTH_INTENT_TTL_SECONDS = 10 * 60;
  *   2. On the apex — verify the signed intent and stash it on `ctx.state` so
  *      `StateStore.store` can fold it into the signed OAuth `state` parameter.
  *
- * Non-custom team subdomains skip the bounce because their cookies are shared
- * with the apex via the base domain. Self-hosted deployments have a single
- * domain and pass through.
+ * Non-custom team subdomains skip the bounce because the start route can read
+ * the host-scoped session and set the OAuth CSRF cookie on the base domain for
+ * the apex callback. Self-hosted deployments have a single domain and pass
+ * through.
  */
 export async function startOAuthFlow(ctx: Context, next: Next) {
   if (!env.isCloudHosted) {
@@ -58,10 +59,11 @@ export async function startOAuthFlow(ctx: Context, next: Next) {
   if (isCustom && !onApex) {
     const url = new URL(ctx.originalUrl, apex);
     const client = getClientFromInput(ctx);
-    const actorId = await getOAuthActorId(ctx);
+    const actor = await getOAuthActor(ctx);
     const flow = signOAuthIntent({
       host: ctx.hostname,
-      actorId,
+      actorId: actor?.id,
+      actorSessionHash: actor ? getActorSessionHash(actor) : undefined,
       client,
     });
 
@@ -128,9 +130,13 @@ export class StateStore {
       parseDomain(context.hostname).host;
     const actorId =
       context.state.oauthIntent?.actorId ?? getAuthenticatedUserId(context);
+    const actorSessionHash =
+      context.state.oauthIntent?.actorSessionHash ??
+      getAuthenticatedUserSessionHash(context);
     const state = signOAuthState({
       host,
       actorId,
+      actorSessionHash,
       client,
       codeVerifier,
       nonceHash: hashOAuthStateNonce(csrfNonce),
@@ -171,7 +177,7 @@ export class StateStore {
 
     if (!safeEqual(hashOAuthStateNonce(csrfNonce ?? ""), state.nonceHash)) {
       return callback(
-        OAuthStateMismatchError("Token in state mismatched"),
+        OAuthStateMismatchError("OAuth CSRF nonce mismatched"),
         false,
         providedToken
       );
@@ -236,21 +242,30 @@ export function getClientFromOAuthState(ctx: Context): Client {
 }
 
 /**
- * Returns the access token from the context if available. This is used
- * to restore the session during the OAuth flow when connecting additional
- * providers to an existing team.
+ * Returns the actor referenced by verified OAuth state, if available. This is
+ * used to restore the originating user during the OAuth flow when connecting
+ * additional providers to an existing team.
  *
  * @param ctx The Koa context
- * @returns The access token if available, otherwise undefined
+ * @returns The actor if available, otherwise undefined
  */
 export async function getUserFromOAuthState(ctx: Context) {
   const context = getKoaContext(ctx);
-  const actorId = context.state.oauthState?.actorId;
-  if (!actorId) {
+  const state = context.state.oauthState;
+  if (!state?.actorId || !state.actorSessionHash) {
     return undefined;
   }
 
-  return User.scope("withTeam").findByPk(actorId);
+  const user = await User.scope("withTeam").findByPk(state.actorId);
+  if (!user) {
+    return undefined;
+  }
+
+  if (!safeEqual(getActorSessionHash(user), state.actorSessionHash)) {
+    return undefined;
+  }
+
+  return user;
 }
 
 type TeamFromContextOptions = {
@@ -259,7 +274,7 @@ type TeamFromContextOptions = {
    * If true, OAuth state will be used to determine the host and infer the team
    * this should only be used in the authentication process.
    */
-  includeStateCookie?: boolean;
+  includeOAuthState?: boolean;
   /**
    * Whether to consider the host query parameter in the context when determining the team.
    * If true, the host query parameter will be used to determine the host and infer the team
@@ -268,7 +283,7 @@ type TeamFromContextOptions = {
 };
 
 /**
- * Infers the team from the context based on the hostname or state cookie.
+ * Infers the team from the context based on the hostname or OAuth state.
  *
  * @param ctx The Koa context
  * @param options Options for determining the team
@@ -276,12 +291,13 @@ type TeamFromContextOptions = {
  */
 export async function getTeamFromContext(
   ctx: Context,
-  options: TeamFromContextOptions = { includeStateCookie: true }
+  options: TeamFromContextOptions = { includeOAuthState: true }
 ) {
   const context = getKoaContext(ctx);
   // "domain" is the domain the user came from when attempting auth
   // we use it to infer the team they intend on signing into
-  const state = options.includeStateCookie
+  const includeOAuthState = options.includeOAuthState ?? true;
+  const state = includeOAuthState
     ? (context.state.oauthState ?? context.state.oauthIntent)
     : undefined;
   const queryHost =
@@ -316,16 +332,25 @@ function getClientFromInput(ctx: Context): Client {
   return clientInput === Client.Desktop ? Client.Desktop : Client.Web;
 }
 
-function getAuthenticatedUserId(ctx: Context): string | undefined {
+function getAuthenticatedUser(ctx: Context): User | undefined {
   return ctx.state.auth && "user" in ctx.state.auth
-    ? ctx.state.auth.user?.id
+    ? ctx.state.auth.user
     : undefined;
 }
 
-async function getOAuthActorId(ctx: Context): Promise<string | undefined> {
-  const authenticatedUserId = getAuthenticatedUserId(ctx);
-  if (authenticatedUserId) {
-    return authenticatedUserId;
+function getAuthenticatedUserId(ctx: Context): string | undefined {
+  return getAuthenticatedUser(ctx)?.id;
+}
+
+function getAuthenticatedUserSessionHash(ctx: Context): string | undefined {
+  const user = getAuthenticatedUser(ctx);
+  return user ? getActorSessionHash(user) : undefined;
+}
+
+async function getOAuthActor(ctx: Context): Promise<User | undefined> {
+  const authenticatedUser = getAuthenticatedUser(ctx);
+  if (authenticatedUser) {
+    return authenticatedUser;
   }
 
   const accessToken = ctx.cookies.get("accessToken");
@@ -335,10 +360,17 @@ async function getOAuthActorId(ctx: Context): Promise<string | undefined> {
 
   try {
     const { user } = await getUserForJWT(accessToken);
-    return user.id;
+    return user;
   } catch {
     return undefined;
   }
+}
+
+function getActorSessionHash(user: User): string {
+  return crypto
+    .createHmac("sha256", env.SECRET_KEY)
+    .update(user.jwtSecret)
+    .digest("hex");
 }
 
 async function storeOAuthIntent(token: string): Promise<void> {

--- a/server/utils/passport.ts
+++ b/server/utils/passport.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 import { addMinutes, subMinutes } from "date-fns";
-import type { Context } from "koa";
+import type { Context, Next } from "koa";
 import type {
   StateStoreStoreCallback,
   StateStoreVerifyCallback,
@@ -13,7 +13,107 @@ import { Team } from "@server/models";
 import { InternalError, OAuthStateMismatchError } from "../errors";
 import { safeEqual } from "./crypto";
 import fetch from "./fetch";
-import { getUserForJWT } from "./jwt";
+import { getJWTPayload, getUserForJWT } from "./jwt";
+
+const TRANSFER_QUERY_PARAM = "_t";
+const ACTOR_STATE_KEY = "oauthActorAccessToken";
+
+/**
+ * Middleware for OAuth start routes that bridges cookie scopes between custom
+ * team domains and the apex (env.URL) where the OAuth callback always lands.
+ *
+ * The OAuth `state` cookie must be set on the same eTLD+1 as the callback URL,
+ * and the user's `accessToken` session cookie is host-scoped to the team
+ * domain it was issued on. To make the "connect a new auth provider while
+ * signed in" flow work from a custom domain (whose cookies aren't shared with
+ * the apex):
+ *
+ *   1. On a custom team domain — mint a single-use transfer token from the
+ *      user's `accessToken` cookie and bounce to the apex with it in the
+ *      query string. Any pre-existing `_t` in the URL is stripped so an
+ *      attacker can't smuggle a token along the bounce.
+ *   2. On the apex with a transfer token — exchange it, but only if the
+ *      transfer's user belongs to the team that owns the host claimed in
+ *      `?host=`. This binding prevents an attacker who controls one team from
+ *      pinning their session into another visitor's OAuth flow. The actor's
+ *      session is stashed on `ctx.state` (not in a cookie) so that
+ *      `StateStore.store` can read it later in the same request — a cookie
+ *      `set` here wouldn't be visible to `get` on the same request anyway.
+ *
+ * Non-custom team subdomains skip the bounce because their `state` cookie is
+ * already shared with the apex via the base domain. Self-hosted deployments
+ * have a single domain and pass through.
+ */
+export async function startOAuthFlow(ctx: Context, next: Next) {
+  if (!env.isCloudHosted) {
+    return next();
+  }
+
+  const apex = new URL(env.URL);
+  const onApex = ctx.hostname === apex.hostname;
+  const isCustom = parseDomain(ctx.hostname).custom;
+
+  if (isCustom && !onApex) {
+    const url = new URL(ctx.originalUrl, apex);
+    if (!url.searchParams.has("host")) {
+      url.searchParams.set("host", ctx.hostname);
+    }
+    url.searchParams.delete(TRANSFER_QUERY_PARAM);
+
+    const accessToken = ctx.cookies.get("accessToken");
+    if (accessToken) {
+      try {
+        const { user } = await getUserForJWT(accessToken);
+        url.searchParams.set(TRANSFER_QUERY_PARAM, user.getTransferToken());
+      } catch {
+        // Stale or invalid session — proceed without; the user can still
+        // complete the OAuth flow as a fresh sign-in.
+      }
+    }
+
+    return ctx.redirect(url.toString());
+  }
+
+  if (!onApex) {
+    return next();
+  }
+
+  const transfer = ctx.query[TRANSFER_QUERY_PARAM];
+  const host = typeof ctx.query.host === "string" ? ctx.query.host : undefined;
+  if (typeof transfer !== "string" || !transfer || !host) {
+    return next();
+  }
+
+  try {
+    // Only accept transfer tokens here, not long-lived session JWTs.
+    if (getJWTPayload(transfer).type !== "transfer") {
+      return next();
+    }
+    const { user } = await getUserForJWT(transfer);
+    // Bind to the host claim: only honor the transfer when the user belongs
+    // to the team that owns the custom domain. Prevents an attacker who
+    // controls one team from pinning their session into another visitor's
+    // OAuth flow via a crafted link.
+    if (
+      user.team?.domain &&
+      user.team.domain.toLowerCase() === host.toLowerCase()
+    ) {
+      // Bump lastActiveAt so the just-used transfer token can't be replayed
+      // within its 1-min TTL.
+      await user.updateActiveAt(ctx, true);
+      ctx.state[ACTOR_STATE_KEY] = user.getJwtToken(addMinutes(new Date(), 10));
+    }
+  } catch {
+    // Invalid/expired transfer — proceed without.
+  }
+
+  return next();
+}
+
+function getOAuthActorAccessToken(ctx: Context): string | undefined {
+  const value = ctx.state?.[ACTOR_STATE_KEY];
+  return typeof value === "string" ? value : undefined;
+}
 
 export class StateStore {
   constructor(private pkce = false) {}
@@ -47,7 +147,8 @@ export class StateStore {
     const clientInput = ctx.query.client?.toString();
     const client = clientInput === Client.Desktop ? Client.Desktop : Client.Web;
     const host = ctx.query.host?.toString() || parseDomain(ctx.hostname).host;
-    const accessToken = ctx.cookies.get("accessToken");
+    const accessToken =
+      getOAuthActorAccessToken(ctx) ?? ctx.cookies.get("accessToken");
     const state = buildState({
       host,
       token,

--- a/server/utils/passport.ts
+++ b/server/utils/passport.ts
@@ -27,6 +27,7 @@ const FLOW_QUERY_PARAM = "flow";
 const OAUTH_CSRF_COOKIE = "oauth_csrf";
 const OAUTH_INTENT_PREFIX = "oauth:intent:";
 const OAUTH_INTENT_TTL_SECONDS = 10 * 60;
+const ACTOR_SESSION_HASH_KEYLEN = 64;
 
 /**
  * Middleware for OAuth start routes that bridges cookie scopes between custom
@@ -368,9 +369,12 @@ async function getOAuthActor(ctx: Context): Promise<User | undefined> {
 
 function getActorSessionHash(user: User): string {
   return crypto
-    .createHmac("sha256", env.SECRET_KEY)
-    .update(user.jwtSecret)
-    .digest("hex");
+    .scryptSync(
+      user.jwtSecret,
+      `oauth-actor-session:${env.SECRET_KEY}:${user.id}`,
+      ACTOR_SESSION_HASH_KEYLEN
+    )
+    .toString("hex");
 }
 
 async function storeOAuthIntent(token: string): Promise<void> {


### PR DESCRIPTION
Introduces signed `OAuthIntent` to pass connection request from custom domain through to OAuth flow which must always be completed on apex domain.