### PR TITLE
fix: Sticky table header styling in Safari

### DIFF
--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -2438,8 +2438,8 @@ table {
     position: relative;
     z-index: 2;
 
-    th {
-      // Safari requires the TD to have raised z-index too
+    > th {
+      // Safari requires the header cell to have raised z-index too
       z-index: 2;
     }
   }

--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -2437,6 +2437,11 @@ table {
   > .${EditorStyleHelper.tableScrollable} > table > tbody > tr:first-child {
     position: relative;
     z-index: 2;
+
+    th {
+      // Safari requires the TD to have raised z-index too
+      z-index: 2;
+    }
   }
 
   > .${EditorStyleHelper.tableScrollable} > table > tbody > tr:first-child > th {


### PR DESCRIPTION
closes #12583