### PR TITLE
Revert optional mention label

### DIFF
--- a/app/editor/components/MentionMenu.tsx
+++ b/app/editor/components/MentionMenu.tsx
@@ -47,9 +47,7 @@ interface MentionItem extends MenuItem {
     id: string;
     type: MentionType;
     modelId: string;
-    // Date mentions intentionally omit a label — their text is derived from
-    // the ISO `modelId` so nothing human-readable is persisted.
-    label?: string;
+    label: string;
     actorId?: string;
   };
 }
@@ -119,6 +117,7 @@ function MentionMenu({ search = "", isActive, ...rest }: Props) {
           id: uuidv4(),
           type: MentionType.Date,
           modelId: parsedISODate,
+          label: parsedISODate,
           actorId,
         },
       } as MentionItem,

--- a/app/editor/menus/block.tsx
+++ b/app/editor/menus/block.tsx
@@ -193,11 +193,15 @@ export default function blockMenuItems(
       keywords: "clock today date time now",
       icon: <CalendarIcon />,
       appendSpace: true,
-      attrs: () => ({
-        id: uuidv4(),
-        type: MentionType.Date,
-        modelId: toISODate(new Date()),
-      }),
+      attrs: () => {
+        const modelId = toISODate(new Date());
+        return {
+          id: uuidv4(),
+          type: MentionType.Date,
+          modelId,
+          label: modelId,
+        };
+      },
     },
     {
       name: "separator",

--- a/shared/editor/nodes/Mention.tsx
+++ b/shared/editor/nodes/Mention.tsx
@@ -14,7 +14,6 @@ import { v4 as uuidv4 } from "uuid";
 import env from "../../env";
 import type { UnfurlResponse } from "../../types";
 import { MentionType, UnfurlResourceType } from "../../types";
-import { dateToReadable } from "../../utils/date";
 import {
   MentionCollection,
   MentionDocument,
@@ -41,25 +40,17 @@ export default class Mention extends Node {
   }
 
   get schema(): NodeSpec {
-    // Date mentions derive their text from the ISO `modelId`, which is the
-    // single source of truth — no human-readable label is persisted for them.
-    const toPlainText = (node: ProsemirrorNode) => {
-      if (node.attrs.type === MentionType.Date) {
-        return dateToReadable(node.attrs.modelId);
-      }
-      return node.attrs.type === MentionType.User
+    const toPlainText = (node: ProsemirrorNode) =>
+      node.attrs.type === MentionType.User
         ? `@${node.attrs.label}`
         : node.attrs.label;
-    };
 
     return {
       attrs: {
         type: {
           default: MentionType.User,
         },
-        label: {
-          default: undefined,
-        },
+        label: {},
         modelId: {},
         actorId: {
           default: undefined,
@@ -94,9 +85,7 @@ export default class Mention extends Node {
               type,
               modelId,
               actorId: dom.dataset.actorid,
-              // Date mentions derive their text from `modelId`; never capture
-              // the rendered text as a persisted label.
-              label: type === MentionType.Date ? undefined : dom.innerText,
+              label: dom.innerText,
               id: dom.id,
               href: dom.getAttribute("href"),
               unfurl: dom.dataset.unfurl
@@ -340,10 +329,7 @@ export default class Mention extends Node {
   toMarkdown(state: MarkdownSerializerState, node: ProsemirrorNode) {
     const mType = node.attrs.type;
     const mId = node.attrs.modelId;
-    // Date mentions have no stored label; the readable text is derived from
-    // the ISO `modelId` so it can never drift from the source of truth.
-    const label =
-      mType === MentionType.Date ? dateToReadable(mId) : node.attrs.label;
+    const label = node.attrs.label;
     const id = node.attrs.id;
 
     // Use regular links for document and collection mentions
@@ -364,10 +350,7 @@ export default class Mention extends Node {
         id: tok.attrGet("id"),
         type: tok.attrGet("type"),
         modelId: tok.attrGet("modelId"),
-        // Date mentions derive their text from `modelId`; the link text is not
-        // persisted as a label.
-        label:
-          tok.attrGet("type") === MentionType.Date ? undefined : tok.content,
+        label: tok.content,
       }),
     };
   }
@@ -386,6 +369,7 @@ export default class Mention extends Node {
       const transaction = tr.setNodeMarkup(pos, undefined, {
         ...node.attrs,
         modelId,
+        label: modelId,
       });
       view.dispatch(transaction);
     };


### PR DESCRIPTION
Decided against this, simplifies a number of paths and eases backwards compat with the tradeoff of duplicate value in `label` and `modelId`