### PR TITLE
Fix SidebarButton top padding regression from default removal

### DIFF
--- a/app/components/Sidebar/components/SidebarButton.tsx
+++ b/app/components/Sidebar/components/SidebarButton.tsx
@@ -11,7 +11,7 @@ import Desktop from "~/utils/Desktop";
 import { HStack } from "~/components/primitives/HStack";
 
 export type SidebarButtonProps = React.ComponentProps<typeof Button> & {
-  position: "top" | "bottom";
+  position?: "top" | "bottom";
   title: React.ReactNode;
   image: React.ReactNode;
   showMoreMenu?: boolean;
@@ -23,7 +23,7 @@ const SidebarButton = observer(
   React.forwardRef<HTMLButtonElement, SidebarButtonProps>(
     function SidebarButton_(
       {
-        position,
+        position = "top",
         showMoreMenu,
         image,
         title,


### PR DESCRIPTION
## Summary

Follow-up to #12617, addressing review feedback from Copilot.

Removing the `position = "top"` default from `SidebarButton` in #12617 introduced a runtime regression. The `position` prop is omitted at several call sites (`app/components/Sidebar/App.tsx`, `Settings.tsx`, `Shared.tsx`) and relied on the `"top"` default. Without it, `position` became `undefined`, which disabled the intended top styling — notably the `Container` top padding when `Desktop.hasInsetTitlebar()` is true.

The prop was typed as required, but that wasn't enforced at the JSX call sites (styled-component prop typing), so the default was load-bearing at runtime.

## Fix

- Make `position?: "top" | "bottom"` optional to reflect actual usage.
- Restore the `= "top"` destructuring default.

Because the property type is now nullish, the default is no longer "useless", so the `no-useless-default-assignment` rule (promoted to error in #12617) remains satisfied. `yarn lint` and `yarn tsc` both pass clean.

https://claude.ai/code/session_019xWZfmBFwYcNCGm54aaNQe

---
_Generated by [Claude Code](https://claude.ai/code/session_019xWZfmBFwYcNCGm54aaNQe)_