### PR TITLE
perf: Move Markdown importer to zip stream

### DIFF
--- a/server/queues/tasks/MarkdownAPIImportTask.ts
+++ b/server/queues/tasks/MarkdownAPIImportTask.ts
@@ -1,10 +1,8 @@
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 import { escapeRegExp } from "es-toolkit/compat";
-import fs from "fs-extra";
 import mime from "mime-types";
 import { UniqueConstraintError } from "sequelize";
-import tmp from "tmp";
 import type {
   ImportTaskInput,
   ImportTaskOutput,
@@ -23,8 +21,7 @@ import { Buckets } from "@server/models/helpers/AttachmentHelper";
 import { ProsemirrorHelper } from "@server/models/helpers/ProsemirrorHelper";
 import { sequelize } from "@server/storage/database";
 import FileStorage from "@server/storage/files";
-import type { FileTreeNode } from "@server/utils/ImportHelper";
-import ImportHelper from "@server/utils/ImportHelper";
+import { deserializeFilename } from "@server/utils/fs";
 import ZipHelper from "@server/utils/ZipHelper";
 import type { ProcessOutput } from "./APIImportTask";
 import APIImportTask from "./APIImportTask";
@@ -32,9 +29,17 @@ import { DocumentConverter } from "@server/utils/DocumentConverter";
 
 type Markdown = IntegrationService.Markdown;
 
-interface ExtractedZip {
-  dirPath: string;
-  cleanup: () => Promise<void>;
+interface ZipTreeNode {
+  /** The title, extracted from the file name. */
+  title: string;
+  /** The file name including extension. */
+  name: string;
+  /** Path of this entry within the zip (relative, no leading slash). */
+  pathInZip: string;
+  /** Nested children — populated for directory entries. */
+  children: ZipTreeNode[];
+  /** Markdown text pre-loaded during the zip walk; undefined for non-md files. */
+  markdownText?: string;
 }
 
 interface DiscoveredDocument {
@@ -173,25 +178,28 @@ export default class MarkdownAPIImportTask extends APIImportTask<Markdown> {
       return;
     }
 
-    const { dirPath, cleanup } = await this.downloadAndExtract(
-      scratch.storageKey
-    );
+    const handle = await FileStorage.getFileHandle(scratch.storageKey);
 
     try {
       const createdBy = lastImportTask.import.createdBy;
+      const manifestByPath = new Map<string, MarkdownAttachmentManifestItem>(
+        scratch.manifest.map((item) => [item.pathInZip, item])
+      );
+      const seen = new Set<string>();
 
-      for (const item of scratch.manifest) {
-        const filePath = path.join(dirPath, item.pathInZip);
-        let buffer: Buffer;
-        try {
-          buffer = await fs.readFile(filePath);
-        } catch (err) {
-          Logger.warn(
-            `Markdown import attachment missing in zip, skipping: ${item.pathInZip}`,
-            err instanceof Error ? err : undefined
-          );
-          continue;
+      await ZipHelper.walk(handle.path, async (entry) => {
+        if (entry.isDirectory) {
+          return;
         }
+        // Normalize to match the bootstrap-phase pathInZip (segments rejoined
+        // with `/`, no leading `./` or empty segments).
+        const normalized = entry.fileName.split("/").filter(Boolean).join("/");
+        const item = manifestByPath.get(normalized);
+        if (!item) {
+          return;
+        }
+        seen.add(item.pathInZip);
+        const buffer = await entry.readBuffer();
 
         try {
           await sequelize.transaction(async (transaction) =>
@@ -214,13 +222,21 @@ export default class MarkdownAPIImportTask extends APIImportTask<Markdown> {
           // this hook can re-encounter ids that already landed. Treat the
           // unique-id collision as a no-op so the import remains resumable.
           if (err instanceof UniqueConstraintError) {
-            continue;
+            return;
           }
           throw err;
         }
+      });
+
+      for (const item of scratch.manifest) {
+        if (!seen.has(item.pathInZip)) {
+          Logger.warn(
+            `Markdown import attachment missing in zip, skipping: ${item.pathInZip}`
+          );
+        }
       }
     } finally {
-      await cleanup();
+      await handle.cleanup().catch(() => {});
     }
   }
 
@@ -232,11 +248,11 @@ export default class MarkdownAPIImportTask extends APIImportTask<Markdown> {
       throw new Error("Markdown import is missing scratch.storageKey");
     }
 
-    const { dirPath, cleanup } = await this.downloadAndExtract(storageKey);
+    const handle = await FileStorage.getFileHandle(storageKey);
 
     try {
-      const tree = await ImportHelper.toFileTree(dirPath);
-      if (!tree) {
+      const tree = await this.buildTreeFromZip(handle.path);
+      if (tree.children.length === 0) {
         throw new Error("Could not find valid content in zip file");
       }
 
@@ -245,14 +261,14 @@ export default class MarkdownAPIImportTask extends APIImportTask<Markdown> {
 
       for (const node of tree.children) {
         if (node.children.length === 0) {
-          Logger.debug("task", `Unhandled file in zip: ${node.path}`, {
+          Logger.debug("task", `Unhandled file in zip: ${node.pathInZip}`, {
             importTaskId: importTask.id,
           });
           continue;
         }
 
         if (this.isAttachmentFolder(node)) {
-          this.collectAttachments(node, manifest, dirPath);
+          this.collectAttachments(node, manifest);
           continue;
         }
 
@@ -263,12 +279,11 @@ export default class MarkdownAPIImportTask extends APIImportTask<Markdown> {
         };
         collections.push(collection);
 
-        await this.collectDocumentsAndAttachments({
+        this.collectDocumentsAndAttachments({
           children: node.children,
           collectionId: collection.id,
           out: collection.children,
           manifest,
-          extractionRoot: dirPath,
         });
       }
 
@@ -336,7 +351,7 @@ export default class MarkdownAPIImportTask extends APIImportTask<Markdown> {
 
       return { taskOutput: collectionOutputs, childTasksInput };
     } finally {
-      await cleanup();
+      await handle.cleanup().catch(() => {});
     }
   }
 
@@ -477,10 +492,10 @@ export default class MarkdownAPIImportTask extends APIImportTask<Markdown> {
    * Detects folders containing only attachments (no markdown documents).
    * Recursively considers nested folders; mirrors the legacy heuristic.
    *
-   * @param node FileTreeNode to inspect.
+   * @param node ZipTreeNode to inspect.
    * @returns true when the folder appears to hold only attachments.
    */
-  private isAttachmentFolder(node: FileTreeNode): boolean {
+  private isAttachmentFolder(node: ZipTreeNode): boolean {
     if (node.children.length === 0) {
       return false;
     }
@@ -501,29 +516,26 @@ export default class MarkdownAPIImportTask extends APIImportTask<Markdown> {
 
   /**
    * Recursively collects all files under an attachment-only folder into the
-   * manifest. `pathInZip` is stored as a path relative to the extraction
-   * root so it can be resolved again after the zip is re-extracted during
-   * the completion phase (which lands in a fresh tmp dir).
+   * manifest. `pathInZip` is stored verbatim so the completion phase can find
+   * the same entry when re-walking the archive.
    *
-   * @param node Attachment-folder FileTreeNode.
+   * @param node Attachment-folder ZipTreeNode.
    * @param manifest Manifest array to push entries into.
-   * @param extractionRoot Absolute path to the zip extraction root.
    */
   private collectAttachments(
-    node: FileTreeNode,
-    manifest: MarkdownAttachmentManifestItem[],
-    extractionRoot: string
+    node: ZipTreeNode,
+    manifest: MarkdownAttachmentManifestItem[]
   ): void {
     for (const child of node.children) {
       if (child.children.length > 0) {
-        this.collectAttachments(child, manifest, extractionRoot);
+        this.collectAttachments(child, manifest);
         continue;
       }
       manifest.push({
         id: randomUUID(),
         name: child.name,
-        pathInZip: path.relative(extractionRoot, child.path),
-        mimeType: mime.lookup(child.path) || "application/octet-stream",
+        pathInZip: child.pathInZip,
+        mimeType: mime.lookup(child.name) || "application/octet-stream",
       });
     }
   }
@@ -534,31 +546,28 @@ export default class MarkdownAPIImportTask extends APIImportTask<Markdown> {
    * entry's `children` holds its direct descendants. This is the shape the
    * per-page task cascade consumes.
    *
-   * @param children FileTreeNode children of the current folder.
+   * @param children ZipTreeNode children of the current folder.
    * @param collectionId Pre-assigned id of the enclosing collection.
    * @param parentDocumentId Optional parent document id when nested.
    * @param out Sibling accumulator to push discovered documents into.
    * @param manifest Attachment manifest accumulator.
-   * @returns Promise that resolves when the subtree has been processed.
    */
-  private async collectDocumentsAndAttachments({
+  private collectDocumentsAndAttachments({
     children,
     collectionId,
     parentDocumentId,
     out,
     manifest,
-    extractionRoot,
   }: {
-    children: FileTreeNode[];
+    children: ZipTreeNode[];
     collectionId: string;
     parentDocumentId?: string;
     out: DiscoveredDocument[];
     manifest: MarkdownAttachmentManifestItem[];
-    extractionRoot: string;
-  }): Promise<void> {
+  }): void {
     for (const child of children) {
       if (child.children.length > 0 && this.isAttachmentFolder(child)) {
-        this.collectAttachments(child, manifest, extractionRoot);
+        this.collectAttachments(child, manifest);
         continue;
       }
 
@@ -570,16 +579,14 @@ export default class MarkdownAPIImportTask extends APIImportTask<Markdown> {
         manifest.push({
           id: randomUUID(),
           name: child.name,
-          pathInZip: path.relative(extractionRoot, child.path),
-          mimeType: mime.lookup(child.path) || "application/octet-stream",
+          pathInZip: child.pathInZip,
+          mimeType: mime.lookup(child.name) || "application/octet-stream",
         });
         continue;
       }
 
       const id = randomUUID();
-      const markdownText = isFolder
-        ? ""
-        : await fs.readFile(child.path, "utf8");
+      const markdownText = isFolder ? "" : (child.markdownText ?? "");
 
       // Folder-and-file with the same title (a "name.md" alongside a "name/"
       // directory) is merged onto a single document: the folder body picks up
@@ -591,13 +598,12 @@ export default class MarkdownAPIImportTask extends APIImportTask<Markdown> {
           sibling.markdownText = markdownText;
         }
         if (isFolder) {
-          await this.collectDocumentsAndAttachments({
+          this.collectDocumentsAndAttachments({
             children: child.children,
             collectionId,
             parentDocumentId: sibling.id,
             out: sibling.children,
             manifest,
-            extractionRoot,
           });
         }
         continue;
@@ -606,7 +612,7 @@ export default class MarkdownAPIImportTask extends APIImportTask<Markdown> {
       const node: DiscoveredDocument = {
         id,
         title: child.title,
-        pathInZip: path.relative(extractionRoot, child.path),
+        pathInZip: child.pathInZip,
         collectionId,
         parentDocumentId,
         markdownText,
@@ -615,58 +621,80 @@ export default class MarkdownAPIImportTask extends APIImportTask<Markdown> {
       out.push(node);
 
       if (isFolder) {
-        await this.collectDocumentsAndAttachments({
+        this.collectDocumentsAndAttachments({
           children: child.children,
           collectionId,
           parentDocumentId: id,
           out: node.children,
           manifest,
-          extractionRoot,
         });
       }
     }
   }
 
   /**
-   * Downloads the zip from object storage and extracts it into a temporary
-   * directory.
+   * Walks the zip once, materializing a tree of nodes and pre-loading the
+   * text of every markdown file. Attachments are recorded as leaf nodes
+   * without reading their bytes — those are streamed lazily in the
+   * completion phase. macOS metadata directories and dotfiles are filtered
+   * out at any path segment, matching the prior on-disk filtering.
    *
-   * @param storageKey Storage key for the uploaded zip.
-   * @returns The temp dir path and a cleanup callback. Caller must invoke
-   *          cleanup() once finished.
+   * @param zipPath Local filesystem path to the zip file.
+   * @returns A synthetic root node whose `children` are the zip's top-level entries.
    */
-  private async downloadAndExtract(storageKey: string): Promise<ExtractedZip> {
-    const handle = await FileStorage.getFileHandle(storageKey);
+  private async buildTreeFromZip(zipPath: string): Promise<ZipTreeNode> {
+    const root: ZipTreeNode = {
+      title: "",
+      name: "",
+      pathInZip: "",
+      children: [],
+    };
 
-    let dirPath: string | undefined;
-    try {
-      dirPath = await new Promise<string>((resolve, reject) => {
-        tmp.dir({ unsafeCleanup: true }, (err, tmpDir) => {
-          if (err) {
-            reject(err);
-            return;
-          }
-          resolve(tmpDir);
-        });
-      });
+    const isFiltered = (segment: string) =>
+      segment === "__MACOSX" || segment.startsWith(".");
 
-      await ZipHelper.extract(handle.path, dirPath);
-
-      return {
-        dirPath,
-        cleanup: async () => {
-          await fs
-            .rm(dirPath!, { recursive: true, force: true })
-            .catch(() => {});
-          await handle.cleanup().catch(() => {});
-        },
-      };
-    } catch (err) {
-      if (dirPath) {
-        await fs.rm(dirPath, { recursive: true, force: true }).catch(() => {});
+    const resolveNode = (entryName: string): ZipTreeNode | null => {
+      const segments = entryName.split("/").filter(Boolean);
+      if (segments.length === 0) {
+        return null;
       }
-      await handle.cleanup().catch(() => {});
-      throw err;
-    }
+
+      let current = root;
+      for (let i = 0; i < segments.length; i++) {
+        const segment = segments[i];
+        if (isFiltered(segment)) {
+          return null;
+        }
+
+        let next = current.children.find((c) => c.name === segment);
+        if (!next) {
+          next = {
+            name: segment,
+            title: deserializeFilename(path.parse(segment).name),
+            pathInZip: segments.slice(0, i + 1).join("/"),
+            children: [],
+          };
+          current.children.push(next);
+        }
+        current = next;
+      }
+
+      return current;
+    };
+
+    await ZipHelper.walk(zipPath, async (entry) => {
+      const node = resolveNode(entry.fileName);
+      if (!node || entry.isDirectory) {
+        return;
+      }
+
+      const ext = path.extname(node.name).toLowerCase();
+      if (ext === ".md" || ext === ".markdown") {
+        const buffer = await entry.readBuffer();
+        node.markdownText = buffer.toString("utf8");
+      }
+    });
+
+    return root;
   }
 }

--- a/server/queues/tasks/MarkdownAPIImportTask.ts
+++ b/server/queues/tasks/MarkdownAPIImportTask.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { escapeRegExp } from "es-toolkit/compat";
 import mime from "mime-types";
 import { UniqueConstraintError } from "sequelize";
+import { DocumentValidation } from "@shared/validations";
 import type {
   ImportTaskInput,
   ImportTaskOutput,
@@ -17,7 +18,9 @@ import env from "@server/env";
 import Logger from "@server/logging/Logger";
 import type { ImportTask } from "@server/models";
 import { Attachment } from "@server/models";
-import { Buckets } from "@server/models/helpers/AttachmentHelper";
+import AttachmentHelper, {
+  Buckets,
+} from "@server/models/helpers/AttachmentHelper";
 import { ProsemirrorHelper } from "@server/models/helpers/ProsemirrorHelper";
 import { sequelize } from "@server/storage/database";
 import FileStorage from "@server/storage/files";
@@ -172,6 +175,9 @@ export default class MarkdownAPIImportTask extends APIImportTask<Markdown> {
       const manifestByPath = new Map<string, MarkdownAttachmentManifestItem>(
         scratch.manifest.map((item) => [item.pathInZip, item])
       );
+      const maxAttachmentSize = AttachmentHelper.presetToMaxUploadSize(
+        AttachmentPreset.DocumentAttachment
+      );
       const seen = new Set<string>();
 
       await ZipHelper.walk(handle.path, async (entry) => {
@@ -186,7 +192,7 @@ export default class MarkdownAPIImportTask extends APIImportTask<Markdown> {
           return;
         }
         seen.add(item.pathInZip);
-        const buffer = await entry.readBuffer();
+        const buffer = await entry.readBuffer(maxAttachmentSize);
 
         try {
           await sequelize.transaction(async (transaction) =>
@@ -248,7 +254,9 @@ export default class MarkdownAPIImportTask extends APIImportTask<Markdown> {
         async (node, entry) => {
           const ext = path.extname(node.name).toLowerCase();
           if (ext === ".md" || ext === ".markdown") {
-            const buffer = await entry.readBuffer();
+            const buffer = await entry.readBuffer(
+              DocumentValidation.maxStateLength
+            );
             markdownByNode.set(node, buffer.toString("utf8"));
           }
         }

--- a/server/queues/tasks/MarkdownAPIImportTask.ts
+++ b/server/queues/tasks/MarkdownAPIImportTask.ts
@@ -21,26 +21,13 @@ import { Buckets } from "@server/models/helpers/AttachmentHelper";
 import { ProsemirrorHelper } from "@server/models/helpers/ProsemirrorHelper";
 import { sequelize } from "@server/storage/database";
 import FileStorage from "@server/storage/files";
-import { deserializeFilename } from "@server/utils/fs";
+import type { ZipTreeNode } from "@server/utils/ZipHelper";
 import ZipHelper from "@server/utils/ZipHelper";
 import type { ProcessOutput } from "./APIImportTask";
 import APIImportTask from "./APIImportTask";
 import { DocumentConverter } from "@server/utils/DocumentConverter";
 
 type Markdown = IntegrationService.Markdown;
-
-interface ZipTreeNode {
-  /** The title, extracted from the file name. */
-  title: string;
-  /** The file name including extension. */
-  name: string;
-  /** Path of this entry within the zip (relative, no leading slash). */
-  pathInZip: string;
-  /** Nested children — populated for directory entries. */
-  children: ZipTreeNode[];
-  /** Markdown text pre-loaded during the zip walk; undefined for non-md files. */
-  markdownText?: string;
-}
 
 interface DiscoveredDocument {
   id: string;
@@ -251,7 +238,22 @@ export default class MarkdownAPIImportTask extends APIImportTask<Markdown> {
     const handle = await FileStorage.getFileHandle(storageKey);
 
     try {
-      const tree = await this.buildTreeFromZip(handle.path);
+      // Side map of pre-loaded markdown text keyed by tree node identity.
+      // ZipHelper's tree carries only metadata; we capture text during the
+      // single walk so the downstream pass doesn't have to re-open the zip.
+      const markdownByNode = new Map<ZipTreeNode, string>();
+
+      const tree = await ZipHelper.toFileTree(
+        handle.path,
+        async (node, entry) => {
+          const ext = path.extname(node.name).toLowerCase();
+          if (ext === ".md" || ext === ".markdown") {
+            const buffer = await entry.readBuffer();
+            markdownByNode.set(node, buffer.toString("utf8"));
+          }
+        }
+      );
+
       if (tree.children.length === 0) {
         throw new Error("Could not find valid content in zip file");
       }
@@ -284,6 +286,7 @@ export default class MarkdownAPIImportTask extends APIImportTask<Markdown> {
           collectionId: collection.id,
           out: collection.children,
           manifest,
+          markdownByNode,
         });
       }
 
@@ -551,6 +554,7 @@ export default class MarkdownAPIImportTask extends APIImportTask<Markdown> {
    * @param parentDocumentId Optional parent document id when nested.
    * @param out Sibling accumulator to push discovered documents into.
    * @param manifest Attachment manifest accumulator.
+   * @param markdownByNode Pre-loaded markdown text keyed by tree node.
    */
   private collectDocumentsAndAttachments({
     children,
@@ -558,12 +562,14 @@ export default class MarkdownAPIImportTask extends APIImportTask<Markdown> {
     parentDocumentId,
     out,
     manifest,
+    markdownByNode,
   }: {
     children: ZipTreeNode[];
     collectionId: string;
     parentDocumentId?: string;
     out: DiscoveredDocument[];
     manifest: MarkdownAttachmentManifestItem[];
+    markdownByNode: Map<ZipTreeNode, string>;
   }): void {
     for (const child of children) {
       if (child.children.length > 0 && this.isAttachmentFolder(child)) {
@@ -586,7 +592,7 @@ export default class MarkdownAPIImportTask extends APIImportTask<Markdown> {
       }
 
       const id = randomUUID();
-      const markdownText = isFolder ? "" : (child.markdownText ?? "");
+      const markdownText = isFolder ? "" : (markdownByNode.get(child) ?? "");
 
       // Folder-and-file with the same title (a "name.md" alongside a "name/"
       // directory) is merged onto a single document: the folder body picks up
@@ -604,6 +610,7 @@ export default class MarkdownAPIImportTask extends APIImportTask<Markdown> {
             parentDocumentId: sibling.id,
             out: sibling.children,
             manifest,
+            markdownByNode,
           });
         }
         continue;
@@ -627,74 +634,9 @@ export default class MarkdownAPIImportTask extends APIImportTask<Markdown> {
           parentDocumentId: id,
           out: node.children,
           manifest,
+          markdownByNode,
         });
       }
     }
-  }
-
-  /**
-   * Walks the zip once, materializing a tree of nodes and pre-loading the
-   * text of every markdown file. Attachments are recorded as leaf nodes
-   * without reading their bytes — those are streamed lazily in the
-   * completion phase. macOS metadata directories and dotfiles are filtered
-   * out at any path segment, matching the prior on-disk filtering.
-   *
-   * @param zipPath Local filesystem path to the zip file.
-   * @returns A synthetic root node whose `children` are the zip's top-level entries.
-   */
-  private async buildTreeFromZip(zipPath: string): Promise<ZipTreeNode> {
-    const root: ZipTreeNode = {
-      title: "",
-      name: "",
-      pathInZip: "",
-      children: [],
-    };
-
-    const isFiltered = (segment: string) =>
-      segment === "__MACOSX" || segment.startsWith(".");
-
-    const resolveNode = (entryName: string): ZipTreeNode | null => {
-      const segments = entryName.split("/").filter(Boolean);
-      if (segments.length === 0) {
-        return null;
-      }
-
-      let current = root;
-      for (let i = 0; i < segments.length; i++) {
-        const segment = segments[i];
-        if (isFiltered(segment)) {
-          return null;
-        }
-
-        let next = current.children.find((c) => c.name === segment);
-        if (!next) {
-          next = {
-            name: segment,
-            title: deserializeFilename(path.parse(segment).name),
-            pathInZip: segments.slice(0, i + 1).join("/"),
-            children: [],
-          };
-          current.children.push(next);
-        }
-        current = next;
-      }
-
-      return current;
-    };
-
-    await ZipHelper.walk(zipPath, async (entry) => {
-      const node = resolveNode(entry.fileName);
-      if (!node || entry.isDirectory) {
-        return;
-      }
-
-      const ext = path.extname(node.name).toLowerCase();
-      if (ext === ".md" || ext === ".markdown") {
-        const buffer = await entry.readBuffer();
-        node.markdownText = buffer.toString("utf8");
-      }
-    });
-
-    return root;
   }
 }

--- a/server/utils/ZipHelper.test.ts
+++ b/server/utils/ZipHelper.test.ts
@@ -122,11 +122,36 @@ describe("ZipHelper.toFileTree", () => {
     const seen: Record<string, string> = {};
     await ZipHelper.toFileTree(zipPath, async (node, entry) => {
       if (node.name.endsWith(".md")) {
-        const buf = await entry.readBuffer();
+        const buf = await entry.readBuffer(100);
         seen[node.pathInZip] = buf.toString("utf8");
       }
     });
 
     expect(seen).toEqual({ "Collection/page.md": "hello world" });
+  });
+
+  it("rejects reads larger than the provided max size", async () => {
+    const zipPath = await writeZip({
+      "Collection/page.md": "hello world",
+    });
+
+    await expect(
+      ZipHelper.toFileTree(zipPath, async (_node, entry) => {
+        await entry.readBuffer(10);
+      })
+    ).rejects.toThrow("Collection/page.md is too large");
+  });
+
+  it("exposes entry sizes before the entry is read", async () => {
+    const zipPath = await writeZip({
+      "Collection/page.md": "hello world",
+    });
+
+    const sizes: Record<string, number> = {};
+    await ZipHelper.toFileTree(zipPath, (node, entry) => {
+      sizes[node.pathInZip] = entry.uncompressedSize;
+    });
+
+    expect(sizes).toEqual({ "Collection/page.md": 11 });
   });
 });

--- a/server/utils/ZipHelper.test.ts
+++ b/server/utils/ZipHelper.test.ts
@@ -66,3 +66,67 @@ describe("ZipHelper.extract", () => {
     expect(await fs.pathExists(path.join(scratchCwd, filename))).toBe(false);
   });
 });
+
+describe("ZipHelper.toFileTree", () => {
+  it("builds a nested tree with normalized pathInZip", async () => {
+    const zipPath = await writeZip({
+      "Collection/sub/page.md": "# hi",
+      "Collection/other.md": "other",
+    });
+
+    const root = await ZipHelper.toFileTree(zipPath);
+    expect(root.children).toHaveLength(1);
+
+    const collection = root.children[0];
+    expect(collection.name).toBe("Collection");
+    expect(collection.pathInZip).toBe("Collection");
+    expect(collection.children.map((c) => c.name).sort()).toEqual([
+      "other.md",
+      "sub",
+    ]);
+
+    const sub = collection.children.find((c) => c.name === "sub");
+    expect(sub?.children[0].pathInZip).toBe("Collection/sub/page.md");
+  });
+
+  it("normalizes `./`-prefixed entries instead of dropping them", async () => {
+    const zipPath = await writeZip({
+      "./Collection/page.md": "body",
+    });
+
+    const root = await ZipHelper.toFileTree(zipPath);
+    expect(root.children).toHaveLength(1);
+    expect(root.children[0].name).toBe("Collection");
+    expect(root.children[0].children[0].pathInZip).toBe("Collection/page.md");
+  });
+
+  it("filters macOS metadata and dotfiles at any depth", async () => {
+    const zipPath = await writeZip({
+      "__MACOSX/Collection/page.md": "junk",
+      "Collection/.DS_Store": "junk",
+      "Collection/page.md": "body",
+    });
+
+    const root = await ZipHelper.toFileTree(zipPath);
+    expect(root.children).toHaveLength(1);
+    expect(root.children[0].name).toBe("Collection");
+    expect(root.children[0].children.map((c) => c.name)).toEqual(["page.md"]);
+  });
+
+  it("invokes onFile for each file entry with a readable handle", async () => {
+    const zipPath = await writeZip({
+      "Collection/page.md": "hello world",
+      "Collection/image.png": "binary",
+    });
+
+    const seen: Record<string, string> = {};
+    await ZipHelper.toFileTree(zipPath, async (node, entry) => {
+      if (node.name.endsWith(".md")) {
+        const buf = await entry.readBuffer();
+        seen[node.pathInZip] = buf.toString("utf8");
+      }
+    });
+
+    expect(seen).toEqual({ "Collection/page.md": "hello world" });
+  });
+});

--- a/server/utils/ZipHelper.ts
+++ b/server/utils/ZipHelper.ts
@@ -5,6 +5,7 @@ import tmp from "tmp";
 import type { Entry } from "yauzl";
 import yauzl, { validateFileName } from "yauzl";
 import { bytesToHumanReadable } from "@shared/utils/files";
+import { ValidationError } from "@server/errors";
 import Logger from "@server/logging/Logger";
 import { trace } from "@server/logging/tracing";
 import { deserializeFilename, trimFilenameAndExt } from "./fs";
@@ -14,13 +15,17 @@ const MAX_FILE_NAME_LENGTH = 255;
 export interface ZipEntryHandle {
   /** UTF-8 filename as recorded in the zip; directory entries end with `/`. */
   fileName: string;
+  /** Size of the uncompressed entry in bytes. */
+  uncompressedSize: number;
   /** True when this entry is a directory marker rather than a file. */
   isDirectory: boolean;
   /**
    * Read the entry's contents into memory. Safe to skip — entries the caller
    * does not read are simply advanced past.
+   *
+   * @param maxSize Maximum uncompressed size to read into memory, in bytes.
    */
-  readBuffer(): Promise<Buffer>;
+  readBuffer(maxSize: number): Promise<Buffer>;
 }
 
 export interface ZipTreeNode {
@@ -134,7 +139,7 @@ export default class ZipHelper {
    *
    * @param filePath The file path where the zip is located.
    * @param onEntry Handler invoked for each entry. Skip an entry by returning
-   *                without calling `entry.readBuffer()`.
+   *                without calling `entry.readBuffer(maxSize)`.
    * @returns Promise that resolves once the archive has been fully walked.
    */
   public static walk(
@@ -175,17 +180,30 @@ export default class ZipHelper {
 
             const handle: ZipEntryHandle = {
               fileName,
+              uncompressedSize: entry.uncompressedSize,
               isDirectory: /\/$/.test(fileName),
-              readBuffer: () =>
+              readBuffer: (maxSize) =>
                 new Promise<Buffer>((res, rej) => {
+                  if (entry.uncompressedSize > maxSize) {
+                    return rej(ZipHelper.entryTooLargeError(fileName, maxSize));
+                  }
+
                   zipfile.openReadStream(entry, (rErr, readStream) => {
                     if (rErr) {
                       return rej(rErr);
                     }
                     const chunks: Buffer[] = [];
-                    readStream.on("data", (chunk: Buffer) =>
-                      chunks.push(chunk)
-                    );
+                    let bytesRead = 0;
+                    readStream.on("data", (chunk: Buffer) => {
+                      bytesRead += chunk.length;
+                      if (bytesRead > maxSize) {
+                        readStream.destroy(
+                          ZipHelper.entryTooLargeError(fileName, maxSize)
+                        );
+                        return;
+                      }
+                      chunks.push(chunk);
+                    });
                     readStream.on("end", () => res(Buffer.concat(chunks)));
                     readStream.on("error", rej);
                   });
@@ -223,7 +241,7 @@ export default class ZipHelper {
    * The optional `onFile` callback fires once per file entry as it is
    * encountered, with both the materialized tree node and a handle to the
    * raw entry. Callers that need to pre-load contents (e.g. small text
-   * files) can call `entry.readBuffer()`; callers that only need the tree
+   * files) can call `entry.readBuffer(maxSize)`; callers that only need the tree
    * structure can omit the callback entirely.
    *
    * @param filePath Local filesystem path to the zip.
@@ -423,5 +441,13 @@ export default class ZipHelper {
         }
       );
     });
+  }
+
+  private static entryTooLargeError(fileName: string, maxSize: number): Error {
+    return ValidationError(
+      `${fileName} is too large - the maximum size is ${bytesToHumanReadable(
+        maxSize
+      )}`
+    );
   }
 }

--- a/server/utils/ZipHelper.ts
+++ b/server/utils/ZipHelper.ts
@@ -245,28 +245,38 @@ export default class ZipHelper {
     const isFiltered = (segment: string) =>
       segment === "__MACOSX" || segment.startsWith(".");
 
+    const nodesByPath = new Map<string, ZipTreeNode>();
+
     const resolveNode = (entryName: string): ZipTreeNode | null => {
-      const segments = entryName.split("/").filter(Boolean);
+      // Drop empty segments and the path-no-op `.` (e.g. entries written as
+      // `./Collection/page.md`). `..` is preserved so the dotfile filter
+      // below rejects it — we never resolve path traversal in zip entries.
+      const segments = entryName
+        .split("/")
+        .filter((s) => s !== "" && s !== ".");
       if (segments.length === 0) {
         return null;
       }
 
       let current = root;
+      let pathSoFar = "";
       for (let i = 0; i < segments.length; i++) {
         const segment = segments[i];
         if (isFiltered(segment)) {
           return null;
         }
 
-        let next = current.children.find((c) => c.name === segment);
+        pathSoFar = pathSoFar ? `${pathSoFar}/${segment}` : segment;
+        let next = nodesByPath.get(pathSoFar);
         if (!next) {
           next = {
             name: segment,
             title: deserializeFilename(path.parse(segment).name),
-            pathInZip: segments.slice(0, i + 1).join("/"),
+            pathInZip: pathSoFar,
             children: [],
           };
           current.children.push(next);
+          nodesByPath.set(pathSoFar, next);
         }
         current = next;
       }

--- a/server/utils/ZipHelper.ts
+++ b/server/utils/ZipHelper.ts
@@ -11,6 +11,18 @@ import { trimFilenameAndExt } from "./fs";
 
 const MAX_FILE_NAME_LENGTH = 255;
 
+export interface ZipEntryHandle {
+  /** UTF-8 filename as recorded in the zip; directory entries end with `/`. */
+  fileName: string;
+  /** True when this entry is a directory marker rather than a file. */
+  isDirectory: boolean;
+  /**
+   * Read the entry's contents into memory. Safe to skip — entries the caller
+   * does not read are simply advanced past.
+   */
+  readBuffer(): Promise<Buffer>;
+}
+
 @trace()
 export default class ZipHelper {
   public static defaultStreamOptions: JSZip.JSZipGeneratorOptions<"nodebuffer"> =
@@ -99,6 +111,94 @@ export default class ZipHelper {
             .on("error", handleError)
             .pipe(dest)
             .on("error", handleError);
+        }
+      );
+    });
+  }
+
+  /**
+   * Iterate through entries in a zip file without extracting it to disk.
+   * Entries are visited serially in archive order. `onEntry` may be async; the
+   * next entry is only read once the previous handler resolves.
+   *
+   * @param filePath The file path where the zip is located.
+   * @param onEntry Handler invoked for each entry. Skip an entry by returning
+   *                without calling `entry.readBuffer()`.
+   * @returns Promise that resolves once the archive has been fully walked.
+   */
+  public static walk(
+    filePath: string,
+    onEntry: (entry: ZipEntryHandle) => Promise<void> | void
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      yauzl.open(
+        filePath,
+        {
+          lazyEntries: true,
+          autoClose: true,
+          decodeStrings: false,
+        },
+        function (err, zipfile) {
+          if (err) {
+            return reject(err);
+          }
+
+          let settled = false;
+          const fail = (error: Error) => {
+            if (settled) {
+              return;
+            }
+            settled = true;
+            zipfile.close();
+            reject(error);
+          };
+
+          zipfile.on("entry", (entry: Entry) => {
+            const fileName = Buffer.from(entry.fileName).toString("utf8");
+
+            if (validateFileName(fileName)) {
+              Logger.warn("Invalid zip entry", { fileName });
+              zipfile.readEntry();
+              return;
+            }
+
+            const handle: ZipEntryHandle = {
+              fileName,
+              isDirectory: /\/$/.test(fileName),
+              readBuffer: () =>
+                new Promise<Buffer>((res, rej) => {
+                  zipfile.openReadStream(entry, (rErr, readStream) => {
+                    if (rErr) {
+                      return rej(rErr);
+                    }
+                    const chunks: Buffer[] = [];
+                    readStream.on("data", (chunk: Buffer) =>
+                      chunks.push(chunk)
+                    );
+                    readStream.on("end", () => res(Buffer.concat(chunks)));
+                    readStream.on("error", rej);
+                  });
+                }),
+            };
+
+            Promise.resolve()
+              .then(() => onEntry(handle))
+              .then(() => {
+                if (!settled) {
+                  zipfile.readEntry();
+                }
+              })
+              .catch(fail);
+          });
+
+          zipfile.on("close", () => {
+            if (!settled) {
+              settled = true;
+              resolve();
+            }
+          });
+          zipfile.on("error", (error) => fail(error));
+          zipfile.readEntry();
         }
       );
     });

--- a/server/utils/ZipHelper.ts
+++ b/server/utils/ZipHelper.ts
@@ -7,7 +7,7 @@ import yauzl, { validateFileName } from "yauzl";
 import { bytesToHumanReadable } from "@shared/utils/files";
 import Logger from "@server/logging/Logger";
 import { trace } from "@server/logging/tracing";
-import { trimFilenameAndExt } from "./fs";
+import { deserializeFilename, trimFilenameAndExt } from "./fs";
 
 const MAX_FILE_NAME_LENGTH = 255;
 
@@ -21,6 +21,17 @@ export interface ZipEntryHandle {
    * does not read are simply advanced past.
    */
   readBuffer(): Promise<Buffer>;
+}
+
+export interface ZipTreeNode {
+  /** The file name (last path segment) including extension. */
+  name: string;
+  /** Title derived from the file name (extension stripped, deserialized). */
+  title: string;
+  /** Path within the zip (no leading slash, segments joined with `/`). */
+  pathInZip: string;
+  /** Nested children — populated for directory entries. */
+  children: ZipTreeNode[];
 }
 
 @trace()
@@ -202,6 +213,78 @@ export default class ZipHelper {
         }
       );
     });
+  }
+
+  /**
+   * Walk a zip file once and build a tree of its entries without extracting
+   * to disk. macOS metadata directories (`__MACOSX`) and dotfiles are
+   * filtered out at any path segment.
+   *
+   * The optional `onFile` callback fires once per file entry as it is
+   * encountered, with both the materialized tree node and a handle to the
+   * raw entry. Callers that need to pre-load contents (e.g. small text
+   * files) can call `entry.readBuffer()`; callers that only need the tree
+   * structure can omit the callback entirely.
+   *
+   * @param filePath Local filesystem path to the zip.
+   * @param onFile Optional per-file hook; not called for directory entries.
+   * @returns A synthetic root node whose `children` are the zip's top-level
+   *          entries.
+   */
+  public static async toFileTree(
+    filePath: string,
+    onFile?: (node: ZipTreeNode, entry: ZipEntryHandle) => Promise<void> | void
+  ): Promise<ZipTreeNode> {
+    const root: ZipTreeNode = {
+      name: "",
+      title: "",
+      pathInZip: "",
+      children: [],
+    };
+
+    const isFiltered = (segment: string) =>
+      segment === "__MACOSX" || segment.startsWith(".");
+
+    const resolveNode = (entryName: string): ZipTreeNode | null => {
+      const segments = entryName.split("/").filter(Boolean);
+      if (segments.length === 0) {
+        return null;
+      }
+
+      let current = root;
+      for (let i = 0; i < segments.length; i++) {
+        const segment = segments[i];
+        if (isFiltered(segment)) {
+          return null;
+        }
+
+        let next = current.children.find((c) => c.name === segment);
+        if (!next) {
+          next = {
+            name: segment,
+            title: deserializeFilename(path.parse(segment).name),
+            pathInZip: segments.slice(0, i + 1).join("/"),
+            children: [],
+          };
+          current.children.push(next);
+        }
+        current = next;
+      }
+
+      return current;
+    };
+
+    await this.walk(filePath, async (entry) => {
+      const node = resolveNode(entry.fileName);
+      if (!node || entry.isDirectory) {
+        return;
+      }
+      if (onFile) {
+        await onFile(node, entry);
+      }
+    });
+
+    return root;
   }
 
   /**


### PR DESCRIPTION
- Avoid unzipping to disk in import task, I feel dejavu like I did this before?
- Avoid unzipping individual files that exceed limits 