### PR TITLE
chore: Drop dead collaborativeEditing column from teams

### DIFF
--- a/server/migrations/20260611000000-drop-team-collaborative-editing.js
+++ b/server/migrations/20260611000000-drop-team-collaborative-editing.js
@@ -1,0 +1,14 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.removeColumn("teams", "collaborativeEditing");
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.addColumn("teams", "collaborativeEditing", {
+      type: Sequelize.BOOLEAN,
+    });
+  },
+};


### PR DESCRIPTION
Drops the long-unused `collaborativeEditing` column from the `teams` table. The toggle has been dead since collaborative editing became always-on (Oct 2022) — the column is no longer defined in the `Team` model nor referenced anywhere in `app/`, `server/`, `shared/`, or `plugins/`. This adds a migration to remove it, with a `down` that restores the boolean column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)