### PR TITLE
feat: Add IP address-aware sort for tables

### DIFF
--- a/shared/editor/commands/table.test.ts
+++ b/shared/editor/commands/table.test.ts
@@ -1,0 +1,103 @@
+import type { Node } from "prosemirror-model";
+import {
+  createEditorStateWithSelection,
+  doc,
+  table,
+  tr,
+  td,
+} from "@shared/test/editor";
+import { sortTable } from "./table";
+
+/**
+ * Builds a table document from a 2D array of cell strings (rows of columns),
+ * runs sortTable on the given column, and returns the resulting rows as a 2D
+ * array of cell text.
+ */
+function runSort(
+  data: string[][],
+  index: number,
+  direction: "asc" | "desc"
+): string[][] {
+  const testDoc = doc([
+    table(data.map((row) => tr(row.map((cell) => td(cell))))),
+  ]);
+  // place the selection inside the first cell of the table
+  let state = createEditorStateWithSelection(testDoc, 4);
+
+  sortTable({ index, direction })(state, (tx) => {
+    state = state.apply(tx);
+  });
+
+  const resultTable = state.doc.firstChild as Node;
+  const rows: string[][] = [];
+  resultTable.forEach((row) => {
+    const cells: string[] = [];
+    row.forEach((cell) => cells.push(cell.textContent));
+    rows.push(cells);
+  });
+  return rows;
+}
+
+describe("sortTable", () => {
+  it("sorts a text column ascending and descending", () => {
+    const data = [["banana"], ["apple"], ["cherry"]];
+    expect(runSort(data, 0, "asc")).toEqual([
+      ["apple"],
+      ["banana"],
+      ["cherry"],
+    ]);
+    expect(runSort(data, 0, "desc")).toEqual([
+      ["cherry"],
+      ["banana"],
+      ["apple"],
+    ]);
+  });
+
+  it("sorts IP addresses octet-wise within a subnet", () => {
+    const data = [["192.168.69.10"], ["192.168.69.9"], ["192.168.69.2"]];
+    expect(runSort(data, 0, "asc")).toEqual([
+      ["192.168.69.2"],
+      ["192.168.69.9"],
+      ["192.168.69.10"],
+    ]);
+  });
+
+  it("sorts IP addresses octet-wise across subnets", () => {
+    const data = [["192.168.150.10"], ["192.168.69.20"], ["10.0.0.1"]];
+    expect(runSort(data, 0, "asc")).toEqual([
+      ["10.0.0.1"],
+      ["192.168.69.20"],
+      ["192.168.150.10"],
+    ]);
+  });
+
+  it("keeps empty cells last in both directions", () => {
+    const data = [["b"], [""], ["a"], ["c"]];
+    expect(runSort(data, 0, "asc")).toEqual([["a"], ["b"], ["c"], [""]]);
+    expect(runSort(data, 0, "desc")).toEqual([["c"], ["b"], ["a"], [""]]);
+  });
+
+  it("is stable so sorts can be chained into a multi-key order", () => {
+    // Inventory of [VLAN, IP]. First sort by the secondary key (IP), then by
+    // the primary key (VLAN). A stable sort must preserve the IP order within
+    // each VLAN group.
+    const inventory = [
+      ["20", "192.168.20.10"],
+      ["10", "192.168.10.5"],
+      ["20", "192.168.20.2"],
+      ["10", "192.168.10.20"],
+      ["10", "192.168.10.3"],
+    ];
+
+    const byIP = runSort(inventory, 1, "asc");
+    const byVlanThenIP = runSort(byIP, 0, "asc");
+
+    expect(byVlanThenIP).toEqual([
+      ["10", "192.168.10.3"],
+      ["10", "192.168.10.5"],
+      ["10", "192.168.10.20"],
+      ["20", "192.168.20.2"],
+      ["20", "192.168.20.10"],
+    ]);
+  });
+});

--- a/shared/editor/commands/table.ts
+++ b/shared/editor/commands/table.ts
@@ -23,6 +23,7 @@ import { ProsemirrorHelper } from "../../utils/ProsemirrorHelper";
 import { CSVHelper } from "../../utils/csv";
 import { isCurrency, parseCurrency } from "../../utils/currency";
 import { parseDate } from "../../utils/date";
+import { isIPv4Address, parseIPv4 } from "../../utils/ip";
 import { chainTransactions } from "../lib/chainTransactions";
 import {
   getAllSelectedColumns,
@@ -400,92 +401,95 @@ export function sortTable({
       // column data before sort
       const columnData = rows.map(getCellContent);
 
-      // determine sorting type: date, currency, number, or text
+      // determine sorting type: date, currency, IP address, number, or text
       let compareAsDate = false;
       let compareAsCurrency = false;
+      let compareAsIP = false;
       let compareAsNumber = false;
 
       const nonEmptyCells = columnData
         .map((content) => content.trim())
         .filter((content): content is string => content.length > 0);
       if (nonEmptyCells.length > 0) {
-        // check if all non-empty cells are valid dates
+        // Dates require every cell to match; `every` short-circuits on the first
+        // miss, so the expensive date parsing is skipped for non-date columns.
         compareAsDate = nonEmptyCells.every((cell) => parseDate(cell) !== null);
 
-        // if not dates, check if cells are currency values
-        // treat as currency if at least 50% of non-empty cells look like currency values
         if (!compareAsDate) {
-          const currencyCells = nonEmptyCells.filter((cell) =>
-            isCurrency(cell)
-          );
-          const currencyRatio = currencyCells.length / nonEmptyCells.length;
-          compareAsCurrency = currencyCells.length >= 2 && currencyRatio >= 0.5;
-        }
+          // Tally the remaining candidate types in a single pass. The checks are
+          // mutually exclusive and ordered by priority — IP must come before the
+          // number check, as IPs would otherwise be parsed as truncated numbers.
+          let currencyCount = 0;
+          let ipCount = 0;
+          let numberCount = 0;
+          for (const cell of nonEmptyCells) {
+            if (isCurrency(cell)) {
+              currencyCount++;
+            } else if (isIPv4Address(cell)) {
+              ipCount++;
+            } else if (!isNaN(parseFloat(cell))) {
+              numberCount++;
+            }
+          }
 
-        // if not currency, check if cells are numbers (same logic)
-        if (!compareAsDate && !compareAsCurrency) {
-          const numberCells = nonEmptyCells.filter(
-            (cell) => !isNaN(parseFloat(cell))
-          );
-          const numberRatio = numberCells.length / nonEmptyCells.length;
-          compareAsNumber = numberCells.length >= 2 && numberRatio >= 0.5;
+          // Treat as a type if at least 2 cells match and they form a majority.
+          const isMajority = (count: number) =>
+            count >= 2 && count / nonEmptyCells.length >= 0.5;
+          if (isMajority(currencyCount)) {
+            compareAsCurrency = true;
+          } else if (isMajority(ipCount)) {
+            compareAsIP = true;
+          } else if (isMajority(numberCount)) {
+            compareAsNumber = true;
+          }
         }
       }
 
-      // sort rows based on column at index
-      rows.sort((a, b) => {
-        const aContent = getCellContent(a);
-        const bContent = getCellContent(b);
-
-        // empty cells always go to the end
-        if (!aContent) {
-          return bContent ? 1 : 0;
+      // Extracts a comparable value for the detected column type. Returns null
+      // for empty or non-matching cells, which always sort to the end.
+      const getSortValue = (content: string): number | string | null => {
+        if (!content) {
+          return null;
         }
-        if (!bContent) {
+        if (compareAsDate) {
+          return parseDate(content)?.getTime() ?? null;
+        }
+        if (compareAsCurrency) {
+          return parseCurrency(content);
+        }
+        if (compareAsIP) {
+          return parseIPv4(content);
+        }
+        if (compareAsNumber) {
+          const num = parseFloat(content);
+          return isNaN(num) ? null : num;
+        }
+        return content;
+      };
+
+      // Sort rows based on column at index. The comparator is direction-aware
+      // rather than reversing afterwards, so the sort stays stable in both
+      // directions — equal cells keep their prior order, which lets sorts be
+      // chained to build a multi-key order (e.g. sort by IP, then by VLAN).
+      const directionMultiplier = direction === "desc" ? -1 : 1;
+      rows.sort((a, b) => {
+        const aValue = getSortValue(getCellContent(a));
+        const bValue = getSortValue(getCellContent(b));
+
+        // empty or non-matching cells always go to the end, regardless of direction
+        if (aValue === null) {
+          return bValue === null ? 0 : 1;
+        }
+        if (bValue === null) {
           return -1;
         }
 
-        if (compareAsDate) {
-          const aDate = parseDate(aContent);
-          const bDate = parseDate(bContent);
-          // non-date cells go to the end (like empty cells)
-          if (!aDate) {
-            return bDate ? 1 : 0;
-          }
-          if (!bDate) {
-            return -1;
-          }
-          return aDate.getTime() - bDate.getTime();
-        } else if (compareAsCurrency) {
-          const aValue = parseCurrency(aContent);
-          const bValue = parseCurrency(bContent);
-          // non-currency cells go to the end (like empty cells)
-          if (aValue === null) {
-            return bValue !== null ? 1 : 0;
-          }
-          if (bValue === null) {
-            return -1;
-          }
-          return aValue - bValue;
-        } else if (compareAsNumber) {
-          const aNum = parseFloat(aContent);
-          const bNum = parseFloat(bContent);
-          // non-number cells go to the end (like empty cells)
-          if (isNaN(aNum)) {
-            return !isNaN(bNum) ? 1 : 0;
-          }
-          if (isNaN(bNum)) {
-            return -1;
-          }
-          return aNum - bNum;
-        } else {
-          return aContent.localeCompare(bContent);
-        }
+        const result =
+          typeof aValue === "string"
+            ? aValue.localeCompare(bValue as string)
+            : aValue - (bValue as number);
+        return directionMultiplier * result;
       });
-
-      if (direction === "desc") {
-        rows.reverse();
-      }
 
       // check if column data changed, if not then do not replace table
       if (columnData.join() === rows.map(getCellContent).join()) {

--- a/shared/utils/ip.test.ts
+++ b/shared/utils/ip.test.ts
@@ -1,0 +1,48 @@
+import { isIPv4Address, parseIPv4 } from "./ip";
+
+describe("parseIPv4", () => {
+  it("parses valid IPv4 addresses", () => {
+    expect(parseIPv4("0.0.0.0")).toBe(0);
+    expect(parseIPv4("255.255.255.255")).toBe(4294967295);
+    expect(parseIPv4("192.168.1.1")).toBe(3232235777);
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(parseIPv4("  192.168.1.1  ")).toBe(parseIPv4("192.168.1.1"));
+  });
+
+  it("orders addresses octet-wise within a subnet", () => {
+    expect(parseIPv4("192.168.69.9")!).toBeLessThan(
+      parseIPv4("192.168.69.10")!
+    );
+  });
+
+  it("orders addresses octet-wise across subnets", () => {
+    expect(parseIPv4("192.168.69.20")!).toBeLessThan(
+      parseIPv4("192.168.150.10")!
+    );
+  });
+
+  it("returns null for invalid input", () => {
+    expect(parseIPv4("")).toBeNull();
+    expect(parseIPv4("192.168.1")).toBeNull();
+    expect(parseIPv4("192.168.1.1.1")).toBeNull();
+    expect(parseIPv4("192.168.1.256")).toBeNull();
+    expect(parseIPv4("not an ip")).toBeNull();
+    expect(parseIPv4("1.2.3.4 ")).toBe(parseIPv4("1.2.3.4"));
+    expect(parseIPv4("192.168.1.x")).toBeNull();
+  });
+});
+
+describe("isIPv4Address", () => {
+  it("returns true for valid addresses", () => {
+    expect(isIPv4Address("10.0.0.1")).toBe(true);
+    expect(isIPv4Address("255.255.255.255")).toBe(true);
+  });
+
+  it("returns false for invalid addresses", () => {
+    expect(isIPv4Address("256.0.0.1")).toBe(false);
+    expect(isIPv4Address("hello")).toBe(false);
+    expect(isIPv4Address("")).toBe(false);
+  });
+});

--- a/shared/utils/ip.ts
+++ b/shared/utils/ip.ts
@@ -1,0 +1,31 @@
+import ipaddr from "ipaddr.js";
+
+/**
+ * Checks if a string is a canonical dotted-quad IPv4 address (e.g. 192.168.1.1).
+ * Stricter than ipaddr's `isValid`, which also accepts shorthand and hex forms
+ * such as "1.2.3" or "0xC0.0xA8.1.1" that would misclassify ordinary numbers.
+ *
+ * @param value - the string to check.
+ * @returns true if the string is a canonical IPv4 address.
+ */
+export function isIPv4Address(value: string): boolean {
+  return ipaddr.IPv4.isValidFourPartDecimal(value.trim());
+}
+
+/**
+ * Parses an IPv4 address into a single numeric value that preserves octet-wise
+ * ordering, so addresses sort correctly both within and across subnets
+ * (e.g. 192.168.69.9 before 192.168.69.10, and 192.168.69.20 before 192.168.150.10).
+ *
+ * @param value - the IPv4 address string to parse.
+ * @returns the numeric value, or null if the string is not a canonical IPv4 address.
+ */
+export function parseIPv4(value: string): number | null {
+  const trimmed = value.trim();
+  if (!ipaddr.IPv4.isValidFourPartDecimal(trimmed)) {
+    return null;
+  }
+  return ipaddr.IPv4.parse(trimmed)
+    .toByteArray()
+    .reduce((acc, octet) => acc * 256 + octet, 0);
+}


### PR DESCRIPTION
This also combines three loops into one during sorting, making this more performant than before and adds tests to the sorting logic.

closes https://github.com/outline/outline/discussions/12733