### PR TITLE
feat: support running under a URL sub-path via the URL env var

### DIFF
--- a/app/components/WebsocketProvider.tsx
+++ b/app/components/WebsocketProvider.tsx
@@ -38,6 +38,7 @@ import type {
   WebsocketEntitiesEvent,
   WebsocketEntityDeletedEvent,
 } from "~/types";
+import env from "~/env";
 import { AuthorizationError, NotFoundError } from "~/utils/errors";
 import Logger from "~/utils/Logger";
 import { getVisibilityListener, getPageVisible } from "~/utils/pageVisibility";
@@ -791,7 +792,7 @@ function WebsocketProvider({ children }: React.PropsWithChildren<object>) {
 
     function createConnection() {
       currentSocket = io(window.location.origin, {
-        path: "/realtime",
+        path: `${env.BASE_PATH}/realtime`,
         transports: ["websocket"],
         reconnectionDelay: 1000,
         reconnectionDelayMax: 30000,

--- a/app/env.ts
+++ b/app/env.ts
@@ -12,10 +12,13 @@ if (!window.env) {
 }
 
 const env: Record<string, any> & {
+  /** Path under which the app is served, e.g. "/outline". Empty when at root. */
+  BASE_PATH: string;
   isDevelopment: boolean;
   isTest: boolean;
   isProduction: boolean;
 } = {
+  BASE_PATH: "",
   ...window.env,
   isDevelopment: window.env.ENVIRONMENT === "development",
   isTest: window.env.ENVIRONMENT === "test",

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -110,9 +110,12 @@ if ("serviceWorker" in navigator && env.ENVIRONMENT !== "development") {
   window.addEventListener("load", () => {
     // see: https://bugs.chromium.org/p/chromium/issues/detail?id=1097616
     // In some rare (<0.1% of cases) this call can return `undefined`
-    const maybePromise = navigator.serviceWorker.register("/static/sw.js", {
-      scope: "/",
-    });
+    const maybePromise = navigator.serviceWorker.register(
+      `${env.BASE_PATH}/static/sw.js`,
+      {
+        scope: `${env.BASE_PATH}/`,
+      }
+    );
 
     if (maybePromise?.then) {
       maybePromise

--- a/app/scenes/Login/Login.tsx
+++ b/app/scenes/Login/Login.tsx
@@ -255,7 +255,7 @@ function Login({ children, onBack }: Props) {
               </Note>
               <Form
                 method="POST"
-                action="/auth/email.callback"
+                action={`${env.BASE_PATH}/auth/email.callback`}
                 style={{ width: "100%" }}
               >
                 <input type="hidden" name="email" value={emailLinkSentTo} />

--- a/app/scenes/Login/OAuthAuthorize.tsx
+++ b/app/scenes/Login/OAuthAuthorize.tsx
@@ -107,7 +107,7 @@ function Authorize() {
     if (window.history.length) {
       window.history.back();
     } else {
-      window.location.href = "/";
+      window.location.href = `${env.BASE_PATH}/`;
     }
   };
 
@@ -256,7 +256,7 @@ function Authorize() {
         </Text>
         <Form
           method="POST"
-          action="/oauth/authorize"
+          action={`${env.BASE_PATH}/oauth/authorize`}
           style={{ width: "100%" }}
           onSubmit={handleSubmit}
         >

--- a/app/scenes/Login/components/AuthenticationProvider.tsx
+++ b/app/scenes/Login/components/AuthenticationProvider.tsx
@@ -9,6 +9,7 @@ import ButtonLarge from "~/components/ButtonLarge";
 import InputLarge from "~/components/InputLarge";
 import PluginIcon from "~/components/PluginIcon";
 import Tooltip from "~/components/Tooltip";
+import env from "~/env";
 import { client } from "~/utils/ApiClient";
 import Desktop from "~/utils/Desktop";
 import { getRedirectUrl } from "~/utils/urls";
@@ -82,7 +83,7 @@ function AuthenticationProvider(props: Props) {
           "/passkeys.generateAuthenticationOptions",
           undefined,
           {
-            baseUrl: "/auth",
+            baseUrl: `${env.BASE_PATH}/auth`,
           }
         );
         const { challengeId, ...optionsData } = resp.data;
@@ -144,7 +145,7 @@ function AuthenticationProvider(props: Props) {
         <Form
           ref={formRef}
           method="POST"
-          action="/auth/passkeys.verifyAuthentication"
+          action={`${env.BASE_PATH}/auth/passkeys.verifyAuthentication`}
           onSubmit={handleSubmitPasskey}
         >
           {isDesktop ? (
@@ -168,7 +169,11 @@ function AuthenticationProvider(props: Props) {
 
     return (
       <Wrapper>
-        <Form method="POST" action="/auth/email" onSubmit={handleSubmitEmail}>
+        <Form
+          method="POST"
+          action={`${env.BASE_PATH}/auth/email`}
+          onSubmit={handleSubmitEmail}
+        >
           {authState === "email" ? (
             <>
               <InputLarge

--- a/app/scenes/Login/components/WorkspaceSetup.tsx
+++ b/app/scenes/Login/components/WorkspaceSetup.tsx
@@ -8,6 +8,7 @@ import Flex from "~/components/Flex";
 import Heading from "~/components/Heading";
 import Input from "~/components/Input";
 import Text from "~/components/Text";
+import env from "~/env";
 import { detectLanguage } from "~/utils/language";
 import { BackButton } from "./BackButton";
 import { Background } from "./Background";
@@ -23,7 +24,7 @@ const WorkspaceSetup = ({ onBack }: { onBack?: () => void }) => {
       <ChangeLanguage locale={detectLanguage()} />
       <Centered
         as={Form}
-        action="/api/installation.create"
+        action={`${env.BASE_PATH}/api/installation.create`}
         method="POST"
         gap={12}
       >

--- a/app/utils/ApiClient.ts
+++ b/app/utils/ApiClient.ts
@@ -51,7 +51,7 @@ class ApiClient {
   private inflightRequests = new Map<string, Promise<any>>();
 
   constructor(options: Options = {}) {
-    this.baseUrl = options.baseUrl || "/api";
+    this.baseUrl = options.baseUrl || `${env.BASE_PATH}/api`;
   }
 
   setShareId = (shareId: string | undefined) => {

--- a/app/utils/history.ts
+++ b/app/utils/history.ts
@@ -1,5 +1,9 @@
 import { createBrowserHistory } from "history";
+import env from "~/env";
 
-const history = createBrowserHistory();
+const history = createBrowserHistory({
+  // Serve the app under a sub-path when BASE_PATH is set (e.g. "/outline").
+  basename: env.BASE_PATH || undefined,
+});
 
 export default history;

--- a/app/utils/urls.ts
+++ b/app/utils/urls.ts
@@ -15,7 +15,9 @@ import Desktop from "~/utils/Desktop";
 export function getRedirectUrl(authUrl: string) {
   const { custom, teamSubdomain, host } = parseDomain(window.location.origin);
   const url = new URL(env.URL);
-  url.pathname = authUrl;
+  // env.URL already carries the base path; prefix it so the auth endpoint is
+  // reachable when the app is served from a sub-path.
+  url.pathname = `${env.BASE_PATH}${authUrl}`;
 
   if (custom || teamSubdomain) {
     url.searchParams.set("host", host);

--- a/server/env.ts
+++ b/server/env.ts
@@ -241,6 +241,21 @@ export class Environment {
   ).replace(/\/$/, "");
 
   /**
+   * The path under which the application is served, derived from the path
+   * component of `URL`. Empty string when served from the domain root, otherwise
+   * a leading-slash path without a trailing slash (e.g. "/outline"). Used to
+   * prefix all routes, assets, cookies, and websocket paths so the app can run
+   * under a sub-path behind a prefix-preserving reverse proxy.
+   */
+  public get basePath(): string {
+    try {
+      return new URL(this.URL).pathname.replace(/\/+$/, "");
+    } catch (_err) {
+      return "";
+    }
+  }
+
+  /**
    * If using a Cloudfront/Cloudflare distribution or similar it can be set below.
    * This will cause paths to javascript, stylesheets, and images to be updated to
    * the hostname defined in CDN_URL. In your CDN configuration the origin server

--- a/server/middlewares/csp.ts
+++ b/server/middlewares/csp.ts
@@ -46,10 +46,15 @@ interface CSPOptions {
  */
 export default function createCSPMiddleware(options?: CSPOptions) {
   // Construct scripts CSP based on options in use
+  // Use the origin (without any base path) as a CSP source. A source that
+  // includes a path without a trailing slash only matches that exact path, so
+  // a sub-path deployment (env.URL = https://host/outline) would otherwise
+  // block assets served from https://host/outline/static/*.
+  const origin = new URL(env.URL).origin;
   const defaultSrc: string[] = ["'self'"];
   const scriptSrc: string[] = [];
   const styleSrc: string[] = ["'self'", "'unsafe-inline'"];
-  const objectSrc: string[] = [env.URL, "'self'"];
+  const objectSrc: string[] = [origin, "'self'"];
 
   if (env.isCloudHosted) {
     scriptSrc.push("www.googletagmanager.com");
@@ -59,10 +64,10 @@ export default function createCSPMiddleware(options?: CSPOptions) {
 
   // Allow to load assets from Vite
   if (!env.isProduction) {
-    scriptSrc.push(env.URL.replace(`:${env.PORT}`, ":3001"));
+    scriptSrc.push(origin.replace(`:${env.PORT}`, ":3001"));
     scriptSrc.push("localhost:3001");
   } else {
-    scriptSrc.push(env.URL);
+    scriptSrc.push(origin);
   }
 
   if (env.GOOGLE_ANALYTICS_ID) {

--- a/server/middlewares/csrf.ts
+++ b/server/middlewares/csrf.ts
@@ -55,7 +55,7 @@ export function verifyCSRFToken() {
     }
 
     // For API routes, use AuthenticationHelper to determine if the operation is read-only
-    if (ctx.originalUrl.startsWith("/api/")) {
+    if (ctx.originalUrl.startsWith(`${env.basePath}/api/`)) {
       const canAccessWithReadOnly = AuthenticationHelper.canAccess(ctx.path, [
         Scope.Read,
       ]);

--- a/server/presenters/env.ts
+++ b/server/presenters/env.ts
@@ -13,6 +13,7 @@ export default function present(
 ): PublicEnv {
   return {
     ROOT_SHARE_ID: options.rootShareId || undefined,
+    BASE_PATH: env.basePath,
     analytics: (options.analytics ?? []).map((integration) => ({
       service: integration?.service,
       settings: integration?.settings,

--- a/server/routes/api/users/users.ts
+++ b/server/routes/api/users/users.ts
@@ -274,7 +274,7 @@ router.get(
       user = res.user;
       email = res.email;
     } catch (_err) {
-      ctx.redirect(`/?notice=expired-token`);
+      ctx.redirect(`${env.basePath}/?notice=expired-token`);
       return;
     }
 

--- a/server/routes/app.ts
+++ b/server/routes/app.ts
@@ -86,12 +86,15 @@ export const renderApp = async (
     allowIndexing?: boolean;
   } = {}
 ) => {
+  // When a CDN is configured assets are served from it, otherwise they are
+  // served by this app under its (possibly sub-path) base path.
+  const assetBase = env.CDN_URL || env.basePath;
   const {
     title = env.APP_NAME,
     description = "A modern team knowledge base for your internal documentation, product specs, support answers, meeting notes, onboarding, &amp; more…",
     canonical = "",
     content = "",
-    shortcutIcon = `${env.CDN_URL || ""}/images/favicon-32.png`,
+    shortcutIcon = `${assetBase}/images/favicon-32.png`,
     allowIndexing = true,
   } = options;
 
@@ -125,7 +128,7 @@ export const renderApp = async (
 
   const scriptTags = env.isProduction
     ? `<script type="module" nonce="${ctx.state.cspNonce}" src="${
-        env.CDN_URL || ""
+        env.CDN_URL || env.basePath
       }/static/${readManifestFile()[entry]["file"]}"></script>`
     : `<script type="module" nonce="${ctx.state.cspNonce}">
         import RefreshRuntime from "${viteHost}/static/@react-refresh"
@@ -151,34 +154,34 @@ export const renderApp = async (
 
   if (options.isShare) {
     headTags += `
-    <link rel="sitemap" type="application/xml" href="/api/shares.sitemap?id=${escape(options.rootShareId || shareId)}">
+    <link rel="sitemap" type="application/xml" href="${env.basePath}/api/shares.sitemap?id=${escape(options.rootShareId || shareId)}">
     `;
   } else {
     headTags += prefetchTags;
     headTags += `
-    <link rel="manifest" href="/static/manifest.webmanifest" />
+    <link rel="manifest" href="${env.basePath}/static/manifest.webmanifest" />
     <link
       rel="apple-touch-icon"
       type="image/png"
-      href="${env.CDN_URL ?? ""}/images/icon-maskable-192.png"
+      href="${assetBase}/images/icon-maskable-192.png"
       sizes="192x192"
     />
     <link
       rel="apple-touch-icon"
       type="image/png"
-      href="${env.CDN_URL ?? ""}/images/icon-maskable-512.png"
+      href="${assetBase}/images/icon-maskable-512.png"
       sizes="512x512"
     />
     <link
       rel="apple-touch-icon"
       type="image/png"
-      href="${env.CDN_URL ?? ""}/images/icon-maskable-1024.png"
+      href="${assetBase}/images/icon-maskable-1024.png"
       sizes="1024x1024"
     />
     <link
       rel="search"
       type="application/opensearchdescription+xml"
-      href="/opensearch.xml"
+      href="${env.basePath}/opensearch.xml"
       title="Outline"
     />
     `;
@@ -196,6 +199,8 @@ export const renderApp = async (
     .replace(/\{description\}/g, escape(description))
     .replace(/\{content\}/g, content)
     .replace(/\{cdn-url\}/g, env.CDN_URL || "")
+    .replace(/\{asset-base\}/g, assetBase)
+    .replace(/\{base-path\}/g, env.basePath)
     .replace(/\{head-tags\}/g, headTags)
     .replace(/\{slack-app-id\}/g, env.public.SLACK_APP_ID || "")
     .replace(/\{script-tags\}/g, scriptTags)

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -124,17 +124,18 @@ router.get(
     const origin = env.isCloudHosted
       ? ctx.request.URL.origin
       : new URL(env.URL).origin;
+    const base = `${origin}${env.basePath}`;
     const team = await getTeamFromContext(ctx, { includeOAuthState: false });
     const mcpEnabled = team?.getPreference(TeamPreference.MCP) ?? true;
 
     ctx.body = {
-      issuer: origin,
-      authorization_endpoint: `${origin}/oauth/authorize`,
-      token_endpoint: `${origin}/oauth/token`,
-      revocation_endpoint: `${origin}/oauth/revoke`,
+      issuer: base,
+      authorization_endpoint: `${base}/oauth/authorize`,
+      token_endpoint: `${base}/oauth/token`,
+      revocation_endpoint: `${base}/oauth/revoke`,
       ...(!env.OAUTH_DISABLE_DCR &&
         mcpEnabled && {
-          registration_endpoint: `${origin}/oauth/register`,
+          registration_endpoint: `${base}/oauth/register`,
         }),
       response_types_supported: ["code"],
       grant_types_supported: ["authorization_code", "refresh_token"],
@@ -164,10 +165,11 @@ router.get(
     const origin = env.isCloudHosted
       ? ctx.request.URL.origin
       : new URL(env.URL).origin;
+    const base = `${origin}${env.basePath}`;
 
     ctx.body = {
-      resource: `${origin}/mcp`,
-      authorization_servers: [origin],
+      resource: `${base}/mcp`,
+      authorization_servers: [base],
       scopes_supported: ["read", "write"],
       bearer_methods_supported: ["header"],
     };
@@ -181,7 +183,7 @@ router.get("/robots.txt", (ctx) => {
 router.get("/opensearch.xml", (ctx) => {
   ctx.type = "text/xml";
   ctx.response.set("Cache-Control", `public, max-age=${7 * Day.seconds}`);
-  ctx.body = opensearchResponse(ctx.request.URL.origin);
+  ctx.body = opensearchResponse(`${ctx.request.URL.origin}${env.basePath}`);
 });
 
 router.get("/s/:shareId.:format", shareDomains(), renderShare);
@@ -210,7 +212,7 @@ router.get("/doc/:documentSlug", async (ctx, next) => {
 
 router.get("/sitemap.xml", async (ctx) => {
   if (ctx.state?.rootShare) {
-    ctx.redirect(`/api/shares.sitemap?id=${ctx.state?.rootShare.id}`);
+    ctx.redirect(`${env.basePath}/api/shares.sitemap?id=${ctx.state?.rootShare.id}`);
   } else {
     ctx.status = 404;
   }

--- a/server/services/collaboration.ts
+++ b/server/services/collaboration.ts
@@ -26,7 +26,7 @@ export default function init(
   server: http.Server,
   serviceNames: string[]
 ) {
-  const path = "/collaboration";
+  const path = `${env.basePath}/collaboration`;
   const wss = new WebSocket.Server({
     noServer: true,
     maxPayload: DocumentValidation.maxStateLength,
@@ -125,7 +125,7 @@ export default function init(
       }
 
       if (
-        req.url?.startsWith("/realtime") &&
+        req.url?.startsWith(`${env.basePath}/realtime`) &&
         serviceNames.includes("websockets")
       ) {
         // Nothing to do, the websockets service will handle this request

--- a/server/services/web.ts
+++ b/server/services/web.ts
@@ -80,8 +80,10 @@ export default function init(app: Koa = new Koa(), server?: Server) {
     Metrics.gaugePerInstance("connections.count", 0);
   });
 
-  app.use(mount("/api", api));
-  app.use(mount("/mcp", mcp));
+  const basePath = env.basePath;
+
+  app.use(mount(`${basePath}/api`, api));
+  app.use(mount(`${basePath}/mcp`, mcp));
 
   // Generate and attach a CSRF token to the session on non-API requests
   app.use(attachCSRFToken());
@@ -102,9 +104,9 @@ export default function init(app: Koa = new Koa(), server?: Server) {
     })
   );
 
-  app.use(mount("/auth", auth));
-  app.use(mount("/oauth", oauth));
-  app.use(mount(routes));
+  app.use(mount(`${basePath}/auth`, auth));
+  app.use(mount(`${basePath}/oauth`, oauth));
+  app.use(basePath ? mount(basePath, routes) : mount(routes));
 
   return app;
 }

--- a/server/services/websockets.ts
+++ b/server/services/websockets.ts
@@ -31,7 +31,7 @@ export default function init(
   server: http.Server,
   serviceNames: string[]
 ) {
-  const path = "/realtime";
+  const path = `${env.basePath}/realtime`;
 
   // Websockets for events and non-collaborative documents
   const io = new IO.Server(server, {

--- a/server/static/index.html
+++ b/server/static/index.html
@@ -18,7 +18,7 @@
         font-family: "Inter";
         font-display: swap;
         font-feature-settings: "ss03", "cv05";
-        src: url("{cdn-url}/fonts/Inter.var.woff2") format("woff2");
+        src: url("{asset-base}/fonts/Inter.var.woff2") format("woff2");
       }
 
       @font-face {
@@ -26,7 +26,7 @@
         font-display: swap;
         font-feature-settings: "ss03", "cv05";
         font-style: italic;
-        src: url("{cdn-url}/fonts/Inter-italic.var.woff2") format("woff2");
+        src: url("{asset-base}/fonts/Inter-italic.var.woff2") format("woff2");
       }
 
       body,
@@ -74,6 +74,15 @@
   <body>
     <div id="root"></div>
     {env}
+    <script nonce="{csp-nonce}">
+      // Resolves bundle-internal asset URLs at runtime so the app can be served
+      // from a sub-path (BASE_PATH) or a CDN without rebuilding. Mirrors the
+      // `renderBuiltUrl` runtime hook in vite.config.ts.
+      window.__assetUrl = function (file) {
+        var e = window.env || {};
+        return (e.CDN_URL || e.BASE_PATH || "") + "/static/" + file;
+      };
+    </script>
     <script nonce="{csp-nonce}">
       if (
         window.localStorage &&

--- a/server/utils/prefetchTags.tsx
+++ b/server/utils/prefetchTags.tsx
@@ -31,6 +31,10 @@ if (env.CDN_URL) {
   );
 }
 
+// When a CDN is configured assets are served from it, otherwise from this app
+// under its (possibly sub-path) base path.
+const assetBase = env.CDN_URL || env.basePath;
+
 if (env.isProduction) {
   const manifest = readManifestFile();
 
@@ -52,7 +56,7 @@ if (env.isProduction) {
       prefetchTags.push(
         <link
           rel="prefetch"
-          href={`${env.CDN_URL || ""}/static/${file}`}
+          href={`${assetBase}/static/${file}`}
           key={file}
           as="script"
           crossOrigin="anonymous"
@@ -62,7 +66,7 @@ if (env.isProduction) {
       prefetchTags.push(
         <link
           rel="prefetch"
-          href={`${env.CDN_URL || ""}/static/${file}`}
+          href={`${assetBase}/static/${file}`}
           key={file}
           as="style"
           crossOrigin="anonymous"

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -126,6 +126,8 @@ export enum MentionType {
 
 export type PublicEnv = {
   ROOT_SHARE_ID?: string;
+  /** Path under which the app is served, e.g. "/outline". Empty when at root. */
+  BASE_PATH: string;
   analytics: {
     service: IntegrationService;
     settings: IntegrationSettings<IntegrationType.Analytics>;

--- a/shared/utils/urls.ts
+++ b/shared/utils/urls.ts
@@ -4,13 +4,37 @@ import { isBrowser } from "./browser";
 import { parseDomain } from "./domains";
 
 /**
- * Prepends the CDN url to the given path (If a CDN is configured).
+ * Returns the base url that app-served assets (images, locales, fonts) are
+ * reachable from. Prefers the CDN url when configured, otherwise the path the
+ * app is served from (empty at the domain root, e.g. "/outline" under a
+ * sub-path). On the client this is read from the injected env; on the server it
+ * is derived from the configured URL.
  *
- * @param path The path to prepend the CDN url to.
- * @returns The path with the CDN url prepended.
+ * @returns the asset base url without a trailing slash.
+ */
+function assetBaseUrl(): string {
+  if (env.CDN_URL) {
+    return env.CDN_URL;
+  }
+  if (typeof env.BASE_PATH === "string") {
+    return env.BASE_PATH;
+  }
+  try {
+    return new URL(env.URL).pathname.replace(/\/+$/, "");
+  } catch (_err) {
+    return "";
+  }
+}
+
+/**
+ * Prepends the asset base url to the given path. Uses the CDN url when
+ * configured, otherwise the app base path so assets resolve under a sub-path.
+ *
+ * @param path The path to prepend the asset base url to.
+ * @returns The path with the asset base url prepended.
  */
 export function cdnPath(path: string): string {
-  return `${env.CDN_URL ?? ""}${path}`;
+  return `${assetBaseUrl()}${path}`;
 }
 
 /**

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -54,9 +54,13 @@ export default () =>
           maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
           globPatterns: ["**/*.{js,css,ico,png,svg}"],
           navigateFallback: null,
-          modifyURLPrefix: {
-            "": `${environment.CDN_URL ?? ""}/static/`,
-          },
+          // With a CDN, precache from its absolute URL. Otherwise leave precache
+          // URLs relative so they resolve against the service worker's own
+          // location (`<base-path>/static/sw.js`) — this keeps offline caching
+          // working when the app is served from a sub-path set at runtime.
+          modifyURLPrefix: environment.CDN_URL
+            ? { "": `${environment.CDN_URL}/static/` }
+            : { "": "" },
           skipWaiting: true,
           clientsClaim: true,
           cleanupOutdatedCaches: true,
@@ -97,8 +101,10 @@ export default () =>
           short_name: "Outline",
           theme_color: "#fff",
           background_color: "#fff",
-          start_url: "/",
-          scope: ".",
+          // Relative to the manifest location (`<base-path>/static/manifest.webmanifest`)
+          // so install scope resolves to `<base-path>/` under any sub-path.
+          start_url: "../",
+          scope: "../",
           display: "standalone",
           // For Chrome, you must provide at least a 192x192 pixel icon, and a 512x512 pixel icon.
           // If only those two icon sizes are provided, Chrome will automatically scale the icons
@@ -106,41 +112,41 @@ export default () =>
           // pixel-perfection, provide icons in increments of 48dp.
           icons: [
             {
-              src: "/images/icon-192.png",
+              src: "../images/icon-192.png",
               sizes: "192x192",
               type: "image/png",
             },
             {
-              src: "/images/icon-512.png",
+              src: "../images/icon-512.png",
               sizes: "512x512",
               type: "image/png",
             },
             {
-              src: "/images/icon-maskable-192.png",
+              src: "../images/icon-maskable-192.png",
               sizes: "192x192",
               type: "image/png",
               purpose: "maskable",
             },
             {
-              src: "/images/icon-maskable-512.png",
+              src: "../images/icon-maskable-512.png",
               sizes: "512x512",
               type: "image/png",
               purpose: "maskable",
             },
             {
-              src: "/images/icon-maskable-1024.png",
+              src: "../images/icon-maskable-1024.png",
               sizes: "1024x1024",
               type: "image/png",
               purpose: "maskable",
             },
             {
-              src: "/images/icon-monochrome-512.png",
+              src: "../images/icon-monochrome-512.png",
               sizes: "512x512",
               type: "image/png",
               purpose: "monochrome",
             },
             {
-              src: "/images/icon-monochrome-1024.png",
+              src: "../images/icon-monochrome-1024.png",
               sizes: "1024x1024",
               type: "image/png",
               purpose: "monochrome",
@@ -153,6 +159,17 @@ export default () =>
     ],
     experimental: {
       enableNativePlugin: true,
+      // Resolve bundle-internal asset URLs at runtime via `window.__assetUrl`
+      // (defined in server/static/index.html). This lets the prebuilt image be
+      // served from a sub-path (BASE_PATH) or CDN set at container start without
+      // rebuilding. CSS/HTML references stay relative to their own file, which
+      // already resolves correctly under any prefix.
+      renderBuiltUrl(filename, { hostType }) {
+        if (hostType === "js") {
+          return { runtime: `window.__assetUrl(${JSON.stringify(filename)})` };
+        }
+        return { relative: true };
+      },
     },
     resolve: {
       alias: {


### PR DESCRIPTION
Derive a base path from the path component of the URL environment variable (e.g. URL=https://host/outline) and thread it through routing, assets, websockets, cookies, and auth so the app can run under a sub-path behind a prefix-preserving reverse proxy.

The base path is applied at runtime, not baked at build time: bundle-internal asset URLs resolve through a window.__assetUrl runtime hook (vite renderBuiltUrl), so a prebuilt image works under any sub-path set at container start without rebuilding. When served from the domain root the base path is an empty string and behavior is unchanged.

- server: prefix koa mounts (/api, /mcp, /auth, /oauth, routes), websocket and collaboration paths, OAuth discovery endpoints, opensearch, and redirects
- client: React Router basename, API client base, service worker scope, auth form actions and redirects
- expose BASE_PATH to the client via the public env