### PR TITLE
fix: TypeError when document.collaboratorIds is null

### DIFF
--- a/server/commands/documentCollaborativeUpdater.ts
+++ b/server/commands/documentCollaborativeUpdater.ts
@@ -71,7 +71,7 @@ export default async function documentCollaborativeUpdater({
     const pud = new Y.PermanentUserData(ydoc);
     const pudIds = Array.from(pud.clients.values());
     const collaboratorIds = uniq([
-      ...document.collaboratorIds,
+      ...(document.collaboratorIds ?? []),
       ...sessionCollaboratorIds,
       ...pudIds,
     ]);


### PR DESCRIPTION
## Summary
- Guard against `null` when spreading `document.collaboratorIds` in `documentCollaborativeUpdater`. The DB column has no default and can be NULL on older rows, causing `TypeError: document.collaboratorIds is not iterable` during collaborative persistence.

## Test plan
- [ ] Verify collaborative editing persists without error for documents with NULL `collaboratorIds`

🤖 Generated with [Claude Code](https://claude.com/claude-code)