### PR TITLE
fix: Ignore "Premature close" stream errors in Sentry

### DIFF
--- a/server/logging/sentry.ts
+++ b/server/logging/sentry.ts
@@ -25,6 +25,9 @@ if (env.SENTRY_DSN) {
       "AuthRedirectError",
       "UserSuspendedError",
       "TooManyRequestsError",
+
+      // Client disconnects
+      "Premature close",
     ],
     beforeSend(event) {
       try {


### PR DESCRIPTION
## Summary
- Adds `"Premature close"` to the Sentry `ignoreErrors` list so client disconnects mid-response stop generating noise, matching the existing EPIPE/ECONNRESET filtering in `requestErrorHandler`.

## Test plan
- [ ] Confirm new "Premature close" errors stop appearing in Sentry after deploy