### PR TITLE
perf: Server startup time

### DIFF
--- a/server/logging/tracer.ts
+++ b/server/logging/tracer.ts
@@ -1,5 +1,4 @@
-import type { Span } from "dd-trace";
-import tracer from "dd-trace";
+import type { Span, Tracer } from "dd-trace";
 import env from "@server/env";
 
 interface ReportableError extends Error {
@@ -22,9 +21,25 @@ type PrivateDatadogContext = {
   };
 };
 
+// dd-trace patches Node internals on require and is comparatively expensive to
+// load, so it is kept off the startup path unless APM is actually enabled. When
+// disabled we fall back to a no-op tracer that satisfies the surface consumed by
+// callers (see tracing.ts) so they don't need to branch.
+const noopSpan = {
+  addTags: () => noopSpan,
+  setTag: () => noopSpan,
+  finish: () => undefined,
+} as unknown as Span;
+
+let tracer: Tracer;
+
 // If the DataDog agent is installed and the DD_API_KEY environment variable is
-// in the environment then we can safely attempt to start the DD tracer
+// in the environment then we can safely attempt to start the DD tracer. This
+// must happen before any instrumented module is imported.
 if (env.DD_API_KEY) {
+  const ddTrace = require("dd-trace") as { default?: Tracer };
+  tracer = ddTrace.default ?? (ddTrace as unknown as Tracer);
+
   tracer.init({
     version: env.VERSION,
     service: env.DD_SERVICE,
@@ -35,6 +50,14 @@ if (env.DD_API_KEY) {
   // Disable per-middleware spans so that non-reportable errors are not captured
   // This is also generally excessive noise
   tracer.use("koa", { middleware: false });
+} else {
+  tracer = {
+    scope: () => ({
+      active: () => null,
+      activate: <T>(_span: Span, fn: () => T) => fn(),
+    }),
+    startSpan: () => noopSpan,
+  } as unknown as Tracer;
 }
 
 const getCurrentSpan = (): Span | null => tracer.scope().active();

--- a/server/models/helpers/DocumentHelper.tsx
+++ b/server/models/helpers/DocumentHelper.tsx
@@ -1,4 +1,3 @@
-import { JSDOM } from "jsdom";
 import { Node, Fragment, type NodeType } from "prosemirror-model";
 import ukkonen from "ukkonen";
 import { updateYFragment, yDocToProsemirrorJSON } from "y-prosemirror";
@@ -367,6 +366,8 @@ export class DocumentHelper {
     }
 
     const html = await DocumentHelper.diff(before, after, options);
+    // Loaded lazily to keep jsdom off the startup path — only HTML export needs it.
+    const { JSDOM } = await import("jsdom");
     const dom = new JSDOM(html);
     const doc = dom.window.document;
 

--- a/server/storage/files/S3Storage.ts
+++ b/server/storage/files/S3Storage.ts
@@ -9,7 +9,6 @@ import {
   CopyObjectCommand,
 } from "@aws-sdk/client-s3";
 import { Upload } from "@aws-sdk/lib-storage";
-import "@aws-sdk/signature-v4-crt"; // https://github.com/aws/aws-sdk-js-v3#functionality-requiring-aws-common-runtime-crt
 import type { PresignedPostOptions } from "@aws-sdk/s3-presigned-post";
 import { createPresignedPost } from "@aws-sdk/s3-presigned-post";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
@@ -25,6 +24,11 @@ import type { AppContext } from "@server/types";
 export default class S3Storage extends BaseStorage {
   constructor() {
     super();
+
+    // Loaded here rather than at module top-level so the native CRT binding
+    // only loads when S3 storage is actually used, keeping it off startup.
+    // https://github.com/aws/aws-sdk-js-v3#functionality-requiring-aws-common-runtime-crt
+    require("@aws-sdk/signature-v4-crt");
 
     this.client = new S3Client({
       bucketEndpoint: env.AWS_S3_ACCELERATE_URL ? true : false,


### PR DESCRIPTION
Moving more heavy and conditional imports of AWS, JSDOM, and `dd-trace` off the main startup path