### PR TITLE
fix: Disable floating toolbar interaction during open animation

### DIFF
--- a/app/editor/components/FloatingToolbar.tsx
+++ b/app/editor/components/FloatingToolbar.tsx
@@ -420,11 +420,24 @@ const Wrapper = styled.div<WrapperProps>`
     box-sizing: border-box;
   }
 
+  & button,
+  & a,
+  & input {
+    pointer-events: none;
+  }
+
   ${({ active }) =>
     active &&
     `
     transform: translateY(-6px) scale(1);
     opacity: 1;
+
+    & button,
+    & a,
+    & input {
+      pointer-events: auto;
+      transition: pointer-events 0s 300ms;
+    }
   `};
 
   @media print {


### PR DESCRIPTION
## Summary
- Inner buttons/links/inputs inside the editor's `FloatingToolbar` now have `pointer-events: none` by default, and switch to `auto` only after the 300ms open animation (150ms delay + 150ms transition) finishes via a delayed `pointer-events` transition.
- Prevents accidental clicks on toolbar controls while the menu is still animating into place.

towards #12503
