### PR TITLE
fix: Allow webhook urls without a top-level domain when self-hosted

### DIFF
--- a/plugins/webhooks/server/api/webhookSubscriptions.test.ts
+++ b/plugins/webhooks/server/api/webhookSubscriptions.test.ts
@@ -123,6 +123,10 @@ describe("#webhookSubscriptions.list", () => {
 });
 
 describe("#webhookSubscriptions.create", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("should fail with status 401 unauthorized when user token is missing", async () => {
     const res = await server.post("/api/webhookSubscriptions.create", {
       body: {},

--- a/plugins/webhooks/server/api/webhookSubscriptions.test.ts
+++ b/plugins/webhooks/server/api/webhookSubscriptions.test.ts
@@ -205,39 +205,6 @@ describe("#webhookSubscriptions.create", () => {
     expect(res.status).toEqual(200);
     expect(body.data.url).toEqual(url);
   });
-
-  it("should allow urls without a top-level domain when not cloud hosted", async () => {
-    vi.spyOn(env, "isCloudHosted", "get").mockReturnValue(false);
-
-    const user = await buildAdmin();
-    const url = "http://webhook";
-    const res = await server.post("/api/webhookSubscriptions.create", user, {
-      body: {
-        name: "Test webhook",
-        url,
-        events: ["comments"],
-      },
-    });
-    const body = await res.json();
-
-    expect(res.status).toEqual(200);
-    expect(body.data.url).toEqual(url);
-  });
-
-  it("should reject urls without a top-level domain when cloud hosted", async () => {
-    vi.spyOn(env, "isCloudHosted", "get").mockReturnValue(true);
-
-    const user = await buildAdmin();
-    const res = await server.post("/api/webhookSubscriptions.create", user, {
-      body: {
-        name: "Test webhook",
-        url: "https://webhook",
-        events: ["comments"],
-      },
-    });
-
-    expect(res.status).toEqual(400);
-  });
 });
 
 describe("#webhookSubscriptions.update", () => {

--- a/plugins/webhooks/server/api/webhookSubscriptions.test.ts
+++ b/plugins/webhooks/server/api/webhookSubscriptions.test.ts
@@ -201,6 +201,39 @@ describe("#webhookSubscriptions.create", () => {
     expect(res.status).toEqual(200);
     expect(body.data.url).toEqual(url);
   });
+
+  it("should allow urls without a top-level domain when not cloud hosted", async () => {
+    vi.spyOn(env, "isCloudHosted", "get").mockReturnValue(false);
+
+    const user = await buildAdmin();
+    const url = "http://webhook";
+    const res = await server.post("/api/webhookSubscriptions.create", user, {
+      body: {
+        name: "Test webhook",
+        url,
+        events: ["comments"],
+      },
+    });
+    const body = await res.json();
+
+    expect(res.status).toEqual(200);
+    expect(body.data.url).toEqual(url);
+  });
+
+  it("should reject urls without a top-level domain when cloud hosted", async () => {
+    vi.spyOn(env, "isCloudHosted", "get").mockReturnValue(true);
+
+    const user = await buildAdmin();
+    const res = await server.post("/api/webhookSubscriptions.create", user, {
+      body: {
+        name: "Test webhook",
+        url: "https://webhook",
+        events: ["comments"],
+      },
+    });
+
+    expect(res.status).toEqual(400);
+  });
 });
 
 describe("#webhookSubscriptions.update", () => {

--- a/plugins/webhooks/server/api/webhookSubscriptions.test.ts
+++ b/plugins/webhooks/server/api/webhookSubscriptions.test.ts
@@ -123,10 +123,6 @@ describe("#webhookSubscriptions.list", () => {
 });
 
 describe("#webhookSubscriptions.create", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it("should fail with status 401 unauthorized when user token is missing", async () => {
     const res = await server.post("/api/webhookSubscriptions.create", {
       body: {},

--- a/server/models/WebhookSubscription.ts
+++ b/server/models/WebhookSubscription.ts
@@ -1,6 +1,5 @@
 import crypto from "node:crypto";
 import { isNil } from "es-toolkit/compat";
-import { isURL } from "validator";
 import type {
   InferAttributes,
   InferCreationAttributes,
@@ -14,7 +13,6 @@ import {
   ForeignKey,
   NotEmpty,
   DataType,
-  Is,
   BeforeCreate,
   AfterCreate,
   AfterUpdate,
@@ -25,7 +23,6 @@ import {
 } from "sequelize-typescript";
 import { Hour } from "@shared/utils/time";
 import { WebhookSubscriptionValidation } from "@shared/validations";
-import env from "@server/env";
 import { ValidationError } from "@server/errors";
 import type { Event } from "@server/types";
 import { CacheHelper } from "@server/utils/CacheHelper";
@@ -35,6 +32,7 @@ import User from "./User";
 import ParanoidModel from "./base/ParanoidModel";
 import Encrypted from "./decorators/Encrypted";
 import Fix from "./decorators/Fix";
+import IsUrl from "./validators/IsUrl";
 import Length from "./validators/Length";
 import { randomString } from "@shared/random";
 
@@ -119,13 +117,7 @@ class WebhookSubscription extends ParanoidModel<
   @Column
   name: string;
 
-  @Is(function isValidUrl(value: string) {
-    // A top-level domain is only required when cloud hosted, allowing
-    // self-hosted installations to use internal hostnames.
-    if (!isURL(value, { require_tld: env.isCloudHosted })) {
-      throw new Error("Must be a valid url");
-    }
-  })
+  @IsUrl
   @NotEmpty
   @Length({
     max: WebhookSubscriptionValidation.maxUrlLength,

--- a/server/models/WebhookSubscription.ts
+++ b/server/models/WebhookSubscription.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import { isNil } from "es-toolkit/compat";
+import { isURL } from "validator";
 import type {
   InferAttributes,
   InferCreationAttributes,
@@ -13,7 +14,7 @@ import {
   ForeignKey,
   NotEmpty,
   DataType,
-  IsUrl,
+  Is,
   BeforeCreate,
   AfterCreate,
   AfterUpdate,
@@ -24,6 +25,7 @@ import {
 } from "sequelize-typescript";
 import { Hour } from "@shared/utils/time";
 import { WebhookSubscriptionValidation } from "@shared/validations";
+import env from "@server/env";
 import { ValidationError } from "@server/errors";
 import type { Event } from "@server/types";
 import { CacheHelper } from "@server/utils/CacheHelper";
@@ -117,7 +119,13 @@ class WebhookSubscription extends ParanoidModel<
   @Column
   name: string;
 
-  @IsUrl
+  @Is(function isValidUrl(value: string) {
+    // A top-level domain is only required when cloud hosted, allowing
+    // self-hosted installations to use internal hostnames.
+    if (!isURL(value, { require_tld: env.isCloudHosted })) {
+      throw new Error("Must be a valid url");
+    }
+  })
   @NotEmpty
   @Length({
     max: WebhookSubscriptionValidation.maxUrlLength,

--- a/server/models/validators/IsUrl.test.ts
+++ b/server/models/validators/IsUrl.test.ts
@@ -1,0 +1,47 @@
+import env from "@server/env";
+import { WebhookSubscription } from "@server/models";
+
+describe("IsUrl", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const validateUrl = (url: string) =>
+    WebhookSubscription.build({ url }).validate({ fields: ["url"] });
+
+  describe("when cloud hosted", () => {
+    beforeEach(() => {
+      vi.spyOn(env, "isCloudHosted", "get").mockReturnValue(true);
+    });
+
+    it("should allow urls with a top-level domain", async () => {
+      await expect(validateUrl("https://example.com")).resolves.toBeTruthy();
+    });
+
+    it("should reject urls without a top-level domain", async () => {
+      await expect(validateUrl("https://webhook")).rejects.toThrow();
+    });
+  });
+
+  describe("when not cloud hosted", () => {
+    beforeEach(() => {
+      vi.spyOn(env, "isCloudHosted", "get").mockReturnValue(false);
+    });
+
+    it("should allow urls with a top-level domain", async () => {
+      await expect(validateUrl("https://example.com")).resolves.toBeTruthy();
+    });
+
+    it("should allow urls without a top-level domain", async () => {
+      await expect(validateUrl("http://webhook")).resolves.toBeTruthy();
+    });
+  });
+
+  it("should reject urls without a protocol", async () => {
+    await expect(validateUrl("example.com")).rejects.toThrow();
+  });
+
+  it("should reject non-http protocols", async () => {
+    await expect(validateUrl("ftp://example.com")).rejects.toThrow();
+  });
+});

--- a/server/models/validators/IsUrl.test.ts
+++ b/server/models/validators/IsUrl.test.ts
@@ -23,7 +23,7 @@ describe("IsUrl", () => {
     });
   });
 
-  describe("when not cloud hosted", () => {
+  describe("self hosted", () => {
     beforeEach(() => {
       vi.spyOn(env, "isCloudHosted", "get").mockReturnValue(false);
     });

--- a/server/models/validators/IsUrl.ts
+++ b/server/models/validators/IsUrl.ts
@@ -1,0 +1,26 @@
+import { isURL } from "class-validator";
+import { addAttributeOptions } from "sequelize-typescript";
+import env from "@server/env";
+
+/**
+ * A decorator that validates that a string is a valid HTTP(S) url. A top-level
+ * domain is only required when cloud hosted, allowing self-hosted installations
+ * to use internal hostnames.
+ */
+export default function IsUrl(target: object, propertyName: string) {
+  return addAttributeOptions(target, propertyName, {
+    validate: {
+      validUrl(value: string) {
+        if (
+          !isURL(value, {
+            protocols: ["http", "https"],
+            require_protocol: true,
+            require_tld: env.isCloudHosted,
+          })
+        ) {
+          throw new Error("Must be a valid url");
+        }
+      },
+    },
+  });
+}


### PR DESCRIPTION
Fixes #12727. Webhook URL validation rejected valid internal hostnames such as `http://webhook` because the model-level validator required a top-level domain. This is common on self-hosted installations using internal DNS search zones or container-to-container references in a Docker Compose stack.

The model's URL validator now only requires a TLD when cloud hosted, mirroring the existing cloud-vs-self-hosted handling already in the request schema. Added tests covering both the self-hosted (allowed) and cloud-hosted (rejected) cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)