### PR TITLE
fix: Undo/redo events duplicated

### DIFF
--- a/app/editor/components/ToolbarMenu.tsx
+++ b/app/editor/components/ToolbarMenu.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import styled from "styled-components";
 import breakpoint from "styled-components-breakpoint";
 import * as Toolbar from "@radix-ui/react-toolbar";
+import { closeHistory } from "@shared/editor/lib/closeHistory";
 import type { MenuItem } from "@shared/editor/types";
 import { hideScrollbars, s } from "@shared/styles";
 import { TooltipProvider } from "~/components/TooltipContext";
@@ -54,6 +55,7 @@ function ToolbarDropdown(props: ToolbarDropdownProps) {
       }
 
       if (commands[menuItem.name]) {
+        closeHistory(view);
         commands[menuItem.name](
           typeof menuItem.attrs === "function"
             ? menuItem.attrs(state)
@@ -158,6 +160,7 @@ function ToolbarMenu(props: Props) {
     }
 
     // otherwise, run the associated editor command
+    closeHistory(view);
     commands[item.name](
       typeof item.attrs === "function" ? item.attrs(state) : item.attrs
     );

--- a/app/editor/components/ToolbarMenu.tsx
+++ b/app/editor/components/ToolbarMenu.tsx
@@ -61,6 +61,7 @@ function ToolbarDropdown(props: ToolbarDropdownProps) {
             ? menuItem.attrs(state)
             : menuItem.attrs
         );
+        closeHistory(view);
       } else if (menuItem.onClick) {
         menuItem.onClick();
       }
@@ -164,6 +165,7 @@ function ToolbarMenu(props: Props) {
     commands[item.name](
       typeof item.attrs === "function" ? item.attrs(state) : item.attrs
     );
+    closeHistory(view);
   };
 
   return (

--- a/app/editor/extensions/Multiplayer.ts
+++ b/app/editor/extensions/Multiplayer.ts
@@ -7,6 +7,8 @@ import {
   yUndoPlugin,
   undo,
   redo,
+  undoCommand,
+  redoCommand,
 } from "y-prosemirror";
 import * as Y from "yjs";
 import Extension from "@shared/editor/lib/Extension";
@@ -134,6 +136,14 @@ export default class Multiplayer extends Extension<MultiplayerOptions> {
     return {
       undo: () => undo,
       redo: () => redo,
+    };
+  }
+
+  keys() {
+    return {
+      "Mod-z": undoCommand,
+      "Mod-y": redoCommand,
+      "Shift-Mod-z": redoCommand,
     };
   }
 }

--- a/app/scenes/Document/components/Document.tsx
+++ b/app/scenes/Document/components/Document.tsx
@@ -309,11 +309,7 @@ function DocumentScene({
   return (
     <ErrorBoundary showTitle>
       <RegisterKeyDown trigger="m" handler={onMove} />
-      <RegisterKeyDown
-        trigger="z"
-        handler={onUndoRedo}
-        options={{ allowInInput: false }}
-      />
+      <RegisterKeyDown trigger="z" handler={onUndoRedo} />
       <RegisterKeyDown trigger="e" handler={goToEdit} />
       <RegisterKeyDown trigger="Escape" handler={goBack} />
       <RegisterKeyDown trigger="h" handler={goToHistory} />

--- a/app/scenes/Document/components/Document.tsx
+++ b/app/scenes/Document/components/Document.tsx
@@ -151,6 +151,11 @@ function DocumentScene({
   const onUndoRedo = useCallback(
     (event: KeyboardEvent) => {
       if (isModKey(event)) {
+        // The editor handles undo/redo through its own keymap when focused
+        if (editorRef.current?.view?.hasFocus()) {
+          return;
+        }
+
         event.preventDefault();
 
         if (event.shiftKey) {

--- a/app/scenes/Document/components/Document.tsx
+++ b/app/scenes/Document/components/Document.tsx
@@ -27,6 +27,7 @@ import type { Editor as TEditor } from "~/editor";
 import type { Properties } from "~/types";
 import { useLocationSidebarContext } from "~/hooks/useLocationSidebarContext";
 import useStores from "~/hooks/useStores";
+import isTextInput from "~/utils/isTextInput";
 import { client } from "~/utils/ApiClient";
 import { emojiToUrl } from "~/utils/emoji";
 import { documentHistoryPath, documentEditPath } from "~/utils/routeHelpers";
@@ -151,8 +152,14 @@ function DocumentScene({
   const onUndoRedo = useCallback(
     (event: KeyboardEvent) => {
       if (isModKey(event)) {
+        const target =
+          event.target instanceof Element ? event.target : undefined;
+
         // The editor handles undo/redo through its own keymap when focused
-        if (editorRef.current?.view?.hasFocus()) {
+        if (
+          editorRef.current?.view?.hasFocus() ||
+          (target && (isTextInput(target) || !!target.closest(".ProseMirror")))
+        ) {
           return;
         }
 
@@ -302,7 +309,11 @@ function DocumentScene({
   return (
     <ErrorBoundary showTitle>
       <RegisterKeyDown trigger="m" handler={onMove} />
-      <RegisterKeyDown trigger="z" handler={onUndoRedo} />
+      <RegisterKeyDown
+        trigger="z"
+        handler={onUndoRedo}
+        options={{ allowInInput: false }}
+      />
       <RegisterKeyDown trigger="e" handler={goToEdit} />
       <RegisterKeyDown trigger="Escape" handler={goBack} />
       <RegisterKeyDown trigger="h" handler={goToHistory} />

--- a/app/scenes/Document/components/MultiplayerEditor.tsx
+++ b/app/scenes/Document/components/MultiplayerEditor.tsx
@@ -15,6 +15,7 @@ import { toast } from "sonner";
 import { IndexeddbPersistence } from "y-indexeddb";
 import * as Y from "yjs";
 import { EditorUpdateError } from "@shared/collaboration/CloseEvents";
+import History from "@shared/editor/extensions/History";
 import EDITOR_VERSION from "@shared/editor/version";
 import { supportsPassiveListener } from "@shared/utils/browser";
 import type { Props as EditorProps } from "~/components/Editor";
@@ -256,8 +257,12 @@ function MultiplayerEditor(
       return props.extensions;
     }
 
+    // The Yjs undo manager (added by the Multiplayer extension below) is the
+    // sole source of undo/redo history when collaborating.
     return [
-      ...(props.extensions || []),
+      ...(props.extensions || []).filter(
+        (extension) => extension !== History && !(extension instanceof History)
+      ),
       new MultiplayerExtension({
         user,
         provider: remoteProvider,

--- a/shared/editor/extensions/History.ts
+++ b/shared/editor/extensions/History.ts
@@ -1,5 +1,4 @@
 import { history, undo, redo } from "prosemirror-history";
-import { undoInputRule } from "prosemirror-inputrules";
 import type { Command } from "prosemirror-state";
 import type { CommandFactory } from "../lib/Extension";
 import Extension from "../lib/Extension";
@@ -21,7 +20,6 @@ export default class History extends Extension {
       "Mod-z": () => this.editor.commands.undo(),
       "Mod-y": () => this.editor.commands.redo(),
       "Shift-Mod-z": () => this.editor.commands.redo(),
-      Backspace: undoInputRule,
     };
   }
 

--- a/shared/editor/extensions/InputRuleUndo.ts
+++ b/shared/editor/extensions/InputRuleUndo.ts
@@ -1,0 +1,15 @@
+import { undoInputRule } from "prosemirror-inputrules";
+import type { Command } from "prosemirror-state";
+import Extension from "../lib/Extension";
+
+export default class InputRuleUndo extends Extension {
+  get name() {
+    return "inputRuleUndo";
+  }
+
+  keys(): Record<string, Command> {
+    return {
+      Backspace: undoInputRule,
+    };
+  }
+}

--- a/shared/editor/lib/closeHistory.ts
+++ b/shared/editor/lib/closeHistory.ts
@@ -1,16 +1,24 @@
-import { closeHistory as pmCloseHistory } from "prosemirror-history";
+import {
+  closeHistory as pmCloseHistory,
+  redoDepth,
+  undoDepth,
+} from "prosemirror-history";
 import type { EditorView } from "prosemirror-view";
 import { yUndoPluginKey } from "y-prosemirror";
 
 /**
  * Closes the current history item so that subsequent changes start a new undo
- * group. Dispatches a closeHistory transaction for prosemirror-history and,
- * when multiplayer is enabled, stops capturing on the yjs undo manager.
+ * group. Dispatches a closeHistory transaction when prosemirror-history is
+ * mounted and, when multiplayer is enabled, stops capturing on the Yjs undo
+ * manager.
  *
  * @param view The editor view.
  */
 export function closeHistory(view: EditorView): void {
-  view.dispatch(pmCloseHistory(view.state.tr));
+  if (undoDepth(view.state) > 0 || redoDepth(view.state) > 0) {
+    view.dispatch(pmCloseHistory(view.state.tr));
+  }
+
   const yUndoState = yUndoPluginKey.getState(view.state);
   yUndoState?.undoManager?.stopCapturing();
 }

--- a/shared/editor/lib/closeHistory.ts
+++ b/shared/editor/lib/closeHistory.ts
@@ -1,0 +1,16 @@
+import { closeHistory as pmCloseHistory } from "prosemirror-history";
+import type { EditorView } from "prosemirror-view";
+import { yUndoPluginKey } from "y-prosemirror";
+
+/**
+ * Closes the current history item so that subsequent changes start a new undo
+ * group. Dispatches a closeHistory transaction for prosemirror-history and,
+ * when multiplayer is enabled, stops capturing on the yjs undo manager.
+ *
+ * @param view The editor view.
+ */
+export function closeHistory(view: EditorView): void {
+  view.dispatch(pmCloseHistory(view.state.tr));
+  const yUndoState = yUndoPluginKey.getState(view.state);
+  yUndoState?.undoManager?.stopCapturing();
+}

--- a/shared/editor/nodes/index.ts
+++ b/shared/editor/nodes/index.ts
@@ -2,6 +2,7 @@ import DateTime from "../extensions/DateTime";
 import DeleteNearAtom from "../extensions/DeleteNearAtom";
 import HexColorPreview from "../extensions/HexColorPreview";
 import History from "../extensions/History";
+import InputRuleUndo from "../extensions/InputRuleUndo";
 import MaxLength from "../extensions/MaxLength";
 import TrailingNode from "../extensions/TrailingNode";
 import type { AnyExtensionClass } from "../lib/types";
@@ -53,6 +54,7 @@ type Nodes = AnyExtensionClass[];
  */
 export const inlineExtensions: Nodes = [
   Doc,
+  InputRuleUndo,
   Paragraph,
   Emoji,
   Text,


### PR DESCRIPTION
This PR updates editor undo/redo handling so collaborative documents use the Yjs undo manager as the single source of history. It removes the standard ProseMirror history extension from multiplayer editors, wires multiplayer undo/redo shortcuts directly to `y-prosemirror`, and prevents the document-level global undo handler from intercepting shortcuts while the editor is focused.

It also closes undo history around toolbar commands so toolbar actions form clean undo boundaries.

closes #12351