### PR TITLE
fix: Avoid logging error when team not found in apex auth redirect

### DIFF
--- a/server/middlewares/apexAuthRedirect.ts
+++ b/server/middlewares/apexAuthRedirect.ts
@@ -39,8 +39,11 @@ export default function apexAuthRedirect<T>({
       try {
         const team = await Team.findByPk(teamId, {
           attributes: ["id", "domain", "subdomain"],
-          rejectOnEmpty: true,
         });
+
+        if (!team) {
+          return ctx.redirect(getErrorPath(ctx));
+        }
 
         return parseDomain(ctx.host).teamSubdomain === team.subdomain
           ? ctx.redirect("/")


### PR DESCRIPTION
## Summary
- `apexAuthRedirect` middleware called `Team.findByPk` with `rejectOnEmpty: true`, so a stale or invalid teamId in an external auth callback threw `SequelizeEmptyResultError` and was logged at error level.
- Drop `rejectOnEmpty` and treat a missing team as a normal redirect to the error path; genuine DB errors still hit the catch.

## Test plan
- [ ] Hit an external auth callback (e.g. Slack/Notion) with a teamId that doesn't exist and confirm the user is redirected to the error path without a logged error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)