### PR TITLE
fix: Skip export attachments with malformed key

### DIFF
--- a/server/queues/tasks/ExportDocumentTreeTask.ts
+++ b/server/queues/tasks/ExportDocumentTreeTask.ts
@@ -70,6 +70,17 @@ export default abstract class ExportDocumentTreeTask extends ExportTask {
         key: attachment.key,
       });
 
+      // Skip attachments with a malformed key that has no filename component,
+      // as yazl rejects entries whose path ends with a slash.
+      if (!attachment.key || attachment.key.endsWith("/")) {
+        Logger.warn(`Skipping attachment with invalid key`, {
+          attachmentId: attachment.id,
+          teamId: attachment.teamId,
+          key: attachment.key,
+        });
+        continue;
+      }
+
       const dir = path.dirname(pathInZip);
       let buffer: Buffer;
       try {


### PR DESCRIPTION
## Summary
Attachments whose `key` ends in a trailing slash have no filename component and cause `yazl` to throw `file path cannot end with '/'`, which aborts the entire collection/document export. This change logs a warning and skips such attachments so the export can complete.

## Test plan
- [ ] Export a collection containing a document that references an attachment with a malformed key and confirm the zip is produced without that attachment