### PR TITLE
fix: Setting attributes from col/row span

### DIFF
--- a/shared/editor/commands/table.ts
+++ b/shared/editor/commands/table.ts
@@ -28,6 +28,8 @@ import {
   getAllSelectedColumns,
   getCellsInColumn,
   getCellsInRow,
+  getCellsInSelectedColumns,
+  getCellsInSelectedRows,
   isHeaderEnabled,
   isTableSelected,
   getWidthFromDom,
@@ -752,7 +754,10 @@ export function setColumnAttr({
 
     if (dispatch) {
       const rect = selectedRect(state);
-      const cells = getCellsInColumn(index)(state) || [];
+      // Apply to every selected column so that aligning a span of columns – or a
+      // column whose header cell spans multiple columns – affects all of them,
+      // not just the first.
+      const cells = getCellsInSelectedColumns(state, index);
       let tr = state.tr;
       cells.forEach((pos) => {
         const node = state.doc.nodeAt(pos);
@@ -1157,7 +1162,9 @@ export function toggleRowBackground({
     }
 
     if (dispatch) {
-      const cells = getCellsInRow(rowIndex)(state) || [];
+      // Apply to every selected row so that coloring a span of rows – or a row
+      // whose cell spans multiple rows – affects all of them, not just the first.
+      const cells = getCellsInSelectedRows(state, rowIndex);
       let tr = state.tr;
 
       cells.forEach((pos) => {
@@ -1211,7 +1218,10 @@ export function toggleColumnBackground({
 
     if (dispatch) {
       const rect = selectedRect(state);
-      const cells = getCellsInColumn(colIndex)(state) || [];
+      // Apply to every selected column so that coloring a span of columns – or a
+      // column whose header cell spans multiple columns – affects all of them,
+      // not just the first.
+      const cells = getCellsInSelectedColumns(state, colIndex);
       let tr = state.tr;
 
       cells.forEach((pos) => {

--- a/shared/editor/queries/table.ts
+++ b/shared/editor/queries/table.ts
@@ -383,6 +383,93 @@ export function getAllSelectedColumns(state: EditorState): number[] {
 }
 
 /**
+ * Get the indices of all currently selected rows.
+ *
+ * @param state The editor state
+ * @returns Array of selected row indices
+ */
+export function getAllSelectedRows(state: EditorState): number[] {
+  const rect = selectedRect(state);
+
+  const selectedRows: number[] = [];
+  for (let row = rect.top; row < rect.bottom; row++) {
+    selectedRows.push(row);
+  }
+
+  return selectedRows;
+}
+
+/**
+ * Get the positions of every unique cell across all selected columns, falling
+ * back to a single column when it is not part of the selection.
+ *
+ * Operating on the full selection ensures column operations affect all selected
+ * columns – including columns spanned by a merged (colspan) header cell, which a
+ * single-column lookup would miss.
+ *
+ * @param state The editor state
+ * @param fallbackIndex The column index to use when nothing is selected
+ * @returns Array of unique cell positions
+ */
+export function getCellsInSelectedColumns(
+  state: EditorState,
+  fallbackIndex: number
+): number[] {
+  const selectedColumns = getAllSelectedColumns(state);
+  const columns = selectedColumns.includes(fallbackIndex)
+    ? selectedColumns
+    : [fallbackIndex];
+
+  const seen = new Set<number>();
+  const cells: number[] = [];
+  columns.forEach((index) => {
+    getCellsInColumn(index)(state).forEach((pos) => {
+      if (!seen.has(pos)) {
+        seen.add(pos);
+        cells.push(pos);
+      }
+    });
+  });
+
+  return cells;
+}
+
+/**
+ * Get the positions of every unique cell across all selected rows, falling back
+ * to a single row when it is not part of the selection.
+ *
+ * Operating on the full selection ensures row operations affect all selected
+ * rows – including rows spanned by a merged (rowspan) cell, which a single-row
+ * lookup would miss.
+ *
+ * @param state The editor state
+ * @param fallbackIndex The row index to use when nothing is selected
+ * @returns Array of unique cell positions
+ */
+export function getCellsInSelectedRows(
+  state: EditorState,
+  fallbackIndex: number
+): number[] {
+  const selectedRows = getAllSelectedRows(state);
+  const rows = selectedRows.includes(fallbackIndex)
+    ? selectedRows
+    : [fallbackIndex];
+
+  const seen = new Set<number>();
+  const cells: number[] = [];
+  rows.forEach((index) => {
+    getCellsInRow(index)(state).forEach((pos) => {
+      if (!seen.has(pos)) {
+        seen.add(pos);
+        cells.push(pos);
+      }
+    });
+  });
+
+  return cells;
+}
+
+/**
  * Get the total width of selected columns by measuring DOM elements.
  * Uses getBoundingClientRect to get precise rendered widths including decimals.
  *


### PR DESCRIPTION
When a column header cell spans multiple columns (colspan > 1), the alignment control only affects the first spanned column, and the same for row equivalent.

closes #12685