### PR TITLE
fix: avoid "Imported from undefined" in document insights

### DIFF
--- a/app/scenes/Document/components/Insights.tsx
+++ b/app/scenes/Document/components/Insights.tsx
@@ -58,12 +58,13 @@ function Insights({ document }: Props) {
                     {t(`Last updated`)}{" "}
                     <Time dateTime={document.updatedAt} addSuffix />
                   </li>
-                  {document.sourceMetadata && (
+                  {(document.sourceName ||
+                    document.sourceMetadata?.fileName) && (
                     <li>
                       {t("Imported from {{ source }}", {
                         source:
                           document.sourceName ??
-                          `“${document.sourceMetadata.fileName}”`,
+                          `“${document.sourceMetadata?.fileName}”`,
                       })}
                     </li>
                   )}


### PR DESCRIPTION
## Summary
- The Insights modal rendered the "Imported from" line whenever `sourceMetadata` was present, but both `sourceName` and `sourceMetadata.fileName` are optional — when neither was set, the result was the literal string `Imported from "undefined"`. The line is now only rendered when at least one is available.

## Test plan
- [ ] Open Insights on a document with no import source — "Imported from" line should not appear
- [ ] Open Insights on an imported document — "Imported from <source>" appears as expected