### PR TITLE
fix: Disable webhooks when deleting associated user

### DIFF
--- a/app/components/UserDialogs.tsx
+++ b/app/components/UserDialogs.tsx
@@ -71,7 +71,7 @@ export function UserDeleteDialog({ user, onSubmit }: Props) {
       danger
     >
       {t(
-        "Are you sure you want to permanently delete {{ userName }}? This operation is unrecoverable, consider suspending the user instead.",
+        "Are you sure you want to permanently delete {{ userName }}? This operation is unrecoverable. Any API keys, webhooks, and integrations they created will stop working — consider suspending the user instead.",
         {
           userName: user.name,
         }

--- a/server/queues/processors/UserDeletedProcessor.test.ts
+++ b/server/queues/processors/UserDeletedProcessor.test.ts
@@ -1,4 +1,3 @@
-import { WebhookSubscription } from "@server/models";
 import UserAuthentication from "@server/models/UserAuthentication";
 import { buildUser, buildWebhookSubscription } from "@server/test/factories";
 import UserDeletedProcessor from "./UserDeletedProcessor";
@@ -34,7 +33,7 @@ describe("UserDeletedProcessor", () => {
     ).toBe(0);
   });
 
-  it("should remove webhook subscriptions created by the user", async () => {
+  it("should disable webhook subscriptions created by the user", async () => {
     const user = await buildUser();
     const webhook = await buildWebhookSubscription({
       teamId: user.teamId,
@@ -50,6 +49,7 @@ describe("UserDeletedProcessor", () => {
       ip,
     });
 
-    expect(await WebhookSubscription.findByPk(webhook.id)).toBeNull();
+    await webhook.reload();
+    expect(webhook.enabled).toEqual(false);
   });
 });

--- a/server/queues/processors/UserDeletedProcessor.test.ts
+++ b/server/queues/processors/UserDeletedProcessor.test.ts
@@ -1,11 +1,12 @@
+import { WebhookSubscription } from "@server/models";
 import UserAuthentication from "@server/models/UserAuthentication";
-import { buildUser } from "@server/test/factories";
+import { buildUser, buildWebhookSubscription } from "@server/test/factories";
 import UserDeletedProcessor from "./UserDeletedProcessor";
 
 const ip = "127.0.0.1";
 
 describe("UserDeletedProcessor", () => {
-  test("should remove relationships", async () => {
+  it("should remove relationships", async () => {
     const user = await buildUser();
     expect(
       await UserAuthentication.count({
@@ -31,5 +32,24 @@ describe("UserDeletedProcessor", () => {
         },
       })
     ).toBe(0);
+  });
+
+  it("should remove webhook subscriptions created by the user", async () => {
+    const user = await buildUser();
+    const webhook = await buildWebhookSubscription({
+      teamId: user.teamId,
+      createdById: user.id,
+    });
+
+    const processor = new UserDeletedProcessor();
+    await processor.perform({
+      name: "users.delete",
+      userId: user.id,
+      actorId: user.id,
+      teamId: user.teamId,
+      ip,
+    });
+
+    expect(await WebhookSubscription.findByPk(webhook.id)).toBeNull();
   });
 });

--- a/server/queues/processors/UserDeletedProcessor.ts
+++ b/server/queues/processors/UserDeletedProcessor.ts
@@ -6,6 +6,7 @@ import {
   Subscription,
   UserAuthentication,
   UserMembership,
+  WebhookSubscription,
 } from "@server/models";
 import { sequelize } from "@server/storage/database";
 import type { Event as TEvent, UserEvent } from "@server/types";
@@ -56,6 +57,12 @@ export default class UserDeletedProcessor extends BaseProcessor {
       await Star.destroy({
         where: {
           userId: event.userId,
+        },
+        transaction,
+      });
+      await WebhookSubscription.destroy({
+        where: {
+          createdById: event.userId,
         },
         transaction,
       });

--- a/server/queues/processors/UserDeletedProcessor.ts
+++ b/server/queues/processors/UserDeletedProcessor.ts
@@ -60,12 +60,16 @@ export default class UserDeletedProcessor extends BaseProcessor {
         },
         transaction,
       });
-      await WebhookSubscription.destroy({
-        where: {
-          createdById: event.userId,
-        },
-        transaction,
-      });
+      await WebhookSubscription.update(
+        { enabled: false },
+        {
+          where: {
+            createdById: event.userId,
+            enabled: true,
+          },
+          transaction,
+        }
+      );
     });
   }
 }

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -542,7 +542,7 @@
   "Viewers can only view and comment on documents.": "Viewers can only view and comment on documents.",
   "Are you sure you want to make {{ userName }} a {{ role }}?": "Are you sure you want to make {{ userName }} a {{ role }}?",
   "I understand, delete": "I understand, delete",
-  "Are you sure you want to permanently delete {{ userName }}? This operation is unrecoverable, consider suspending the user instead.": "Are you sure you want to permanently delete {{ userName }}? This operation is unrecoverable, consider suspending the user instead.",
+  "Are you sure you want to permanently delete {{ userName }}? This operation is unrecoverable. Any API keys, webhooks, and integrations they created will stop working — consider suspending the user instead.": "Are you sure you want to permanently delete {{ userName }}? This operation is unrecoverable. Any API keys, webhooks, and integrations they created will stop working — consider suspending the user instead.",
   "Are you sure you want to suspend {{ userName }}? Suspended users will be prevented from logging in.": "Are you sure you want to suspend {{ userName }}? Suspended users will be prevented from logging in.",
   "New name": "New name",
   "Name can't be empty": "Name can't be empty",


### PR DESCRIPTION
When deleting a user from a workspace, any webhooks they created should become automatically disabled.