### PR TITLE
fix: documents.list with Draft status filter throws database error

### DIFF
--- a/server/models/Document.ts
+++ b/server/models/Document.ts
@@ -157,14 +157,6 @@ type AdditionalFindOptions = {
         paranoid: false,
       },
     ],
-    where: {
-      sourceMetadata: {
-        trial: {
-          [Op.is]: null,
-        },
-      },
-      template: false,
-    },
   },
   withViews: (userId: string) => {
     if (!userId) {

--- a/server/models/Document.ts
+++ b/server/models/Document.ts
@@ -157,6 +157,14 @@ type AdditionalFindOptions = {
         paranoid: false,
       },
     ],
+    where: {
+      sourceMetadata: {
+        trial: {
+          [Op.is]: null,
+        },
+      },
+      template: false,
+    },
   },
   withViews: (userId: string) => {
     if (!userId) {

--- a/server/routes/api/documents/documents.test.ts
+++ b/server/routes/api/documents/documents.test.ts
@@ -707,6 +707,49 @@ describe("#documents.list", () => {
     expect(body.data.length).toEqual(0);
   });
 
+  it("should return draft documents when filtering with statusFilter", async () => {
+    const user = await buildUser();
+    const document = await buildDraftDocument({
+      userId: user.id,
+      teamId: user.teamId,
+    });
+    const res = await server.post("/api/documents.list", user, {
+      body: {
+        statusFilter: [StatusFilter.Draft],
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.data.length).toEqual(1);
+    expect(body.data[0].id).toEqual(document.id);
+    expect(body.pagination.total).toEqual(1);
+  });
+
+  it("should return drafts shared directly with the user", async () => {
+    const user = await buildUser();
+    const author = await buildUser({ teamId: user.teamId });
+    const document = await buildDraftDocument({
+      userId: author.id,
+      teamId: user.teamId,
+    });
+    await UserMembership.create({
+      documentId: document.id,
+      userId: user.id,
+      createdById: author.id,
+      permission: DocumentPermission.Read,
+    });
+    const res = await server.post("/api/documents.list", user, {
+      body: {
+        statusFilter: [StatusFilter.Draft],
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.data.length).toEqual(1);
+    expect(body.data[0].id).toEqual(document.id);
+    expect(body.pagination.total).toEqual(1);
+  });
+
   it("should not return archived documents", async () => {
     const user = await buildUser();
     const document = await buildDocument({

--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -308,6 +308,16 @@ router.post(
 
     const includeDrafts = !!statusFilter?.includes(StatusFilter.Draft);
 
+    // Switching to the withDrafts scope drops the defaultScope filters, so
+    // re-apply the ones we still want (templates and trial-import documents
+    // should never appear in this listing).
+    if (includeDrafts) {
+      where[Op.and].push({
+        template: false,
+        sourceMetadata: { trial: { [Op.is]: null } },
+      });
+    }
+
     // When sorting by index, pagination is already handled by slicing documentIds,
     // so we skip the SQL-level offset to avoid double-pagination
     const { results: documents, pagination } = await paginateQuery(

--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -244,6 +244,19 @@ router.post(
     }
 
     if (statusFilter?.includes(StatusFilter.Draft)) {
+      // Pre-fetch document IDs the user has a direct membership on so the
+      // filter can be expressed without referencing the (separately-loaded)
+      // memberships association, which would otherwise break the COUNT query.
+      const membershipDocumentIds = (
+        await UserMembership.findAll({
+          attributes: ["documentId"],
+          where: {
+            userId: user.id,
+            documentId: { [Op.ne]: null },
+          },
+        })
+      ).map((m) => m.documentId as string);
+
       statusQuery.push({
         [Op.and]: [
           {
@@ -256,7 +269,7 @@ router.post(
             [Op.or]: [
               // Only ever include draft results for the user's own documents
               { createdById: user.id },
-              { "$memberships.id$": { [Op.ne]: null } },
+              { id: membershipDocumentIds },
             ],
           },
         ],
@@ -293,12 +306,14 @@ router.post(
           : undefined
         : [[sort, direction]];
 
+    const includeDrafts = !!statusFilter?.includes(StatusFilter.Draft);
+
     // When sorting by index, pagination is already handled by slicing documentIds,
     // so we skip the SQL-level offset to avoid double-pagination
     const { results: documents, pagination } = await paginateQuery(
       ctx,
       ({ offset: queryOffset, limit: queryLimit }) =>
-        Document.withMembershipScope(user.id).findAll({
+        Document.withMembershipScope(user.id, { includeDrafts }).findAll({
           where,
           order: orderClause as Order,
           offset: sort === "index" ? 0 : queryOffset,
@@ -307,7 +322,10 @@ router.post(
             documentIds,
           },
         }),
-      () => Document.count({ where })
+      () =>
+        Document.withMembershipScope(user.id, { includeDrafts }).count({
+          where,
+        })
     );
 
     const data = await presentDocuments(ctx, documents);

--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -308,6 +308,16 @@ router.post(
 
     const includeDrafts = !!statusFilter?.includes(StatusFilter.Draft);
 
+    // The withDrafts scope drops the defaultScope filters, so re-apply the
+    // ones we still want — templates and trial-import documents should never
+    // appear in this listing.
+    if (includeDrafts) {
+      where[Op.and].push({
+        template: false,
+        sourceMetadata: { trial: { [Op.is]: null } },
+      });
+    }
+
     // When sorting by index, pagination is already handled by slicing documentIds,
     // so we skip the SQL-level offset to avoid double-pagination
     const { results: documents, pagination } = await paginateQuery(

--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -308,16 +308,6 @@ router.post(
 
     const includeDrafts = !!statusFilter?.includes(StatusFilter.Draft);
 
-    // Switching to the withDrafts scope drops the defaultScope filters, so
-    // re-apply the ones we still want (templates and trial-import documents
-    // should never appear in this listing).
-    if (includeDrafts) {
-      where[Op.and].push({
-        template: false,
-        sourceMetadata: { trial: { [Op.is]: null } },
-      });
-    }
-
     // When sorting by index, pagination is already handled by slicing documentIds,
     // so we skip the SQL-level offset to avoid double-pagination
     const { results: documents, pagination } = await paginateQuery(


### PR DESCRIPTION
## Summary
- `documents.list` with `statusFilter: [Draft]` failed with `SequelizeDatabaseError: missing FROM-clause entry for table "memberships"` because the `count()` query referenced `\$memberships.id\$` in the `WHERE` but had no membership include. The `findAll` was also silently dropping drafts because `withMembershipScope` defaulted to `defaultScope` (which filters `publishedAt != null`).
- Pre-fetch the user's `UserMembership` document IDs and filter by `id IN (...)` instead of using the cross-table `\$memberships.id\$` reference, so both find and count produce valid SQL.
- Pass `includeDrafts: true` to `withMembershipScope` (find and count) when the Draft filter is active.

## Test plan
- [x] Added tests covering drafts created by the user and drafts shared directly with the user; both assert `pagination.total` to exercise the count path.