### PR TITLE
feat(s3): add optional CloudFront support for signed attachment URLs

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -122,7 +122,7 @@ AWS_S3_ACL=private
 
 # Optional CloudFront CDN for attachment downloads (uploads stay on S3).
 # Requires a key pair for signed URLs; otherwise downloads fall back to S3.
-AWS_CLOUDFRONT_URL=https://d1234567890abcdef.cloudfront.net
+AWS_CLOUDFRONT_URL=
 AWS_CLOUDFRONT_KEY_PAIR_ID=K2XXXXXXXXXX
 AWS_CLOUDFRONT_PRIVATE_KEY=
 AWS_CLOUDFRONT_PRIVATE_KEY_BASE64=

--- a/.env.sample
+++ b/.env.sample
@@ -123,9 +123,8 @@ AWS_S3_ACL=private
 # Optional CloudFront CDN for attachment downloads (uploads stay on S3).
 # Requires a key pair for signed URLs; otherwise downloads fall back to S3.
 AWS_CLOUDFRONT_URL=
-AWS_CLOUDFRONT_KEY_PAIR_ID=K2XXXXXXXXXX
+AWS_CLOUDFRONT_KEY_PAIR_ID=
 AWS_CLOUDFRONT_PRIVATE_KEY=
-AWS_CLOUDFRONT_PRIVATE_KEY_BASE64=
 
 # ––––––––––––––––––––––––––––––––––––––
 # ––––––––––––––––  SSL  –––––––––––––––

--- a/.env.sample
+++ b/.env.sample
@@ -120,6 +120,12 @@ AWS_S3_UPLOAD_BUCKET_NAME=bucket_name_here
 AWS_S3_FORCE_PATH_STYLE=true
 AWS_S3_ACL=private
 
+# Optional CloudFront CDN for attachment downloads (uploads stay on S3).
+# Requires a key pair for signed URLs; otherwise downloads fall back to S3.
+AWS_CLOUDFRONT_URL=https://d1234567890abcdef.cloudfront.net
+AWS_CLOUDFRONT_KEY_PAIR_ID=K2XXXXXXXXXX
+AWS_CLOUDFRONT_PRIVATE_KEY=
+AWS_CLOUDFRONT_PRIVATE_KEY_BASE64=
 
 # ––––––––––––––––––––––––––––––––––––––
 # ––––––––––––––––  SSL  –––––––––––––––

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   ],
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1053.0",
+    "@aws-sdk/cloudfront-signer": "^3.1053.0",
     "@aws-sdk/lib-storage": "^3.1053.0",
     "@aws-sdk/s3-presigned-post": "^3.1053.0",
     "@aws-sdk/s3-request-presigner": "^3.1053.0",

--- a/server/env.ts
+++ b/server/env.ts
@@ -651,24 +651,19 @@ export class Environment {
    * private key when AWS_CLOUDFRONT_URL is set.
    */
   @IsOptional()
-  public AWS_CLOUDFRONT_KEY_PAIR_ID =
-    environment.AWS_CLOUDFRONT_KEY_PAIR_ID ?? "";
+  public AWS_CLOUDFRONT_KEY_PAIR_ID = this.toOptionalString(
+    environment.AWS_CLOUDFRONT_KEY_PAIR_ID
+  );
 
   /**
-   * PEM-encoded RSA private key for CloudFront signed URLs. Use a YAML block
-   * scalar in docker-compose for multi-line values.
+   * PEM-encoded RSA private key for CloudFront signed URLs, or a base64-encoded
+   * PEM string on a single line. Use a YAML block scalar in docker-compose for
+   * multi-line PEM values.
    */
   @IsOptional()
-  public AWS_CLOUDFRONT_PRIVATE_KEY =
-    environment.AWS_CLOUDFRONT_PRIVATE_KEY ?? "";
-
-  /**
-   * Base64-encoded CloudFront private key. Takes precedence over
-   * AWS_CLOUDFRONT_PRIVATE_KEY when set.
-   */
-  @IsOptional()
-  public AWS_CLOUDFRONT_PRIVATE_KEY_BASE64 =
-    environment.AWS_CLOUDFRONT_PRIVATE_KEY_BASE64 ?? "";
+  public AWS_CLOUDFRONT_PRIVATE_KEY = this.toOptionalString(
+    environment.AWS_CLOUDFRONT_PRIVATE_KEY
+  );
 
   /**
    * Optional AWS S3 endpoint URL for file attachments.

--- a/server/env.ts
+++ b/server/env.ts
@@ -636,6 +636,41 @@ export class Environment {
   public AWS_S3_ACCELERATE_URL = environment.AWS_S3_ACCELERATE_URL ?? "";
 
   /**
+   * Optional CloudFront distribution URL for serving attachment downloads.
+   * Uploads continue to use the S3 endpoint directly. When set together with
+   * AWS_CLOUDFRONT_KEY_PAIR_ID and a private key, signed CloudFront URLs are
+   * used for downloads. If signing credentials are missing, S3 presigned URLs
+   * are used instead.
+   * Example: https://d1a2b3c4d5e6f.cloudfront.net (no trailing slash)
+   */
+  @IsOptional()
+  public AWS_CLOUDFRONT_URL = environment.AWS_CLOUDFRONT_URL ?? "";
+
+  /**
+   * CloudFront key pair ID for signed download URLs. Required together with a
+   * private key when AWS_CLOUDFRONT_URL is set.
+   */
+  @IsOptional()
+  public AWS_CLOUDFRONT_KEY_PAIR_ID =
+    environment.AWS_CLOUDFRONT_KEY_PAIR_ID ?? "";
+
+  /**
+   * PEM-encoded RSA private key for CloudFront signed URLs. Use a YAML block
+   * scalar in docker-compose for multi-line values.
+   */
+  @IsOptional()
+  public AWS_CLOUDFRONT_PRIVATE_KEY =
+    environment.AWS_CLOUDFRONT_PRIVATE_KEY ?? "";
+
+  /**
+   * Base64-encoded CloudFront private key. Takes precedence over
+   * AWS_CLOUDFRONT_PRIVATE_KEY when set.
+   */
+  @IsOptional()
+  public AWS_CLOUDFRONT_PRIVATE_KEY_BASE64 =
+    environment.AWS_CLOUDFRONT_PRIVATE_KEY_BASE64 ?? "";
+
+  /**
    * Optional AWS S3 endpoint URL for file attachments.
    */
   @Public

--- a/server/env.ts
+++ b/server/env.ts
@@ -644,7 +644,7 @@ export class Environment {
    * Example: https://d1a2b3c4d5e6f.cloudfront.net (no trailing slash)
    */
   @IsOptional()
-  public AWS_CLOUDFRONT_URL = environment.AWS_CLOUDFRONT_URL ?? "";
+  public AWS_CLOUDFRONT_URL = this.toOptionalString(environment.AWS_CLOUDFRONT_URL);
 
   /**
    * CloudFront key pair ID for signed download URLs. Required together with a

--- a/server/storage/files/S3Storage.cloudfront.test.ts
+++ b/server/storage/files/S3Storage.cloudfront.test.ts
@@ -1,10 +1,11 @@
+import type S3Storage from "./S3Storage";
+
 const { mockEnv, mockGetS3SignedUrl, mockGetCloudFrontSignedUrl } = vi.hoisted(
   () => ({
     mockEnv: {
-      AWS_CLOUDFRONT_URL: "",
-      AWS_CLOUDFRONT_KEY_PAIR_ID: "",
-      AWS_CLOUDFRONT_PRIVATE_KEY: "",
-      AWS_CLOUDFRONT_PRIVATE_KEY_BASE64: "",
+      AWS_CLOUDFRONT_URL: undefined as string | undefined,
+      AWS_CLOUDFRONT_KEY_PAIR_ID: undefined as string | undefined,
+      AWS_CLOUDFRONT_PRIVATE_KEY: undefined as string | undefined,
       AWS_S3_UPLOAD_BUCKET_URL: "http://s3:4569",
       AWS_S3_UPLOAD_BUCKET_NAME: "bucket",
       AWS_S3_ACCELERATE_URL: "",
@@ -40,23 +41,20 @@ vi.mock("@aws-sdk/client-s3", () => ({
   CopyObjectCommand: vi.fn(),
 }));
 
-type S3StorageClass = typeof import("./S3Storage").default;
-
 describe("S3Storage CloudFront signed URLs", () => {
-  let S3Storage: S3StorageClass;
+  let Storage: typeof S3Storage;
 
   beforeEach(async () => {
     vi.resetModules();
-    mockEnv.AWS_CLOUDFRONT_URL = "";
-    mockEnv.AWS_CLOUDFRONT_KEY_PAIR_ID = "";
-    mockEnv.AWS_CLOUDFRONT_PRIVATE_KEY = "";
-    mockEnv.AWS_CLOUDFRONT_PRIVATE_KEY_BASE64 = "";
+    mockEnv.AWS_CLOUDFRONT_URL = undefined;
+    mockEnv.AWS_CLOUDFRONT_KEY_PAIR_ID = undefined;
+    mockEnv.AWS_CLOUDFRONT_PRIVATE_KEY = undefined;
     mockGetS3SignedUrl.mockReset();
     mockGetCloudFrontSignedUrl.mockReset();
     mockGetS3SignedUrl.mockResolvedValue("https://s3.example/presigned");
     mockGetCloudFrontSignedUrl.mockReturnValue("https://cf.example/signed");
 
-    S3Storage = (await import("./S3Storage")).default;
+    Storage = (await import("./S3Storage")).default;
   });
 
   it("should return a CloudFront signed URL when signing is configured", async () => {
@@ -64,7 +62,7 @@ describe("S3Storage CloudFront signed URLs", () => {
     mockEnv.AWS_CLOUDFRONT_KEY_PAIR_ID = "K2ABCDEF";
     mockEnv.AWS_CLOUDFRONT_PRIVATE_KEY = "-----BEGIN RSA PRIVATE KEY-----";
 
-    const storage = new S3Storage();
+    const storage = new Storage();
     const url = await storage.getSignedUrl("uploads/test.png");
 
     expect(url).toBe("https://cf.example/signed");
@@ -81,7 +79,7 @@ describe("S3Storage CloudFront signed URLs", () => {
   it("should fall back to S3 when CloudFront signing credentials are missing", async () => {
     mockEnv.AWS_CLOUDFRONT_URL = "https://d111.cloudfront.net";
 
-    const storage = new S3Storage();
+    const storage = new Storage();
     const url = await storage.getSignedUrl("uploads/test.png");
 
     expect(url).toBe("http://localhost:4569/bucket/uploads/test.png");
@@ -92,27 +90,26 @@ describe("S3Storage CloudFront signed URLs", () => {
   it("should fall back to S3 when CloudFront signing fails", async () => {
     mockEnv.AWS_CLOUDFRONT_URL = "https://d111.cloudfront.net";
     mockEnv.AWS_CLOUDFRONT_KEY_PAIR_ID = "K2ABCDEF";
-    mockEnv.AWS_CLOUDFRONT_PRIVATE_KEY = "invalid-key";
+    mockEnv.AWS_CLOUDFRONT_PRIVATE_KEY = "-----BEGIN RSA PRIVATE KEY-----";
     mockGetCloudFrontSignedUrl.mockImplementationOnce(() => {
       throw new Error("signing failed");
     });
 
-    const storage = new S3Storage();
+    const storage = new Storage();
     const url = await storage.getSignedUrl("uploads/test.png");
 
     expect(url).toBe("http://localhost:4569/bucket/uploads/test.png");
     expect(mockGetS3SignedUrl).not.toHaveBeenCalled();
   });
 
-  it("should use base64-encoded private key when provided", async () => {
+  it("should decode a base64-encoded private key in AWS_CLOUDFRONT_PRIVATE_KEY", async () => {
     mockEnv.AWS_CLOUDFRONT_URL = "https://d111.cloudfront.net";
     mockEnv.AWS_CLOUDFRONT_KEY_PAIR_ID = "K2ABCDEF";
-    mockEnv.AWS_CLOUDFRONT_PRIVATE_KEY = "";
-    mockEnv.AWS_CLOUDFRONT_PRIVATE_KEY_BASE64 = Buffer.from(
+    mockEnv.AWS_CLOUDFRONT_PRIVATE_KEY = Buffer.from(
       "-----BEGIN RSA PRIVATE KEY-----"
     ).toString("base64");
 
-    const storage = new S3Storage();
+    const storage = new Storage();
     await storage.getSignedUrl("uploads/test.png");
 
     expect(mockGetCloudFrontSignedUrl).toHaveBeenCalledWith(

--- a/server/storage/files/S3Storage.cloudfront.test.ts
+++ b/server/storage/files/S3Storage.cloudfront.test.ts
@@ -1,0 +1,124 @@
+const { mockEnv, mockGetS3SignedUrl, mockGetCloudFrontSignedUrl } = vi.hoisted(
+  () => ({
+    mockEnv: {
+      AWS_CLOUDFRONT_URL: "",
+      AWS_CLOUDFRONT_KEY_PAIR_ID: "",
+      AWS_CLOUDFRONT_PRIVATE_KEY: "",
+      AWS_CLOUDFRONT_PRIVATE_KEY_BASE64: "",
+      AWS_S3_UPLOAD_BUCKET_URL: "http://s3:4569",
+      AWS_S3_UPLOAD_BUCKET_NAME: "bucket",
+      AWS_S3_ACCELERATE_URL: "",
+      AWS_REGION: "us-east-1",
+      AWS_S3_FORCE_PATH_STYLE: true,
+    },
+    mockGetS3SignedUrl: vi.fn(),
+    mockGetCloudFrontSignedUrl: vi.fn(),
+  })
+);
+
+vi.mock("@server/env", () => ({
+  default: mockEnv,
+}));
+
+vi.mock("@aws-sdk/signature-v4-crt", () => ({}));
+
+vi.mock("@aws-sdk/s3-request-presigner", () => ({
+  getSignedUrl: mockGetS3SignedUrl,
+}));
+
+vi.mock("@aws-sdk/cloudfront-signer", () => ({
+  getSignedUrl: mockGetCloudFrontSignedUrl,
+}));
+
+vi.mock("@aws-sdk/client-s3", () => ({
+  S3Client: class MockS3Client {
+    send = vi.fn();
+  },
+  DeleteObjectCommand: vi.fn(),
+  GetObjectCommand: vi.fn(),
+  HeadObjectCommand: vi.fn(),
+  CopyObjectCommand: vi.fn(),
+}));
+
+type S3StorageClass = typeof import("./S3Storage").default;
+
+describe("S3Storage CloudFront signed URLs", () => {
+  let S3Storage: S3StorageClass;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mockEnv.AWS_CLOUDFRONT_URL = "";
+    mockEnv.AWS_CLOUDFRONT_KEY_PAIR_ID = "";
+    mockEnv.AWS_CLOUDFRONT_PRIVATE_KEY = "";
+    mockEnv.AWS_CLOUDFRONT_PRIVATE_KEY_BASE64 = "";
+    mockGetS3SignedUrl.mockReset();
+    mockGetCloudFrontSignedUrl.mockReset();
+    mockGetS3SignedUrl.mockResolvedValue("https://s3.example/presigned");
+    mockGetCloudFrontSignedUrl.mockReturnValue("https://cf.example/signed");
+
+    S3Storage = (await import("./S3Storage")).default;
+  });
+
+  it("should return a CloudFront signed URL when signing is configured", async () => {
+    mockEnv.AWS_CLOUDFRONT_URL = "https://d111.cloudfront.net";
+    mockEnv.AWS_CLOUDFRONT_KEY_PAIR_ID = "K2ABCDEF";
+    mockEnv.AWS_CLOUDFRONT_PRIVATE_KEY = "-----BEGIN RSA PRIVATE KEY-----";
+
+    const storage = new S3Storage();
+    const url = await storage.getSignedUrl("uploads/test.png");
+
+    expect(url).toBe("https://cf.example/signed");
+    expect(mockGetCloudFrontSignedUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://d111.cloudfront.net/uploads/test.png",
+        keyPairId: "K2ABCDEF",
+        privateKey: "-----BEGIN RSA PRIVATE KEY-----",
+      })
+    );
+    expect(mockGetS3SignedUrl).not.toHaveBeenCalled();
+  });
+
+  it("should fall back to S3 when CloudFront signing credentials are missing", async () => {
+    mockEnv.AWS_CLOUDFRONT_URL = "https://d111.cloudfront.net";
+
+    const storage = new S3Storage();
+    const url = await storage.getSignedUrl("uploads/test.png");
+
+    expect(url).toBe("http://localhost:4569/bucket/uploads/test.png");
+    expect(mockGetCloudFrontSignedUrl).not.toHaveBeenCalled();
+    expect(mockGetS3SignedUrl).not.toHaveBeenCalled();
+  });
+
+  it("should fall back to S3 when CloudFront signing fails", async () => {
+    mockEnv.AWS_CLOUDFRONT_URL = "https://d111.cloudfront.net";
+    mockEnv.AWS_CLOUDFRONT_KEY_PAIR_ID = "K2ABCDEF";
+    mockEnv.AWS_CLOUDFRONT_PRIVATE_KEY = "invalid-key";
+    mockGetCloudFrontSignedUrl.mockImplementationOnce(() => {
+      throw new Error("signing failed");
+    });
+
+    const storage = new S3Storage();
+    const url = await storage.getSignedUrl("uploads/test.png");
+
+    expect(url).toBe("http://localhost:4569/bucket/uploads/test.png");
+    expect(mockGetS3SignedUrl).not.toHaveBeenCalled();
+  });
+
+  it("should use base64-encoded private key when provided", async () => {
+    mockEnv.AWS_CLOUDFRONT_URL = "https://d111.cloudfront.net";
+    mockEnv.AWS_CLOUDFRONT_KEY_PAIR_ID = "K2ABCDEF";
+    mockEnv.AWS_CLOUDFRONT_PRIVATE_KEY = "";
+    mockEnv.AWS_CLOUDFRONT_PRIVATE_KEY_BASE64 = Buffer.from(
+      "-----BEGIN RSA PRIVATE KEY-----"
+    ).toString("base64");
+
+    const storage = new S3Storage();
+    await storage.getSignedUrl("uploads/test.png");
+
+    expect(mockGetCloudFrontSignedUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        privateKey: "-----BEGIN RSA PRIVATE KEY-----",
+      })
+    );
+  });
+});

--- a/server/storage/files/S3Storage.ts
+++ b/server/storage/files/S3Storage.ts
@@ -13,6 +13,7 @@ import "@aws-sdk/signature-v4-crt"; // https://github.com/aws/aws-sdk-js-v3#func
 import type { PresignedPostOptions } from "@aws-sdk/s3-presigned-post";
 import { createPresignedPost } from "@aws-sdk/s3-presigned-post";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { getSignedUrl as getCloudFrontSignedUrl } from "@aws-sdk/cloudfront-signer";
 import fs from "fs-extra";
 import invariant from "invariant";
 import { compact } from "es-toolkit/compat";
@@ -96,6 +97,10 @@ export default class S3Storage extends BaseStorage {
   }
 
   public getUrlForKey(key: string): string {
+    if (env.AWS_CLOUDFRONT_URL) {
+      const base = env.AWS_CLOUDFRONT_URL.replace(/\/$/, "");
+      return `${base}/${key}`;
+    }
     return `${this.getPublicEndpoint()}/${key}`;
   }
 
@@ -142,35 +147,34 @@ export default class S3Storage extends BaseStorage {
     key: string,
     expiresIn = S3Storage.defaultSignedUrlExpires
   ) => {
-    const isDocker = env.AWS_S3_UPLOAD_BUCKET_URL.match(/http:\/\/s3:/);
-    const params = {
-      Bucket: this.getBucket(),
-      Key: key,
-    };
-
-    if (isDocker) {
-      return `${this.getPublicEndpoint()}/${key}`;
-    } else {
-      // Ensure expiration does not exceed AWS S3 Signature V4 limit of 7 days
-      const clampedExpiresIn = Math.min(
-        expiresIn,
-        S3Storage.maxSignedUrlExpires
-      );
-
-      const command = new GetObjectCommand(params);
-      const url = await getSignedUrl(this.client, command, {
-        expiresIn: clampedExpiresIn,
-      });
-
-      if (env.AWS_S3_ACCELERATE_URL) {
-        return url.replace(
-          env.AWS_S3_UPLOAD_BUCKET_URL,
-          env.AWS_S3_ACCELERATE_URL
+    if (env.AWS_CLOUDFRONT_URL) {
+      if (!this.hasCloudFrontSigningConfig()) {
+        Logger.warn(
+          "AWS_CLOUDFRONT_URL is set but signing credentials are missing, falling back to S3 presigned URLs",
+          { key }
         );
+        return this.getS3PresignedUrl(key, expiresIn);
       }
 
-      return url;
+      const cfUrl = this.getCloudFrontUrlForKey(key);
+
+      try {
+        return getCloudFrontSignedUrl({
+          url: cfUrl,
+          keyPairId: env.AWS_CLOUDFRONT_KEY_PAIR_ID,
+          privateKey: this.getCloudFrontPrivateKey(),
+          dateLessThan: new Date(Date.now() + expiresIn * 1000).toISOString(),
+        });
+      } catch (err) {
+        Logger.error("Failed to sign CloudFront URL, falling back to S3", err, {
+          key,
+          cfUrl,
+        });
+        return this.getS3PresignedUrl(key, expiresIn);
+      }
     }
+
+    return this.getS3PresignedUrl(key, expiresIn);
   };
 
   public getFileHandle(key: string): Promise<{
@@ -256,6 +260,64 @@ export default class S3Storage extends BaseStorage {
   }
 
   private client: S3Client;
+
+  private getCloudFrontUrlForKey(key: string): string {
+    const base = env.AWS_CLOUDFRONT_URL.replace(/\/$/, "");
+    return `${base}/${encodeURI(key)}`;
+  }
+
+  private getCloudFrontPrivateKey(): string {
+    if (env.AWS_CLOUDFRONT_PRIVATE_KEY_BASE64) {
+      return Buffer.from(
+        env.AWS_CLOUDFRONT_PRIVATE_KEY_BASE64,
+        "base64"
+      ).toString("utf-8");
+    }
+
+    return env.AWS_CLOUDFRONT_PRIVATE_KEY;
+  }
+
+  private hasCloudFrontSigningConfig(): boolean {
+    return Boolean(
+      env.AWS_CLOUDFRONT_KEY_PAIR_ID &&
+        (env.AWS_CLOUDFRONT_PRIVATE_KEY || env.AWS_CLOUDFRONT_PRIVATE_KEY_BASE64)
+    );
+  }
+
+  private getS3PresignedUrl = async (
+    key: string,
+    expiresIn = S3Storage.defaultSignedUrlExpires
+  ) => {
+    const isDocker = env.AWS_S3_UPLOAD_BUCKET_URL.match(/http:\/\/s3:/);
+    const params = {
+      Bucket: this.getBucket(),
+      Key: key,
+    };
+
+    if (isDocker) {
+      return `${this.getPublicEndpoint()}/${key}`;
+    }
+
+    // Ensure expiration does not exceed AWS S3 Signature V4 limit of 7 days
+    const clampedExpiresIn = Math.min(
+      expiresIn,
+      S3Storage.maxSignedUrlExpires
+    );
+
+    const command = new GetObjectCommand(params);
+    const url = await getSignedUrl(this.client, command, {
+      expiresIn: clampedExpiresIn,
+    });
+
+    if (env.AWS_S3_ACCELERATE_URL) {
+      return url.replace(
+        env.AWS_S3_UPLOAD_BUCKET_URL,
+        env.AWS_S3_ACCELERATE_URL
+      );
+    }
+
+    return url;
+  };
 
   private getEndpoint() {
     if (env.AWS_S3_ACCELERATE_URL) {

--- a/server/storage/files/S3Storage.ts
+++ b/server/storage/files/S3Storage.ts
@@ -148,7 +148,8 @@ export default class S3Storage extends BaseStorage {
     expiresIn = S3Storage.defaultSignedUrlExpires
   ) => {
     if (env.AWS_CLOUDFRONT_URL) {
-      if (!this.hasCloudFrontSigningConfig()) {
+      const privateKey = this.getCloudFrontPrivateKey();
+      if (!env.AWS_CLOUDFRONT_KEY_PAIR_ID || !privateKey) {
         Logger.warn(
           "AWS_CLOUDFRONT_URL is set but signing credentials are missing, falling back to S3 presigned URLs",
           { key }
@@ -162,7 +163,7 @@ export default class S3Storage extends BaseStorage {
         return getCloudFrontSignedUrl({
           url: cfUrl,
           keyPairId: env.AWS_CLOUDFRONT_KEY_PAIR_ID,
-          privateKey: this.getCloudFrontPrivateKey(),
+          privateKey,
           dateLessThan: new Date(Date.now() + expiresIn * 1000).toISOString(),
         });
       } catch (err) {
@@ -262,26 +263,24 @@ export default class S3Storage extends BaseStorage {
   private client: S3Client;
 
   private getCloudFrontUrlForKey(key: string): string {
+    if (!env.AWS_CLOUDFRONT_URL) {
+      throw new Error("CloudFront URL is not configured");
+    }
     const base = env.AWS_CLOUDFRONT_URL.replace(/\/$/, "");
     return `${base}/${encodeURI(key)}`;
   }
 
-  private getCloudFrontPrivateKey(): string {
-    if (env.AWS_CLOUDFRONT_PRIVATE_KEY_BASE64) {
-      return Buffer.from(
-        env.AWS_CLOUDFRONT_PRIVATE_KEY_BASE64,
-        "base64"
-      ).toString("utf-8");
+  private getCloudFrontPrivateKey(): string | undefined {
+    const key = env.AWS_CLOUDFRONT_PRIVATE_KEY;
+    if (!key) {
+      return undefined;
     }
 
-    return env.AWS_CLOUDFRONT_PRIVATE_KEY;
-  }
+    if (key.includes("BEGIN")) {
+      return key;
+    }
 
-  private hasCloudFrontSigningConfig(): boolean {
-    return Boolean(
-      env.AWS_CLOUDFRONT_KEY_PAIR_ID &&
-        (env.AWS_CLOUDFRONT_PRIVATE_KEY || env.AWS_CLOUDFRONT_PRIVATE_KEY_BASE64)
-    );
+    return Buffer.from(key, "base64").toString("utf-8");
   }
 
   private getS3PresignedUrl = async (

--- a/yarn.lock
+++ b/yarn.lock
@@ -136,6 +136,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/cloudfront-signer@npm:^3.1053.0":
+  version: 3.1063.0
+  resolution: "@aws-sdk/cloudfront-signer@npm:3.1063.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.6"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/1215bf0910da66d41863e4ab6fc22cc9db6366c4f1411583978ef9ba5215286278279a32b586a69ee3344d5d028752441fd149d9cfa3c5b9cb06c52b424a01e8
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/core@npm:^3.974.13":
   version: 3.974.13
   resolution: "@aws-sdk/core@npm:3.974.13"
@@ -5914,6 +5924,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/core@npm:^3.24.6":
+  version: 3.24.6
+  resolution: "@smithy/core@npm:3.24.6"
+  dependencies:
+    "@aws-crypto/crc32": "npm:5.2.0"
+    "@smithy/types": "npm:^4.14.3"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/4d3db2296a99a4bcb17007b8276a243930f63c3169b9b86b973a2d1422e8dee7e95e3b98eea115e2759b989b23db1ff89ca505bddbacb7391ca3fe4e222b84ff
+  languageName: node
+  linkType: hard
+
 "@smithy/credential-provider-imds@npm:^4.3.2":
   version: 4.3.4
   resolution: "@smithy/credential-provider-imds@npm:4.3.4"
@@ -5973,6 +5994,15 @@ __metadata:
   dependencies:
     tslib: "npm:^2.6.2"
   checksum: 10c0/8bdad874d9e47233c6f2f74ac001e810b87b0a7c6504b9a9490536c9733ffec36b7b2a73010b31044f22553819a8d1e8bb9b2310f09257b1278a048a5f9679f8
+  languageName: node
+  linkType: hard
+
+"@smithy/types@npm:^4.14.3":
+  version: 4.14.3
+  resolution: "@smithy/types@npm:4.14.3"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/c80244d5ca88992e5609e372eaf2441497d36063688af44e9f0e81ab0ee8d5a4cbdb644822243e4cdfad2dd6484c6274e618dc2a9e91b3b9befe7c7b55e09ddc
   languageName: node
   linkType: hard
 
@@ -15037,6 +15067,7 @@ __metadata:
   resolution: "outline@workspace:."
   dependencies:
     "@aws-sdk/client-s3": "npm:^3.1053.0"
+    "@aws-sdk/cloudfront-signer": "npm:^3.1053.0"
     "@aws-sdk/lib-storage": "npm:^3.1053.0"
     "@aws-sdk/s3-presigned-post": "npm:^3.1053.0"
     "@aws-sdk/s3-request-presigner": "npm:^3.1053.0"


### PR DESCRIPTION
## Summary

- Adds optional CloudFront CDN support for **attachment downloads** (files, avatars, previews) while keeping **uploads on the direct S3 endpoint**
- Uses `@aws-sdk/cloudfront-signer` to generate short-lived signed CloudFront URLs with the same TTL as existing S3 presigned URLs
- Preserves the existing auth model: access checks still happen via `/api/attachments.redirect` before redirecting to storage
- Fully backward compatible: if CloudFront env vars are unset, behavior is unchanged (S3 presigned URLs only)

## Motivation

Self-hosted Outline instances with many attachments or public shares can incur significant **S3 egress costs**. CloudFront reduces egress cost (including AWS free tier and flat-rate plans) and improves download performance globally.

`AWS_S3_ACCELERATE_URL` does **not** solve this use case because it replaces the storage endpoint for **both** downloads and uploads. CloudFront does not proxy S3 presigned POST uploads the same way S3 does — pointing accelerate URL at a CloudFront domain breaks uploads (403/signature mismatch). This PR introduces a **separate** `AWS_CLOUDFRONT_URL` used only in `getSignedUrl` / `getUrlForKey`, leaving upload paths untouched.

## Related

- Supersedes #12548 and earlier attempts (#11853, #11814)
- Discussion: https://github.com/outline/outline/discussions/12655

## What changed

| File | Change |
|------|--------|
| `server/storage/files/S3Storage.ts` | CloudFront signed URLs for downloads; S3 fallback on missing/invalid signing config |
| `server/env.ts` | New env vars for CloudFront URL and signing credentials |
| `.env.sample` | Sample CloudFront configuration |
| `package.json` / `yarn.lock` | Add `@aws-sdk/cloudfront-signer` |
| `server/storage/files/S3Storage.cloudfront.test.ts` | Unit tests for signing and fallback behavior |

## Configuration

New environment variables (all optional):

```env
# CloudFront distribution domain (no trailing slash)
AWS_CLOUDFRONT_URL=https://d1234567890abcdef.cloudfront.net

# Required together for signed download URLs
AWS_CLOUDFRONT_KEY_PAIR_ID=K2XXXXXXXXXX
AWS_CLOUDFRONT_PRIVATE_KEY=          # PEM, multi-line OK in docker-compose
AWS_CLOUDFRONT_PRIVATE_KEY_BASE64=   # alternative to PEM; takes precedence
```

**Expected AWS setup (self-hosted):**

1. S3 bucket remains **private**
2. CloudFront distribution with **Origin Access Control (OAC)** to the bucket
3. CloudFront **trusted key group** + RSA key pair for signed URLs
4. Outline only needs the distribution URL and signing key — no bucket policy changes in app code

**Behavior matrix:**

| `AWS_CLOUDFRONT_URL` | Key pair + private key | Download URL |
|----------------------|------------------------|--------------|
| unset | — | S3 presigned (unchanged) |
| set | set | CloudFront signed URL |
| set | missing | S3 presigned + warning log |
| set | set but signing fails | S3 presigned + error log |

Uploads (`getPresignedPost`, `store`) always use the S3 endpoint — never CloudFront.

## Security notes

- CloudFront private keys are **not** exposed to the client (`@Public` decorator is not used on secrets)
- Unsigned CloudFront URLs are **not** returned as a fallback — if signing is unavailable, the code falls back to S3 presigned URLs instead of permanent public CDN links
- Auth checks before redirect are unchanged (`/api/attachments.redirect`)

## Differences from previous PR #12548

1. **Single clean commit** on branch `feat/cloudfront` (not `main` of fork with 37+ merge commits)
2. **No `@Public` on private keys** — previous version would leak signing secrets to the web client
3. **Safe fallback** — missing or broken signing config uses S3 presigned URLs, not unsigned CloudFront URLs
4. **Unit tests** added for CloudFront signing paths
5. Rebased on current `outline/main`

## Test plan

Manual (self-hosted with real AWS):

- [ ] Upload attachment via editor → file lands in S3 (not via CloudFront)
- [ ] Download attachment via `/api/attachments.redirect` → redirects to CloudFront signed URL
- [ ] Image preview in document renders correctly
- [ ] Avatar upload/update works
- [ ] Public document share with attachments works
- [ ] With `AWS_CLOUDFRONT_URL` unset → identical behavior to before (S3 presigned URLs)
- [ ] With `AWS_CLOUDFRONT_URL` set but keys missing → downloads still work via S3 fallback; warning in logs

Automated:

```bash
yarn test server/storage/files/S3Storage.cloudfront.test.ts
yarn test server/storage/files/S3Storage.test.ts
yarn lint
yarn tsc
```

## Notes for reviewers

- This is an **opt-in** infra feature for self-hosted deployments; cloud Outline is unaffected unless these env vars are set
- Happy to add hosting docs in a follow-up PR once approach is approved
- CI from fork PRs may need workflow approval from a maintainer
