### PR TITLE
fix: Race condition can cause error calling undo/redo on editor transitioning from readonly.

### DIFF
--- a/app/scenes/Document/components/Document.tsx
+++ b/app/scenes/Document/components/Document.tsx
@@ -155,11 +155,11 @@ function DocumentScene({
 
         if (event.shiftKey) {
           if (!readOnly) {
-            editorRef.current?.commands.redo();
+            editorRef.current?.commands.redo?.();
           }
         } else {
           if (!readOnly) {
-            editorRef.current?.commands.undo();
+            editorRef.current?.commands.undo?.();
           }
         }
       }


### PR DESCRIPTION
Optional-chaining the call (commands.undo?.()) makes it a no-op.