### PR TITLE
Keep mobile selection toolbar sticky above the iOS keyboard

### DIFF
--- a/app/components/CenteredContent.tsx
+++ b/app/components/CenteredContent.tsx
@@ -12,7 +12,7 @@ type Props = {
 const Container = styled.div<Props>`
   width: 100%;
   max-width: 100vw;
-  padding: ${(props) => (props.withStickyHeader ? "4px 12px" : "60px 12px")};
+  padding: ${(props) => (props.withStickyHeader ? "4px 16px" : "60px 16px")};
 
   ${breakpoint("tablet")`
     padding: ${(props: Props) =>

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -161,7 +161,7 @@ const Wrapper = styled(Flex)<WrapperProps>`
       backdrop-filter: blur(20px);
       `};
 
-  padding: 12px;
+  padding: 12px 16px;
   transform: translate3d(0, 0, 0);
   min-height: ${HEADER_HEIGHT}px;
   justify-content: flex-start;

--- a/app/components/Heading.ts
+++ b/app/components/Heading.ts
@@ -5,7 +5,7 @@ const Heading = styled.h1<{ as?: string; centered?: boolean }>`
   display: flex;
   align-items: center;
   user-select: none;
-  ${(props) => (props.as ? "" : "margin-top: 3vh; font-weight: 600;")}
+  ${(props) => (props.as ? "" : "margin-top: 8vh; font-weight: 600;")}
   ${(props) => (props.centered ? "text-align: center;" : "")}
 
   ${breakpoint("tablet")`

--- a/app/editor/components/FloatingToolbar.tsx
+++ b/app/editor/components/FloatingToolbar.tsx
@@ -7,12 +7,11 @@ import { isCode } from "@shared/editor/lib/isCode";
 import { findParentNode } from "@shared/editor/queries/findParentNode";
 import { EditorStyleHelper } from "@shared/editor/styles/EditorStyleHelper";
 import { depths, s } from "@shared/styles";
-import { getSafeAreaInsets } from "@shared/utils/browser";
 import { HEADER_HEIGHT } from "~/components/Header";
 import { Portal } from "~/components/Portal";
 import useEventListener from "~/hooks/useEventListener";
+import useKeyboardStickyOffset from "~/hooks/useKeyboardStickyOffset";
 import useMobile from "~/hooks/useMobile";
-import useWindowSize from "~/hooks/useWindowSize";
 import Logger from "~/utils/Logger";
 import { useEditor } from "./EditorContext";
 import { ColumnSelection } from "@shared/editor/selection/ColumnSelection";
@@ -267,23 +266,20 @@ const FloatingToolbar = React.forwardRef(function FloatingToolbar_(
   });
 
   const isMobile = useMobile();
-  const { height } = useWindowSize();
+  const isMobileToolbarVisible = isMobile && !!props.active && position.visible;
+
+  // Keep the mobile toolbar glued to the top of the on-screen keyboard. The
+  // hook tracks the visual viewport directly — see its implementation for the
+  // iOS specifics.
+  useKeyboardStickyOffset(menuRef, isMobileToolbarVisible);
 
   if (isMobile) {
-    if (props.active && position.visible) {
-      const rect = document.body.getBoundingClientRect();
-      const safeAreaInsets = getSafeAreaInsets();
-
+    if (isMobileToolbarVisible) {
+      // Vertical position (above the keyboard) is owned entirely by
+      // useKeyboardStickyOffset, which writes the transform directly.
       return (
         <ReactPortal>
-          <MobileWrapper
-            ref={menuRef}
-            style={{
-              bottom: `calc(100% - ${
-                height - rect.y - safeAreaInsets.bottom
-              }px)`,
-            }}
-          >
+          <MobileWrapper ref={menuRef}>
             {props.children && (
               <MobileBackground>{props.children}</MobileBackground>
             )}
@@ -347,12 +343,14 @@ const arrow = (props: WrapperProps) =>
     : "";
 
 const MobileWrapper = styled.div`
-  position: absolute;
+  position: fixed;
+  bottom: 0;
   left: 0;
   right: 0;
   width: 100vw;
   box-sizing: border-box;
   z-index: ${depths.editorToolbar};
+  will-change: transform;
 
   @media print {
     display: none;

--- a/app/hooks/useKeyboardStickyOffset.ts
+++ b/app/hooks/useKeyboardStickyOffset.ts
@@ -1,0 +1,95 @@
+import * as React from "react";
+import { getSafeAreaInsets } from "@shared/utils/browser";
+
+/**
+ * Pins a `position: fixed; bottom: 0` element directly above the on-screen
+ * keyboard on mobile browsers.
+ *
+ * On iOS Safari the layout viewport (which fixed elements are positioned
+ * against) does not shrink when the software keyboard opens — only the visual
+ * viewport does. As a result an element anchored to the bottom of the screen
+ * ends up hidden behind the keyboard. This hook measures the gap between the
+ * bottom of the layout viewport and the bottom of the visual viewport and
+ * translates the element upwards by that amount so it always rests on top of
+ * the keyboard.
+ *
+ * The transform is re-applied after every render (so a parent re-render cannot
+ * clobber it) and on visual viewport `resize`/`scroll` events. A short-lived
+ * `requestAnimationFrame` loop tracks the keyboard's open/close animation so
+ * the element glides with it rather than snapping into place once the
+ * transition settles. Writes go directly to the node's style to avoid React
+ * re-render latency during the animation.
+ *
+ * @param ref A ref to the fixed-position element to keep pinned.
+ * @param enabled Whether the behavior should be active.
+ */
+export default function useKeyboardStickyOffset(
+  ref: React.RefObject<HTMLElement>,
+  enabled: boolean
+) {
+  const apply = React.useCallback(() => {
+    const viewport = window.visualViewport;
+    const node = ref.current;
+    if (!enabled || !viewport || !node) {
+      return;
+    }
+
+    // Distance from the bottom of the layout viewport (where the element is
+    // anchored) up to the bottom of the visible area — i.e. the height of the
+    // keyboard, if any. On browsers that resize the layout viewport with the
+    // keyboard this is ~0 and we fall back to the safe area inset so the bar
+    // clears the home indicator.
+    const keyboardInset = Math.max(
+      0,
+      window.innerHeight - (viewport.offsetTop + viewport.height)
+    );
+    const offset = Math.round(
+      Math.max(keyboardInset, getSafeAreaInsets().bottom)
+    );
+
+    node.style.transform = `translate3d(0, ${-offset}px, 0)`;
+  }, [ref, enabled]);
+
+  // Re-apply after every render, before paint, so the keyboard-aware transform
+  // survives parent re-renders and there is no flash on first mount.
+  React.useLayoutEffect(apply);
+
+  React.useEffect(() => {
+    const viewport = window.visualViewport;
+    if (!enabled || !viewport) {
+      return;
+    }
+
+    let frame = 0;
+    let trackUntil = 0;
+
+    const tick = (now: number) => {
+      apply();
+      frame = now < trackUntil ? requestAnimationFrame(tick) : 0;
+    };
+
+    const schedule = () => {
+      // Keep re-measuring for a short window so the element follows the
+      // keyboard animation rather than jumping once it settles.
+      trackUntil = performance.now() + 350;
+      if (!frame) {
+        frame = requestAnimationFrame(tick);
+      }
+    };
+
+    viewport.addEventListener("resize", schedule);
+    viewport.addEventListener("scroll", schedule);
+    window.addEventListener("focusin", schedule);
+    window.addEventListener("orientationchange", schedule);
+
+    return () => {
+      if (frame) {
+        cancelAnimationFrame(frame);
+      }
+      viewport.removeEventListener("resize", schedule);
+      viewport.removeEventListener("scroll", schedule);
+      window.removeEventListener("focusin", schedule);
+      window.removeEventListener("orientationchange", schedule);
+    };
+  }, [enabled, apply]);
+}

--- a/app/menus/CollectionMenu.tsx
+++ b/app/menus/CollectionMenu.tsx
@@ -59,7 +59,7 @@ function CollectionMenu({
         align={align}
         onOpen={onOpen}
         onClose={onClose}
-        ariaLabel={t("Collection menu")}
+        ariaLabel={t("Collection options")}
       >
         <OverflowMenuButton
           neutral={neutral}

--- a/app/scenes/Collection/components/Header.tsx
+++ b/app/scenes/Collection/components/Header.tsx
@@ -90,7 +90,7 @@ const StyledHeading = styled(Heading)`
   display: flex;
   align-items: center;
   position: relative;
-  margin-left: 40px;
+  margin-left: 16px;
 
   ${breakpoint("tablet")`
     margin-left: 0;

--- a/app/scenes/Document/components/Document.tsx
+++ b/app/scenes/Document/components/Document.tsx
@@ -518,9 +518,10 @@ type EditorContainerProps = {
 
 const EditorContainer = styled.div<EditorContainerProps>`
   // Adds space to the gutter to make room for icon & heading annotations
-  padding: 0 44px;
+  padding: 0 32px;
 
   ${breakpoint("tablet")`
+    padding: 0 44px;
     grid-row: 1;
 
     // Decides the editor column position & span

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -698,7 +698,6 @@
   "Activate user": "Activate user",
   "API key": "API key",
   "Show path to document": "Show path to document",
-  "Collection menu": "Collection menu",
   "Comment options": "Comment options",
   "Enable viewer insights": "Enable viewer insights",
   "Enable embeds": "Enable embeds",


### PR DESCRIPTION
The mobile selection toolbar positioned itself with absolute positioning and a bottom calc derived from the document body rect and visual viewport height. On iOS the layout viewport (which fixed/absolute elements anchor to) does not shrink when the software keyboard opens, only the visual viewport does, so the toolbar drifted and lagged relative to the keyboard.