### PR TITLE
perf: Improve performance of in-page search

### DIFF
--- a/app/editor/components/FindAndReplace.tsx
+++ b/app/editor/components/FindAndReplace.tsx
@@ -225,7 +225,7 @@ export default function FindAndReplace({
         }) => {
           editor.commands.find(attrs);
         },
-        250
+        100
       ),
     [editor.commands]
   );

--- a/app/editor/components/FindAndReplace.tsx
+++ b/app/editor/components/FindAndReplace.tsx
@@ -1,3 +1,4 @@
+import { debounce } from "es-toolkit/compat";
 import {
   CaretDownIcon,
   CaretUpIcon,
@@ -211,9 +212,32 @@ export default function FindAndReplace({
     });
   }, [caseSensitive, editor.commands, searchTerm]);
 
+  // Searching the document on every keystroke is expensive in long documents –
+  // it traverses the entire doc and rebuilds highlights – so debounce it to keep
+  // typing in the input responsive. The input value itself updates immediately.
+  const debouncedFind = React.useMemo(
+    () =>
+      debounce(
+        (attrs: {
+          text: string;
+          caseSensitive: boolean;
+          regexEnabled: boolean;
+        }) => {
+          editor.commands.find(attrs);
+        },
+        250
+      ),
+    [editor.commands]
+  );
+
+  React.useEffect(() => () => debouncedFind.cancel(), [debouncedFind]);
+
   const handleKeyDown = React.useCallback(
     (ev: React.KeyboardEvent<HTMLInputElement>) => {
       function nextPrevious() {
+        // Ensure any pending debounced search has run so navigation acts on the
+        // results for the text currently in the input.
+        debouncedFind.flush();
         if (ev.shiftKey) {
           editor.commands.prevSearchMatch();
         } else {
@@ -243,7 +267,7 @@ export default function FindAndReplace({
         }
       }
     },
-    [editor.commands, selectInputText]
+    [debouncedFind, editor.commands, selectInputText]
   );
 
   const handleReplace = React.useCallback(
@@ -274,13 +298,13 @@ export default function FindAndReplace({
       ev.stopPropagation();
       setSearchTerm(ev.currentTarget.value);
 
-      editor.commands.find({
+      debouncedFind({
         text: ev.currentTarget.value,
         caseSensitive,
         regexEnabled,
       });
     },
-    [caseSensitive, editor.commands, regexEnabled]
+    [caseSensitive, debouncedFind, regexEnabled]
   );
 
   const handleReplaceKeyDown = React.useCallback(

--- a/app/editor/components/FindAndReplace.tsx
+++ b/app/editor/components/FindAndReplace.tsx
@@ -213,8 +213,7 @@ export default function FindAndReplace({
   }, [caseSensitive, editor.commands, searchTerm]);
 
   // Searching the document on every keystroke is expensive in long documents –
-  // it traverses the entire doc and rebuilds highlights – so debounce it to keep
-  // typing in the input responsive. The input value itself updates immediately.
+  // it traverses the entire doc and rebuilds highlights – so debounce.
   const debouncedFind = React.useMemo(
     () =>
       debounce(
@@ -225,7 +224,7 @@ export default function FindAndReplace({
         }) => {
           editor.commands.find(attrs);
         },
-        100
+        250
       ),
     [editor.commands]
   );
@@ -355,6 +354,9 @@ export default function FindAndReplace({
     } else {
       onClose();
       setShowReplace(false);
+      // Cancel any pending debounced find so it can't reactivate highlights
+      // after the search has been cleared.
+      debouncedFind.cancel();
       editor.commands.clearSearch();
     }
     // oxlint-disable-next-line react-hooks/exhaustive-deps
@@ -370,7 +372,10 @@ export default function FindAndReplace({
       >
         <ButtonLarge
           disabled={disabled}
-          onClick={() => editor.commands.prevSearchMatch()}
+          onClick={() => {
+            debouncedFind.flush();
+            editor.commands.prevSearchMatch();
+          }}
           aria-label={t("Previous match")}
         >
           <CaretUpIcon />
@@ -379,7 +384,10 @@ export default function FindAndReplace({
       <Tooltip content={t("Next match")} shortcut="Enter" placement="bottom">
         <ButtonLarge
           disabled={disabled}
-          onClick={() => editor.commands.nextSearchMatch()}
+          onClick={() => {
+            debouncedFind.flush();
+            editor.commands.nextSearchMatch();
+          }}
           aria-label={t("Next match")}
         >
           <CaretDownIcon />

--- a/app/editor/extensions/FindAndReplace.tsx
+++ b/app/editor/extensions/FindAndReplace.tsx
@@ -490,6 +490,7 @@ export default class FindAndReplaceExtension extends Extension<FindAndReplaceOpt
       }
     }
 
+    this.highlightRanges = allRanges;
     CSS.highlights.set("search-results", new Highlight(...allRanges));
     if (currentRanges.length) {
       CSS.highlights.set(
@@ -502,12 +503,32 @@ export default class FindAndReplaceExtension extends Extension<FindAndReplaceOpt
   }
 
   private clearHighlights() {
+    this.highlightRanges = [];
     if (!supportsHighlightAPI) {
       return;
     }
     CSS.highlights.delete("search-results");
     CSS.highlights.delete("search-results-current");
     this.currentHighlightRange = undefined;
+  }
+
+  /**
+   * Determine whether the highlight ranges need to be rebuilt against the live
+   * DOM. The CSS Custom Highlight API holds static ranges that detach when the
+   * editor re-renders its DOM without changing the doc, so highlights are stale
+   * when a built range's nodes have disconnected, or when some matches have not
+   * yet been resolved to ranges (e.g. inside a node view that mounts later).
+   *
+   * @returns whether the highlights should be rebuilt.
+   */
+  private highlightsStale() {
+    if (this.highlightRanges.length < this.results.length) {
+      return true;
+    }
+    return this.highlightRanges.some(
+      (range) =>
+        !range.startContainer.isConnected || !range.endContainer.isConnected
+    );
   }
 
   private handleEscape = () => {
@@ -542,6 +563,8 @@ export default class FindAndReplaceExtension extends Extension<FindAndReplaceOpt
   };
 
   private currentHighlightRange?: StaticRange;
+
+  private highlightRanges: StaticRange[] = [];
 
   get allowInReadOnly() {
     return true;
@@ -611,15 +634,22 @@ export default class FindAndReplaceExtension extends Extension<FindAndReplaceOpt
         return {
           update: (view) => {
             const generation = pluginKey.getState(view.state) as number;
-            // Rebuild highlights when the results change (generation bump) or,
-            // while a search is active, on any view update. The CSS Custom
-            // Highlight API relies on static DOM ranges that become detached
-            // when the editor re-renders its DOM — e.g. content settling after
-            // sync when navigating from search results, collaboration cursors,
-            // or node views mounting — none of which bump the generation. This
-            // keeps the highlights tracking the live DOM, as decorations do.
-            if (generation !== lastGeneration || this.searchTerm) {
+            // The results changed (search ran, doc changed, fold toggled), so
+            // always rebuild.
+            if (generation !== lastGeneration) {
               lastGeneration = generation;
+              this.updateHighlights();
+              return;
+            }
+            // The results are unchanged, but the CSS Custom Highlight API relies
+            // on static DOM ranges that become detached when the editor
+            // re-renders its DOM without bumping the generation — e.g. content
+            // settling after sync when navigating from search results,
+            // collaboration cursors, or node views mounting. Only pay for an
+            // O(n) domAtPos rebuild when the ranges have actually gone stale;
+            // otherwise the live highlights are still valid and we skip the work
+            // (cheap isConnected checks only, no layout).
+            if (this.searchTerm && this.highlightsStale()) {
               this.updateHighlights();
             }
           },

--- a/app/editor/extensions/FindAndReplace.tsx
+++ b/app/editor/extensions/FindAndReplace.tsx
@@ -410,8 +410,8 @@ export default class FindAndReplaceExtension extends Extension<FindAndReplaceOpt
             continue;
           }
 
-          // Check if already exists in results, possible due to duplicated
-          // search string on L257
+          // Check if already exists in results, possible because we search
+          // over `deburr(text) + text`
           const key = `${from}:${to}`;
           if (seen.has(key)) {
             continue;

--- a/app/editor/extensions/FindAndReplace.tsx
+++ b/app/editor/extensions/FindAndReplace.tsx
@@ -381,6 +381,11 @@ export default class FindAndReplaceExtension extends Extension<FindAndReplaceOpt
       }
     });
 
+    // Tracks already-seen match positions so duplicate matches (possible because
+    // we search the deburred text concatenated with the original) can be skipped
+    // in constant time rather than rescanning the entire results array.
+    const seen = new Set<string>();
+
     mergedTextNodes.forEach((node) => {
       const { text = "", pos, type } = node;
       try {
@@ -407,9 +412,11 @@ export default class FindAndReplaceExtension extends Extension<FindAndReplaceOpt
 
           // Check if already exists in results, possible due to duplicated
           // search string on L257
-          if (this.results.some((r) => r.from === from && r.to === to)) {
+          const key = `${from}:${to}`;
+          if (seen.has(key)) {
             continue;
           }
+          seen.add(key);
 
           this.results.push({ from, to, type });
         }

--- a/app/editor/extensions/FindAndReplace.tsx
+++ b/app/editor/extensions/FindAndReplace.tsx
@@ -641,14 +641,8 @@ export default class FindAndReplaceExtension extends Extension<FindAndReplaceOpt
               this.updateHighlights();
               return;
             }
-            // The results are unchanged, but the CSS Custom Highlight API relies
-            // on static DOM ranges that become detached when the editor
-            // re-renders its DOM without bumping the generation — e.g. content
-            // settling after sync when navigating from search results,
-            // collaboration cursors, or node views mounting. Only pay for an
-            // O(n) domAtPos rebuild when the ranges have actually gone stale;
-            // otherwise the live highlights are still valid and we skip the work
-            // (cheap isConnected checks only, no layout).
+            // Results unchanged: only rebuild when the static highlight ranges
+            // have detached from a DOM re-render that didn't bump the generation.
             if (this.searchTerm && this.highlightsStale()) {
               this.updateHighlights();
             }


### PR DESCRIPTION
O(n²) de-duplication in search() — `this.results.some(...)` scans all prior results for each new match, so a common term matching thousands of times in a long document is quadratic.