### PR TITLE
Add document restore functionality to MCP tools

### DIFF
--- a/server/commands/documentRestorer.ts
+++ b/server/commands/documentRestorer.ts
@@ -1,6 +1,7 @@
 import { traceFunction } from "@server/logging/tracing";
 import { ValidationError } from "@server/errors";
-import { Collection, Document, Revision } from "@server/models";
+import { Collection, Revision } from "@server/models";
+import type { Document } from "@server/models";
 import { authorize } from "@server/policies";
 import type { APIContext } from "@server/types";
 import { assertPresent } from "@server/validation";

--- a/server/commands/documentRestorer.ts
+++ b/server/commands/documentRestorer.ts
@@ -1,0 +1,97 @@
+import { traceFunction } from "@server/logging/tracing";
+import { ValidationError } from "@server/errors";
+import { Collection, Document, Revision } from "@server/models";
+import { authorize } from "@server/policies";
+import type { APIContext } from "@server/types";
+import { assertPresent } from "@server/validation";
+
+type Props = {
+  /** The document to restore. Must be loaded with `paranoid: false`. */
+  document: Document;
+  /** Destination collection to restore into. Defaults to the original collection. */
+  collectionId?: string | null;
+  /** Revision to restore the document's content from, when not archived or deleted. */
+  revisionId?: string | null;
+};
+
+/**
+ * Restores a previously archived or deleted document, or restores a document's
+ * content to a specific revision. Re-attaches the document to the destination
+ * collection's structure when applicable and authorizes the acting user.
+ *
+ * @param ctx - the API context, providing the acting user and transaction.
+ * @param props - the document and restore options.
+ * @returns the restored document.
+ * @throws ValidationError if the destination collection is not active.
+ */
+async function documentRestorer(
+  ctx: APIContext,
+  { document, collectionId, revisionId }: Props
+): Promise<Document> {
+  const { user } = ctx.state.auth;
+  const { transaction } = ctx.state;
+
+  const sourceCollectionId = document.collectionId;
+  const destCollectionId = collectionId ?? sourceCollectionId;
+
+  const srcCollection = sourceCollectionId
+    ? await Collection.findByPk(sourceCollectionId, {
+        userId: user.id,
+        includeDocumentStructure: true,
+        paranoid: false,
+        transaction,
+      })
+    : undefined;
+
+  const destCollection = destCollectionId
+    ? await Collection.findByPk(destCollectionId, {
+        userId: user.id,
+        includeDocumentStructure: true,
+        transaction,
+      })
+    : undefined;
+
+  if (!destCollection?.isActive) {
+    throw ValidationError(
+      "Unable to restore, the collection may have been deleted or archived"
+    );
+  }
+
+  if (sourceCollectionId && sourceCollectionId !== destCollection.id) {
+    authorize(user, "updateDocument", srcCollection);
+    await srcCollection?.removeDocumentInStructure(document, {
+      save: true,
+      transaction,
+    });
+  }
+
+  if (document.deletedAt) {
+    authorize(user, "restore", document);
+    authorize(user, "updateDocument", destCollection);
+
+    // restore a previously deleted document
+    await document.restoreTo(ctx, { collectionId: destCollection.id });
+  } else if (document.archivedAt) {
+    authorize(user, "unarchive", document);
+    authorize(user, "updateDocument", destCollection);
+
+    // restore a previously archived document
+    await document.restoreTo(ctx, { collectionId: destCollection.id });
+  } else if (revisionId) {
+    // restore a document to a specific revision
+    authorize(user, "update", document);
+    const revision = await Revision.findByPk(revisionId, { transaction });
+    authorize(document, "restore", revision);
+
+    await document.restoreFromRevision(revision);
+    await document.saveWithCtx(ctx, undefined, { name: "restore" });
+  } else {
+    assertPresent(revisionId, "revisionId is required");
+  }
+
+  return document;
+}
+
+export default traceFunction({
+  spanName: "documentRestorer",
+})(documentRestorer);

--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -29,6 +29,7 @@ import documentDuplicator from "@server/commands/documentDuplicator";
 import documentLoader from "@server/commands/documentLoader";
 import documentMover from "@server/commands/documentMover";
 import documentPermanentDeleter from "@server/commands/documentPermanentDeleter";
+import documentRestorer from "@server/commands/documentRestorer";
 import documentUpdater from "@server/commands/documentUpdater";
 import env from "@server/env";
 import {
@@ -51,7 +52,6 @@ import {
   Document,
   DocumentInsight,
   Event,
-  Revision,
   SearchQuery,
   Template,
   User,
@@ -89,7 +89,6 @@ import { RateLimiterStrategy } from "@server/utils/RateLimiter";
 import { convertBareUrlsToEmbedMarkdown } from "@server/utils/embeds";
 import { streamZipResponse } from "@server/utils/koa";
 import { getTeamFromContext } from "@server/utils/passport";
-import { assertPresent } from "@server/validation";
 import pagination, { paginateQuery } from "../middlewares/pagination";
 import * as T from "./schema";
 import {
@@ -968,63 +967,7 @@ router.post(
       transaction,
     });
 
-    const sourceCollectionId = document.collectionId;
-    const destCollectionId = collectionId ?? sourceCollectionId;
-
-    const srcCollection = sourceCollectionId
-      ? await Collection.findByPk(sourceCollectionId, {
-          userId: user.id,
-          includeDocumentStructure: true,
-          paranoid: false,
-          transaction,
-        })
-      : undefined;
-
-    const destCollection = destCollectionId
-      ? await Collection.findByPk(destCollectionId, {
-          userId: user.id,
-          includeDocumentStructure: true,
-          transaction,
-        })
-      : undefined;
-
-    if (!destCollection?.isActive) {
-      throw ValidationError(
-        "Unable to restore, the collection may have been deleted or archived"
-      );
-    }
-
-    if (sourceCollectionId && sourceCollectionId !== destCollectionId) {
-      authorize(user, "updateDocument", srcCollection);
-      await srcCollection?.removeDocumentInStructure(document, {
-        save: true,
-        transaction,
-      });
-    }
-
-    if (document.deletedAt) {
-      authorize(user, "restore", document);
-      authorize(user, "updateDocument", destCollection);
-
-      // restore a previously deleted document
-      await document.restoreTo(ctx, { collectionId: destCollectionId! }); // destCollectionId is guaranteed to be defined here
-    } else if (document.archivedAt) {
-      authorize(user, "unarchive", document);
-      authorize(user, "updateDocument", destCollection);
-
-      // restore a previously archived document
-      await document.restoreTo(ctx, { collectionId: destCollectionId! }); // destCollectionId is guaranteed to be defined here
-    } else if (revisionId) {
-      // restore a document to a specific revision
-      authorize(user, "update", document);
-      const revision = await Revision.findByPk(revisionId, { transaction });
-      authorize(document, "restore", revision);
-
-      await document.restoreFromRevision(revision);
-      await document.saveWithCtx(ctx, undefined, { name: "restore" });
-    } else {
-      assertPresent(revisionId, "revisionId is required");
-    }
+    await documentRestorer(ctx, { document, collectionId, revisionId });
 
     ctx.body = {
       data: await presentDocument(ctx, document),

--- a/server/tools/documents.test.ts
+++ b/server/tools/documents.test.ts
@@ -143,66 +143,6 @@ describe("list_documents", () => {
 
     expect(ids).toContain(document.id);
   });
-
-  it("lists archived documents when status is archived", async () => {
-    const { user, accessToken } = await buildOAuthUser();
-    const collection = await buildCollection({
-      teamId: user.teamId,
-      userId: user.id,
-    });
-    const active = await buildDocument({
-      teamId: user.teamId,
-      userId: user.id,
-      collectionId: collection.id,
-    });
-    const archived = await buildDocument({
-      teamId: user.teamId,
-      userId: user.id,
-      collectionId: collection.id,
-      archivedAt: new Date(),
-    });
-
-    const res = await callMcpTool(server, accessToken, "list_documents", {
-      status: "archived",
-    });
-    const data = (res?.result?.content ?? []).map((c: { text: string }) =>
-      JSON.parse(c.text)
-    );
-    const ids = data.map((d: { document: { id: string } }) => d.document.id);
-
-    expect(ids).toContain(archived.id);
-    expect(ids).not.toContain(active.id);
-  });
-
-  it("lists trashed documents when status is trashed", async () => {
-    const { user, accessToken } = await buildOAuthUser();
-    const collection = await buildCollection({
-      teamId: user.teamId,
-      userId: user.id,
-    });
-    const active = await buildDocument({
-      teamId: user.teamId,
-      userId: user.id,
-      collectionId: collection.id,
-    });
-    const trashed = await buildDocument({
-      teamId: user.teamId,
-      userId: user.id,
-      collectionId: collection.id,
-    });
-    await trashed.destroy();
-
-    const res = await callMcpTool(server, accessToken, "list_documents", {
-      status: "trashed",
-    });
-    const data = (res?.result?.content ?? []).map((c: { text: string }) =>
-      JSON.parse(c.text)
-    );
-    const ids = data.map((d: { document: { id: string } }) => d.document.id);
-
-    expect(ids).toContain(trashed.id);
-    expect(ids).not.toContain(active.id);
-  });
 });
 
 describe("create_document", () => {

--- a/server/tools/documents.test.ts
+++ b/server/tools/documents.test.ts
@@ -143,6 +143,66 @@ describe("list_documents", () => {
 
     expect(ids).toContain(document.id);
   });
+
+  it("lists archived documents when status is archived", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const active = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+    });
+    const archived = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+      archivedAt: new Date(),
+    });
+
+    const res = await callMcpTool(server, accessToken, "list_documents", {
+      status: "archived",
+    });
+    const data = (res?.result?.content ?? []).map((c: { text: string }) =>
+      JSON.parse(c.text)
+    );
+    const ids = data.map((d: { document: { id: string } }) => d.document.id);
+
+    expect(ids).toContain(archived.id);
+    expect(ids).not.toContain(active.id);
+  });
+
+  it("lists trashed documents when status is trashed", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const active = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+    });
+    const trashed = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+    });
+    await trashed.destroy();
+
+    const res = await callMcpTool(server, accessToken, "list_documents", {
+      status: "trashed",
+    });
+    const data = (res?.result?.content ?? []).map((c: { text: string }) =>
+      JSON.parse(c.text)
+    );
+    const ids = data.map((d: { document: { id: string } }) => d.document.id);
+
+    expect(ids).toContain(trashed.id);
+    expect(ids).not.toContain(active.id);
+  });
 });
 
 describe("create_document", () => {
@@ -453,6 +513,104 @@ describe("move_document", () => {
     const res = await callMcpTool(server, accessToken, "move_document", {
       id: document.id,
       parentDocumentId: document.id,
+    });
+
+    expect(res?.result?.isError).toBe(true);
+  });
+});
+
+describe("restore_document", () => {
+  it("restores an archived document", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const document = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+      archivedAt: new Date(),
+    });
+
+    const res = await callMcpTool(server, accessToken, "restore_document", {
+      id: document.id,
+    });
+    const data = JSON.parse(res?.result?.content?.[0]?.text ?? "{}");
+
+    expect(res?.result?.isError).toBeUndefined();
+    expect(data.document.id).toEqual(document.id);
+
+    const reloaded = await Document.unscoped().findByPk(document.id);
+    expect(reloaded?.archivedAt).toBeNull();
+  });
+
+  it("restores a trashed document", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const document = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+    });
+    await document.destroy();
+
+    const res = await callMcpTool(server, accessToken, "restore_document", {
+      id: document.id,
+    });
+
+    expect(res?.result?.isError).toBeUndefined();
+
+    const reloaded = await Document.unscoped().findByPk(document.id, {
+      paranoid: false,
+    });
+    expect(reloaded?.deletedAt).toBeNull();
+  });
+
+  it("restores into a different collection", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const source = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const destination = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const document = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: source.id,
+      archivedAt: new Date(),
+    });
+
+    const res = await callMcpTool(server, accessToken, "restore_document", {
+      id: document.id,
+      collectionId: destination.id,
+    });
+    const data = JSON.parse(res?.result?.content?.[0]?.text ?? "{}");
+
+    expect(res?.result?.isError).toBeUndefined();
+    expect(data.document.collectionId).toEqual(destination.id);
+  });
+
+  it("fails when the document is not archived or trashed", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const document = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+    });
+
+    const res = await callMcpTool(server, accessToken, "restore_document", {
+      id: document.id,
     });
 
     expect(res?.result?.isError).toBe(true);

--- a/server/tools/documents.ts
+++ b/server/tools/documents.ts
@@ -67,7 +67,7 @@ export function documentTools(server: McpServer, scopes: string[]) {
       {
         title: "Search documents",
         description:
-          "Searches documents the user has access to. Performs full-text search across document content when a query is provided, or lists recent documents when no query is given. Optionally filter by collection. Set status to 'archived' or 'trashed' to list archived or deleted documents instead (full-text search via query is not applied in these modes). To retrieve the full contents or hierarchy of a specific collection, use list_collection_documents instead.",
+          "Searches documents the user has access to. Performs full-text search across document content when a query is provided, or lists recent documents when no query is given. Optionally filter by collection. To retrieve the full contents or hierarchy of a specific collection, use list_collection_documents instead.",
         annotations: {
           idempotentHint: true,
           readOnlyHint: true,
@@ -79,12 +79,6 @@ export function documentTools(server: McpServer, scopes: string[]) {
           collectionId: optionalString().describe(
             "A collection ID to filter documents by."
           ),
-          status: z
-            .enum(["archived", "trashed"])
-            .optional()
-            .describe(
-              "Filter by document lifecycle status. Omit to return active documents. Set to 'archived' to list archived documents, or 'trashed' to list documents in the trash. Full-text search via query is not applied in these modes."
-            ),
           offset: z.coerce
             .number()
             .int()
@@ -104,89 +98,11 @@ export function documentTools(server: McpServer, scopes: string[]) {
       },
       withTracing(
         "list_documents",
-        async ({ query, collectionId, status, offset, limit }, extra) => {
+        async ({ query, collectionId, offset, limit }, extra) => {
           try {
             const user = getActorFromContext(extra);
             const effectiveOffset = offset ?? 0;
             const effectiveLimit = limit ?? 25;
-
-            if (status === "archived" || status === "trashed") {
-              if (collectionId) {
-                const collection = await Collection.findByPk(collectionId, {
-                  userId: user.id,
-                });
-                authorize(user, "readDocument", collection);
-              }
-
-              let documents: Document[];
-
-              if (status === "archived") {
-                documents = await Document.withMembershipScope(user.id).findAll(
-                  {
-                    where: {
-                      teamId: user.teamId,
-                      archivedAt: { [Op.ne]: null },
-                      collectionId:
-                        collectionId ?? (await user.collectionIds()),
-                    },
-                    order: [["archivedAt", "DESC"]],
-                    offset: effectiveOffset,
-                    limit: effectiveLimit,
-                  }
-                );
-              } else {
-                const collectionIds = await user.collectionIds({
-                  paranoid: false,
-                });
-                documents = await Document.withMembershipScope(user.id, {
-                  includeDrafts: true,
-                  paranoid: false,
-                }).findAll({
-                  where: {
-                    teamId: user.teamId,
-                    deletedAt: { [Op.ne]: null },
-                    ...(collectionId
-                      ? { collectionId }
-                      : {
-                          [Op.or]: [
-                            { collectionId: { [Op.in]: collectionIds } },
-                            {
-                              createdById: user.id,
-                              collectionId: { [Op.is]: null },
-                            },
-                          ],
-                        }),
-                  },
-                  paranoid: false,
-                  order: [["deletedAt", "DESC"]],
-                  offset: effectiveOffset,
-                  limit: effectiveLimit,
-                });
-              }
-
-              const breadcrumbs = await getBreadcrumbsForDocuments(
-                documents,
-                user
-              );
-
-              const presented = await Promise.all(
-                documents.map(async (document) => {
-                  const doc = pathToUrl(
-                    user.team,
-                    await presentDocument(document, {
-                      includeData: false,
-                      includeText: false,
-                    })
-                  );
-                  const breadcrumb = breadcrumbs.get(document.id);
-                  return {
-                    document: doc,
-                    ...(breadcrumb !== undefined && { breadcrumb }),
-                  };
-                })
-              );
-              return success(presented);
-            }
 
             let indexMap: Map<string, number> | undefined;
 

--- a/server/tools/documents.ts
+++ b/server/tools/documents.ts
@@ -6,6 +6,7 @@ import documentCreator, {
   authorizeDocumentPublish,
 } from "@server/commands/documentCreator";
 import documentMover from "@server/commands/documentMover";
+import documentRestorer from "@server/commands/documentRestorer";
 import documentUpdater from "@server/commands/documentUpdater";
 import { Op } from "sequelize";
 import { Collection, Document } from "@server/models";
@@ -66,7 +67,7 @@ export function documentTools(server: McpServer, scopes: string[]) {
       {
         title: "Search documents",
         description:
-          "Searches documents the user has access to. Performs full-text search across document content when a query is provided, or lists recent documents when no query is given. Optionally filter by collection. To retrieve the full contents or hierarchy of a specific collection, use list_collection_documents instead.",
+          "Searches documents the user has access to. Performs full-text search across document content when a query is provided, or lists recent documents when no query is given. Optionally filter by collection. Set status to 'archived' or 'trashed' to list archived or deleted documents instead (full-text search via query is not applied in these modes). To retrieve the full contents or hierarchy of a specific collection, use list_collection_documents instead.",
         annotations: {
           idempotentHint: true,
           readOnlyHint: true,
@@ -78,6 +79,12 @@ export function documentTools(server: McpServer, scopes: string[]) {
           collectionId: optionalString().describe(
             "A collection ID to filter documents by."
           ),
+          status: z
+            .enum(["archived", "trashed"])
+            .optional()
+            .describe(
+              "Filter by document lifecycle status. Omit to return active documents. Set to 'archived' to list archived documents, or 'trashed' to list documents in the trash. Full-text search via query is not applied in these modes."
+            ),
           offset: z.coerce
             .number()
             .int()
@@ -97,11 +104,89 @@ export function documentTools(server: McpServer, scopes: string[]) {
       },
       withTracing(
         "list_documents",
-        async ({ query, collectionId, offset, limit }, extra) => {
+        async ({ query, collectionId, status, offset, limit }, extra) => {
           try {
             const user = getActorFromContext(extra);
             const effectiveOffset = offset ?? 0;
             const effectiveLimit = limit ?? 25;
+
+            if (status === "archived" || status === "trashed") {
+              if (collectionId) {
+                const collection = await Collection.findByPk(collectionId, {
+                  userId: user.id,
+                });
+                authorize(user, "readDocument", collection);
+              }
+
+              let documents: Document[];
+
+              if (status === "archived") {
+                documents = await Document.withMembershipScope(user.id).findAll(
+                  {
+                    where: {
+                      teamId: user.teamId,
+                      archivedAt: { [Op.ne]: null },
+                      collectionId:
+                        collectionId ?? (await user.collectionIds()),
+                    },
+                    order: [["archivedAt", "DESC"]],
+                    offset: effectiveOffset,
+                    limit: effectiveLimit,
+                  }
+                );
+              } else {
+                const collectionIds = await user.collectionIds({
+                  paranoid: false,
+                });
+                documents = await Document.withMembershipScope(user.id, {
+                  includeDrafts: true,
+                  paranoid: false,
+                }).findAll({
+                  where: {
+                    teamId: user.teamId,
+                    deletedAt: { [Op.ne]: null },
+                    ...(collectionId
+                      ? { collectionId }
+                      : {
+                          [Op.or]: [
+                            { collectionId: { [Op.in]: collectionIds } },
+                            {
+                              createdById: user.id,
+                              collectionId: { [Op.is]: null },
+                            },
+                          ],
+                        }),
+                  },
+                  paranoid: false,
+                  order: [["deletedAt", "DESC"]],
+                  offset: effectiveOffset,
+                  limit: effectiveLimit,
+                });
+              }
+
+              const breadcrumbs = await getBreadcrumbsForDocuments(
+                documents,
+                user
+              );
+
+              const presented = await Promise.all(
+                documents.map(async (document) => {
+                  const doc = pathToUrl(
+                    user.team,
+                    await presentDocument(document, {
+                      includeData: false,
+                      includeText: false,
+                    })
+                  );
+                  const breadcrumb = breadcrumbs.get(document.id);
+                  return {
+                    document: doc,
+                    ...(breadcrumb !== undefined && { breadcrumb }),
+                  };
+                })
+              );
+              return success(presented);
+            }
 
             let indexMap: Map<string, number> | undefined;
 
@@ -691,6 +776,79 @@ export function documentTools(server: McpServer, scopes: string[]) {
           });
 
           return success({ success: true });
+        } catch (message) {
+          return error(message);
+        }
+      })
+    );
+  }
+
+  if (AuthenticationHelper.canAccess("documents.restore", scopes)) {
+    server.registerTool(
+      "restore_document",
+      {
+        title: "Restore document",
+        description:
+          "Restores an archived or trashed document, making it active again. Optionally provide a collectionId to restore the document into a different collection; otherwise it returns to its original collection.",
+        annotations: {
+          idempotentHint: false,
+          readOnlyHint: false,
+        },
+        inputSchema: {
+          id: z
+            .string()
+            .describe("The unique identifier of the document to restore."),
+          collectionId: optionalString().describe(
+            "The collection to restore the document into. Defaults to its original collection."
+          ),
+        },
+      },
+      withTracing("restore_document", async ({ id, collectionId }, context) => {
+        try {
+          const ctx = buildAPIContext(context);
+          const { user } = ctx.state.auth;
+
+          return await sequelize.transaction(async (transaction) => {
+            ctx.state.transaction = transaction;
+            ctx.context.transaction = transaction;
+
+            const document = await Document.findByPk(id, {
+              userId: user.id,
+              paranoid: false,
+              rejectOnEmpty: true,
+              transaction,
+            });
+
+            if (!document.deletedAt && !document.archivedAt) {
+              return error("Document is not archived or trashed");
+            }
+
+            await documentRestorer(ctx, { document, collectionId });
+
+            const [{ text, ...attributes }, breadcrumb] = await Promise.all([
+              presentDocument(document, {
+                includeData: false,
+                includeText: true,
+                includeUpdatedAt: true,
+              }),
+              getDocumentBreadcrumb(document, user),
+            ]);
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: JSON.stringify({
+                    document: pathToUrl(user.team, attributes),
+                    ...(breadcrumb !== undefined && { breadcrumb }),
+                  }),
+                },
+                {
+                  type: "text" as const,
+                  text: typeof text === "string" ? text : "",
+                },
+              ],
+            } satisfies CallToolResult;
+          });
         } catch (message) {
           return error(message);
         }


### PR DESCRIPTION
## Summary

This PR adds the ability to restore archived or trashed documents through the MCP tools interface, and enhances the document listing functionality to filter by lifecycle status (archived or trashed).

## Key Changes

- **New `restore_document` MCP tool**: Allows restoring archived or trashed documents to active status, with optional collection relocation
- **Enhanced `list_documents` tool**: Added `status` parameter to filter documents by lifecycle state (archived/trashed), separate from active documents
- **New `documentRestorer` command**: Extracted document restoration logic into a reusable command module that handles both archived and deleted document restoration, with proper authorization and collection management
- **Comprehensive test coverage**: Added tests for listing archived/trashed documents and restoring documents with various scenarios

## Implementation Details

- The `documentRestorer` command centralizes restoration logic previously inline in the REST API, making it reusable across both REST and MCP interfaces
- Document listing with `status` filter bypasses full-text search and uses direct database queries with appropriate ordering (by `archivedAt` or `deletedAt`)
- Restoration properly handles collection relocation, removing documents from source collections and re-attaching to destination collections
- Authorization checks ensure users can only restore documents they have access to
- All operations use database transactions for consistency

https://claude.ai/code/session_01HpFcYtgEZJ96iaFMuGGCmc