### PR TITLE
fix: Slack notifications show "Untitled" for documents without titles

### DIFF
--- a/plugins/slack/server/presenters/messageAttachment.ts
+++ b/plugins/slack/server/presenters/messageAttachment.ts
@@ -22,7 +22,7 @@ export function presentMessageAttachment(
 
   return {
     color: collection?.color,
-    title: document.title,
+    title: document.titleWithDefault,
     title_link: `${team.url}${document.url}`,
     footer: collection?.name,
     callback_id: document.id,

--- a/plugins/slack/server/processors/SlackProcessor.ts
+++ b/plugins/slack/server/processors/SlackProcessor.ts
@@ -124,10 +124,10 @@ export default class SlackProcessor extends BaseProcessor {
     if (!integration) {
       return;
     }
-    let text = `${document.updatedBy.name} updated "${document.title}"`;
+    let text = `${document.updatedBy.name} updated "${document.titleWithDefault}"`;
 
     if (event.name === "documents.publish") {
-      text = `${document.createdBy.name} published "${document.title}"`;
+      text = `${document.createdBy.name} published "${document.titleWithDefault}"`;
     }
 
     await fetch(integration.settings.url, {


### PR DESCRIPTION
## Summary
- Use `document.titleWithDefault` in Slack notification text and message attachment titles so documents with empty titles render as `Untitled` instead of an empty string (e.g. `Tom Moor updated ""`).

## Test plan
- [ ] Trigger a Slack notification for an untitled document and confirm the message reads `… updated "Untitled"`.
- [ ] Confirm the attachment title also shows `Untitled` for an untitled document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)