### PR TITLE
fix: Show upload progress on import dialog button

### DIFF
--- a/app/scenes/Settings/components/DropToImport.tsx
+++ b/app/scenes/Settings/components/DropToImport.tsx
@@ -149,7 +149,9 @@ function DropToImport({ disabled, onSubmit, children, format }: Props) {
       <Flex justify="flex-end">
         <Button disabled={!file || isImporting} onClick={handleStartImport}>
           {isImporting
-            ? `${t("Uploading")} ${Math.round(uploadProgress * 100)}%`
+            ? t("Uploading {{progress}}%", {
+                progress: Math.min(99, Math.floor(uploadProgress * 100)),
+              })
             : t("Start import")}
         </Button>
       </Flex>

--- a/app/scenes/Settings/components/DropToImport.tsx
+++ b/app/scenes/Settings/components/DropToImport.tsx
@@ -35,6 +35,7 @@ function DropToImport({ disabled, onSubmit, children, format }: Props) {
   const { collections, imports } = useStores();
   const [file, setFile] = useState<File | null>(null);
   const [isImporting, setImporting] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState(0);
   const [permission, setPermission] = useState<CollectionPermission | null>(
     CollectionPermission.ReadWrite
   );
@@ -52,11 +53,13 @@ function DropToImport({ disabled, onSubmit, children, format }: Props) {
       return;
     }
     setImporting(true);
+    setUploadProgress(0);
 
     try {
       const attachment = await uploadFile(file, {
         name: file.name,
         preset: AttachmentPreset.WorkspaceImport,
+        onProgress: (progress) => setUploadProgress(progress),
       });
 
       if (format === FileOperationFormat.MarkdownZip) {
@@ -89,6 +92,7 @@ function DropToImport({ disabled, onSubmit, children, format }: Props) {
       toast.error(err.message);
     } finally {
       setImporting(false);
+      setUploadProgress(0);
     }
   };
 
@@ -144,7 +148,9 @@ function DropToImport({ disabled, onSubmit, children, format }: Props) {
       </div>
       <Flex justify="flex-end">
         <Button disabled={!file || isImporting} onClick={handleStartImport}>
-          {isImporting ? t("Uploading") + "…" : t("Start import")}
+          {isImporting
+            ? `${t("Uploading")} ${Math.round(uploadProgress * 100)}%`
+            : t("Start import")}
         </Button>
       </Flex>
     </Flex>

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -1162,6 +1162,7 @@
   "Your import is being processed, you can safely leave this page": "Your import is being processed, you can safely leave this page",
   "File not supported – please upload a valid ZIP file": "File not supported – please upload a valid ZIP file",
   "Set the default permission level for collections created from the import": "Set the default permission level for collections created from the import",
+  "Uploading {{progress}}%": "Uploading {{progress}}%",
   "Start import": "Start import",
   "Added by": "Added by",
   "Date added": "Date added",


### PR DESCRIPTION
## Summary
- Track upload progress via the existing `onProgress` callback on `uploadFile` and display it as a percentage on the disabled Start Import button while the file uploads.

## Test plan
- [ ] Open Settings → Import, drop a sizeable zip file, click Start import, and confirm the button shows "Uploading N%" counting up to 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)