### PR TITLE
fix: Reset `focusedCommentId` on document nav

### DIFF
--- a/app/components/DocumentContext.tsx
+++ b/app/components/DocumentContext.tsx
@@ -31,6 +31,10 @@ class DocumentContext {
 
   @action
   setDocument = (document: Document) => {
+    // Reset the focused comment when navigating between documents
+    if (this.document && this.document.id !== document.id) {
+      this.focusedCommentId = null;
+    }
     this.document = document;
     this.updateState();
   };


### PR DESCRIPTION
This persisted in the store, giving the impression of the common sidebar potentially reopening "randomly".