### PR TITLE
perf: Avoid redundant import lookup when presenting documents

### DIFF
--- a/server/presenters/document.ts
+++ b/server/presenters/document.ts
@@ -103,8 +103,6 @@ async function presentDocument(
   }
 
   if (!options.isPublic) {
-    const source = document.import ?? (await document.$get("import"));
-
     res.tasks = document.tasks;
     res.isCollectionDeleted = await document.isCollectionDeleted();
     res.collectionId = document.collectionId;
@@ -118,15 +116,16 @@ async function presentDocument(
     if (options.includeCommentCount) {
       res.commentCount = await document.commentCount;
     }
-    res.sourceMetadata = document.sourceMetadata
-      ? {
-          importedAt: source?.createdAt ?? document.createdAt,
-          importType: source?.format,
-          createdByName: document.sourceMetadata.createdByName,
-          fileName: document.sourceMetadata?.fileName,
-          originalDocumentId: document.sourceMetadata?.originalDocumentId,
-        }
-      : undefined;
+    if (document.sourceMetadata) {
+      const source = document.import ?? (await document.$get("import"));
+      res.sourceMetadata = {
+        importedAt: source?.createdAt ?? document.createdAt,
+        importType: source?.format,
+        createdByName: document.sourceMetadata.createdByName,
+        fileName: document.sourceMetadata?.fileName,
+        originalDocumentId: document.sourceMetadata?.originalDocumentId,
+      };
+    }
   }
 
   return res;


### PR DESCRIPTION
The `FileOperation` import association was being fetched for every non-public document in `presentDocument`, but its result is only used when `sourceMetadata` is present. Since that association is not eager-loaded by the scopes these code paths use, this triggered a wasted `file_operations` query for every document that isn't an import. Moving the lookup inside the `sourceMetadata` branch eliminates that N+1, benefiting `groupMemberships.list`, `userMemberships.list`, and every other endpoint that presents documents. The JSON output is unchanged (an absent key serializes identically to `undefined`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)