### PR TITLE
fix: Make search highlight chip clickable in desktop app

### DIFF
--- a/app/scenes/Document/components/SearchHighlightChip.tsx
+++ b/app/scenes/Document/components/SearchHighlightChip.tsx
@@ -6,6 +6,7 @@ import styled from "styled-components";
 import { ellipsis } from "@shared/styles";
 import { useDocumentContext } from "~/components/DocumentContext";
 import Tooltip from "~/components/Tooltip";
+import { undraggableOnDesktop } from "~/styles";
 
 export function SearchHighlightChip() {
   const { t } = useTranslation();
@@ -50,6 +51,7 @@ export function SearchHighlightChip() {
 }
 
 const Chip = styled.button`
+  ${undraggableOnDesktop()}
   display: inline-flex;
   align-items: center;
   gap: 2px;


### PR DESCRIPTION
The search highlight chip in the document header sits inside the header's `-webkit-app-region: drag` region, so clicks were swallowed by the Electron titlebar drag handler. Applies the existing `undraggableOnDesktop()` mixin to the chip button, matching how other interactive header elements (Button, Breadcrumb, etc.) opt out of the drag region.