### PR TITLE
fix: Don't report upstream OAuth provider errors to Sentry

### DIFF
--- a/server/middlewares/passport.ts
+++ b/server/middlewares/passport.ts
@@ -1,6 +1,10 @@
 import passport from "@outlinewiki/koa-passport";
 import type { Context } from "koa";
-import { InternalOAuthError } from "passport-oauth2";
+import {
+  AuthorizationError,
+  InternalOAuthError,
+  TokenError,
+} from "passport-oauth2";
 import { Client } from "@shared/types";
 import { parseDomain } from "@shared/utils/domains";
 import env from "@server/env";
@@ -56,6 +60,17 @@ export default function createMiddleware(providerName: string) {
       },
       async (err, user, result: AuthenticationResult) => {
         if (err) {
+          // TokenError / AuthorizationError surface input problems reported by
+          // the upstream OAuth provider (expired or already-redeemed codes,
+          // access_denied, etc). They are not server bugs, so log at warn
+          // level and skip the error reporter.
+          if (err instanceof TokenError || err instanceof AuthorizationError) {
+            Logger.warn(`OAuth error during authentication: ${err.message}`, {
+              code: err.code,
+            });
+            return ctx.redirect(`/?notice=auth-error`);
+          }
+
           Logger.error(
             "Error during authentication",
             err instanceof InternalOAuthError ? err.oauthError : err

--- a/server/middlewares/passport.ts
+++ b/server/middlewares/passport.ts
@@ -68,13 +68,12 @@ export default function createMiddleware(providerName: string) {
             Logger.warn(`OAuth error during authentication: ${err.message}`, {
               code: err.code,
             });
-            return ctx.redirect(`/?notice=auth-error`);
+          } else {
+            Logger.error(
+              "Error during authentication",
+              err instanceof InternalOAuthError ? err.oauthError : err
+            );
           }
-
-          Logger.error(
-            "Error during authentication",
-            err instanceof InternalOAuthError ? err.oauthError : err
-          );
 
           if (err.id) {
             const notice = err.id.replace(/_/g, "-");


### PR DESCRIPTION
## Summary

`TokenError` and `AuthorizationError` from `passport-oauth2` represent input problems reported by the upstream provider (e.g. an expired or already-redeemed authorization code, `access_denied`) rather than server bugs, but were being routed through `Logger.error` and surfaced in Sentry. They are now logged at `warn` level with the OAuth `code` and the user is redirected with the standard `auth-error` notice.

## Test plan

- [ ] Trigger an OAuth callback with a reused code and confirm the user sees the auth-error notice and no Sentry event is created.