### PR TITLE
fix: Retry Notion API 5xx errors with exponential backoff

### DIFF
--- a/plugins/notion/server/notion.ts
+++ b/plugins/notion/server/notion.ts
@@ -6,6 +6,7 @@ import {
   isFullPageOrDatabase,
   isFullUser,
   RequestTimeoutError,
+  UnknownHTTPResponseError,
 } from "@notionhq/client";
 import type {
   BlockObjectResponse,
@@ -60,6 +61,7 @@ export class NotionClient {
   private limiter: ReturnType<typeof RateLimit>;
   private pageSize = 100;
   private maxRetries = 3;
+  private maxServerErrorRetries = 8;
   private retryDelay = 1000;
   private skipChildrenForBlock = [
     "unsupported",
@@ -94,6 +96,7 @@ export class NotionClient {
    */
   private async fetchWithRetry<T>(apiCall: () => Promise<T>): Promise<T> {
     let retries = 0;
+    let serverErrorRetries = 0;
 
     // oxlint-disable-next-line no-constant-condition
     while (true) {
@@ -145,6 +148,32 @@ export class NotionClient {
 
           Logger.warn(
             `Notion API rate limit exceeded after ${this.maxRetries} retries`,
+            { error: error.message }
+          );
+        }
+
+        // Check if this is a server-side error (5xx) — Notion's API can be
+        // unreliable, so retry these for longer with exponential backoff.
+        if (
+          (error instanceof APIResponseError ||
+            error instanceof UnknownHTTPResponseError) &&
+          error.status >= 500
+        ) {
+          if (serverErrorRetries < this.maxServerErrorRetries) {
+            serverErrorRetries++;
+            const delay = this.retryDelay * 2 ** (serverErrorRetries - 1);
+            Logger.info(
+              "task",
+              `Notion API returned ${error.status}, retrying in ${delay}ms (retry ${serverErrorRetries}/${this.maxServerErrorRetries})`
+            );
+
+            // Wait before retrying
+            await new Promise((resolve) => setTimeout(resolve, delay));
+            continue;
+          }
+
+          Logger.warn(
+            `Notion API returned ${error.status} after ${this.maxServerErrorRetries} retries`,
             { error: error.message }
           );
         }


### PR DESCRIPTION
Notion's API returns transient 5xx errors (e.g. 502) during imports that previously aborted the entire task. The Notion client now retries any 5xx response up to 8 times with exponential backoff (1s → 128s), tracked separately from the existing timeout and rate-limit retry budgets so a run of server errors doesn't starve other retries.
