### PR TITLE
feat: Add support for code blocks in comments

### DIFF
--- a/app/scenes/Document/components/Comments/CommentEditor.tsx
+++ b/app/scenes/Document/components/Comments/CommentEditor.tsx
@@ -1,6 +1,7 @@
 import { observer } from "mobx-react";
 import * as React from "react";
 import { basicExtensions, withComments } from "@shared/editor/nodes";
+import CodeBlock from "@shared/editor/nodes/CodeBlock";
 import CodeFence from "@shared/editor/nodes/CodeFence";
 import HardBreak from "@shared/editor/nodes/HardBreak";
 import type { Props as EditorProps } from "~/components/Editor";
@@ -18,6 +19,7 @@ import useCurrentUser from "~/hooks/useCurrentUser";
 
 const extensions = [
   ...withComments(basicExtensions),
+  CodeBlock,
   CodeFence,
   HardBreak,
   SmartText,

--- a/app/scenes/Document/components/Comments/CommentEditor.tsx
+++ b/app/scenes/Document/components/Comments/CommentEditor.tsx
@@ -1,6 +1,7 @@
 import { observer } from "mobx-react";
 import * as React from "react";
 import { basicExtensions, withComments } from "@shared/editor/nodes";
+import CodeFence from "@shared/editor/nodes/CodeFence";
 import HardBreak from "@shared/editor/nodes/HardBreak";
 import type { Props as EditorProps } from "~/components/Editor";
 import Editor from "~/components/Editor";
@@ -17,6 +18,7 @@ import useCurrentUser from "~/hooks/useCurrentUser";
 
 const extensions = [
   ...withComments(basicExtensions),
+  CodeFence,
   HardBreak,
   SmartText,
   PasteHandler,

--- a/server/editor/index.ts
+++ b/server/editor/index.ts
@@ -9,6 +9,7 @@ import {
   richExtensions,
   withComments,
 } from "@shared/editor/nodes";
+import CodeBlock from "@shared/editor/nodes/CodeBlock";
 import CodeFence from "@shared/editor/nodes/CodeFence";
 import Mention from "@shared/editor/nodes/Mention";
 
@@ -57,7 +58,7 @@ export const basicParser = basicExtensionManager.parser({
   plugins: basicExtensionManager.rulePlugins,
 });
 
-const commentExtensions = [...basicExtensions, CodeFence, Mention];
+const commentExtensions = [...basicExtensions, CodeBlock, CodeFence, Mention];
 export const commentExtensionManager = new ExtensionManager(commentExtensions);
 
 export const commentSchema = new Schema({

--- a/server/editor/index.ts
+++ b/server/editor/index.ts
@@ -9,6 +9,7 @@ import {
   richExtensions,
   withComments,
 } from "@shared/editor/nodes";
+import CodeFence from "@shared/editor/nodes/CodeFence";
 import Mention from "@shared/editor/nodes/Mention";
 
 populateEmojiData(data as EmojiMartData);
@@ -56,7 +57,7 @@ export const basicParser = basicExtensionManager.parser({
   plugins: basicExtensionManager.rulePlugins,
 });
 
-const commentExtensions = [...basicExtensions, Mention];
+const commentExtensions = [...basicExtensions, CodeFence, Mention];
 export const commentExtensionManager = new ExtensionManager(commentExtensions);
 
 export const commentSchema = new Schema({


### PR DESCRIPTION
Previously supplying a code block via the API would result in ISE