### PR TITLE
fix: Reject image/video dimension promises with real Error

### DIFF
--- a/shared/editor/lib/FileHelper.ts
+++ b/shared/editor/lib/FileHelper.ts
@@ -80,7 +80,10 @@ export default class FileHelper {
         window.URL.revokeObjectURL(video.src);
         resolve({ width: video.videoWidth, height: video.videoHeight });
       };
-      video.onerror = reject;
+      video.onerror = () => {
+        window.URL.revokeObjectURL(video.src);
+        reject(new Error("Failed to load video for dimensions"));
+      };
       video.src = URL.createObjectURL(file);
     });
   }
@@ -154,7 +157,10 @@ export default class FileHelper {
         resolve({ width: img.width, height: img.height });
       };
 
-      img.onerror = reject;
+      img.onerror = () => {
+        window.URL.revokeObjectURL(img.src);
+        reject(new Error("Failed to load image for dimensions"));
+      };
       img.src = URL.createObjectURL(file);
     });
   }


### PR DESCRIPTION
## Summary
The `onerror` handlers in `FileHelper.getImageDimensions` and `getVideoDimensions` passed the raw DOM `Event` straight to `reject`, which Sentry surfaced as opaque "Event captured as promise rejection" reports with no stack. They now reject with a real `Error` and revoke the blob URL on failure.

## Test plan
- [ ] Trigger a corrupt/unsupported image upload and confirm the rejection has a proper message and stack in Sentry