### PR TITLE
Add responsive margin to search input on mobile/tablet

### DIFF
--- a/app/components/InputSearchPage.tsx
+++ b/app/components/InputSearchPage.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 import styled, { useTheme } from "styled-components";
+import breakpoint from "styled-components-breakpoint";
 import { s } from "@shared/styles";
 import {
   isModKey,
@@ -117,6 +118,12 @@ function InputSearchPage({
 
 const InputMaxWidth = styled(Input).attrs({ round: true })`
   max-width: min(calc(30vw + 20px), 100%);
+
+  /* On mobile the input grows to fill the header, so add a gap before the
+   * adjacent action button (e.g. "New doc"). */
+  ${breakpoint("mobile", "tablet")`
+    margin-inline-end: 8px;
+  `}
 `;
 
 const Shortcut = styled.span<{ $visible: boolean }>`


### PR DESCRIPTION
## Summary
Adds responsive spacing to the search input component to prevent it from overlapping with adjacent action buttons (e.g., "New doc") on mobile and tablet devices.

## Changes
- Import `breakpoint` utility from `styled-components-breakpoint`
- Add responsive margin rule to `InputMaxWidth` styled component that applies an 8px inline-end margin on mobile and tablet breakpoints
- Include explanatory comment documenting the purpose of the responsive spacing

## Implementation Details
The search input grows to fill the header on smaller screens, so this change ensures proper spacing between the input and adjacent action buttons by applying a margin-inline-end of 8px on mobile and tablet viewports. This improves the visual layout and prevents UI elements from appearing cramped on smaller devices.

https://claude.ai/code/session_018V13UpihVFLn3TbvmEFPXu