### PR TITLE
fix(mcp): honor legacy append:true / prepend:true on update_document

### DIFF
--- a/server/tools/documents.test.ts
+++ b/server/tools/documents.test.ts
@@ -394,6 +394,90 @@ describe("update_document", () => {
     expect(res?.result?.isError).toBe(true);
   });
 
+  it("appends text instead of replacing when the legacy append:true alias is set", async () => {
+    // Regression for #12672. The REST API silently accepts `append: true` and
+    // translates it to editMode="append" — the MCP tool used to drop the flag,
+    // collapse to editMode="replace", and overwrite the document body.
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const document = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+      text: "Existing content",
+    });
+
+    const res = await callMcpTool(server, accessToken, "update_document", {
+      id: document.id,
+      text: "Added content",
+      append: true,
+    });
+
+    expect(res?.result?.isError).toBeUndefined();
+    const reloaded = await Document.findByPk(document.id);
+    expect(reloaded?.text).toContain("Existing content");
+    expect(reloaded?.text).toContain("Added content");
+  });
+
+  it("prepends text instead of replacing when the legacy prepend:true alias is set", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const document = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+      text: "Existing content",
+    });
+
+    const res = await callMcpTool(server, accessToken, "update_document", {
+      id: document.id,
+      text: "Prepended content",
+      prepend: true,
+    });
+
+    expect(res?.result?.isError).toBeUndefined();
+    const reloaded = await Document.findByPk(document.id);
+    expect(reloaded?.text).toContain("Existing content");
+    expect(reloaded?.text).toContain("Prepended content");
+    expect(reloaded?.text?.indexOf("Prepended content")).toBeLessThan(
+      reloaded?.text?.indexOf("Existing content") ?? -1
+    );
+  });
+
+  it("prefers an explicit editMode over the legacy append:true alias", async () => {
+    // When both are supplied, editMode wins — the legacy alias is a fallback
+    // only when editMode is omitted, never an override.
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const document = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+      text: "Existing content",
+    });
+
+    const res = await callMcpTool(server, accessToken, "update_document", {
+      id: document.id,
+      text: "Replacement content",
+      append: true,
+      editMode: "replace",
+    });
+
+    expect(res?.result?.isError).toBeUndefined();
+    const reloaded = await Document.findByPk(document.id);
+    expect(reloaded?.text).not.toContain("Existing content");
+    expect(reloaded?.text).toContain("Replacement content");
+  });
+
   it("does not allow a viewer to publish their draft into a restricted collection", async () => {
     const viewer = await buildViewer();
     const collection = await buildCollection({

--- a/server/tools/documents.ts
+++ b/server/tools/documents.ts
@@ -594,6 +594,18 @@ export function documentTools(server: McpServer, scopes: string[]) {
             .describe(
               "Whether the document should occupy full width of the screen."
             ),
+          append: z
+            .boolean()
+            .optional()
+            .describe(
+              'Deprecated alias for editMode="append". When true and editMode is not set, text is added to the end of the document instead of replacing it. Prefer editMode="append" in new code.'
+            ),
+          prepend: z
+            .boolean()
+            .optional()
+            .describe(
+              'Deprecated alias for editMode="prepend". When true and editMode is not set, text is added to the beginning of the document instead of replacing it. Prefer editMode="prepend" in new code.'
+            ),
         },
       },
       withTracing("update_document", async (input, context) => {
@@ -606,6 +618,23 @@ export function documentTools(server: McpServer, scopes: string[]) {
             includeState: true,
             rejectOnEmpty: true,
           });
+
+          // Resolve the legacy boolean aliases (`append: true`, `prepend: true`)
+          // into the canonical `editMode` value. The REST API has historically
+          // accepted these (see server/routes/api/documents/schema.ts) and LLM
+          // clients reaching for the MCP tool sometimes infer the same shape;
+          // without this translation the boolean is silently ignored, the
+          // editMode defaults to "replace", and the document body is overwritten
+          // instead of appended — the silent data loss reported in #12672.
+          const { append, prepend, editMode: rawEditMode, ...rest } = input;
+          let editMode = rawEditMode;
+          if (editMode === undefined) {
+            if (append) {
+              editMode = TextEditMode.Append;
+            } else if (prepend) {
+              editMode = TextEditMode.Prepend;
+            }
+          }
 
           let updated;
 
@@ -624,7 +653,8 @@ export function documentTools(server: McpServer, scopes: string[]) {
 
             updated = await documentUpdater(ctx, {
               document,
-              ...input,
+              ...rest,
+              editMode,
             });
           }
 


### PR DESCRIPTION
## Summary

Closes #12672 — silent data loss when an MCP client calls `update_document` with `append: true`.

## Root cause

Two places parse update-document input, and they disagreed on the legacy shape:

- **REST API** (`server/routes/api/documents/schema.ts`) accepts the deprecated `append: true` boolean and runs a `.transform()` block that rewrites it into `editMode: "append"` before the handler ever sees it. This is intentional back-compat.
- **MCP tool** (`server/tools/documents.ts`) only documents `editMode`. The boolean shorthand isn't in the schema, so Zod silently strips it.

LLM clients reaching for the MCP tool often infer `append: true` from the REST API shape, general API convention, or the verbal phrasing of the tool description ("In append mode it is added to the end"). The boolean disappears at validation, `editMode` falls back to its default of `replace`, and the document body is overwritten instead of appended — only detected when a user later opens the doc and notices content is gone.

## Fix

Add the two deprecated aliases to the MCP tool's input schema and fold them into `editMode` inside the handler before forwarding to `documentUpdater`:

```ts
const { append, prepend, editMode: rawEditMode, ...rest } = input;
let editMode = rawEditMode;
if (editMode === undefined) {
  if (append) {
    editMode = TextEditMode.Append;
  } else if (prepend) {
    editMode = TextEditMode.Prepend;
  }
}
```

Both schema descriptions explicitly mark the new fields as deprecated and steer callers toward `editMode`, so an LLM that reads the tool definition picks the canonical name in new code:

```ts
append: z
  .boolean()
  .optional()
  .describe(
    'Deprecated alias for editMode="append". When true and editMode is not set, text is added to the end of the document instead of replacing it. Prefer editMode="append" in new code.'
  ),
```

**Precedence:** explicit `editMode` always wins. The alias is a fallback, not an override — so `append: true, editMode: "replace"` still replaces.

## Tests

Three new tests in `server/tools/documents.test.ts`:

- `appends text instead of replacing when the legacy append:true alias is set` — regression for #12672, builds a doc with `"Existing content"`, calls the tool with `append: true`, asserts both substrings are present.
- `prepends text instead of replacing when the legacy prepend:true alias is set` — same shape for the prepend alias, also asserts ordering.
- `prefers an explicit editMode over the legacy append:true alias` — guards the precedence rule.

## Test plan

- [x] `yarn tsc --noEmit` — clean
- [x] Test code mirrors the existing `update_document` test patterns (`buildOAuthUser` / `callMcpTool` / `Document.findByPk`).
- [ ] Local `yarn test server/tools/documents.test.ts` — could not run end-to-end on my machine due to a missing local Postgres `user` role (env issue, not test code). CI will run the full suite.

## Notes for review

- I considered adding the aliases to the canonical `documentUpdater` props instead of stripping them in the tool handler. Kept the translation localized to the MCP layer because the REST API already handles its own (slightly different) Zod transform there, and `documentUpdater` would otherwise grow back-compat semantics that have nothing to do with its model contract.
- The tool description's existing "always prefer editMode patch" guidance is left intact — this PR just makes the misread cases safe, it doesn't change which mode LLMs should reach for first.