### PR TITLE
fix: Upgrade uuid dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -388,7 +388,8 @@
     "minimatch@npm:9.0.1": "9.0.9",
     "lodash@npm:4.17.21": "^4.18.1",
     "i18next-parser/i18next": "^23.16.8",
-    "ws@npm:~8.17.1": "^8.20.1"
+    "ws@npm:~8.17.1": "^8.20.1",
+    "uuid": "^11.1.1"
   },
   "version": "1.7.1",
   "packageManager": "yarn@4.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19770,39 +19770,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^11.1.0 || ^12 || ^13 || ^14.0.0":
-  version: 14.0.0
-  resolution: "uuid@npm:14.0.0"
-  bin:
-    uuid: dist-node/bin/uuid
-  checksum: 10c0/a57ae7794c45005c1a9208989196c5baf79a7679c30f43c1bee9033a2c4d113a2cea216fa6fcc9663b08b0d55635df1a7c6eb7e7f3d21c3e50688c698fa39a50
-  languageName: node
-  linkType: hard
-
 "uuid@npm:^11.1.1":
   version: 11.1.1
   resolution: "uuid@npm:11.1.1"
   bin:
     uuid: dist/esm/bin/uuid
   checksum: 10c0/9e3af58eba872ece5a5e76f4773a94fc78a0ef2c2444c38dbe6b42f41dadf76c01850fd783604f27986f6195e6286aef064d45987d401b2a33127b98ddf7c0c5
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^8.3.0, uuid@npm:^8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 10c0/bcbb807a917d374a49f475fae2e87fdca7da5e5530820ef53f65ba1d12131bd81a92ecf259cc7ce317cbe0f289e7d79fdfebcef9bfa3087c8c8a2fa304c9be54
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^9.0.0":
-  version: 9.0.1
-  resolution: "uuid@npm:9.0.1"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 10c0/1607dd32ac7fc22f2d8f77051e6a64845c9bce5cd3dd8aa0070c074ec73e666a1f63c7b4e0f4bf2bc8b9d59dc85a15e17807446d9d2b17c8485fbc2147b27f9b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Patches Dependabot alert [#336](https://github.com/outline/outline/security/dependabot/336) (CVE-2026-41907 / GHSA-w5hq-g745-h8pq), a missing buffer bounds check in uuid's `v3`/`v5`/`v6`.

Our direct dependency was already safe, but vulnerable transitive copies remained: `uuid@8.3.2` (via `sequelize` and `bull`) and `uuid@9.0.1` (via `@hocuspocus/*`). Adds a single `resolutions` entry forcing all uuid onto the patched `^11.1.1`, which is the highest version that is both patched and still ships a CommonJS build that the `require()`-based consumers depend on (uuid 12+ is ESM-only and would break sequelize/bull).