### PR TITLE
fix: Prevent ISE when tsquery tail interleaves operator and escape chars

### DIFF
--- a/plugins/search-postgres/server/PostgresSearchProvider.test.ts
+++ b/plugins/search-postgres/server/PostgresSearchProvider.test.ts
@@ -1412,5 +1412,13 @@ describe("PostgresSearchProvider", () => {
         `"this<->is<->a<->test"`
       );
     });
+    it("should strip interleaved trailing operator and escape characters", () => {
+      // pg-tsquery reorders trailing operators and may emit a tail like
+      // `&\` that, if stripped one character at a time in the wrong order,
+      // leaves a dangling `&` and triggers "no operand in tsquery".
+      expect(PostgresSearchProvider.webSearchQuery(`"plugins"\\&`)).toBe(
+        `"plugins"`
+      );
+    });
   });
 });

--- a/plugins/search-postgres/server/PostgresSearchProvider.ts
+++ b/plugins/search-postgres/server/PostgresSearchProvider.ts
@@ -861,10 +861,10 @@ export default class PostgresSearchProvider extends BaseSearchProvider {
         // spaces. Ref: https://github.com/caub/pg-tsquery/issues/27
         quotedSearch ? limitedQuery.trim() : `${limitedQuery.trim()}*`
       )
-        // Remove any trailing join characters
-        .replace(/&$/, "")
-        // Remove any trailing escape characters
-        .replace(/\\$/, "")
+        // Strip any trailing join (&) or escape (\) characters, in any
+        // combination, so we never hand to_tsquery an operator with no
+        // operand (e.g. a tail of "&\" would leave a dangling "&").
+        .replace(/[&\\]+$/, "")
     );
   }
 


### PR DESCRIPTION
## Summary

`PostgresSearchProvider.webSearchQuery` previously stripped trailing `&` and `\` characters with two sequential single-character regexes. When a user query produced a pg-tsquery tail like `"plugins"&\` (operators reordered by pg-tsquery for inputs such as `"plugins"\&`), the first regex didn't match (last char is `\`), the second stripped only the `\`, leaving a dangling `&` — which Postgres rejected with `no operand in tsquery: ""plugins"&"`, surfacing as an ISE on document search. Collapsed the two strippers into a single character-class regex `/[&\\]+$/` that atomically removes any combination of trailing `&`/`\`.

## Test plan

- [x] Added regression test in `PostgresSearchProvider.test.ts` covering the interleaved-tail case
- [x] All 54 unit tests in `PostgresSearchProvider.test.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)