### PR TITLE
fix: Normalize IP addresses to avoid validation errors

### DIFF
--- a/server/models/Event.ts
+++ b/server/models/Event.ts
@@ -20,6 +20,7 @@ import {
 import { globalEventQueue } from "../queues";
 import type { APIContext } from "../types";
 import { AuthenticationType } from "../types";
+import { normalizeIp } from "../utils/ip";
 import Collection from "./Collection";
 import Document from "./Document";
 import Team from "./Team";
@@ -75,10 +76,7 @@ class Event extends IdModel<
 
   @BeforeCreate
   static cleanupIp(model: Event) {
-    if (model.ip) {
-      // cleanup IPV6 representations of IPV4 addresses
-      model.ip = model.ip.replace(/^::ffff:/, "");
-    }
+    model.ip = normalizeIp(model.ip);
   }
 
   @AfterSave

--- a/server/models/User.test.ts
+++ b/server/models/User.test.ts
@@ -76,6 +76,30 @@ describe("user model", () => {
     });
   });
 
+  describe("ip setters", () => {
+    it("normalizes lastActiveIp and lastSignedInIp on assignment", async () => {
+      const user = await buildUser();
+
+      user.lastActiveIp = "::ffff:127.0.0.1";
+      user.lastSignedInIp = "203.0.113.1, 70.41.3.18";
+      await user.save({ hooks: false });
+
+      expect(user.lastActiveIp).toBe("127.0.0.1");
+      expect(user.lastSignedInIp).toBe("203.0.113.1");
+    });
+
+    it("nulls out invalid IP values without failing validation", async () => {
+      const user = await buildUser();
+
+      user.lastActiveIp = "unknown";
+      user.lastSignedInIp = "not-an-ip";
+      await expect(user.save({ hooks: false })).resolves.toBeDefined();
+
+      expect(user.lastActiveIp).toBeNull();
+      expect(user.lastSignedInIp).toBeNull();
+    });
+  });
+
   describe("destroy", () => {
     it("should clear PII", async () => {
       const user = await buildUser();

--- a/server/models/User.ts
+++ b/server/models/User.ts
@@ -170,14 +170,15 @@ class User extends ParanoidModel<
   lastActiveAt: Date | null;
 
   @IsIP
-  @Column({
-    type: DataType.STRING,
-    set(this: User, value: string | null) {
-      this.setDataValue("lastActiveIp", normalizeIp(value));
-    },
-  })
   @SkipChangeset
-  lastActiveIp: string | null;
+  @Column(DataType.STRING)
+  get lastActiveIp(): string | null {
+    return this.getDataValue("lastActiveIp");
+  }
+
+  set lastActiveIp(value: string | null) {
+    this.setDataValue("lastActiveIp", normalizeIp(value));
+  }
 
   @IsDate
   @Column
@@ -185,14 +186,15 @@ class User extends ParanoidModel<
   lastSignedInAt: Date | null;
 
   @IsIP
-  @Column({
-    type: DataType.STRING,
-    set(this: User, value: string | null) {
-      this.setDataValue("lastSignedInIp", normalizeIp(value));
-    },
-  })
   @SkipChangeset
-  lastSignedInIp: string | null;
+  @Column(DataType.STRING)
+  get lastSignedInIp(): string | null {
+    return this.getDataValue("lastSignedInIp");
+  }
+
+  set lastSignedInIp(value: string | null) {
+    this.setDataValue("lastSignedInIp", normalizeIp(value));
+  }
 
   @IsDate
   @Column

--- a/server/models/User.ts
+++ b/server/models/User.ts
@@ -54,6 +54,7 @@ import type { APIContext } from "@server/types";
 import { VerificationCode } from "@server/utils/VerificationCode";
 import parseAttachmentIds from "@server/utils/parseAttachmentIds";
 import { CacheHelper } from "@server/utils/CacheHelper";
+import { normalizeIp } from "@server/utils/ip";
 import { RedisPrefixHelper } from "@server/utils/RedisPrefixHelper";
 import { ValidationError } from "../errors";
 import Attachment from "./Attachment";
@@ -169,7 +170,12 @@ class User extends ParanoidModel<
   lastActiveAt: Date | null;
 
   @IsIP
-  @Column
+  @Column({
+    type: DataType.STRING,
+    set(this: User, value: string | null) {
+      this.setDataValue("lastActiveIp", normalizeIp(value));
+    },
+  })
   @SkipChangeset
   lastActiveIp: string | null;
 
@@ -179,7 +185,12 @@ class User extends ParanoidModel<
   lastSignedInAt: Date | null;
 
   @IsIP
-  @Column
+  @Column({
+    type: DataType.STRING,
+    set(this: User, value: string | null) {
+      this.setDataValue("lastSignedInIp", normalizeIp(value));
+    },
+  })
   @SkipChangeset
   lastSignedInIp: string | null;
 

--- a/server/utils/ip.test.ts
+++ b/server/utils/ip.test.ts
@@ -1,0 +1,38 @@
+import { normalizeIp } from "./ip";
+
+describe("normalizeIp", () => {
+  it("returns null for nullish or empty input", () => {
+    expect(normalizeIp(null)).toBeNull();
+    expect(normalizeIp(undefined)).toBeNull();
+    expect(normalizeIp("")).toBeNull();
+    expect(normalizeIp("   ")).toBeNull();
+  });
+
+  it("returns valid IPv4 unchanged", () => {
+    expect(normalizeIp("192.168.1.1")).toBe("192.168.1.1");
+  });
+
+  it("returns valid IPv6 unchanged", () => {
+    expect(normalizeIp("2001:db8::1")).toBe("2001:db8::1");
+  });
+
+  it("strips ::ffff: IPv4-mapped IPv6 prefix", () => {
+    expect(normalizeIp("::ffff:127.0.0.1")).toBe("127.0.0.1");
+  });
+
+  it("strips IPv6 zone identifier", () => {
+    expect(normalizeIp("fe80::1%eth0")).toBe("fe80::1");
+  });
+
+  it("takes the first entry from an X-Forwarded-For chain", () => {
+    expect(normalizeIp("203.0.113.1, 70.41.3.18, 150.172.238.178")).toBe(
+      "203.0.113.1"
+    );
+  });
+
+  it("returns null for non-IP values", () => {
+    expect(normalizeIp("unknown")).toBeNull();
+    expect(normalizeIp("not-an-ip")).toBeNull();
+    expect(normalizeIp("999.999.999.999")).toBeNull();
+  });
+});

--- a/server/utils/ip.ts
+++ b/server/utils/ip.ts
@@ -1,0 +1,27 @@
+import net from "node:net";
+
+/**
+ * Normalize an IP address string for storage in audit columns.
+ *
+ * Handles common upstream-proxy artifacts that would otherwise fail
+ * Sequelize's `isIP` validation: IPv4-mapped IPv6 prefixes, IPv6 zone
+ * identifiers, and `X-Forwarded-For` chains. Returns `null` for any
+ * value that is not a valid IPv4 or IPv6 address after normalization.
+ *
+ * @param value the raw IP string (e.g. from `ctx.request.ip`).
+ * @returns a valid IP string, or `null`.
+ */
+export function normalizeIp(value: string | null | undefined): string | null {
+  if (!value || typeof value !== "string") {
+    return null;
+  }
+
+  let ip = value.split(",")[0]?.trim() ?? "";
+  ip = ip.replace(/^::ffff:/i, "");
+  const zoneIndex = ip.indexOf("%");
+  if (zoneIndex !== -1) {
+    ip = ip.slice(0, zoneIndex);
+  }
+
+  return net.isIP(ip) !== 0 ? ip : null;
+}


### PR DESCRIPTION
## Summary

`SequelizeValidationError: Validation isIP on ip failed` was firing on `Event` and `User` writes when Koa's `ctx.request.ip` returned values that fail `validator.isIP()`, IPv6 zone identifiers (`fe80::1%eth0`), or `"unknown"` from misconfigured upstream proxies.

A new `normalizeIp` helper strips the `::ffff:` IPv4-mapped prefix, takes the first entry of an XFF chain, drops zone IDs, and returns `null` for anything that still isn't a valid IPv4/IPv6 address.

The Event model's existing `cleanupIp` hook now delegates to it, and `User.lastActiveIp` / `lastSignedInIp` get column-level `set` callbacks (chosen over `@BeforeSave` because both write paths use `save({ hooks: false })`, which skips hooks but still runs validators). Net effect: a malformed proxy header drops the optional IP metadata silently instead of throwing a 500.
