### PR TITLE
fix: Allow service worker to load on custom domains

### DIFF
--- a/package.json
+++ b/package.json
@@ -307,7 +307,6 @@
     "@types/katex": "^0.16.8",
     "@types/koa": "^2.15.1",
     "@types/koa-compress": "^4.0.7",
-    "@types/koa-helmet": "^6.0.8",
     "@types/koa-logger": "^3.1.5",
     "@types/koa-mount": "^4.0.5",
     "@types/koa-router": "^7.4.9",

--- a/server/middlewares/csp.ts
+++ b/server/middlewares/csp.ts
@@ -84,30 +84,31 @@ export default function createCSPMiddleware(options?: CSPOptions) {
   return function cspMiddleware(ctx: Context, next: Next) {
     ctx.state.cspNonce = crypto.randomBytes(16).toString("hex");
 
-    return contentSecurityPolicy({
-      directives: {
-        baseUri: ["'none'"],
-        defaultSrc,
-        styleSrc,
-        scriptSrc: [
-          // Allow the service worker to load on custom domains, where the
-          // document origin differs from env.URL / env.CDN_URL. worker-src
-          // falls back to script-src and 'self' matches the document origin.
-          "'self'",
-          ...uniq(scriptSrc),
-          ...(options?.extraScriptSrc ?? []),
-          env.DEVELOPMENT_UNSAFE_INLINE_CSP
-            ? "'unsafe-inline'"
-            : `'nonce-${ctx.state.cspNonce}'`,
-        ],
-        mediaSrc: ["*", "data:", "blob:"],
-        imgSrc: ["*", "data:", "blob:"],
-        frameSrc: ["*", "data:"],
-        objectSrc,
-        // Do not use connect-src: because self + websockets does not work in
-        // Safari, ref: https://bugs.webkit.org/show_bug.cgi?id=201591
-        connectSrc: ["*"],
-      },
-    })(ctx, next);
+    // Note: workerSrc is included even though it's missing from the koa-helmet
+    // type definitions — the underlying helmet supports it. The service worker
+    // is served from the same origin as the document, which may be a custom
+    // domain that is not present in scriptSrc.
+    const directives = {
+      baseUri: ["'none'"],
+      defaultSrc,
+      styleSrc,
+      scriptSrc: [
+        ...uniq(scriptSrc),
+        ...(options?.extraScriptSrc ?? []),
+        env.DEVELOPMENT_UNSAFE_INLINE_CSP
+          ? "'unsafe-inline'"
+          : `'nonce-${ctx.state.cspNonce}'`,
+      ],
+      mediaSrc: ["*", "data:", "blob:"],
+      imgSrc: ["*", "data:", "blob:"],
+      frameSrc: ["*", "data:"],
+      workerSrc: ["'self'"],
+      objectSrc,
+      // Do not use connect-src: because self + websockets does not work in
+      // Safari, ref: https://bugs.webkit.org/show_bug.cgi?id=201591
+      connectSrc: ["*"],
+    };
+
+    return contentSecurityPolicy({ directives })(ctx, next);
   };
 }

--- a/server/middlewares/csp.ts
+++ b/server/middlewares/csp.ts
@@ -99,6 +99,9 @@ export default function createCSPMiddleware(options?: CSPOptions) {
         mediaSrc: ["*", "data:", "blob:"],
         imgSrc: ["*", "data:", "blob:"],
         frameSrc: ["*", "data:"],
+        // Service worker is served from the same origin as the document, which
+        // may be a custom domain that is not present in scriptSrc.
+        workerSrc: ["'self'"],
         objectSrc,
         // Do not use connect-src: because self + websockets does not work in
         // Safari, ref: https://bugs.webkit.org/show_bug.cgi?id=201591

--- a/server/middlewares/csp.ts
+++ b/server/middlewares/csp.ts
@@ -90,6 +90,10 @@ export default function createCSPMiddleware(options?: CSPOptions) {
         defaultSrc,
         styleSrc,
         scriptSrc: [
+          // Allow the service worker to load on custom domains, where the
+          // document origin differs from env.URL / env.CDN_URL. worker-src
+          // falls back to script-src and 'self' matches the document origin.
+          "'self'",
           ...uniq(scriptSrc),
           ...(options?.extraScriptSrc ?? []),
           env.DEVELOPMENT_UNSAFE_INLINE_CSP
@@ -99,9 +103,6 @@ export default function createCSPMiddleware(options?: CSPOptions) {
         mediaSrc: ["*", "data:", "blob:"],
         imgSrc: ["*", "data:", "blob:"],
         frameSrc: ["*", "data:"],
-        // Service worker is served from the same origin as the document, which
-        // may be a custom domain that is not present in scriptSrc.
-        workerSrc: ["'self'"],
         objectSrc,
         // Do not use connect-src: because self + websockets does not work in
         // Safari, ref: https://bugs.webkit.org/show_bug.cgi?id=201591

--- a/yarn.lock
+++ b/yarn.lock
@@ -6919,17 +6919,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/koa-helmet@npm:^6.0.8":
-  version: 6.0.8
-  resolution: "@types/koa-helmet@npm:6.0.8"
-  dependencies:
-    "@types/koa": "npm:*"
-    "@types/node": "npm:*"
-    helmet: "npm:^4.0.0"
-  checksum: 10c0/73c2ad0b37561b399e9493cf5ca2dccc0e37c3ea5da3cd281685728a242bc63f1b83d77838ff2ec616fad023e79c0f3a74ca935c740c4cc3c63a1fed3c27fe84
-  languageName: node
-  linkType: hard
-
 "@types/koa-logger@npm:^3.1.5":
   version: 3.1.5
   resolution: "@types/koa-logger@npm:3.1.5"
@@ -11869,7 +11858,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"helmet@npm:^4.0.0, helmet@npm:^4.4.1":
+"helmet@npm:^4.4.1":
   version: 4.6.0
   resolution: "helmet@npm:4.6.0"
   checksum: 10c0/fe0d986fc465be0f652e67dd1feab576d9b08b797846fdac5719d5ca857977d6b1712327223a7c25695104dfde118fdf303f4a18efca7cddf0159821bf36b7f8
@@ -15132,7 +15121,6 @@ __metadata:
     "@types/katex": "npm:^0.16.8"
     "@types/koa": "npm:^2.15.1"
     "@types/koa-compress": "npm:^4.0.7"
-    "@types/koa-helmet": "npm:^6.0.8"
     "@types/koa-logger": "npm:^3.1.5"
     "@types/koa-mount": "npm:^4.0.5"
     "@types/koa-router": "npm:^7.4.9"


### PR DESCRIPTION
## Summary

Add an explicit `worker-src 'self'` directive to the CSP so the service worker can register on team custom domains. Previously browsers fell back to `script-src`, which only includes `env.URL` and `env.CDN_URL`, blocking `/static/sw.js` on hosts like `docs.getoutline.com`.

## Test plan

- [ ] Visit a team using a custom domain and confirm the service worker registers without a CSP violation in the console.