### PR TITLE
chore(deps): Remove obsolete lodash-es resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -388,7 +388,6 @@
     "ip-address@npm:10.1.0": "^10.2.0",
     "minimatch@npm:9.0.1": "9.0.9",
     "lodash@npm:4.17.21": "^4.18.1",
-    "lodash-es@npm:4.17.23": "^4.18.1",
     "i18next-parser/i18next": "^23.16.8"
   },
   "version": "1.7.1",


### PR DESCRIPTION
## Summary

Re-audited every entry in the `resolutions` block by removing it individually and running `yarn install` to see if any package would resolve to a lower version. Only `lodash-es@npm:4.17.23: ^4.18.1` proved to be a no-op — its targeted descriptor `lodash-es@npm:4.17.23` is no longer requested by any package in the tree (only `lodash-es: ^4.17.21` is requested, which resolves naturally to 4.18.1). Removing this resolution produces no change in `yarn.lock`.

### Audit results

Each resolution was tested. Kept entries fall into two buckets matching the rationale in #12304:

| Resolution | Effect when removed | Decision |
|---|---|---|
| `@types/react: 17.0.91` | adds @types/react 19.2.14 for `*` descriptors | KEEP (dedupe against React 17 pin) |
| `@types/koa: 2.15.0` | adds @types/koa 3.0.2 for `*` descriptors | KEEP (dedupe) |
| `prosemirror-transform: 1.10.5` | adds prosemirror-transform 1.12.0 for transitives | KEEP (dedupe) |
| `debug: 4.3.4` | adds debug 2.6.9, 3.2.7 (LOWER), ms 2.0.0 (LOWER) | KEEP |
| `prismjs: 1.30.0` | downgrades to 1.27.0 | KEEP |
| `zod: ^4.3.6` | adds zod 3.25.76 for koa-body | KEEP |
| `ajv@npm:~8.13.0: ^8.18.0` | adds ajv 8.13.0 for @rushstack | KEEP |
| `@types/markdown-it: 14.1.2` | adds @types/markdown-it 13.0.9 for `<14` | KEEP |
| `ip-address@npm:10.1.0: ^10.2.0` | adds ip-address 10.1.0 for express-rate-limit | KEEP |
| `minimatch@npm:9.0.1: 9.0.9` | adds minimatch 9.0.1 for editorconfig | KEEP |
| `lodash@npm:4.17.21: ^4.18.1` | adds lodash 4.17.21 for @relative-ci/agent and @bundle-stats | KEEP |
| `lodash-es@npm:4.17.23: ^4.18.1` | **no change** — descriptor not requested | **REMOVE** |
| `i18next-parser/i18next: ^23.16.8` | bumps to i18next 24.2.3, which changes plural-key format incompatible with runtime i18next 22.5.1 (per #12307) | KEEP |

## Test plan

- [x] `yarn install` succeeds with the resolution removed
- [x] `yarn.lock` is byte-identical to the previous lockfile (the removal had no effect)


---
_Generated by [Claude Code](https://claude.ai/code/session_012GPJzRpRnFJN9dZHoUebBn)_