### PR TITLE
fix: Toggle block within collapsed heading display

### DIFF
--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -2651,6 +2651,12 @@ li > .${EditorStyleHelper.toggleBlock} {
 .${EditorStyleHelper.toggleBlock} {
   display: flex;
 
+  /* When a toggle block is inside a collapsed heading it receives the
+     folded-content decoration; ensure it stays hidden despite display: flex. */
+  &.folded-content {
+    display: none;
+  }
+
   &:focus-within {
     transition-delay: 0.1s;
   }


### PR DESCRIPTION
Fixes a css specificity issue in toggle blocks

closes #12173