### PR TITLE
fix: Avoid team invariant violation on OAuth authorize error

### DIFF
--- a/app/scenes/Login/OAuthAuthorize.tsx
+++ b/app/scenes/Login/OAuthAuthorize.tsx
@@ -76,7 +76,7 @@ function inputScopes(scope?: string): string[] {
  * and allows the user to either authorize or cancel the request.
  */
 function Authorize() {
-  const team = useCurrentTeam();
+  const team = useCurrentTeam({ rejectOnEmpty: false });
   const params = useQuery();
   const { t } = useTranslation();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -133,7 +133,7 @@ function Authorize() {
     !state && "state",
   ].filter(Boolean);
 
-  if (missingParams.length || clientError) {
+  if (missingParams.length || clientError || !team) {
     return (
       <Background>
         <Centered>


### PR DESCRIPTION
## Summary
- When `/oauthClients.info` returned an `AuthorizationError`, `ApiClient` logged the user out and cleared `auth.team`. The subsequent re-render hit the strict `useCurrentTeam()` in `Authorize` and threw `Invariant Violation: team required` before the error UI could render.
- Switched the inner hook to `rejectOnEmpty: false` and folded a missing team into the existing error branch.

## Test plan
- [ ] Trigger `/oauthClients.info` to return an authorization error (e.g. wrong workspace subdomain) and confirm the OAuth authorize screen renders the error UI instead of crashing.
- [ ] Confirm the happy path still renders the consent screen with team name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)