### PR TITLE
fix: Guard table content changing mid-drag

### DIFF
--- a/shared/editor/nodes/TableHeader.ts
+++ b/shared/editor/nodes/TableHeader.ts
@@ -133,8 +133,7 @@ function setupColumnDragTracking(
 
     if (isDragging && currentToIndex !== fromIndex && isInTable(view.state)) {
       // Verify both indices are still valid for the current table. The document
-      // may have changed during the drag (e.g. collaborative editing) which can
-      // leave the captured fromIndex out of bounds and crash prosemirror-tables.
+      // may have changed during the drag (e.g. collaborative editing)
       const currentCols = getCellsInRow(0)(view.state);
       const inBounds =
         fromIndex >= 0 &&

--- a/shared/editor/nodes/TableHeader.ts
+++ b/shared/editor/nodes/TableHeader.ts
@@ -132,13 +132,25 @@ function setupColumnDragTracking(
     document.body.classList.remove(EditorStyleHelper.tableDragging);
 
     if (isDragging && currentToIndex !== fromIndex && isInTable(view.state)) {
-      const moved = moveTableColumn({ from: fromIndex, to: currentToIndex })(
-        view.state,
-        view.dispatch
-      );
-      if (moved) {
-        // Select the column at its new position
-        selectColumn(currentToIndex)(view.state, view.dispatch);
+      // Verify both indices are still valid for the current table. The document
+      // may have changed during the drag (e.g. collaborative editing) which can
+      // leave the captured fromIndex out of bounds and crash prosemirror-tables.
+      const currentCols = getCellsInRow(0)(view.state);
+      const inBounds =
+        fromIndex >= 0 &&
+        fromIndex < currentCols.length &&
+        currentToIndex >= 0 &&
+        currentToIndex < currentCols.length;
+
+      if (inBounds) {
+        const moved = moveTableColumn({ from: fromIndex, to: currentToIndex })(
+          view.state,
+          view.dispatch
+        );
+        if (moved) {
+          // Select the column at its new position
+          selectColumn(currentToIndex)(view.state, view.dispatch);
+        }
       }
     }
 

--- a/shared/editor/nodes/TableRow.ts
+++ b/shared/editor/nodes/TableRow.ts
@@ -121,8 +121,7 @@ function setupRowDragTracking(
 
     if (isDragging && currentToIndex !== fromIndex && isInTable(view.state)) {
       // Verify both indices are still valid for the current table. The document
-      // may have changed during the drag (e.g. collaborative editing) which can
-      // leave the captured fromIndex out of bounds and crash prosemirror-tables.
+      // may have changed during the drag (e.g. collaborative editing)
       const currentRows = getRowsInTable(view.state);
       const inBounds =
         fromIndex >= 0 &&

--- a/shared/editor/nodes/TableRow.ts
+++ b/shared/editor/nodes/TableRow.ts
@@ -120,13 +120,25 @@ function setupRowDragTracking(
     document.body.classList.remove(EditorStyleHelper.tableDragging);
 
     if (isDragging && currentToIndex !== fromIndex && isInTable(view.state)) {
-      const moved = moveTableRow({ from: fromIndex, to: currentToIndex })(
-        view.state,
-        view.dispatch
-      );
-      if (moved) {
-        // Select the row at its new position
-        selectRow(currentToIndex)(view.state, view.dispatch);
+      // Verify both indices are still valid for the current table. The document
+      // may have changed during the drag (e.g. collaborative editing) which can
+      // leave the captured fromIndex out of bounds and crash prosemirror-tables.
+      const currentRows = getRowsInTable(view.state);
+      const inBounds =
+        fromIndex >= 0 &&
+        fromIndex < currentRows.length &&
+        currentToIndex >= 0 &&
+        currentToIndex < currentRows.length;
+
+      if (inBounds) {
+        const moved = moveTableRow({ from: fromIndex, to: currentToIndex })(
+          view.state,
+          view.dispatch
+        );
+        if (moved) {
+          // Select the row at its new position
+          selectRow(currentToIndex)(view.state, view.dispatch);
+        }
       }
     }
 


### PR DESCRIPTION
If the table updates underneath the user as they are dragging a row or column then it could trigger an error `TypeError: undefined is not an object (evaluating 'o[o.length-1].pos')`