### PR TITLE
fix: Nested list behavior

### DIFF
--- a/app/editor/menus/formatting.tsx
+++ b/app/editor/menus/formatting.tsx
@@ -29,6 +29,7 @@ import HighlightColorPicker from "../components/HighlightColorPicker";
 import { getDocumentHighlightColors } from "@shared/editor/queries/getDocumentHighlightColors";
 import { getMarksBetween } from "@shared/editor/queries/getMarksBetween";
 import { isInList } from "@shared/editor/queries/isInList";
+import { isListActive } from "@shared/editor/queries/isListActive";
 import { isMarkActive } from "@shared/editor/queries/isMarkActive";
 import { isNodeActive } from "@shared/editor/queries/isNodeActive";
 import type { MenuItem, SelectionContext } from "@shared/editor/types";
@@ -384,7 +385,7 @@ export default function formattingMenuItems(ctx: SelectionContext): MenuItem[] {
       shortcut: `⇧+Ctrl+7`,
       icon: <TodoListIcon />,
       keywords: "checklist checkbox task",
-      active: isNodeActive(schema.nodes.checkbox_list),
+      active: isListActive(schema.nodes.checkbox_list),
       visible: !isInCodeBlock && !isTableCell && (!isList || !isTouch),
     },
     {
@@ -392,7 +393,7 @@ export default function formattingMenuItems(ctx: SelectionContext): MenuItem[] {
       tooltip: t("Bulleted list"),
       shortcut: `⇧+Ctrl+8`,
       icon: <BulletedListIcon />,
-      active: isNodeActive(schema.nodes.bullet_list),
+      active: isListActive(schema.nodes.bullet_list),
       visible: !isInCodeBlock && !isTableCell && (!isList || !isTouch),
     },
     {
@@ -400,7 +401,7 @@ export default function formattingMenuItems(ctx: SelectionContext): MenuItem[] {
       tooltip: t("Ordered list"),
       shortcut: `⇧+Ctrl+9`,
       icon: <OrderedListIcon />,
-      active: isNodeActive(schema.nodes.ordered_list),
+      active: isListActive(schema.nodes.ordered_list),
       visible: !isInCodeBlock && !isTableCell && (!isList || !isTouch),
     },
     {

--- a/shared/editor/commands/toggleList.test.ts
+++ b/shared/editor/commands/toggleList.test.ts
@@ -8,13 +8,21 @@ import {
 } from "@shared/test/editor";
 import toggleList from "./toggleList";
 
-const { bullet_list, ordered_list, list_item } = schema.nodes;
+const { bullet_list, ordered_list, list_item, checkbox_list, checkbox_item } =
+  schema.nodes;
 
 /**
  * Creates a list item node with the given block content.
  */
 function li(content: Node[]) {
   return list_item.create(null, content);
+}
+
+/**
+ * Creates a checkbox item node with the given block content.
+ */
+function cli(content: Node[], checked = false) {
+  return checkbox_item.create({ checked }, content);
 }
 
 /**
@@ -95,6 +103,116 @@ describe("toggleList", () => {
     const outer = result.firstChild;
     expect(outer?.type.name).toBe("bullet_list");
     expect(outer?.child(1).child(1).type.name).toBe("bullet_list");
+  });
+
+  it("preserves nesting when converting a bullet list with a nested list to a checklist", () => {
+    const testDoc = doc([
+      bullet_list.create(null, [
+        li([p("one")]),
+        li([p("two"), bullet_list.create(null, [li([p("nested")])])]),
+      ]),
+    ]);
+
+    const result = run(
+      testDoc,
+      "two",
+      toggleList(checkbox_list, checkbox_item)
+    );
+
+    const outer = result.firstChild;
+    expect(outer?.type.name).toBe("checkbox_list");
+    expect(outer?.childCount).toBe(2);
+    expect(outer?.child(0).type.name).toBe("checkbox_item");
+    expect(outer?.child(1).type.name).toBe("checkbox_item");
+
+    const nested = outer?.child(1).child(1);
+    expect(nested?.type.name).toBe("checkbox_list");
+    expect(nested?.child(0).type.name).toBe("checkbox_item");
+    expect(nested?.child(0).textContent).toBe("nested");
+  });
+
+  it("preserves nesting when converting a checklist with a nested checklist to a bullet list", () => {
+    const testDoc = doc([
+      checkbox_list.create(null, [
+        cli([p("one")]),
+        cli([p("two"), checkbox_list.create(null, [cli([p("nested")])])]),
+      ]),
+    ]);
+
+    const result = run(testDoc, "two", toggleList(bullet_list, list_item));
+
+    const outer = result.firstChild;
+    expect(outer?.type.name).toBe("bullet_list");
+    expect(outer?.childCount).toBe(2);
+    expect(outer?.child(0).type.name).toBe("list_item");
+    expect(outer?.child(1).type.name).toBe("list_item");
+
+    const nested = outer?.child(1).child(1);
+    expect(nested?.type.name).toBe("bullet_list");
+    expect(nested?.child(0).type.name).toBe("list_item");
+    expect(nested?.child(0).textContent).toBe("nested");
+  });
+
+  it("converts a checklist nested in a bullet list without changing the parent list", () => {
+    const testDoc = doc([
+      bullet_list.create(null, [
+        li([p("one")]),
+        li([p("two"), checkbox_list.create(null, [cli([p("nested")])])]),
+      ]),
+    ]);
+
+    const result = run(testDoc, "nested", toggleList(bullet_list, list_item));
+
+    const outer = result.firstChild;
+    expect(outer?.type.name).toBe("bullet_list");
+    expect(outer?.child(1).type.name).toBe("list_item");
+
+    const nested = outer?.child(1).child(1);
+    expect(nested?.type.name).toBe("bullet_list");
+    expect(nested?.child(0).type.name).toBe("list_item");
+    expect(nested?.child(0).textContent).toBe("nested");
+  });
+
+  it("converts a bullet list nested in a checklist to a checklist without changing the parent list", () => {
+    const testDoc = doc([
+      checkbox_list.create(null, [
+        cli([p("one")]),
+        cli([p("two"), bullet_list.create(null, [li([p("nested")])])]),
+      ]),
+    ]);
+
+    const result = run(
+      testDoc,
+      "nested",
+      toggleList(checkbox_list, checkbox_item)
+    );
+
+    const outer = result.firstChild;
+    expect(outer?.type.name).toBe("checkbox_list");
+    expect(outer?.child(1).type.name).toBe("checkbox_item");
+
+    const nested = outer?.child(1).child(1);
+    expect(nested?.type.name).toBe("checkbox_list");
+    expect(nested?.child(0).type.name).toBe("checkbox_item");
+    expect(nested?.child(0).textContent).toBe("nested");
+  });
+
+  it("preserves the checked state of items already part of a nested checklist", () => {
+    const testDoc = doc([
+      bullet_list.create(null, [
+        li([p("one"), checkbox_list.create(null, [cli([p("nested")], true)])]),
+      ]),
+    ]);
+
+    const result = run(
+      testDoc,
+      "one",
+      toggleList(checkbox_list, checkbox_item)
+    );
+
+    const outer = result.firstChild;
+    expect(outer?.type.name).toBe("checkbox_list");
+    expect(outer?.child(0).child(1).child(0).attrs.checked).toBe(true);
   });
 
   it("lifts the item out of the list when toggling the same list type", () => {

--- a/shared/editor/commands/toggleList.ts
+++ b/shared/editor/commands/toggleList.ts
@@ -1,4 +1,9 @@
-import type { NodeType } from "prosemirror-model";
+import type {
+  Attrs,
+  Node as ProsemirrorNode,
+  NodeType,
+  Schema,
+} from "prosemirror-model";
 import { liftListItem, wrapInList } from "prosemirror-schema-list";
 import type { Command } from "prosemirror-state";
 import { chainTransactions } from "../lib/chainTransactions";
@@ -40,10 +45,31 @@ export default function toggleList(
       const differentType = currentItemType && currentItemType !== itemType;
 
       if (differentType) {
-        return chainTransactions(
-          clearNodes(),
-          wrapInList(listType, { listStyle })
-        )(state, dispatch);
+        // Convert the list in place, preserving any nested list structure,
+        // rather than clearing the nodes and re-wrapping which would flatten
+        // nesting – this path is hit when toggling to or from a checklist.
+        try {
+          const converted = convertListType(
+            parentList.node,
+            listType,
+            itemType,
+            schema,
+            listStyle ? { listStyle } : undefined
+          );
+          dispatch?.(
+            tr.replaceWith(
+              parentList.pos,
+              parentList.pos + parentList.node.nodeSize,
+              converted
+            )
+          );
+          return true;
+        } catch (_err) {
+          return chainTransactions(
+            clearNodes(),
+            wrapInList(listType, { listStyle })
+          )(state, dispatch);
+        }
       }
 
       if (
@@ -84,4 +110,48 @@ export default function toggleList(
       dispatch
     );
   };
+}
+
+/**
+ * Recursively converts a list node, its items, and any lists nested within
+ * those items to the given list and item type, preserving nesting structure.
+ *
+ * @param node the list node to convert.
+ * @param listType the node type to convert lists to.
+ * @param itemType the node type to convert list items to.
+ * @param schema the document schema.
+ * @param attrs optional attributes for the converted lists.
+ * @returns the converted list node.
+ * @throws if the content of an item is not valid for the new item type.
+ */
+function convertListType(
+  node: ProsemirrorNode,
+  listType: NodeType,
+  itemType: NodeType,
+  schema: Schema,
+  attrs?: Attrs
+): ProsemirrorNode {
+  const items: ProsemirrorNode[] = [];
+  node.forEach((item) => {
+    const content: ProsemirrorNode[] = [];
+    item.forEach((child) => {
+      content.push(
+        isList(child, schema)
+          ? convertListType(child, listType, itemType, schema, attrs)
+          : child
+      );
+    });
+    items.push(
+      itemType.createChecked(
+        item.type === itemType ? item.attrs : null,
+        content,
+        item.marks
+      )
+    );
+  });
+  return listType.createChecked(
+    node.type === listType ? node.attrs : (attrs ?? null),
+    items,
+    node.marks
+  );
 }

--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -1478,11 +1478,11 @@ ol li {
 .${EditorStyleHelper.checklistWrapper} {
   position: relative;
   margin: 1em 0;
+}
 
-  .${EditorStyleHelper.checklistWrapper} {
-    position: static;
-    margin: 0;
-  }
+li .${EditorStyleHelper.checklistWrapper} {
+  position: static;
+  margin: 0;
 }
 
 .${EditorStyleHelper.checklistCompletedToggle} {

--- a/shared/editor/lib/listInputRule.test.ts
+++ b/shared/editor/lib/listInputRule.test.ts
@@ -1,0 +1,151 @@
+import type { InputRule } from "prosemirror-inputrules";
+import type { Node } from "prosemirror-model";
+import {
+  createEditorStateWithSelection,
+  doc,
+  p,
+  schema,
+} from "@shared/test/editor";
+import { checkboxListInputRule } from "./listInputRule";
+
+const { bullet_list, ordered_list, list_item, checkbox_list, checkbox_item } =
+  schema.nodes;
+
+/**
+ * Creates a list item node with the given block content.
+ */
+function li(content: Node[]) {
+  return list_item.create(null, content);
+}
+
+/**
+ * Returns the position directly after the first occurrence of the given text.
+ *
+ * @throws if no matching text node exists in the document.
+ */
+function posAfterText(node: Node, text: string) {
+  let found = -1;
+  node.descendants((child, pos) => {
+    if (found === -1 && child.isText && child.text?.startsWith(text)) {
+      found = pos;
+    }
+    return found === -1;
+  });
+  if (found === -1) {
+    throw new Error(`Text "${text}" not found in document`);
+  }
+  return found + text.length;
+}
+
+/**
+ * Simulates typing the trigger character of an input rule, mirroring the way
+ * prosemirror-inputrules invokes a rule's handler, and returns the resulting
+ * document (or the unchanged document when the rule does not fire).
+ */
+function typeTrigger(
+  rule: InputRule,
+  testDoc: Node,
+  markerInDoc: string,
+  triggerChar: string
+) {
+  let state = createEditorStateWithSelection(
+    testDoc,
+    posAfterText(testDoc, markerInDoc)
+  );
+  const { from, to } = state.selection;
+  const $from = state.doc.resolve(from);
+  const textBefore =
+    $from.parent.textBetween(
+      Math.max(0, $from.parentOffset - 500),
+      $from.parentOffset,
+      null,
+      "￼"
+    ) + triggerChar;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const match = (rule as any).match.exec(textBefore) as RegExpMatchArray | null;
+  if (!match) {
+    return state.doc;
+  }
+  const startPos = from - (match[0].length - triggerChar.length);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const tr = (rule as any).handler(state, match, startPos, to);
+  if (tr) {
+    state = state.apply(tr);
+  }
+  return state.doc;
+}
+
+const rule = checkboxListInputRule(
+  /^-?\s*(\[\s?\])\s$/i,
+  checkbox_list,
+  checkbox_item
+);
+
+describe("checkboxListInputRule", () => {
+  it("converts a plain bullet list to a checklist", () => {
+    const testDoc = doc([
+      bullet_list.create(null, [li([p("[ ]")]), li([p("two")])]),
+    ]);
+
+    const result = typeTrigger(rule, testDoc, "[ ]", " ");
+
+    const list = result.firstChild;
+    expect(list?.type.name).toBe("checkbox_list");
+    expect(list?.childCount).toBe(2);
+    expect(list?.child(0).type.name).toBe("checkbox_item");
+    expect(list?.child(0).textContent).toBe("");
+    expect(list?.child(1).textContent).toBe("two");
+  });
+
+  it("converts a plain ordered list to a checklist", () => {
+    const testDoc = doc([
+      ordered_list.create(null, [li([p("[ ]")]), li([p("two")])]),
+    ]);
+
+    const result = typeTrigger(rule, testDoc, "[ ]", " ");
+
+    expect(result.firstChild?.type.name).toBe("checkbox_list");
+  });
+
+  it("preserves nesting when converting a list with a nested list", () => {
+    const testDoc = doc([
+      bullet_list.create(null, [
+        li([p("[ ]")]),
+        li([p("two"), bullet_list.create(null, [li([p("nested")])])]),
+      ]),
+    ]);
+
+    const result = typeTrigger(rule, testDoc, "[ ]", " ");
+
+    const list = result.firstChild;
+    expect(list?.type.name).toBe("checkbox_list");
+    const nested = list?.child(1).child(1);
+    expect(nested?.type.name).toBe("checkbox_list");
+    expect(nested?.child(0).type.name).toBe("checkbox_item");
+    expect(nested?.child(0).textContent).toBe("nested");
+  });
+
+  it("does nothing when already in a checklist", () => {
+    const testDoc = doc([
+      checkbox_list.create(null, [
+        checkbox_item.create(null, p("[ ]")),
+        checkbox_item.create(null, p("two")),
+      ]),
+    ]);
+
+    const result = typeTrigger(rule, testDoc, "[ ]", " ");
+
+    // The rule should not fire; the marker text is left untouched.
+    expect(result.firstChild?.type.name).toBe("checkbox_list");
+    expect(result.firstChild?.child(0).textContent).toBe("[ ]");
+  });
+
+  it("does nothing when not inside a list", () => {
+    const testDoc = doc([p("[ ]")]);
+
+    const result = typeTrigger(rule, testDoc, "[ ]", " ");
+
+    expect(result.firstChild?.type.name).toBe("paragraph");
+    expect(result.firstChild?.textContent).toBe("[ ]");
+  });
+});

--- a/shared/editor/lib/listInputRule.test.ts
+++ b/shared/editor/lib/listInputRule.test.ts
@@ -40,7 +40,7 @@ function posAfterText(node: Node, text: string) {
 /**
  * Simulates typing the trigger character of an input rule, mirroring the way
  * prosemirror-inputrules invokes a rule's handler, and returns the resulting
- * document (or the unchanged document when the rule does not fire).
+ * editor state (unchanged when the rule does not fire).
  */
 function typeTrigger(
   rule: InputRule,
@@ -64,7 +64,7 @@ function typeTrigger(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const match = (rule as any).match.exec(textBefore) as RegExpMatchArray | null;
   if (!match) {
-    return state.doc;
+    return state;
   }
   const startPos = from - (match[0].length - triggerChar.length);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -72,7 +72,7 @@ function typeTrigger(
   if (tr) {
     state = state.apply(tr);
   }
-  return state.doc;
+  return state;
 }
 
 const rule = checkboxListInputRule(
@@ -89,12 +89,28 @@ describe("checkboxListInputRule", () => {
 
     const result = typeTrigger(rule, testDoc, "[ ]", " ");
 
-    const list = result.firstChild;
+    const list = result.doc.firstChild;
     expect(list?.type.name).toBe("checkbox_list");
     expect(list?.childCount).toBe(2);
     expect(list?.child(0).type.name).toBe("checkbox_item");
     expect(list?.child(0).textContent).toBe("");
     expect(list?.child(1).textContent).toBe("two");
+  });
+
+  it("places the cursor at the start of the converted item", () => {
+    const testDoc = doc([
+      bullet_list.create(null, [li([p("[ ]")]), li([p("two")])]),
+    ]);
+
+    const result = typeTrigger(rule, testDoc, "[ ]", " ");
+
+    // The selection should sit empty at the start of the first item's content.
+    const { selection } = result;
+    expect(selection.empty).toBe(true);
+    const $from = result.doc.resolve(selection.from);
+    expect($from.parent.type.name).toBe("paragraph");
+    expect($from.parentOffset).toBe(0);
+    expect($from.node(-1).type.name).toBe("checkbox_item");
   });
 
   it("converts a plain ordered list to a checklist", () => {
@@ -104,7 +120,7 @@ describe("checkboxListInputRule", () => {
 
     const result = typeTrigger(rule, testDoc, "[ ]", " ");
 
-    expect(result.firstChild?.type.name).toBe("checkbox_list");
+    expect(result.doc.firstChild?.type.name).toBe("checkbox_list");
   });
 
   it("preserves nesting when converting a list with a nested list", () => {
@@ -117,7 +133,7 @@ describe("checkboxListInputRule", () => {
 
     const result = typeTrigger(rule, testDoc, "[ ]", " ");
 
-    const list = result.firstChild;
+    const list = result.doc.firstChild;
     expect(list?.type.name).toBe("checkbox_list");
     const nested = list?.child(1).child(1);
     expect(nested?.type.name).toBe("checkbox_list");
@@ -136,8 +152,8 @@ describe("checkboxListInputRule", () => {
     const result = typeTrigger(rule, testDoc, "[ ]", " ");
 
     // The rule should not fire; the marker text is left untouched.
-    expect(result.firstChild?.type.name).toBe("checkbox_list");
-    expect(result.firstChild?.child(0).textContent).toBe("[ ]");
+    expect(result.doc.firstChild?.type.name).toBe("checkbox_list");
+    expect(result.doc.firstChild?.child(0).textContent).toBe("[ ]");
   });
 
   it("does nothing when not inside a list", () => {
@@ -145,7 +161,7 @@ describe("checkboxListInputRule", () => {
 
     const result = typeTrigger(rule, testDoc, "[ ]", " ");
 
-    expect(result.firstChild?.type.name).toBe("paragraph");
-    expect(result.firstChild?.textContent).toBe("[ ]");
+    expect(result.doc.firstChild?.type.name).toBe("paragraph");
+    expect(result.doc.firstChild?.textContent).toBe("[ ]");
   });
 });

--- a/shared/editor/lib/listInputRule.ts
+++ b/shared/editor/lib/listInputRule.ts
@@ -4,6 +4,7 @@ import type {
   Node as ProsemirrorNode,
   Attrs,
 } from "prosemirror-model";
+import { TextSelection } from "prosemirror-state";
 import toggleList from "../commands/toggleList";
 import { findParentNodeClosestToPos } from "../queries/findParentNode";
 import { isInHeading } from "../queries/isInHeading";
@@ -68,6 +69,10 @@ export function checkboxListInputRule(
     toggleList(listType, itemType)(after, (toggleTr) => {
       toggleTr.steps.forEach((step) => tr.step(step));
     });
+
+    // Place the cursor at the start of the converted item, where the marker
+    // was, so the user can continue typing.
+    tr.setSelection(TextSelection.near(tr.doc.resolve(start)));
     return tr;
   });
 }

--- a/shared/editor/lib/listInputRule.ts
+++ b/shared/editor/lib/listInputRule.ts
@@ -4,7 +4,10 @@ import type {
   Node as ProsemirrorNode,
   Attrs,
 } from "prosemirror-model";
+import toggleList from "../commands/toggleList";
+import { findParentNodeClosestToPos } from "../queries/findParentNode";
 import { isInHeading } from "../queries/isInHeading";
+import { isList } from "../queries/isList";
 
 /**
  * A wrapper for wrappingInputRule that prevents execution inside heading nodes.
@@ -29,5 +32,42 @@ export function listWrappingInputRule(
     // Otherwise, execute the original wrappingInputRule handler
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return (rule as any).handler(state, match, start, end);
+  });
+}
+
+/**
+ * An input rule that converts an existing plain list (bullet or ordered) to a
+ * checklist when the checkbox marker is typed at the start of a list item,
+ * preserving any nested list structure.
+ *
+ * @param regexp the pattern matching the checkbox marker, e.g. "[ ] ".
+ * @param listType the checkbox list node type to convert to.
+ * @param itemType the checkbox item node type to convert items to.
+ * @returns the input rule.
+ */
+export function checkboxListInputRule(
+  regexp: RegExp,
+  listType: NodeType,
+  itemType: NodeType
+): InputRule {
+  return new InputRule(regexp, (state, _match, start, end) => {
+    const { schema } = state;
+
+    // Only act when the selection sits inside a plain (non-checkbox) list —
+    // converting a paragraph is already handled by listWrappingInputRule.
+    const list = findParentNodeClosestToPos(state.selection.$from, (node) =>
+      isList(node, schema)
+    );
+    if (!list || list.node.type === listType) {
+      return null;
+    }
+
+    // Remove the typed marker, then convert the list in place.
+    const tr = state.tr.delete(start, end);
+    const after = state.apply(tr);
+    toggleList(listType, itemType)(after, (toggleTr) => {
+      toggleTr.steps.forEach((step) => tr.step(step));
+    });
+    return tr;
   });
 }

--- a/shared/editor/nodes/CheckboxList.ts
+++ b/shared/editor/nodes/CheckboxList.ts
@@ -8,7 +8,10 @@ import { Plugin } from "prosemirror-state";
 import { v4 as generateUuid } from "uuid";
 import toggleList from "../commands/toggleList";
 import type { MarkdownSerializerState } from "../lib/markdown/serializer";
-import { listWrappingInputRule } from "../lib/listInputRule";
+import {
+  checkboxListInputRule,
+  listWrappingInputRule,
+} from "../lib/listInputRule";
 import { findBlockNodes } from "../queries/findChildren";
 import { CheckboxListView } from "./CheckboxListView";
 import Node from "./Node";
@@ -84,8 +87,14 @@ export default class CheckboxList extends Node {
     return () => toggleList(type, schema.nodes.checkbox_item);
   }
 
-  inputRules({ type }: { type: NodeType }) {
-    return [listWrappingInputRule(/^-?\s*(\[\s?\])\s$/i, type)];
+  inputRules({ type, schema }: { type: NodeType; schema: Schema }) {
+    const pattern = /^-?\s*(\[\s?\])\s$/i;
+    return [
+      // Convert an existing plain list to a checklist, keeping nesting intact.
+      checkboxListInputRule(pattern, type, schema.nodes.checkbox_item),
+      // Wrap a plain paragraph into a new checklist.
+      listWrappingInputRule(pattern, type),
+    ];
   }
 
   toMarkdown(state: MarkdownSerializerState, node: ProsemirrorNode) {

--- a/shared/editor/queries/isListActive.test.ts
+++ b/shared/editor/queries/isListActive.test.ts
@@ -1,5 +1,7 @@
 import type { Node } from "prosemirror-model";
+import { NodeSelection } from "prosemirror-state";
 import {
+  createEditorState,
   createEditorStateWithSelection,
   doc,
   p,
@@ -53,6 +55,38 @@ function stateAt(testDoc: Node, selectionText: string) {
   );
 }
 
+/**
+ * Returns the position directly before the first node of the given type.
+ *
+ * @throws if no matching node exists in the document.
+ */
+function posOfNode(node: Node, typeName: string) {
+  let found = -1;
+  node.descendants((child, pos) => {
+    if (found === -1 && child.type.name === typeName) {
+      found = pos;
+    }
+    return found === -1;
+  });
+  if (found === -1) {
+    throw new Error(`Node "${typeName}" not found in document`);
+  }
+  return found;
+}
+
+/**
+ * Builds an editor state with a NodeSelection on the first node of the given
+ * type.
+ */
+function nodeSelectionStateAt(testDoc: Node, typeName: string) {
+  const state = createEditorState(testDoc);
+  const selection = NodeSelection.create(
+    state.doc,
+    posOfNode(testDoc, typeName)
+  );
+  return state.apply(state.tr.setSelection(selection));
+}
+
 describe("isListActive", () => {
   it("matches the closest list type", () => {
     const testDoc = doc([
@@ -93,6 +127,30 @@ describe("isListActive", () => {
 
     expect(isListActive(checkbox_list)(state)).toBe(true);
     expect(isListActive(ordered_list)(state)).toBe(false);
+  });
+
+  it("matches a list selected directly via a NodeSelection", () => {
+    const testDoc = doc([
+      bullet_list.create(null, [li([p("one")]), li([p("two")])]),
+    ]);
+    const state = nodeSelectionStateAt(testDoc, "bullet_list");
+
+    expect(isListActive(bullet_list)(state)).toBe(true);
+    expect(isListActive(ordered_list)(state)).toBe(false);
+    expect(isListActive(checkbox_list)(state)).toBe(false);
+  });
+
+  it("matches the selected nested list, not its parent, via a NodeSelection", () => {
+    const testDoc = doc([
+      checkbox_list.create(null, [
+        cli([p("moo"), ordered_list.create(null, [li([p("dfsdf")])])]),
+      ]),
+    ]);
+    const state = nodeSelectionStateAt(testDoc, "ordered_list");
+
+    expect(isListActive(ordered_list)(state)).toBe(true);
+    expect(isListActive(checkbox_list)(state)).toBe(false);
+    expect(isListActive(bullet_list)(state)).toBe(false);
   });
 
   it("returns false when the selection is not in a list", () => {

--- a/shared/editor/queries/isListActive.test.ts
+++ b/shared/editor/queries/isListActive.test.ts
@@ -1,0 +1,106 @@
+import type { Node } from "prosemirror-model";
+import {
+  createEditorStateWithSelection,
+  doc,
+  p,
+  schema,
+} from "@shared/test/editor";
+import { isListActive } from "./isListActive";
+
+const { bullet_list, ordered_list, list_item, checkbox_list, checkbox_item } =
+  schema.nodes;
+
+/**
+ * Creates a list item node with the given block content.
+ */
+function li(content: Node[]) {
+  return list_item.create(null, content);
+}
+
+/**
+ * Creates a checkbox item node with the given block content.
+ */
+function cli(content: Node[]) {
+  return checkbox_item.create(null, content);
+}
+
+/**
+ * Returns a position inside the first text node matching the given text.
+ *
+ * @throws if no matching text node exists in the document.
+ */
+function posOfText(node: Node, text: string) {
+  let found = -1;
+  node.descendants((child, pos) => {
+    if (found === -1 && child.isText && child.text === text) {
+      found = pos;
+    }
+    return found === -1;
+  });
+  if (found === -1) {
+    throw new Error(`Text "${text}" not found in document`);
+  }
+  return found + 1;
+}
+
+/**
+ * Builds an editor state with the selection placed inside the given text.
+ */
+function stateAt(testDoc: Node, selectionText: string) {
+  return createEditorStateWithSelection(
+    testDoc,
+    posOfText(testDoc, selectionText)
+  );
+}
+
+describe("isListActive", () => {
+  it("matches the closest list type", () => {
+    const testDoc = doc([
+      bullet_list.create(null, [li([p("one")]), li([p("two")])]),
+    ]);
+    const state = stateAt(testDoc, "one");
+
+    expect(isListActive(bullet_list)(state)).toBe(true);
+    expect(isListActive(ordered_list)(state)).toBe(false);
+    expect(isListActive(checkbox_list)(state)).toBe(false);
+  });
+
+  it("does not mark an ancestor list of a different type as active", () => {
+    // An ordered list nested inside a checkbox list, selection in the
+    // ordered list item.
+    const testDoc = doc([
+      checkbox_list.create(null, [
+        cli([
+          p("moo"),
+          ordered_list.create(null, [li([p("dfsdf")]), li([p("sd")])]),
+        ]),
+      ]),
+    ]);
+    const state = stateAt(testDoc, "dfsdf");
+
+    expect(isListActive(ordered_list)(state)).toBe(true);
+    expect(isListActive(checkbox_list)(state)).toBe(false);
+    expect(isListActive(bullet_list)(state)).toBe(false);
+  });
+
+  it("matches the parent list when the selection is in the parent item", () => {
+    const testDoc = doc([
+      checkbox_list.create(null, [
+        cli([p("moo"), ordered_list.create(null, [li([p("dfsdf")])])]),
+      ]),
+    ]);
+    const state = stateAt(testDoc, "moo");
+
+    expect(isListActive(checkbox_list)(state)).toBe(true);
+    expect(isListActive(ordered_list)(state)).toBe(false);
+  });
+
+  it("returns false when the selection is not in a list", () => {
+    const testDoc = doc([p("hello")]);
+    const state = stateAt(testDoc, "hello");
+
+    expect(isListActive(bullet_list)(state)).toBe(false);
+    expect(isListActive(ordered_list)(state)).toBe(false);
+    expect(isListActive(checkbox_list)(state)).toBe(false);
+  });
+});

--- a/shared/editor/queries/isListActive.ts
+++ b/shared/editor/queries/isListActive.ts
@@ -1,0 +1,22 @@
+import type { NodeType } from "prosemirror-model";
+import type { EditorState } from "prosemirror-state";
+import { findParentNode } from "./findParentNode";
+import { isList } from "./isList";
+
+/**
+ * Checks whether the list closest to the current selection is of the given
+ * type. Unlike isNodeActive, this only matches the innermost list so that a
+ * nested list does not also mark an ancestor list of a different type as
+ * active in the toolbar.
+ *
+ * @param type the list node type to check for.
+ * @returns a function that returns true when the closest list is of the type.
+ */
+export const isListActive =
+  (type: NodeType) =>
+  (state: EditorState): boolean => {
+    const closestList = findParentNode((node) => isList(node, state.schema))(
+      state.selection
+    );
+    return closestList?.node.type === type;
+  };

--- a/shared/editor/queries/isListActive.ts
+++ b/shared/editor/queries/isListActive.ts
@@ -1,5 +1,6 @@
 import type { NodeType } from "prosemirror-model";
 import type { EditorState } from "prosemirror-state";
+import { NodeSelection } from "prosemirror-state";
 import { findParentNode } from "./findParentNode";
 import { isList } from "./isList";
 
@@ -15,8 +16,19 @@ import { isList } from "./isList";
 export const isListActive =
   (type: NodeType) =>
   (state: EditorState): boolean => {
+    const { selection } = state;
+
+    // When the list node itself is selected via a NodeSelection, consider that
+    // node directly — findParentNode would otherwise report its parent list.
+    if (
+      selection instanceof NodeSelection &&
+      isList(selection.node, state.schema)
+    ) {
+      return selection.node.type === type;
+    }
+
     const closestList = findParentNode((node) => isList(node, state.schema))(
-      state.selection
+      selection
     );
     return closestList?.node.type === type;
   };


### PR DESCRIPTION
This branch fixes numerous issues with changing the type of a nested list and adds the ability to type `[ ]` at the start of an existing list item to convert to a todo list.