### PR TITLE
feat: Add Catalan language option

### DIFF
--- a/shared/i18n/index.ts
+++ b/shared/i18n/index.ts
@@ -9,6 +9,10 @@ type LanguageOption = {
 // locales array in shared/utils/date.ts to enable translation for timestamps.
 export const languageOptions: LanguageOption[] = [
   {
+    label: "Català (Catalan)",
+    value: "ca_ES",
+  },
+  {
     label: "简体中文 (Chinese, Simplified)",
     value: "zh_CN",
   },

--- a/shared/utils/date.ts
+++ b/shared/utils/date.ts
@@ -11,6 +11,7 @@ import {
   parse,
 } from "date-fns";
 import {
+  ca,
   cs,
   de,
   enGB,
@@ -259,6 +260,7 @@ export function getCurrentDateTimeAsString(locale?: Intl.LocalesArgument) {
 }
 
 const locales = {
+  ca_ES: ca,
   cs_CZ: cs,
   de_DE: de,
   en_GB: enGB,


### PR DESCRIPTION
## Summary
- Adds Catalan (ca_ES) to the available language options
- Wires up the date-fns Catalan locale so timestamps localize correctly

The translation file at shared/i18n/locales/ca_ES/translation.json already exists from Crowdin.

## Test plan
- [ ] Verify Catalan appears in the language picker under Settings → Preferences
- [ ] Switch to Catalan and confirm UI strings and relative timestamps render in Catalan

🤖 Generated with [Claude Code](https://claude.com/claude-code)