### PR TITLE
fix: Pinterest host matching too broad

### DIFF
--- a/server/routes/embeds.ts
+++ b/server/routes/embeds.ts
@@ -153,7 +153,8 @@ ${resizeObserverScript(ctx)}
   }
 
   if (
-    parsed.host.endsWith("pinterest.com") &&
+    (parsed.host === "pinterest.com" ||
+      parsed.host.endsWith(".pinterest.com")) &&
     parsed.protocol === "https:" &&
     ctx.path === "/embeds/pinterest"
   ) {


### PR DESCRIPTION
Tighten it up to prevent domains ending in `pinterest.com` from being renderable at this endpoint