### PR TITLE
perf: Add missing indexes on foreign keys referencing documents

### DIFF
--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,12 +1,27 @@
+// Mirrors ignorePatterns in .oxlintrc.json. When every staged file matches one
+// of these, oxlint exits with "No files found to lint" and fails the hook.
+const isOxlintIgnored = (file) =>
+  file.includes("/server/migrations/") ||
+  file.includes("/server/scripts/") ||
+  file.includes("/build/") ||
+  file.includes("/public/") ||
+  file.includes("/patches/") ||
+  file.endsWith(".d.ts");
+
 export default {
   // Run prettier first for formatting, then oxlint for linting, and translation updates on changes to JS and
   // TypeScript files
   "**/*.[tj]s?(x)": [
     (f) => `prettier --write ${f.join(" ")}`,
-    (f) =>
-      f.length > 20
+    (f) => {
+      const lintable = f.filter((file) => !isOxlintIgnored(file));
+      if (lintable.length === 0) {
+        return [];
+      }
+      return lintable.length > 20
         ? `yarn lint --fix`
-        : `oxlint ${f.join(" ")} --fix --type-aware`,
+        : `oxlint ${lintable.join(" ")} --fix --type-aware`;
+    },
     () => `yarn build:i18n`,
     () => "git add shared/i18n/locales/en_US/translation.json",
   ],

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,27 +1,15 @@
-// Mirrors ignorePatterns in .oxlintrc.json. When every staged file matches one
-// of these, oxlint exits with "No files found to lint" and fails the hook.
-const isOxlintIgnored = (file) =>
-  file.includes("/server/migrations/") ||
-  file.includes("/server/scripts/") ||
-  file.includes("/build/") ||
-  file.includes("/public/") ||
-  file.includes("/patches/") ||
-  file.endsWith(".d.ts");
+// oxlint exits 1 when every input matches .oxlintrc.json ignorePatterns
+// (e.g. migration-only commits). Swallow that specific case so the hook
+// passes, while still surfacing real lint failures.
+const oxlint = (files) =>
+  `bash -c 'out=$(oxlint ${files.join(" ")} --fix --type-aware 2>&1); rc=$?; printf "%s\\n" "$out"; if [ $rc -ne 0 ] && ! printf "%s" "$out" | grep -q "No files found to lint"; then exit $rc; fi'`;
 
 export default {
   // Run prettier first for formatting, then oxlint for linting, and translation updates on changes to JS and
   // TypeScript files
   "**/*.[tj]s?(x)": [
     (f) => `prettier --write ${f.join(" ")}`,
-    (f) => {
-      const lintable = f.filter((file) => !isOxlintIgnored(file));
-      if (lintable.length === 0) {
-        return [];
-      }
-      return lintable.length > 20
-        ? `yarn lint --fix`
-        : `oxlint ${lintable.join(" ")} --fix --type-aware`;
-    },
+    (f) => (f.length > 20 ? `yarn lint --fix` : oxlint(f)),
     () => `yarn build:i18n`,
     () => "git add shared/i18n/locales/en_US/translation.json",
   ],

--- a/server/migrations/20260526092836-add-document-foreign-key-indexes.js
+++ b/server/migrations/20260526092836-add-document-foreign-key-indexes.js
@@ -1,0 +1,22 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.addIndex("file_operations", ["documentId"], {
+      concurrently: true,
+    });
+    await queryInterface.addIndex("share_subscriptions", ["documentId"], {
+      concurrently: true,
+    });
+    await queryInterface.addIndex("access_requests", ["documentId"], {
+      concurrently: true,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeIndex("access_requests", ["documentId"]);
+    await queryInterface.removeIndex("share_subscriptions", ["documentId"]);
+    await queryInterface.removeIndex("file_operations", ["documentId"]);
+  },
+};


### PR DESCRIPTION
## Summary

Permanent document deletion was running slowly because three tables with `ON DELETE CASCADE` foreign keys to `documents.id` lacked a usable single-column index on the referencing column, forcing a sequential scan on each cascade check:

- `file_operations.documentId` — no index
- `share_subscriptions.documentId` — only present in a composite where `documentId` was not the leading column
- `access_requests.documentId` — only present in a partial index gated on `status='pending'`

Adds the three indexes concurrently in a new migration.

Also tweaks `lint-staged.config.mjs` to skip oxlint when every staged file matches a pattern in `.oxlintrc.json`'s `ignorePatterns` (e.g. migration-only commits), since oxlint exits 1 with "No files found to lint" in that case.

## Test plan

- [ ] `yarn db:migrate` succeeds and the three indexes appear in the referenced tables
- [ ] `EXPLAIN ANALYZE` of a documents DELETE shows index-driven cascade work for the three FKs instead of sequential scans
- [ ] `yarn db:migrate:undo` reverses cleanly