### PR TITLE
fix: Remove parsing rules when not supported in editor

### DIFF
--- a/shared/editor/lib/markdown/rules.test.ts
+++ b/shared/editor/lib/markdown/rules.test.ts
@@ -1,0 +1,37 @@
+import type { Schema } from "prosemirror-model";
+import makeRules from "./rules";
+
+const tableMarkdown = "| a | b |\n| --- | --- |\n| 1 | 2 |";
+
+const schemaWith = (nodes: string[]) =>
+  ({
+    nodes: Object.fromEntries(nodes.map((name) => [name, {}])),
+  }) as unknown as Schema;
+
+describe("makeRules", () => {
+  it("parses tables when the schema supports them", () => {
+    const md = makeRules({ schema: schemaWith(["table"]) });
+    const types = md.parse(tableMarkdown, {}).map((token) => token.type);
+    expect(types).toContain("table_open");
+  });
+
+  it("does not emit table tokens when the schema lacks table support", () => {
+    const md = makeRules({ schema: schemaWith([]) });
+    const types = md.parse(tableMarkdown, {}).map((token) => token.type);
+    expect(types).not.toContain("table_open");
+  });
+
+  it("does not emit heading tokens for setext headings when the schema lacks heading support", () => {
+    const md = makeRules({ schema: schemaWith([]) });
+    const types = md.parse("Title\n=====\n", {}).map((token) => token.type);
+    expect(types).not.toContain("heading_open");
+  });
+
+  it("does not emit code_block tokens when the schema lacks code block support", () => {
+    const md = makeRules({ schema: schemaWith([]) });
+    const indented = md.parse("    foo\n", {}).map((token) => token.type);
+    const fenced = md.parse("```\nfoo\n```\n", {}).map((token) => token.type);
+    expect(indented).not.toContain("code_block");
+    expect(fenced).not.toContain("fence");
+  });
+});

--- a/shared/editor/lib/markdown/rules.ts
+++ b/shared/editor/lib/markdown/rules.ts
@@ -38,6 +38,9 @@ export default function makeRules({
   if (!schema?.nodes.heading) {
     markdownIt.disable("heading");
   }
+  if (!schema?.nodes.table) {
+    markdownIt.disable("table");
+  }
 
   plugins.forEach((plugin) => markdownIt.use(plugin));
   return markdownIt;

--- a/shared/editor/lib/markdown/rules.ts
+++ b/shared/editor/lib/markdown/rules.ts
@@ -36,10 +36,15 @@ export default function makeRules({
     markdownIt.disable("hr");
   }
   if (!schema?.nodes.heading) {
-    markdownIt.disable("heading");
+    // "heading" is ATX (# Title), "lheading" is setext (Title\n=====).
+    markdownIt.disable(["heading", "lheading"]);
   }
   if (!schema?.nodes.table) {
     markdownIt.disable("table");
+  }
+  if (!schema?.nodes.code_block) {
+    // "code" is indented code blocks, "fence" is ``` delimited blocks.
+    markdownIt.disable(["code", "fence"]);
   }
 
   plugins.forEach((plugin) => markdownIt.use(plugin));


### PR DESCRIPTION
Fixes `Error: Token type table_open not supported by Markdown parser`