### PR TITLE
fix: Allow deleting failed and canceled imports

### DIFF
--- a/server/policies/import.ts
+++ b/server/policies/import.ts
@@ -3,6 +3,12 @@ import { User, Team, Import } from "@server/models";
 import { allow, can } from "./cancan";
 import { and, isTeamAdmin, isTeamMutable, or } from "./utils";
 
+const TerminalStates = [
+  ImportState.Completed,
+  ImportState.Errored,
+  ImportState.Canceled,
+];
+
 allow(User, ["createImport", "listImports"], Team, (actor, team) =>
   and(isTeamAdmin(actor, team), isTeamMutable(actor))
 );
@@ -14,7 +20,7 @@ allow(User, "read", Import, (actor, importModel) =>
 allow(User, "delete", Import, (actor, importModel) =>
   and(
     can(actor, "read", importModel),
-    importModel?.state === ImportState.Completed
+    !!importModel && TerminalStates.includes(importModel.state)
   )
 );
 

--- a/server/routes/api/imports/imports.test.ts
+++ b/server/routes/api/imports/imports.test.ts
@@ -177,24 +177,27 @@ describe("#imports.info", () => {
 });
 
 describe("#imports.delete", () => {
-  it("should delete the import", async () => {
-    const admin = await buildAdmin();
-    const importModel = await buildImport({
-      state: ImportState.Completed,
-      createdById: admin.id,
-      teamId: admin.teamId,
-    });
+  it.each([ImportState.Completed, ImportState.Errored, ImportState.Canceled])(
+    "should delete the import when in %s state",
+    async (state) => {
+      const admin = await buildAdmin();
+      const importModel = await buildImport({
+        state,
+        createdById: admin.id,
+        teamId: admin.teamId,
+      });
 
-    const res = await server.post("/api/imports.delete", admin, {
-      body: {
-        id: importModel.id,
-      },
-    });
-    const body = await res.json();
+      const res = await server.post("/api/imports.delete", admin, {
+        body: {
+          id: importModel.id,
+        },
+      });
+      const body = await res.json();
 
-    expect(res.status).toEqual(200);
-    expect(body.success).toEqual(true);
-  });
+      expect(res.status).toEqual(200);
+      expect(body.success).toEqual(true);
+    }
+  );
 
   it("should throw error when import is not in deletable state", async () => {
     const admin = await buildAdmin();


### PR DESCRIPTION
## Summary

The delete policy in `server/policies/import.ts` only permitted imports in the `Completed` state. Since the `cancel` action is also restricted to non-terminal states, the overflow menu on failed (`Errored`) or `Canceled` imports rendered with no items. This relaxes the delete check to allow any terminal state.

## Test plan

- [ ] Trigger a failed import and confirm the overflow menu now shows Delete
- [ ] Confirm the Delete action still appears for Completed imports
- [ ] Confirm Cancel still appears (and Delete does not) for in-progress imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)