### PR TITLE
Add `PROXY_HEADERS_TRUSTED` env

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -140,6 +140,11 @@ FORCE_HTTPS=true
 # and "X-Client-IP".
 # PROXY_IP_HEADER=
 
+# Whether to trust the X-Forwarded-* headers (e.g. X-Forwarded-For,
+# X-Forwarded-Proto) set by an upstream proxy. Set to false if not
+# running behind a proxy in production.
+# PROXY_HEADERS_TRUSTED=true
+
 
 # ––––––––––––––––––––––––––––––––––––––
 # ––––––––––  AUTHENTICATION  ––––––––––

--- a/server/env.ts
+++ b/server/env.ts
@@ -373,6 +373,16 @@ export class Environment {
   public PROXY_IP_HEADER = this.toOptionalString(environment.PROXY_IP_HEADER);
 
   /**
+   * Whether to trust the X-Forwarded-* headers (e.g. X-Forwarded-For,
+   * X-Forwarded-Proto) set by an upstream proxy or load balancer. Defaults to
+   * true for backwards compat. Set to false if not running behind a proxy in production.
+   */
+  @IsBoolean()
+  public PROXY_HEADERS_TRUSTED = this.toBoolean(
+    environment.PROXY_HEADERS_TRUSTED ?? "true"
+  );
+
+  /**
    * Should the installation send anonymized statistics to the maintainers.
    * Defaults to true.
    */

--- a/server/services/web.ts
+++ b/server/services/web.ts
@@ -47,7 +47,10 @@ export default function init(app: Koa = new Koa(), server?: Server) {
             if (httpsResolver(ctx)) {
               return true;
             }
-            return xForwardedProtoResolver(ctx);
+            // Only honor X-Forwarded-Proto when proxy headers are trusted
+            return env.PROXY_HEADERS_TRUSTED
+              ? xForwardedProtoResolver(ctx)
+              : false;
           },
         })
       );

--- a/server/services/web.ts
+++ b/server/services/web.ts
@@ -29,6 +29,16 @@ export default function init(app: Koa = new Koa(), server?: Server) {
   void initI18n();
 
   if (env.isProduction) {
+    // Trust the X-Forwarded-* headers set by an upstream proxy, eg
+    // X-Forwarded-For. Defaults to true, but can be disabled with
+    // PROXY_HEADERS_TRUSTED when the app is reachable directly.
+    if (env.PROXY_HEADERS_TRUSTED) {
+      app.proxy = true;
+      if (env.PROXY_IP_HEADER) {
+        app.proxyIpHeader = env.PROXY_IP_HEADER;
+      }
+    }
+
     // Force redirect to HTTPS protocol unless explicitly disabled
     if (env.FORCE_HTTPS) {
       app.use(
@@ -43,12 +53,6 @@ export default function init(app: Koa = new Koa(), server?: Server) {
       );
     } else {
       Logger.warn("Enforced https was disabled with FORCE_HTTPS env variable");
-    }
-
-    // trust header fields set by our proxy. eg X-Forwarded-For
-    app.proxy = true;
-    if (env.PROXY_IP_HEADER) {
-      app.proxyIpHeader = env.PROXY_IP_HEADER;
     }
   }
 


### PR DESCRIPTION
Whether to trust the X-Forwarded-* headers (e.g. X-Forwarded-For, X-Forwarded-Proto) set by an upstream proxy.