### PR TITLE
fix: Collapse code blocks taller than half the viewport

### DIFF
--- a/shared/editor/nodes/CodeFence.ts
+++ b/shared/editor/nodes/CodeFence.ts
@@ -57,10 +57,15 @@ import { isInCode } from "../queries/isInCode";
 import Node from "./Node";
 
 const DEFAULT_LANGUAGE = "javascript";
-const COLLAPSE_LINE_THRESHOLD = 12;
+
+/** Fraction of the viewport height above which a code block is collapsible. */
+const COLLAPSE_HEIGHT_RATIO = 0.5;
+
+/** Approximate rendered line height of a code block, in pixels. */
+const CODE_LINE_HEIGHT = 20;
 
 interface CollapseState {
-  /** Positions of code blocks with more than COLLAPSE_LINE_THRESHOLD lines. */
+  /** Positions of code blocks taller than COLLAPSE_HEIGHT_RATIO of the viewport. */
   tallBlocks: Set<number>;
   /** Positions of code blocks currently collapsed by the user or auto-collapse. */
   collapsedBlocks: Set<number>;
@@ -69,17 +74,23 @@ interface CollapseState {
 }
 
 /**
- * Find all code block positions in the document that exceed the line threshold.
+ * Find all code block positions whose estimated height exceeds
+ * COLLAPSE_HEIGHT_RATIO of the viewport height.
  *
  * @param doc - the document to scan.
  * @returns set of positions of tall code blocks.
  */
 function findTallBlocks(doc: ProsemirrorNode): Set<number> {
   const tall = new Set<number>();
+  if (!isBrowser) {
+    return tall;
+  }
+  const maxLines =
+    (window.innerHeight * COLLAPSE_HEIGHT_RATIO) / CODE_LINE_HEIGHT;
   for (const block of findBlockNodes(doc, true)) {
     if (isCode(block.node)) {
       const lines = (block.node.textContent.match(/\n/g)?.length ?? 0) + 1;
-      if (lines > COLLAPSE_LINE_THRESHOLD) {
+      if (lines > maxLines) {
         tall.add(block.pos);
       }
     }
@@ -415,13 +426,6 @@ export default class CodeFence extends Node<CodeFenceOptions> {
         key: collapseKey,
         state: {
           init: (_config, state) => {
-            if (!isBrowser) {
-              return {
-                tallBlocks: new Set<number>(),
-                collapsedBlocks: new Set<number>(),
-                decorations: DecorationSet.empty,
-              };
-            }
             const tallBlocks = findTallBlocks(state.doc);
             return build(state.doc, tallBlocks, new Set(tallBlocks));
           },


### PR DESCRIPTION
Code blocks were collapsed behind an "Expand" toggle based on a fixed 12-line threshold. This replaces that with a viewport-relative threshold so a block is only collapsed when its estimated height exceeds 50% of the screen height, adapting to different screen sizes. The threshold is derived from `window.innerHeight` and an approximate code line height, keeping `findTallBlocks` a synchronous, pure function with no DOM measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)