### PR TITLE
Trigger hover previews when editor has focus

### DIFF
--- a/app/editor/extensions/HoverPreviews.tsx
+++ b/app/editor/extensions/HoverPreviews.tsx
@@ -51,7 +51,7 @@ export default class HoverPreviews extends Extension<HoverPreviewsOptions> {
       new Plugin({
         props: {
           handleDOMEvents: {
-            mouseover: (view: EditorView, event: MouseEvent) => {
+            mouseover: (_view: EditorView, event: MouseEvent) => {
               const target = (event.target as HTMLElement)?.closest(
                 ".use-hover-preview"
               );
@@ -78,7 +78,15 @@ export default class HoverPreviews extends Extension<HoverPreviewsOptions> {
                         documentId,
                       });
 
-                      if (unfurl) {
+                      // The fetch is async, so the pointer may have already
+                      // left the target (or the node may have been removed) by
+                      // the time it resolves – only show the preview if the
+                      // element is still hovered.
+                      if (
+                        unfurl &&
+                        element.isConnected &&
+                        element.matches(":hover")
+                      ) {
                         this.state.activeLinkElement = element;
                         this.state.unfurlId = transformedUrl;
                       } else {
@@ -93,7 +101,7 @@ export default class HoverPreviews extends Extension<HoverPreviewsOptions> {
               }
               return false;
             },
-            mouseout: action((view: EditorView, event: MouseEvent) => {
+            mouseout: action((_view: EditorView, event: MouseEvent) => {
               const target = (event.target as HTMLElement)?.closest(
                 ".use-hover-preview"
               );

--- a/app/editor/extensions/HoverPreviews.tsx
+++ b/app/editor/extensions/HoverPreviews.tsx
@@ -41,10 +41,9 @@ export default class HoverPreviews extends Extension<HoverPreviewsOptions> {
   }
 
   get plugins() {
-    const isHoverTarget = (target: Element | null, view: EditorView) =>
+    const isHoverTarget = (target: Element | null) =>
       target instanceof HTMLElement &&
-      this.editor.elementRef.current?.contains(target) &&
-      (!view.editable || (view.editable && !view.hasFocus()));
+      this.editor.elementRef.current?.contains(target);
 
     let hoveringTimeout: ReturnType<typeof setTimeout>;
 
@@ -56,7 +55,7 @@ export default class HoverPreviews extends Extension<HoverPreviewsOptions> {
               const target = (event.target as HTMLElement)?.closest(
                 ".use-hover-preview"
               );
-              if (isHoverTarget(target, view)) {
+              if (isHoverTarget(target)) {
                 hoveringTimeout = setTimeout(
                   action(async () => {
                     const element = target as HTMLElement;
@@ -98,7 +97,7 @@ export default class HoverPreviews extends Extension<HoverPreviewsOptions> {
               const target = (event.target as HTMLElement)?.closest(
                 ".use-hover-preview"
               );
-              if (isHoverTarget(target, view)) {
+              if (isHoverTarget(target)) {
                 clearTimeout(hoveringTimeout);
                 this.state.activeLinkElement = null;
               }


### PR DESCRIPTION
Previously this was suppressed since the initial implementation, but now that's just kind of annoying and unpredictable for users - better to keep the behavior consistent