### PR TITLE
fix(github): resolve ESM require error when loading plugin

### DIFF
--- a/plugins/github/server/github.ts
+++ b/plugins/github/server/github.ts
@@ -1,12 +1,10 @@
-import {
-  createOAuthUserAuth,
-  createAppAuth,
-  type OAuthWebFlowAuthOptions,
-  type InstallationAuthOptions,
+import type {
+  OAuthWebFlowAuthOptions,
+  InstallationAuthOptions,
 } from "@octokit/auth-app";
 import { Sequelize } from "sequelize";
 import type { Endpoints, OctokitResponse } from "@octokit/types";
-import { Octokit } from "octokit";
+import type { Octokit } from "octokit";
 import pluralize from "pluralize";
 import type { IntegrationType } from "@shared/types";
 import { IntegrationService, UnfurlResourceType } from "@shared/types";
@@ -199,7 +197,20 @@ const requestPlugin = (octokit: Octokit) => ({
     }),
 });
 
-const CustomOctokit = Octokit.plugin(requestPlugin);
+type CustomOctokit = Octokit & ReturnType<typeof requestPlugin>;
+
+let cachedCustomOctokitPromise:
+  | Promise<ReturnType<typeof Octokit.plugin<[typeof requestPlugin]>>>
+  | undefined;
+
+async function getCustomOctokit() {
+  if (!cachedCustomOctokitPromise) {
+    cachedCustomOctokitPromise = import("octokit").then(({ Octokit }) =>
+      Octokit.plugin(requestPlugin)
+    );
+  }
+  return cachedCustomOctokitPromise;
+}
 
 export class GitHub {
   private static appId = env.GITHUB_APP_ID;
@@ -210,7 +221,7 @@ export class GitHub {
   private static clientId = env.GITHUB_CLIENT_ID;
   private static clientSecret = env.GITHUB_CLIENT_SECRET;
 
-  private static appOctokit: Octokit;
+  private static appOctokitPromise: Promise<CustomOctokit> | undefined;
 
   private static supportedResources = [
     UnfurlResourceType.Issue,
@@ -279,19 +290,22 @@ export class GitHub {
   }
 
   private static authenticateAsApp = () => {
-    if (!GitHub.appOctokit) {
-      GitHub.appOctokit = new CustomOctokit({
-        authStrategy: createAppAuth,
-        auth: {
-          appId: GitHub.appId,
-          privateKey: GitHub.appKey,
-          clientId: GitHub.clientId,
-          clientSecret: GitHub.clientSecret,
-        },
-      });
+    if (!GitHub.appOctokitPromise) {
+      GitHub.appOctokitPromise = (async () => {
+        const CustomOctokit = await getCustomOctokit();
+        const { createAppAuth } = await import("@octokit/auth-app");
+        return new CustomOctokit({
+          authStrategy: createAppAuth,
+          auth: {
+            appId: GitHub.appId,
+            privateKey: GitHub.appKey,
+            clientId: GitHub.clientId,
+            clientSecret: GitHub.clientSecret,
+          },
+        });
+      })();
     }
-
-    return GitHub.appOctokit;
+    return GitHub.appOctokitPromise;
   };
 
   /**
@@ -299,13 +313,16 @@ export class GitHub {
    *
    * @param code Temporary code received in callback url after user authorizes
    * @param state A string received in callback url to protect against CSRF
-   * @returns {Octokit} User-authenticated octokit instance
+   * @returns user-authenticated octokit instance.
    */
   public static authenticateAsUser = async (
     code: string,
     state?: string | null
-  ) =>
-    GitHub.authenticateAsApp().auth({
+  ) => {
+    const appOctokit = await GitHub.authenticateAsApp();
+    const CustomOctokit = await getCustomOctokit();
+    const { createOAuthUserAuth } = await import("@octokit/auth-app");
+    return appOctokit.auth({
       type: "oauth-user",
       code,
       state,
@@ -314,16 +331,20 @@ export class GitHub {
           authStrategy: createOAuthUserAuth,
           auth: options,
         }),
-    }) as Promise<InstanceType<typeof CustomOctokit>>;
+    }) as Promise<CustomOctokit>;
+  };
 
   /**
    * [Authenticates as a GitHub app installation](https://github.com/octokit/auth-app.js/?tab=readme-ov-file#authenticate-as-installation)
    *
    * @param installationId Id of an installation
-   * @returns {Octokit} Installation-authenticated octokit instance
+   * @returns installation-authenticated octokit instance.
    */
-  public static authenticateAsInstallation = async (installationId: number) =>
-    GitHub.authenticateAsApp().auth({
+  public static authenticateAsInstallation = async (installationId: number) => {
+    const appOctokit = await GitHub.authenticateAsApp();
+    const CustomOctokit = await getCustomOctokit();
+    const { createAppAuth } = await import("@octokit/auth-app");
+    return appOctokit.auth({
       type: "installation",
       installationId,
       factory: (options: InstallationAuthOptions) =>
@@ -331,7 +352,8 @@ export class GitHub {
           authStrategy: createAppAuth,
           auth: options,
         }),
-    }) as Promise<InstanceType<typeof CustomOctokit>>;
+    }) as Promise<CustomOctokit>;
+  };
 
   /**
    *
@@ -391,7 +413,7 @@ export class GitHub {
   };
 
   private static async unfurlProject(
-    client: InstanceType<typeof CustomOctokit>,
+    client: CustomOctokit,
     resource: ParsedProject
   ) {
     let project: GitHubProject | undefined;


### PR DESCRIPTION
### Summary
This PR fixes a fatal startup crash (`ERR_REQUIRE_ESM`) in self-hosted instances running with the GitHub plugin enabled.

### Detail
Recently, `@octokit/auth-app` was upgraded to `v8` in #12472. Since `v8` is a pure ES Module, and the production server environment loads plugins dynamically via CommonJS `require()` in `PluginManager.loadPlugins()`, attempting to require the compiled plugin server file results in a runtime crash:
`Error [ERR_REQUIRE_ESM]: require() of ES Module /app/node_modules/@octokit/auth-app/dist-node/index.js from /app/dist/plugins/github/server/github.js not supported.`

To resolve this, we convert the static import of `@octokit/auth-app` in `plugins/github/server/github.ts` into a type-only import for compilation, and dynamically `import()` the runtime methods (`createAppAuth`, `createOAuthUserAuth`) within the asynchronous authentication functions.

### Testing
- Ran `yarn build:server` to verify that compilation succeeds and output type checking passes.