### PR TITLE
fix: Mention menu does not appear when pasting link with trailing newline

### DIFF
--- a/app/editor/extensions/PasteHandler.tsx
+++ b/app/editor/extensions/PasteHandler.tsx
@@ -108,22 +108,25 @@ export default class PasteHandler extends Extension {
                 return false;
               }
 
-              // Check if the clipboard contents can be parsed as a single url
-              if (isUrl(text)) {
+              // Check if the clipboard contents can be parsed as a single url.
+              // Trim first so surrounding whitespace from the clipboard (e.g. a
+              // trailing newline appended by the source) doesn't prevent URL
+              // detection and skip the paste menu.
+              const trimmedText = text.trim();
+              if (isUrl(trimmedText)) {
                 // If there is selected text then we want to wrap it in a link to the url
                 if (!state.selection.empty) {
-                  toggleMark(this.editor.schema.marks.link, { href: text })(
-                    state,
-                    dispatch
-                  );
+                  toggleMark(this.editor.schema.marks.link, {
+                    href: trimmedText,
+                  })(state, dispatch);
                   return true;
                 }
 
                 // Is the link a link to a document? If so, we can grab the title and insert it.
-                const containsHash = text.includes("#");
+                const containsHash = trimmedText.includes("#");
 
-                if (isDocumentUrl(text)) {
-                  const slug = parseDocumentSlug(text);
+                if (isDocumentUrl(trimmedText)) {
+                  const slug = parseDocumentSlug(trimmedText);
 
                   if (slug) {
                     void stores.documents
@@ -147,7 +150,7 @@ export default class PasteHandler extends Extension {
                               )
                             );
                           } else {
-                            const { hash } = new URL(text);
+                            const { hash } = new URL(trimmedText);
                             const hasEmoji =
                               determineIconType(document.icon) ===
                               IconType.Emoji;
@@ -164,11 +167,11 @@ export default class PasteHandler extends Extension {
                         if (view.isDestroyed) {
                           return;
                         }
-                        this.insertLink(text);
+                        this.insertLink(trimmedText);
                       });
                   }
-                } else if (isCollectionUrl(text)) {
-                  const slug = parseCollectionSlug(text);
+                } else if (isCollectionUrl(trimmedText)) {
+                  const slug = parseCollectionSlug(trimmedText);
 
                   if (slug) {
                     stores.collections
@@ -192,7 +195,7 @@ export default class PasteHandler extends Extension {
                               )
                             );
                           } else {
-                            const { hash } = new URL(text);
+                            const { hash } = new URL(trimmedText);
                             const hasEmoji =
                               determineIconType(collection.icon) ===
                               IconType.Emoji;
@@ -209,11 +212,11 @@ export default class PasteHandler extends Extension {
                         if (view.isDestroyed) {
                           return;
                         }
-                        this.insertLink(text);
+                        this.insertLink(trimmedText);
                       });
                   }
                 } else {
-                  this.insertLink(text);
+                  this.insertLink(trimmedText);
                 }
 
                 return true;


### PR DESCRIPTION
closes #12399