### PR TITLE
fix: Protocol error with http->https redirect

### DIFF
--- a/server/utils/fetch.ts
+++ b/server/utils/fetch.ts
@@ -167,7 +167,13 @@ export default async function fetch(
       ...rest,
       headers,
       signal,
-      agent: buildAgent(url, { signal, allowPrivateIPAddress }),
+      // Passed as a function rather than a static agent so that node-fetch
+      // re-selects the correct http/https agent for each request in a redirect
+      // chain. Otherwise an http:// URL redirecting to https:// (or vice versa)
+      // would reuse the original protocol's agent and throw
+      // `Protocol "https:" not supported. Expected "http:"`.
+      agent: (parsedURL) =>
+        buildAgent(parsedURL.href, { signal, allowPrivateIPAddress }),
     });
 
     if (!response.ok) {


### PR DESCRIPTION
TypeError: Protocol "https:" not supported. Expected "http:" (and its inverse) is thrown by Node’s core http/https modules when an http.Agent is used to open an https connection or vice versa.

We must rebuild the agent for each redirect instead of reusing the one based on the initial protocol.