### PR TITLE
fix: Drawer content padding to account for safe area inset

### DIFF
--- a/app/components/primitives/Drawer.tsx
+++ b/app/components/primitives/Drawer.tsx
@@ -102,6 +102,7 @@ const StyledContent = styled(m.div)`
 
 const StyledInnerContent = styled(Flex)`
   padding: 6px;
+  padding-bottom: calc(6px + var(--sab, 0px));
   height: 100%;
 `;
 


### PR DESCRIPTION
## Summary

Adjusts the bottom padding of the Drawer's inner content to account for the safe area inset on devices with notches or home indicators (e.g., mobile devices with rounded corners or dynamic islands).

## Changes

- Added `padding-bottom: calc(6px + var(--sab, 0px))` to `StyledInnerContent` in the Drawer component
  - `--sab` is the CSS variable for safe area inset bottom, commonly used for responsive mobile layouts
  - Falls back to `0px` on devices that don't define this variable
  - Maintains the existing `6px` base padding while adding the safe area offset

## Implementation Details

This change ensures that content within the Drawer doesn't get obscured by system UI elements (notches, home indicators, etc.) on mobile devices, improving the user experience on modern smartphones and tablets. The use of CSS custom properties with a fallback value ensures backward compatibility with devices that don't support safe area insets.

https://claude.ai/code/session_01QkYpSNjiSYD7QiBp2nJCAj