### PR TITLE
fix: Prevent Linear unfurl errors from bubbling to error tracking

### DIFF
--- a/plugins/linear/server/linear.ts
+++ b/plugins/linear/server/linear.ts
@@ -148,9 +148,9 @@ export class Linear {
 
       switch (resource.type) {
         case UnfurlResourceType.Issue:
-          return Linear.unfurlIssue(client, resource.id, actor);
+          return await Linear.unfurlIssue(client, resource.id, actor);
         case UnfurlResourceType.Project:
-          return Linear.unfurlProject(client, resource.id, actor);
+          return await Linear.unfurlProject(client, resource.id, actor);
         default:
           return;
       }


### PR DESCRIPTION
The `unfurl` method's `try/catch` is meant to swallow Linear API failures (such as `Entity not found: Issue` for stale links) and return a handled `{ error }` result. But the Issue and Project branches returned their promises without `await`, so the rejections escaped the `catch` and were reported to error tracking. Awaiting the calls keeps the rejection within the `try` scope so it is caught, logged as a warning, and returned as `{ error }` as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)