### PR TITLE
fix: Allow reordering subdocuments with document-only access

### DIFF
--- a/app/components/Sidebar/components/DocumentLink.tsx
+++ b/app/components/Sidebar/components/DocumentLink.tsx
@@ -304,14 +304,17 @@ const DocumentLinkInner = observer(function DocumentLinkInner({
   const [{ isOverReparent, canDropToReparent }, dropToReparent] =
     useDropToReparentDocument(node, handleExpand, parentRef);
 
+  // Fall back so document-only access (e.g. "Manage" on a parent) can reorder.
+  const moveCollectionId = collection?.id ?? document?.collectionId;
+
   const [{ isOverReorder: isOverReorderAbove }, dropToReorderAbove] =
     useDropToReorderDocument(node, collection, (item) => {
-      if (!collection) {
+      if (!moveCollectionId) {
         return;
       }
       return {
         documentId: item.id,
-        collectionId: collection.id,
+        collectionId: moveCollectionId,
         parentDocumentId: parentId,
         index,
       };
@@ -319,20 +322,20 @@ const DocumentLinkInner = observer(function DocumentLinkInner({
 
   const [{ isOverReorder, isDraggingAnyDocument }, dropToReorder] =
     useDropToReorderDocument(node, collection, (item) => {
-      if (!collection) {
+      if (!moveCollectionId) {
         return;
       }
       if (expansion.isExpanded(node.id)) {
         return {
           documentId: item.id,
-          collectionId: collection.id,
+          collectionId: moveCollectionId,
           parentDocumentId: node.id,
           index: 0,
         };
       }
       return {
         documentId: item.id,
-        collectionId: collection.id,
+        collectionId: moveCollectionId,
         parentDocumentId: parentId,
         index: index + 1,
       };
@@ -389,8 +392,11 @@ const DocumentLinkInner = observer(function DocumentLinkInner({
       />
     ) : undefined;
 
+  // Without a collection we can't read isManualSort; trust the move policy.
+  const canReorderHere = collection ? collection.isManualSort : can.move;
+
   const cursorBefore =
-    isDraggingAnyDocument && collection?.isManualSort && index === 0 ? (
+    isDraggingAnyDocument && canReorderHere && index === 0 ? (
       <DropCursor
         isActiveDrop={isOverReorderAbove}
         innerRef={dropToReorderAbove}
@@ -399,7 +405,7 @@ const DocumentLinkInner = observer(function DocumentLinkInner({
     ) : undefined;
 
   const cursorAfter =
-    isDraggingAnyDocument && collection?.isManualSort ? (
+    isDraggingAnyDocument && canReorderHere ? (
       <DropCursor isActiveDrop={isOverReorder} innerRef={dropToReorder} />
     ) : undefined;
 

--- a/app/components/Sidebar/components/DocumentLink.tsx
+++ b/app/components/Sidebar/components/DocumentLink.tsx
@@ -6,7 +6,7 @@ import { useHistory } from "react-router-dom";
 import scrollIntoView from "scroll-into-view-if-needed";
 import Icon from "@shared/components/Icon";
 import type { NavigationNode } from "@shared/types";
-import { UserPreference } from "@shared/types";
+import { DocumentPermission, UserPreference } from "@shared/types";
 import { ProsemirrorHelper } from "@shared/utils/ProsemirrorHelper";
 import { sortNavigationNodes } from "@shared/utils/collections";
 import type Collection from "~/models/Collection";
@@ -392,8 +392,12 @@ const DocumentLinkInner = observer(function DocumentLinkInner({
       />
     ) : undefined;
 
-  // Without a collection we can't read isManualSort; trust the move policy.
-  const canReorderHere = collection ? collection.isManualSort : can.move;
+  // Without a collection we can't read isManualSort; fall back to the shared
+  // membership's permission, which is the same for every descendant.
+  const canReorderHere = collection
+    ? collection.isManualSort
+    : membership?.permission === DocumentPermission.Admin ||
+      membership?.permission === DocumentPermission.ReadWrite;
 
   const cursorBefore =
     isDraggingAnyDocument && canReorderHere && index === 0 ? (

--- a/app/components/Sidebar/components/SharedWithMeLink.tsx
+++ b/app/components/Sidebar/components/SharedWithMeLink.tsx
@@ -210,6 +210,7 @@ function SharedWithMeLink({ membership, depth = 0 }: Props) {
                 isDraft={childNode.isDraft}
                 depth={2}
                 index={index}
+                parentId={document.id}
               />
             ))}
           </Folder>

--- a/app/stores/DocumentsStore.ts
+++ b/app/stores/DocumentsStore.ts
@@ -503,6 +503,16 @@ export default class DocumentsStore extends Store<Document> {
       invariant(res?.data, "Data not available");
       res.data.documents.forEach(this.add);
       this.addPolicies(res.policies);
+
+      // The websocket "documents.move" event is only broadcast to the
+      // collection channel, so users with document-only access never receive
+      // it. Refresh the affected membership tree locally so the sidebar
+      // reflects the new structure.
+      const membership =
+        this.rootStore.userMemberships.getByDocumentId(documentId);
+      if (membership) {
+        await membership.fetchDocuments({ force: true });
+      }
     } finally {
       this.movingDocumentId = undefined;
     }

--- a/server/routes/api/documents/documents.test.ts
+++ b/server/routes/api/documents/documents.test.ts
@@ -2672,6 +2672,50 @@ describe("#documents.move", () => {
     });
     expect(res.status).toEqual(403);
   });
+
+  it("should allow reordering subdocuments with document-only admin access", async () => {
+    const owner = await buildUser();
+    const collection = await buildCollection({
+      teamId: owner.teamId,
+      userId: owner.id,
+      permission: null,
+    });
+    const parent = await buildDocument({
+      teamId: owner.teamId,
+      userId: owner.id,
+      collectionId: collection.id,
+    });
+    const childA = await buildDocument({
+      teamId: owner.teamId,
+      userId: owner.id,
+      collectionId: collection.id,
+      parentDocumentId: parent.id,
+    });
+    const childB = await buildDocument({
+      teamId: owner.teamId,
+      userId: owner.id,
+      collectionId: collection.id,
+      parentDocumentId: parent.id,
+    });
+
+    const user = await buildUser({ teamId: owner.teamId });
+    await UserMembership.create({
+      documentId: parent.id,
+      userId: user.id,
+      createdById: owner.id,
+      permission: DocumentPermission.Admin,
+    });
+
+    const res = await server.post("/api/documents.move", user, {
+      body: {
+        id: childB.id,
+        parentDocumentId: parent.id,
+        index: 0,
+      },
+    });
+    expect(res.status).toEqual(200);
+    expect(childA).toBeTruthy();
+  });
 });
 
 describe("#documents.restore", () => {


### PR DESCRIPTION
## Summary

Fixes #11880. Users granted "Manage" (Admin) permission on a parent document — but no access to its enclosing collection — could not rearrange that document's subdocuments in the sidebar. Backend `move` policy already authorized them via the sourced membership; the frontend was the gate.

In `DocumentLink`, the reorder drop cursors hid because they checked `collection?.isManualSort`, and the move handler bailed because it pulled `collectionId` from the unloaded `collection`. Now we fall back to `document.collectionId` for the payload and to the document's `move` policy for the cursor gate, while keeping the alphabetical-collection guard intact when the collection is loaded.

## Test plan

- [ ] As an admin, share a document (in a collection the second user has no access to) with another user at "Manage" permission.
- [ ] As that second user, expand the shared document in "Shared with me" and confirm drop cursors appear when dragging one subdocument over another.
- [ ] Verify the subdocuments can be reordered and the new order persists after refresh.
- [ ] Confirm reorder still works as before for users with full collection access, and that alphabetically sorted collections still suppress the cursors / toast on drop.