### PR TITLE
fix: correct Safari heading widget handling for Chinese IME

### DIFF
--- a/shared/editor/nodes/Heading.ts
+++ b/shared/editor/nodes/Heading.ts
@@ -207,6 +207,30 @@ export default class Heading extends Node<HeadingOptions> {
       ...options,
       Backspace: backspaceToParagraph(type),
       Enter: splitHeading(type),
+      ArrowLeft: ((state, dispatch) => {
+        if (!isSafari) {
+          return false;
+        }
+
+        const { $from, empty } = state.selection;
+        if (!empty || $from.parent.type !== type) {
+          return false;
+        }
+
+        const end = $from.end();
+        if ($from.pos !== end || !$from.parent.lastChild?.isText) {
+          return false;
+        }
+
+        if (dispatch) {
+          dispatch(
+            state.tr
+              .setSelection(TextSelection.create(state.doc, end - 1))
+              .scrollIntoView()
+          );
+        }
+        return true;
+      }) as Command,
       // Cmd+Left in Firefox lands the DOM caret inside the heading-actions
       // widget (contentEditable=false, ignoreSelection: true), so Prosemirror
       // does not update its model. Subsequent commands like Enter then operate
@@ -287,9 +311,11 @@ export default class Heading extends Node<HeadingOptions> {
               isSafari ? pos + node.nodeSize - 1 : pos + 1,
               container,
               {
-                side: -1,
+                // Safari keeps this widget at the end; positive side preserves IME
+                // insertion order, while relaxed side preserves caret navigation.
+                side: isSafari ? 1 : -1,
                 ignoreSelection: true,
-                relaxedSide: false,
+                relaxedSide: isSafari,
                 key: pos.toString(),
               }
             )


### PR DESCRIPTION
## Summary

Closes #12452 

Fixes a Safari editing bug where Backspace stops working after committing Chinese IME input at the end of a heading.

Safari uses a special placement for the heading actions widget: unlike other browsers, the `heading-actions` widget is placed at the end of the heading. That widget is `contentEditable=false` and is rendered as a ProseMirror widget decoration.

The Safari trailing widget was using `side: -1`, which is better suited to the leading widget placement. With Chinese IME composition at the end of a heading, same-position insertion could interact with the trailing widget and leave the editor
selection stuck. After that, Backspace no longer worked until refresh.

This updates the Safari-only widget metadata and adds a narrow Safari-only ArrowLeft fallback for the exact heading-end widget boundary.

## Regression context

This appears consistent with the Safari heading selection workaround in #11184. That change first appears in `v1.3.0` according to `git tag --contains ec87cb030`.

Earlier Safari heading widget handling in #10671 used a trailing widget shape with positive side / relaxed selection behavior. The later Safari-specific placement kept the widget at the end but used stricter side handling, which appears to expose this
IME composition issue. This fix restores positive side and relaxed selection for the Safari trailing widget, consistent with the original intent in #10671.

## Validation

Manually verified in Safari:

- Type `## ` to create an H2 heading.
- Type `ab`.
- Insert Chinese IME text in the middle, producing `a你好b`.
- Move to the end and insert Chinese IME text, producing `a你好b你好`.
- Backspace works after the IME text is committed.
- Plain English input at the heading end still works.
- Backspace at the beginning of a heading still works.
- Plain ArrowLeft at the end of a heading moves the caret back into heading text.
- Plain Left/Right navigation works after returning to heading text.
- Option+Shift+Left/Right selection in Safari headings still works.

I have only verified Chinese IME. Other composition-based IMEs may be related, but are not claimed as tested in this PR.