### PR TITLE
fix: Guard against out-of-range position in scrollToAnchor

### DIFF
--- a/app/editor/index.tsx
+++ b/app/editor/index.tsx
@@ -572,12 +572,18 @@ export class Editor extends React.PureComponent<
       this.mutationObserver = observe(
         hash,
         (element) => {
-          const pos = this.view.posAtDOM(element, 0, 1);
-          this.view.dispatch(
-            this.view.state.tr.setSelection(
-              TextSelection.near(this.view.state.doc.resolve(pos), 1)
-            )
-          );
+          try {
+            const pos = this.view.posAtDOM(element, 0, 1);
+            if (pos >= 0 && pos <= this.view.state.doc.content.size) {
+              this.view.dispatch(
+                this.view.state.tr.setSelection(
+                  TextSelection.near(this.view.state.doc.resolve(pos), 1)
+                )
+              );
+            }
+          } catch (_err) {
+            // posAtDOM may throw if the element is not part of the editor doc
+          }
 
           if (isVisible(element)) {
             element.scrollIntoView();


### PR DESCRIPTION
## Summary
- Fixes an uncaught `RangeError: Position -1 out of range` thrown from the editor's `scrollToAnchor` MutationObserver callback.
- `view.posAtDOM` could resolve to a position outside the document when the matched anchor element lived inside a node view, and `doc.resolve(pos)` then threw. The pre-existing `try/catch` only wrapped observer setup, not the async callback.
- Adds a bounds check on `pos` and wraps the selection logic in `try/catch` so `scrollIntoView` still runs.

## Test plan
- [ ] Navigate to a document URL with a `#hash` anchor that resolves to a heading inside a node view and confirm no error is thrown
- [ ] Confirm normal in-document anchor scroll still selects and scrolls into view

🤖 Generated with [Claude Code](https://claude.com/claude-code)