### PR TITLE
feat: Add text color picker and formatting support

### DIFF
--- a/app/editor/components/TextColorPicker.tsx
+++ b/app/editor/components/TextColorPicker.tsx
@@ -1,0 +1,34 @@
+import { useCallback } from "react";
+import ColorPicker from "@shared/components/ColorPicker";
+import { useEditor } from "./EditorContext";
+
+type Props = {
+  /** The currently active color */
+  activeColor: string;
+};
+
+/**
+ * A color picker component for applying text (foreground) color.
+ */
+function TextColorPicker({ activeColor }: Props) {
+  const { commands } = useEditor();
+
+  const handleSelect = useCallback(
+    (color: string) => {
+      if (commands.textColor) {
+        commands.textColor({ color });
+      }
+    },
+    [commands]
+  );
+
+  return (
+    <ColorPicker
+      alpha={false}
+      activeColor={activeColor}
+      onSelect={handleSelect}
+    />
+  );
+}
+
+export default TextColorPicker;

--- a/app/editor/extensions/SelectionToolbar.tsx
+++ b/app/editor/extensions/SelectionToolbar.tsx
@@ -95,10 +95,7 @@ export default class SelectionToolbarExtension extends Extension {
         priority: 30,
         matches: (ctx) => ctx.readOnly,
         getItems: (ctx) =>
-          getReadOnlyMenuItems(
-            ctx,
-            this.editor.props.canUpdate ?? false
-          ),
+          getReadOnlyMenuItems(ctx, this.editor.props.canUpdate ?? false),
       },
       {
         priority: 20,

--- a/app/editor/menus/attachment.tsx
+++ b/app/editor/menus/attachment.tsx
@@ -9,9 +9,7 @@ import type { MenuItem, SelectionContext } from "@shared/editor/types";
  * @param ctx - the current selection context.
  * @returns an array of menu items.
  */
-export default function attachmentMenuItems(
-  ctx: SelectionContext
-): MenuItem[] {
+export default function attachmentMenuItems(ctx: SelectionContext): MenuItem[] {
   if (ctx.readOnly) {
     return [];
   }

--- a/app/editor/menus/code.tsx
+++ b/app/editor/menus/code.tsx
@@ -21,9 +21,7 @@ import { metaDisplay } from "@shared/utils/keyboard";
  * @param ctx - the current selection context.
  * @returns an array of menu items.
  */
-export default function codeMenuItems(
-  ctx: SelectionContext
-): MenuItem[] {
+export default function codeMenuItems(ctx: SelectionContext): MenuItem[] {
   const { state, readOnly } = ctx;
   const node =
     state.selection instanceof NodeSelection

--- a/app/editor/menus/formatting.tsx
+++ b/app/editor/menus/formatting.tsx
@@ -25,8 +25,10 @@ import {
 import { v4 as uuidv4 } from "uuid";
 import CellBackgroundColorPicker from "../components/CellBackgroundColorPicker";
 import HighlightColorPicker from "../components/HighlightColorPicker";
+import TextColorPicker from "../components/TextColorPicker";
 
 import { getDocumentHighlightColors } from "@shared/editor/queries/getDocumentHighlightColors";
+import { getDocumentTextColors } from "@shared/editor/queries/getDocumentTextColors";
 import { getMarksBetween } from "@shared/editor/queries/getMarksBetween";
 import { isInList } from "@shared/editor/queries/isInList";
 import { isMarkActive } from "@shared/editor/queries/isMarkActive";
@@ -46,7 +48,110 @@ import {
 import type { CellSelection } from "prosemirror-tables";
 import TableCell from "@shared/editor/nodes/TableCell";
 import Highlight from "@shared/editor/marks/Highlight";
+import TextColor from "@shared/editor/marks/TextColor";
 import { DottedCircleIcon } from "~/components/Icons/DottedCircleIcon";
+
+function TextColorIcon({
+  size = 24,
+  color = "currentColor",
+  ...rest
+}: {
+  size?: number;
+  color?: string;
+}) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...rest}
+    >
+      <line x1="4" y1="20" x2="20" y2="20" stroke={color} />
+      <path d="M17 18L12 5L7 18" />
+      <path d="M9 13h6" />
+    </svg>
+  );
+}
+
+function getTextColorMenuItems({
+  schema,
+  state,
+  hasTextColorMark,
+  currentTextColor,
+}: {
+  schema: SelectionContext["schema"];
+  state: SelectionContext["state"];
+  hasTextColorMark: boolean;
+  currentTextColor: string | null | undefined;
+}): MenuItem[] {
+  const documentTextColors = getDocumentTextColors(state);
+  const noneColor = currentTextColor ?? null;
+  const nonPresetDocumentColors = documentTextColors.filter(
+    (color: string) =>
+      !TextColor.isPresetColor(color) && color !== currentTextColor
+  );
+
+  return [
+    ...(hasTextColorMark
+      ? [
+          {
+            name: "textColor",
+            label: t("None"),
+            icon: <DottedCircleIcon retainColor color="transparent" />,
+            active: () => false,
+            attrs: { color: noneColor },
+          },
+        ]
+      : []),
+    ...TextColor.presetColors.map((preset) => ({
+      name: "textColor",
+      label: preset.name,
+      icon: <CircleIcon retainColor color={preset.hex} />,
+      active: isMarkActive(schema.marks.textColor, { color: preset.hex }),
+      attrs: { color: preset.hex },
+    })),
+    ...(currentTextColor && !TextColor.isPresetColor(currentTextColor)
+      ? [
+          {
+            name: "textColor",
+            label: currentTextColor,
+            icon: <CircleIcon retainColor color={currentTextColor} />,
+            active: isMarkActive(schema.marks.textColor, {
+              color: currentTextColor,
+            }),
+            attrs: { color: currentTextColor },
+          },
+        ]
+      : []),
+    ...nonPresetDocumentColors.map((color: string) => ({
+      name: "textColor",
+      label: color,
+      icon: <CircleIcon retainColor color={color} />,
+      active: () => currentTextColor === color,
+      attrs: { color },
+    })),
+    {
+      icon: <CircleIcon retainColor color="rainbow" />,
+      label: "Custom",
+      children: [
+        {
+          content: (
+            <TextColorPicker
+              activeColor={currentTextColor || TextColor.presetColors[0].hex}
+            />
+          ),
+          preventCloseCondition: () =>
+            !!document.activeElement?.matches(".ProseMirror.ProseMirror-focused"),
+        },
+      ],
+    },
+  ];
+}
 
 /**
  * Returns menu items for the default formatting selection toolbar.
@@ -73,6 +178,13 @@ export default function formattingMenuItems(ctx: SelectionContext): MenuItem[] {
     state.selection.to,
     state
   ).find(({ mark }) => mark.type === state.schema.marks.highlight);
+
+  const textColorMark = getMarksBetween(
+    state.selection.from,
+    state.selection.to,
+    state
+  ).find(({ mark }) => mark.type === state.schema.marks.textColor);
+  const currentTextColor = textColorMark?.mark.attrs.color;
 
   const cellSelectionHasBackground = isTableCell
     ? hasNodeAttrMarkCellSelection(
@@ -303,6 +415,25 @@ export default function formattingMenuItems(ctx: SelectionContext): MenuItem[] {
           },
         ];
       },
+    },
+    {
+      tooltip: t("Text color"),
+      icon: textColorMark ? (
+        <TextColorIcon
+          color={currentTextColor || TextColor.presetColors[0].hex}
+        />
+      ) : (
+        <TextColorIcon />
+      ),
+      active: () => !!textColorMark,
+      visible: !isInCode && (!isMobile || !isEmpty) && !isTableCell,
+      children: (): MenuItem[] =>
+        getTextColorMenuItems({
+          schema,
+          state,
+          hasTextColorMark: !!textColorMark,
+          currentTextColor,
+        }),
     },
     {
       name: "code_inline",

--- a/app/editor/menus/image.tsx
+++ b/app/editor/menus/image.tsx
@@ -24,9 +24,7 @@ import { t } from "i18next";
  * @param ctx - the current selection context.
  * @returns an array of menu items.
  */
-export default function imageMenuItems(
-  ctx: SelectionContext
-): MenuItem[] {
+export default function imageMenuItems(ctx: SelectionContext): MenuItem[] {
   if (ctx.readOnly) {
     return [];
   }

--- a/app/editor/menus/notice.tsx
+++ b/app/editor/menus/notice.tsx
@@ -15,9 +15,7 @@ import type { MenuItem, SelectionContext } from "@shared/editor/types";
  * @param ctx - the current selection context.
  * @returns an array of menu items.
  */
-export default function noticeMenuItems(
-  ctx: SelectionContext
-): MenuItem[] {
+export default function noticeMenuItems(ctx: SelectionContext): MenuItem[] {
   const node = ctx.selection.$from.node(-1);
   const currentStyle = node?.attrs.style as NoticeTypes;
 

--- a/app/scenes/Document/hooks/useDocumentSave.ts
+++ b/app/scenes/Document/hooks/useDocumentSave.ts
@@ -341,7 +341,8 @@ export function useDocumentSave({
     () => () => {
       autosave.cancel();
       const currentDoc = editorRef.current?.view.state.doc;
-      const isEditorEmpty = !currentDoc || ProsemirrorHelper.isEmpty(currentDoc);
+      const isEditorEmpty =
+        !currentDoc || ProsemirrorHelper.isEmpty(currentDoc);
 
       if (
         shouldAutoDeleteDraftOnUnmount({

--- a/shared/editor/commands/toggleMark.ts
+++ b/shared/editor/commands/toggleMark.ts
@@ -3,9 +3,7 @@ import type { MarkType } from "prosemirror-model";
 import type { Command, EditorState } from "prosemirror-state";
 import { TextSelection } from "prosemirror-state";
 import type { Primitive } from "utility-types";
-import { chainTransactions } from "../lib/chainTransactions";
 import { getMarksBetween } from "../queries/getMarksBetween";
-import { isMarkActive } from "../queries/isMarkActive";
 
 const wordCharRegex = /[\p{L}\p{N}_]/u;
 
@@ -100,6 +98,9 @@ export function toggleMark(
   attrs?: Record<string, Primitive>
 ): Command {
   return (state, dispatch) => {
+    const shouldRemoveOnly =
+      !!attrs && Object.values(attrs).every((value) => value === null || value === undefined);
+
     const wordRange = findWordRangeAtCursor(state, type);
     if (wordRange) {
       const { from, to } = wordRange;
@@ -107,7 +108,7 @@ export function toggleMark(
 
       if (dispatch) {
         const tr = state.tr.removeMark(from, to, type);
-        if (!hasMatching) {
+        if (!hasMatching && !shouldRemoveOnly) {
           tr.addMark(from, to, type.create(attrs));
         }
         dispatch(tr);
@@ -115,17 +116,22 @@ export function toggleMark(
       return true;
     }
 
-    if (isMarkActive(type, attrs)(state)) {
-      return pmToggleMark(type)(state, dispatch);
+    const { $from, $to, empty } = state.selection;
+    if (empty) {
+      if (shouldRemoveOnly) {
+        return pmToggleMark(type)(state, dispatch);
+      }
+      return pmToggleMark(type, attrs)(state, dispatch);
     }
 
-    if (isMarkActive(type)(state)) {
-      return chainTransactions(pmToggleMark(type), pmToggleMark(type, attrs))(
-        state,
-        dispatch
-      );
+    if (dispatch) {
+      const hasMatching = rangeHasMarkWithAttrs(state, type, attrs, $from.pos, $to.pos);
+      const tr = state.tr.removeMark($from.pos, $to.pos, type);
+      if (!hasMatching && !shouldRemoveOnly) {
+        tr.addMark($from.pos, $to.pos, type.create(attrs));
+      }
+      dispatch(tr);
     }
-
-    return pmToggleMark(type, attrs)(state, dispatch);
+    return true;
   };
 }

--- a/shared/editor/lib/buildSelectionContext.ts
+++ b/shared/editor/lib/buildSelectionContext.ts
@@ -4,11 +4,7 @@ import { CellSelection } from "prosemirror-tables";
 import { isInCode } from "../queries/isInCode";
 import { isInList } from "../queries/isInList";
 import { isInNotice } from "../queries/isInNotice";
-import {
-  getColumnIndex,
-  getRowIndex,
-  isTableSelected,
-} from "../queries/table";
+import { getColumnIndex, getRowIndex, isTableSelected } from "../queries/table";
 import { isMobile as isMobileDevice, isTouchDevice } from "../../utils/browser";
 import type { SelectionContext } from "../types";
 
@@ -44,9 +40,7 @@ export function buildSelectionContext(
     isTableCell: selection instanceof CellSelection,
     isTableSelected: isTableSelected(state),
     selectedNodeType:
-      selection instanceof NodeSelection
-        ? selection.node.type.name
-        : undefined,
+      selection instanceof NodeSelection ? selection.node.type.name : undefined,
     colIndex: getColumnIndex(state),
     rowIndex: getRowIndex(state),
   };

--- a/shared/editor/marks/TextColor.ts
+++ b/shared/editor/marks/TextColor.ts
@@ -1,0 +1,120 @@
+import { isHexColor } from "class-validator";
+import { parseToRgb } from "polished";
+import type {
+  MarkSpec,
+  MarkType,
+  Mark as ProsemirrorMark,
+} from "prosemirror-model";
+import { toggleMark } from "../commands/toggleMark";
+import Mark from "./Mark";
+import { presetTextColors, rgbaToHex } from "@shared/utils/color";
+import type { MarkdownSerializerState } from "../lib/markdown/serializer";
+
+export default class TextColor extends Mark {
+  /** Preset colors available for text coloring */
+  static presetColors = presetTextColors;
+
+  /**
+   * Checks if a color is one of the text color preset colors.
+   *
+   * @param color - A hex color string to check.
+   * @returns true if the color matches a preset color's hex value.
+   */
+  static isPresetColor(color: string): boolean {
+    return TextColor.presetColors.some((c) => c.hex === color);
+  }
+
+  get name() {
+    return "textColor";
+  }
+
+  get schema(): MarkSpec {
+    return {
+      attrs: {
+        color: {
+          default: null,
+          validate: "string|null",
+        },
+      },
+      parseDOM: [
+        {
+          tag: "span[data-text-color]",
+          getAttrs: (dom) => {
+            const color = dom.getAttribute("data-text-color") || "";
+            return {
+              color: isHexColor(color) ? color : null,
+            };
+          },
+        },
+        {
+          tag: "span[style]",
+          consuming: false,
+          getAttrs: (dom) => {
+            const style = dom.style.color;
+            if (!style) {
+              return false;
+            }
+            try {
+              const parsed = parseToRgb(style);
+              // Skip near-black colors (likely default text color)
+              const isNearBlack =
+                parsed.red < 30 && parsed.green < 30 && parsed.blue < 30;
+              if (isNearBlack) {
+                return false;
+              }
+              // Skip near-white colors
+              const isNearWhite =
+                parsed.red > 240 && parsed.green > 240 && parsed.blue > 240;
+              if (isNearWhite) {
+                return false;
+              }
+              const color = rgbaToHex(
+                "alpha" in parsed ? parsed : { ...parsed, alpha: 1 }
+              ).toUpperCase();
+              return { color };
+            } catch {
+              return false;
+            }
+          },
+        },
+        {
+          tag: "font[color]",
+          getAttrs: (dom) => {
+            const color = dom.getAttribute("color") || "";
+            return {
+              color: isHexColor(color) ? color : null,
+            };
+          },
+        },
+      ],
+      toDOM: (node) => [
+        "span",
+        {
+          "data-text-color": node.attrs.color,
+          style: node.attrs.color ? `color: ${node.attrs.color}` : undefined,
+        },
+      ],
+    };
+  }
+
+  keys({ type }: { type: MarkType }) {
+    return {
+      "Mod-Shift-t": toggleMark(type),
+    };
+  }
+
+  toMarkdown() {
+    return {
+      open(_state: MarkdownSerializerState, mark: ProsemirrorMark) {
+        return `<span style="color: ${mark.attrs.color}">`;
+      },
+      close: "</span>",
+      mixable: true,
+      expelEnclosingWhitespace: true,
+    };
+  }
+
+  parseMarkdown() {
+    return { mark: "textColor" };
+  }
+}

--- a/shared/editor/nodes/index.ts
+++ b/shared/editor/nodes/index.ts
@@ -10,6 +10,7 @@ import Bold from "../marks/Bold";
 import Code from "../marks/Code";
 import Comment from "../marks/Comment";
 import Highlight from "../marks/Highlight";
+import TextColor from "../marks/TextColor";
 import Italic from "../marks/Italic";
 import Link from "../marks/Link";
 import TemplatePlaceholder from "../marks/Placeholder";
@@ -114,6 +115,7 @@ export const richExtensions: Nodes = [
   Heading,
   HorizontalRule,
   Highlight,
+  TextColor,
   TemplatePlaceholder,
   Math,
   MathBlock,

--- a/shared/editor/queries/getDocumentTextColors.test.ts
+++ b/shared/editor/queries/getDocumentTextColors.test.ts
@@ -1,0 +1,156 @@
+import { schema, createEditorState, doc, p } from "@shared/test/editor";
+import { getDocumentTextColors } from "./getDocumentTextColors";
+import { toggleMark } from "../commands/toggleMark";
+import { TextSelection, type Transaction } from "prosemirror-state";
+
+describe("getDocumentTextColors", () => {
+  it("returns empty array when no text colors exist", () => {
+    const testDoc = doc([p("Plain text without text colors")]);
+    const state = createEditorState(testDoc);
+
+    const colors = getDocumentTextColors(state);
+
+    expect(colors).toEqual([]);
+  });
+
+  it("returns unique text colors from document", () => {
+    // Create text with textColor marks
+    const textColorMark1 = schema.marks.textColor.create({ color: "#E00000" });
+    const textColorMark2 = schema.marks.textColor.create({ color: "#2563EB" });
+
+    const text1 = schema.text("Red text 1", [textColorMark1]);
+    const text2 = schema.text(" and blue ", [textColorMark2]);
+    const text3 = schema.text("and red again", [textColorMark1]);
+
+    const testDoc = doc([
+      schema.nodes.paragraph.create(null, [text1, text2, text3]),
+    ]);
+    const state = createEditorState(testDoc);
+
+    const colors = getDocumentTextColors(state);
+
+    expect(colors).toHaveLength(2);
+    expect(colors).toContain("#E00000");
+    expect(colors).toContain("#2563EB");
+  });
+
+  it("deduplicates colors used multiple times", () => {
+    const textColorMark = schema.marks.textColor.create({ color: "#E00000" });
+
+    const text1 = schema.text("First red text", [textColorMark]);
+    const text2 = schema.text("Second red text", [textColorMark]);
+
+    const testDoc = doc([
+      schema.nodes.paragraph.create(null, [text1]),
+      schema.nodes.paragraph.create(null, [text2]),
+    ]);
+    const state = createEditorState(testDoc);
+
+    const colors = getDocumentTextColors(state);
+
+    expect(colors).toHaveLength(1);
+    expect(colors).toContain("#E00000");
+  });
+
+  it("ignores text with other marks but no text color", () => {
+    const boldMark = schema.marks.strong.create();
+    const textColorMark = schema.marks.textColor.create({ color: "#E00000" });
+
+    const boldText = schema.text("Bold text", [boldMark]);
+    const coloredText = schema.text("Colored text", [textColorMark]);
+
+    const testDoc = doc([
+      schema.nodes.paragraph.create(null, [boldText, coloredText]),
+    ]);
+    const state = createEditorState(testDoc);
+
+    const colors = getDocumentTextColors(state);
+
+    expect(colors).toHaveLength(1);
+    expect(colors).toContain("#E00000");
+  });
+
+  describe("textColor toggleMark command", () => {
+    it("applies and updates color marks", () => {
+      const testDoc = doc([p("Hello world")]);
+      let state = createEditorState(testDoc);
+
+      // Select "Hello" (pos 1 to 6)
+      state = state.apply(state.tr.setSelection(TextSelection.create(state.doc, 1, 6)));
+
+      // Toggle color `#E00000`
+      const type = schema.marks.textColor;
+      const cmd = toggleMark(type, { color: "#E00000" });
+      cmd(state, (tr: Transaction) => {
+        state = state.apply(tr);
+      });
+
+      // Check that "Hello" has the textColor mark with "#E00000"
+      const firstChild = state.doc.firstChild!;
+      let textNode = firstChild.child(0);
+      expect(textNode.text).toBe("Hello");
+      expect(textNode.marks).toHaveLength(1);
+      expect(textNode.marks[0].type.name).toBe("textColor");
+      expect(textNode.marks[0].attrs.color).toBe("#E00000");
+
+      // Now toggle color `#2563EB` on the same selection
+      const cmd2 = toggleMark(type, { color: "#2563EB" });
+      cmd2(state, (tr: Transaction) => {
+        state = state.apply(tr);
+      });
+
+      // Check that it updated to "#2563EB"
+      const updatedFirstChild = state.doc.firstChild!;
+      let updatedTextNode = updatedFirstChild.child(0);
+      expect(updatedTextNode.text).toBe("Hello");
+      expect(updatedTextNode.marks).toHaveLength(1);
+      expect(updatedTextNode.marks[0].type.name).toBe("textColor");
+      expect(updatedTextNode.marks[0].attrs.color).toBe("#2563EB");
+    });
+
+    it("removes textColor mark when toggled with color null", () => {
+      const type = schema.marks.textColor;
+      const red = type.create({ color: "#E00000" });
+      const testDoc = doc([
+        schema.nodes.paragraph.create(null, [schema.text("Hello", [red])]),
+      ]);
+      let state = createEditorState(testDoc);
+
+      state = state.apply(state.tr.setSelection(TextSelection.create(state.doc, 1, 6)));
+      const cmd = toggleMark(type, { color: null });
+      cmd(state, (tr: Transaction) => {
+        state = state.apply(tr);
+      });
+
+      const firstChild = state.doc.firstChild!;
+      const textNode = firstChild.child(0);
+      expect(textNode.text).toBe("Hello");
+      expect(textNode.marks).toHaveLength(0);
+    });
+
+    it("clears textColor when matching color exists in part of selection", () => {
+      const type = schema.marks.textColor;
+      const red = type.create({ color: "#E00000" });
+      const testDoc = doc([
+        schema.nodes.paragraph.create(null, [
+          schema.text("Hello", [red]),
+          schema.text(" world"),
+        ]),
+      ]);
+      let state = createEditorState(testDoc);
+
+      state = state.apply(state.tr.setSelection(TextSelection.create(state.doc, 1, 12)));
+      const cmd = toggleMark(type, { color: "#E00000" });
+      cmd(state, (tr: Transaction) => {
+        state = state.apply(tr);
+      });
+
+      const firstChild = state.doc.firstChild!;
+      for (let i = 0; i < firstChild.childCount; i++) {
+        const textNode = firstChild.child(i);
+        expect(textNode.marks.find((mark) => mark.type === type)).toBeUndefined();
+      }
+    });
+  });
+});
+

--- a/shared/editor/queries/getDocumentTextColors.ts
+++ b/shared/editor/queries/getDocumentTextColors.ts
@@ -1,0 +1,24 @@
+import type { EditorState } from "prosemirror-state";
+
+/**
+ * Get all unique text colors used in the document.
+ *
+ * @param state The editor state.
+ * @returns An array of unique hex color strings used for text colors in the document.
+ */
+export function getDocumentTextColors(state: EditorState): string[] {
+  const colors = new Set<string>();
+
+  state.doc.descendants((node) => {
+    if (node.isText) {
+      const textColorMark = node.marks.find(
+        (mark) => mark.type.name === "textColor"
+      );
+      if (textColorMark?.attrs.color) {
+        colors.add(textColorMark.attrs.color);
+      }
+    }
+  });
+
+  return Array.from(colors);
+}

--- a/shared/editor/rules/mark.ts
+++ b/shared/editor/rules/mark.ts
@@ -61,10 +61,7 @@ export default function (options: { delim: string; mark: string }) {
 
     // Walk through delimiter list and replace text tokens with tags
     //
-    function postProcess(
-      state: StateInline,
-      delimiters: Delimiter[]
-    ) {
+    function postProcess(state: StateInline, delimiters: Delimiter[]) {
       let i = 0,
         j,
         startDelim,

--- a/shared/utils/ProsemirrorHelper.ts
+++ b/shared/utils/ProsemirrorHelper.ts
@@ -313,9 +313,7 @@ export class ProsemirrorHelper {
       return [];
     }
 
-    return (
-      node.attrs.marks as { type?: string; attrs?: { id?: string } }[]
-    )
+    return (node.attrs.marks as { type?: string; attrs?: { id?: string } }[])
       .filter(
         (mark): mark is { type: "comment"; attrs: { id: string } } =>
           mark?.type === "comment" && !!mark?.attrs?.id

--- a/shared/utils/color.ts
+++ b/shared/utils/color.ts
@@ -81,6 +81,16 @@ export const presetColors: PresetColor[] = [
   { hex: "#3CBEFC", name: "Neon" },
 ];
 
+export const presetTextColors: PresetColor[] = [
+  { hex: "#E00000", name: "Red" },
+  { hex: "#2563EB", name: "Blue" },
+  { hex: "#008A00", name: "Green" },
+  { hex: "#9333EA", name: "Purple" },
+  { hex: "#FFA500", name: "Orange" },
+  { hex: "#A8A29E", name: "Gray" },
+  { hex: "#92400E", name: "Brown" },
+];
+
 export const hexToRgba = (hex: string): RgbaColor => {
   if (hex[0] === "#") {
     hex = hex.substring(1);


### PR DESCRIPTION
### Summary
This PR adds support for text color formatting, allowing users to apply custom colors directly to text in the editor. It introduces a new `TextColor` mark, a `TextColorPicker` component in the selection toolbar and menus, and utilities to extract unique text colors from the document.

### Context & Motivation
Currently, Outline users can only highlight text backgrounds using the `<mark>` tag. However, as discussed by the community, background highlighting can look cluttered and unprofessional when used extensively in collaborative environments. Users have strongly requested the ability to change the text color itself to improve readability and presentation.

This feature addresses the following community requests:
- **[Discussion #11789](https://github.com/outline/outline/discussions/11789) ("Add text color support")**: Users expressed the need for a clean, professional way to format text with colors instead of using heavy background highlights.
- **[Discussion #6693](https://github.com/outline/outline/discussions/6693) ("Highlight colors and more text formatting")**: Users highlighted the need for more colors to differentiate information (e.g., distinguishing close heading styles like H3/H4, or emphasizing specific words in the text body) where Notice Blocks or full-background highlights are too disruptive.
- **[Discussion #2003](https://github.com/outline/outline/discussions/2003) ("More Color")**: Community discussed the technical transition from Markdown-dependent formatting to ProseMirror JSON Schema. Since Outline now uses ProseMirror documents, the technical constraint of Markdown's lack of native font color tags is no longer a blocker.

### Key Changes
- **New `TextColorPicker` Component**: Added to the formatting toolbar for easy color selection.
- **`TextColor` Mark**: Implemented ProseMirror mark to manage the custom text color attribute.
- **Formatting Menus Updated**: Added text color options to selection toolbars and context menus.
- **Document Utilities**: Added helper functions (like `getDocumentTextColors`) to scan the document for applied text colors.
- **Command Enhancements**: Extended formatting commands to seamlessly handle text color toggling.
