### PR TITLE
fix: Apply `statement_timeout` on request-handling processes

### DIFF
--- a/server/storage/database.ts
+++ b/server/storage/database.ts
@@ -51,7 +51,6 @@ const schema = env.DATABASE_SCHEMA;
 // are exempted because background jobs may legitimately run long queries.
 const isApiProcess =
   (env.SERVICES.includes("web") ||
-    env.SERVICES.includes("api") ||
     env.SERVICES.includes("collaboration") ||
     env.SERVICES.includes("websockets") ||
     env.SERVICES.includes("admin")) &&

--- a/server/storage/database.ts
+++ b/server/storage/database.ts
@@ -45,6 +45,20 @@ const poolMin = env.DATABASE_CONNECTION_POOL_MIN ?? 0;
 const databaseConfig = env.DATABASE_CONNECTION_POOL_URL || getDatabaseConfig();
 const schema = env.DATABASE_SCHEMA;
 
+// Request-handling processes get a Postgres `statement_timeout` matching the
+// HTTP request timeout, so a single slow query cannot hold a connection past
+// the point at which its response could be delivered. Worker/cron processes
+// are exempted because background jobs may legitimately run long queries.
+const isApiProcess =
+  (env.SERVICES.includes("web") ||
+    env.SERVICES.includes("api") ||
+    env.SERVICES.includes("collaboration") ||
+    env.SERVICES.includes("websockets") ||
+    env.SERVICES.includes("admin")) &&
+  !env.SERVICES.includes("worker") &&
+  !env.SERVICES.includes("cron");
+const statementTimeout = isApiProcess ? env.REQUEST_TIMEOUT : undefined;
+
 export function createDatabaseInstance(
   databaseConfig: string | object,
   input: {
@@ -68,6 +82,7 @@ export function createDatabaseInstance(
       logQueryParameters: env.isDevelopment,
       dialectOptions: {
         application_name: getConnectionName(),
+        statement_timeout: statementTimeout,
         ssl:
           env.isProduction && !isSSLDisabled
             ? {

--- a/server/storage/database.ts
+++ b/server/storage/database.ts
@@ -1,3 +1,4 @@
+import cluster from "node:cluster";
 import path from "node:path";
 import type { InferAttributes, InferCreationAttributes } from "sequelize";
 import sequelizeStrictAttributes from "sequelize-strict-attributes";
@@ -49,6 +50,8 @@ const schema = env.DATABASE_SCHEMA;
 // HTTP request timeout, so a single slow query cannot hold a connection past
 // the point at which its response could be delivered. Worker/cron processes
 // are exempted because background jobs may legitimately run long queries.
+// Only applied in forked cluster workers so that startup work driven from
+// the master process (notably migrations) is not subject to the timeout.
 const isApiProcess =
   (env.SERVICES.includes("web") ||
     env.SERVICES.includes("collaboration") ||
@@ -56,7 +59,8 @@ const isApiProcess =
     env.SERVICES.includes("admin")) &&
   !env.SERVICES.includes("worker") &&
   !env.SERVICES.includes("cron");
-const statementTimeout = isApiProcess ? env.REQUEST_TIMEOUT : undefined;
+const statementTimeout =
+  isApiProcess && cluster.isWorker ? env.REQUEST_TIMEOUT : undefined;
 
 export function createDatabaseInstance(
   databaseConfig: string | object,


### PR DESCRIPTION
## Summary
- Sets Postgres `statement_timeout` on the Sequelize connection pool to `REQUEST_TIMEOUT` (default 10s) when the process handles HTTP requests (web/api/collaboration/websockets/admin) and does not also run worker/cron.
- Prevents a single runaway query from holding connections past the point its response could be delivered.
- Worker and cron processes are exempted because background jobs may legitimately run long queries.
