### PR TITLE
fix: Skip Sentry capture for expected websocket "No access token" error

### DIFF
--- a/app/components/WebsocketProvider.tsx
+++ b/app/components/WebsocketProvider.tsx
@@ -96,6 +96,10 @@ function useConnectionHandlers() {
 
       toast.error(message);
 
+      if (message === "No access token") {
+        return;
+      }
+
       if (err instanceof Error) {
         Sentry.captureException(err);
       } else {


### PR DESCRIPTION
## Summary
The websocket server emits an `unauthorized` event with message `"No access token"` whenever a client connects without an auth cookie — an expected state, not a bug. Skip the `Sentry.captureException` call for that specific message; other unauthorized variants (bad/expired JWT, etc.) are still reported, and the toast continues to surface it to the user.

## Test plan
- [ ] Connect a websocket while logged out and verify no Sentry event is recorded
- [ ] Confirm other `unauthorized` payloads still reach Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)