### PR TITLE
fix: Cmd+A in image/video captions

### DIFF
--- a/shared/editor/components/Caption.tsx
+++ b/shared/editor/components/Caption.tsx
@@ -23,7 +23,14 @@ type Props = {
 /**
  * A component that renders a caption for an image or video.
  */
-function Caption({ placeholder, children, isSelected, width, ...rest }: Props) {
+function Caption({
+  placeholder,
+  children,
+  isSelected,
+  width,
+  onKeyDown,
+  ...rest
+}: Props) {
   const { t } = useTranslation();
   const handlePaste = (event: React.ClipboardEvent<HTMLParagraphElement>) => {
     event.preventDefault();
@@ -36,12 +43,28 @@ function Caption({ placeholder, children, isSelected, width, ...rest }: Props) {
     ev.stopPropagation();
   };
 
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLParagraphElement>) => {
+    // Cmd/Ctrl-A should select the caption text, not the whole document.
+    if ((event.metaKey || event.ctrlKey) && event.key === "a") {
+      event.preventDefault();
+      event.stopPropagation();
+      const selection = window.getSelection();
+      const range = window.document.createRange();
+      range.selectNodeContents(event.currentTarget);
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+      return;
+    }
+    onKeyDown(event);
+  };
+
   return (
     <Content
       $width={width}
       $isSelected={isSelected}
       onMouseDown={handleMouseDown}
       onPaste={handlePaste}
+      onKeyDown={handleKeyDown}
       className={EditorStyleHelper.imageCaption}
       tabIndex={-1}
       aria-label={t("Caption")}
@@ -64,7 +87,7 @@ const Content = styled.p<{ $width: number; $isSelected: boolean }>`
   max-width: 100%;
 
   &:empty:not(:focus) {
-    display: ${(props) => (props.$isSelected ? "block" : "none")}};
+    display: ${(props) => (props.$isSelected ? "block" : "none")};
   }
 
   &:empty::before {

--- a/shared/editor/nodes/Image.tsx
+++ b/shared/editor/nodes/Image.tsx
@@ -346,6 +346,18 @@ export default class Image extends SimpleImage {
         return;
       }
 
+      // Cmd/Ctrl-A should select the caption text, not the whole document.
+      if ((event.metaKey || event.ctrlKey) && event.key === "a") {
+        event.preventDefault();
+        event.stopPropagation();
+        const selection = window.getSelection();
+        const range = window.document.createRange();
+        range.selectNodeContents(event.currentTarget);
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+        return;
+      }
+
       // Pressing Backspace in an empty caption field focused the image.
       if (event.key === "Backspace" && event.currentTarget.innerText === "") {
         event.preventDefault();

--- a/shared/editor/nodes/Image.tsx
+++ b/shared/editor/nodes/Image.tsx
@@ -346,18 +346,6 @@ export default class Image extends SimpleImage {
         return;
       }
 
-      // Cmd/Ctrl-A should select the caption text, not the whole document.
-      if ((event.metaKey || event.ctrlKey) && event.key === "a") {
-        event.preventDefault();
-        event.stopPropagation();
-        const selection = window.getSelection();
-        const range = window.document.createRange();
-        range.selectNodeContents(event.currentTarget);
-        selection?.removeAllRanges();
-        selection?.addRange(range);
-        return;
-      }
-
       // Pressing Backspace in an empty caption field focused the image.
       if (event.key === "Backspace" && event.currentTarget.innerText === "") {
         event.preventDefault();


### PR DESCRIPTION
Pressing Cmd/Ctrl+A while editing an image or video caption was selecting the entire document, because the caption is a separate `contentEditable` whose keydown bubbles up to ProseMirror's global `selectAll` keymap. This adds select-all handling in the shared `Caption` component so both image and video captions select only their own text. It also fixes a stray brace in the caption styled-component (`display: ...}};`) that corrupted the empty-caption CSS rule and caused the placeholder to not reliably appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)