### PR TITLE
fix: Encode code & math fences in table cells with <br> to avoid breaking rows

### DIFF
--- a/server/models/helpers/DocumentHelper.test.ts
+++ b/server/models/helpers/DocumentHelper.test.ts
@@ -635,6 +635,60 @@ This is a [test paragraph](https://example.net)`,
       expect(result).toContain("[x] done");
     });
 
+    it("should export code fences inside table cells on a single line", async () => {
+      const document = await buildDocument({
+        content: {
+          type: "doc",
+          content: [
+            {
+              type: "table",
+              content: [
+                {
+                  type: "tr",
+                  content: [
+                    {
+                      type: "th",
+                      attrs: { colspan: 1, rowspan: 1 },
+                      content: [
+                        {
+                          type: "paragraph",
+                          content: [{ type: "text", text: "Header" }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  type: "tr",
+                  content: [
+                    {
+                      type: "td",
+                      attrs: { colspan: 1, rowspan: 1 },
+                      content: [
+                        {
+                          type: "code_fence",
+                          attrs: { language: "abap" },
+                          content: [{ type: "text", text: "line 1\nline 2" }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      });
+      const result = await DocumentHelper.toMarkdown(document, {
+        includeTitle: false,
+      });
+      // Code fences inside tables should use <br> tags rather than literal
+      // newlines that would break the table row structure.
+      expect(result).toContain("```abap<br>line 1<br>line 2<br>```");
+      // The fence content must not introduce raw newlines inside the table.
+      expect(result).not.toMatch(/```abap\n/);
+    });
+
     it("should include collection title by default", async () => {
       const collection = await buildCollection({
         name: "Test Collection",

--- a/server/models/helpers/DocumentHelper.test.ts
+++ b/server/models/helpers/DocumentHelper.test.ts
@@ -668,7 +668,9 @@ This is a [test paragraph](https://example.net)`,
                         {
                           type: "code_fence",
                           attrs: { language: "abap" },
-                          content: [{ type: "text", text: "line 1\nline 2" }],
+                          content: [
+                            { type: "text", text: "a | b\nc \\ d\nline 2" },
+                          ],
                         },
                       ],
                     },
@@ -683,8 +685,11 @@ This is a [test paragraph](https://example.net)`,
         includeTitle: false,
       });
       // Code fences inside tables should use <br> tags rather than literal
-      // newlines that would break the table row structure.
-      expect(result).toContain("```abap<br>line 1<br>line 2<br>```");
+      // newlines that would break the table row structure, with pipes and
+      // backslashes escaped so the content cannot break out of the column.
+      expect(result).toContain(
+        "```abap<br>a \\| b<br>c \\\\ d<br>line 2<br>```"
+      );
       // The fence content must not introduce raw newlines inside the table.
       expect(result).not.toMatch(/```abap\n/);
     });

--- a/server/models/helpers/DocumentHelper.test.ts
+++ b/server/models/helpers/DocumentHelper.test.ts
@@ -694,6 +694,62 @@ This is a [test paragraph](https://example.net)`,
       expect(result).not.toMatch(/```abap\n/);
     });
 
+    it("should export math blocks inside table cells on a single line", async () => {
+      const document = await buildDocument({
+        content: {
+          type: "doc",
+          content: [
+            {
+              type: "table",
+              content: [
+                {
+                  type: "tr",
+                  content: [
+                    {
+                      type: "th",
+                      attrs: { colspan: 1, rowspan: 1 },
+                      content: [
+                        {
+                          type: "paragraph",
+                          content: [{ type: "text", text: "Header" }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  type: "tr",
+                  content: [
+                    {
+                      type: "td",
+                      attrs: { colspan: 1, rowspan: 1 },
+                      content: [
+                        {
+                          type: "math_block",
+                          content: [
+                            { type: "text", text: "a | b\n\\frac{1}{2}" },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      });
+      const result = await DocumentHelper.toMarkdown(document, {
+        includeTitle: false,
+      });
+      // Math blocks inside tables should use <br> tags rather than literal
+      // newlines that would break the table row structure, with pipes and
+      // backslashes escaped so the content cannot break out of the column.
+      expect(result).toContain("$$<br>a \\| b<br>\\\\frac{1}{2}<br>$$");
+      // The block content must not introduce raw newlines inside the table.
+      expect(result).not.toMatch(/\$\$\n/);
+    });
+
     it("should include collection title by default", async () => {
       const collection = await buildCollection({
         name: "Test Collection",

--- a/shared/editor/nodes/CodeFence.ts
+++ b/shared/editor/nodes/CodeFence.ts
@@ -695,10 +695,11 @@ export default class CodeFence extends Node<CodeFenceOptions> {
 
   toMarkdown(state: MarkdownSerializerState, node: ProsemirrorNode) {
     // Inside table cells literal newlines break the row structure, so encode
-    // the fence on a single line using <br> for line breaks and escape pipes.
+    // the fence on a single line using <br> for line breaks. Backslashes and
+    // pipes are escaped so the cell content cannot break out of the column.
     if (state.inTable) {
       const code = node.textContent
-        .replace(/\|/g, "\\|")
+        .replace(/[\\|]/g, "\\$&")
         .replace(/\n/g, "<br>");
       state.write(
         "```" + (node.attrs.language || "") + "<br>" + code + "<br>```"

--- a/shared/editor/nodes/CodeFence.ts
+++ b/shared/editor/nodes/CodeFence.ts
@@ -694,6 +694,18 @@ export default class CodeFence extends Node<CodeFenceOptions> {
   }
 
   toMarkdown(state: MarkdownSerializerState, node: ProsemirrorNode) {
+    // Inside table cells literal newlines break the row structure, so encode
+    // the fence on a single line using <br> for line breaks and escape pipes.
+    if (state.inTable) {
+      const code = node.textContent
+        .replace(/\|/g, "\\|")
+        .replace(/\n/g, "<br>");
+      state.write(
+        "```" + (node.attrs.language || "") + "<br>" + code + "<br>```"
+      );
+      return;
+    }
+
     state.write("```" + (node.attrs.language || "") + "\n");
     state.text(node.textContent, false);
     state.ensureNewLine();

--- a/shared/editor/nodes/MathBlock.ts
+++ b/shared/editor/nodes/MathBlock.ts
@@ -47,10 +47,11 @@ export default class MathBlock extends Node {
 
   toMarkdown(state: MarkdownSerializerState, node: ProsemirrorNode) {
     // Inside table cells literal newlines break the row structure, so encode
-    // the block on a single line using <br> for line breaks and escape pipes.
+    // the block on a single line using <br> for line breaks. Backslashes and
+    // pipes are escaped so the cell content cannot break out of the column.
     if (state.inTable) {
       const math = node.textContent
-        .replace(/\|/g, "\\|")
+        .replace(/[\\|]/g, "\\$&")
         .replace(/\n/g, "<br>");
       state.write("$$<br>" + math + "<br>$$");
       return;

--- a/shared/editor/nodes/MathBlock.ts
+++ b/shared/editor/nodes/MathBlock.ts
@@ -46,6 +46,16 @@ export default class MathBlock extends Node {
   }
 
   toMarkdown(state: MarkdownSerializerState, node: ProsemirrorNode) {
+    // Inside table cells literal newlines break the row structure, so encode
+    // the block on a single line using <br> for line breaks and escape pipes.
+    if (state.inTable) {
+      const math = node.textContent
+        .replace(/\|/g, "\\|")
+        .replace(/\n/g, "<br>");
+      state.write("$$<br>" + math + "<br>$$");
+      return;
+    }
+
     state.write("$$\n");
     state.text(node.textContent, false);
     state.ensureNewLine();


### PR DESCRIPTION
Code and LaTeX fences inside table cells were emitting literal newlines during Markdown serialization, which broke the single-line table-row structure and corrupted the rendering of the entire table. These nodes are now serialized on a single line using `<br>` for line breaks and escaped pipes when inside a table, matching the existing handling for lists and hard breaks. The fix covers `CodeFence` (and `CodeBlock`, which subclasses it) and `MathBlock`, and a test was added to `DocumentHelper.test.ts` verifying a code fence in a table cell serializes without raw newlines.

Note: this fixes serialization only — a multi-line fenced block can't round-trip back into a code block since Markdown parses table-cell content as inline, but the table itself no longer breaks.

closes #12510