### PR TITLE
ci: pin third-party GitHub Actions to commit SHAs (supply-chain hardening)

### DIFF
--- a/.github/workflows/calibreapp-image-actions.yml
+++ b/.github/workflows/calibreapp-image-actions.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v5
       - name: Compress Images
         id: calibre
-        uses: calibreapp/image-actions@main
+        uses: calibreapp/image-actions@3d5873ac3e7bf1a38b24d9778d8dc639d5706d8b  # main
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           # For non-Pull Requests, run in compressOnly mode and we'll PR after.
@@ -54,7 +54,7 @@ jobs:
         if: |
           github.event_name != 'pull_request' &&
           steps.calibre.outputs.markdown != ''
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@18f7dc018cc2cd597073088f7c7591b9d1c02672  # v3
         with:
           title: "chore: Auto Compress Images"
           branch-suffix: timestamp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       deps: ${{ steps.filter.outputs.deps }}
     steps:
       - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50  # v2
         id: filter
         with:
           filters: |
@@ -126,7 +126,7 @@ jobs:
         run: echo "NODE_ENV=production" >> $GITHUB_ENV
       - run: yarn vite:build
       - name: Send bundle stats to RelativeCI
-        uses: relative-ci/agent-action@v2
+        uses: relative-ci/agent-action@38328454d6a23942175eba485fca4fbb807b1f03  # v2
         with:
           key: ${{ secrets.RELATIVE_CI_KEY }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+        uses: useblacksmith/setup-docker-builder@ab5c1da94f53f5cd75c1038092aa276dddfccbba  # v1
 
       - name: Docker base meta
         id: base_meta
@@ -38,7 +38,7 @@ jobs:
 
       - name: Build and push base image
         id: base_build
-        uses: useblacksmith/build-push-action@v2
+        uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8  # v2
         with:
           context: .
           file: Dockerfile.base
@@ -60,7 +60,7 @@ jobs:
 
       - name: Build and push
         id: build
-        uses: useblacksmith/build-push-action@v2
+        uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8  # v2
         with:
           context: .
           file: Dockerfile
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+        uses: useblacksmith/setup-docker-builder@ab5c1da94f53f5cd75c1038092aa276dddfccbba  # v1
 
       - name: Docker base meta
         id: base_meta
@@ -113,7 +113,7 @@ jobs:
 
       - name: Build and push base image
         id: base_build
-        uses: useblacksmith/build-push-action@v2
+        uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8  # v2
         with:
           context: .
           file: Dockerfile.base
@@ -135,7 +135,7 @@ jobs:
 
       - name: Build and push
         id: build
-        uses: useblacksmith/build-push-action@v2
+        uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8  # v2
         with:
           context: .
           file: Dockerfile
@@ -182,7 +182,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+        uses: useblacksmith/setup-docker-builder@ab5c1da94f53f5cd75c1038092aa276dddfccbba  # v1
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/update-node.yml
+++ b/.github/workflows/update-node.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Create pull request
         if: steps.check.outputs.updated == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676  # v7
         with:
           commit-message: "fix: Update Node.js to ${{ steps.check.outputs.latest }}"
           title: "fix: Update Node.js to ${{ steps.check.outputs.latest }}"


### PR DESCRIPTION
## What
Pins **every** third-party GitHub Action currently referenced by a mutable tag to the exact commit that tag resolves to today, across 4 workflow file(s) (12 references, 6 distinct actions). Each line keeps a `# tag` comment so the version stays legible. This is the complete set in scope, not a sample.

## Why
A mutable tag can be re-pointed by the upstream maintainer, or by an attacker who compromises that account, and the new code would then run in your workflows with the job's token. Pinning to an immutable commit SHA is the [GitHub-recommended hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) for third-party actions.

Maintenance note: this repo does not currently configure a GitHub Actions updater, so SHA pins are static. Enabling the `github-actions` ecosystem in Dependabot (or Renovate) keeps them current automatically while preserving the `# tag` comment.

## How
Ref-only changes; no behavior change. Each `@tag` becomes `@<sha>  # tag`. First-party `actions/*` and actions you own are intentionally left alone.

## Testing
Verification level: **static**.
- SHA resolution: confirmed the pinned SHA is the commit the tag currently resolves to.
- Syntax: workflow YAML parsed/linted cleanly.
- I have **not** run this repository's CI; this is a configuration ref change only, no behavior change.

<sub>Prepared by [TaskBounty](https://task-bounty.com). The pinned SHA was verified against the upstream tag. Glad to adjust or close if this isn't useful.</sub>