### PR TITLE
fix: Prevent concurrent OAuth refresh attempts from revoking grant

### DIFF
--- a/server/routes/oauth/index.test.ts
+++ b/server/routes/oauth/index.test.ts
@@ -264,6 +264,13 @@ describe("#oauth.token", () => {
       const body1 = await res1.json();
       const auth2RefreshToken = body1.refresh_token;
 
+      // Simulate the rotation having happened outside the reuse interval, so the
+      // replay below is treated as genuine reuse rather than a concurrent refresh.
+      await OAuthAuthentication.update(
+        { deletedAt: new Date(Date.now() - 60 * 1000) },
+        { where: { id: auth1.id }, paranoid: false, silent: true }
+      );
+
       // Create an unrelated authentication
       const otherAuth = await buildOAuthAuthentication({
         user,
@@ -334,6 +341,13 @@ describe("#oauth.token", () => {
         }),
       });
 
+      // Simulate the rotation having happened outside the reuse interval, so the
+      // replay below is treated as genuine reuse rather than a concurrent refresh.
+      await OAuthAuthentication.update(
+        { deletedAt: new Date(Date.now() - 60 * 1000) },
+        { where: { id: auth.id }, paranoid: false, silent: true }
+      );
+
       // Use the OLD refresh token again (reuse detection)
       await server.post("/oauth/token", {
         headers: {
@@ -350,6 +364,58 @@ describe("#oauth.token", () => {
       // The authorization code should be gone
       const foundCode = await OAuthAuthorizationCode.findByPk(code.id);
       expect(foundCode).toBeNull();
+    });
+
+    it("should not revoke the grant when a rotated refresh token is replayed within the reuse interval", async () => {
+      const user = await buildUser();
+      const client = await buildOAuthClient({
+        teamId: user.teamId,
+        clientType: "confidential",
+      });
+      const grantId = crypto.randomUUID();
+
+      const auth1 = await buildOAuthAuthentication({
+        user,
+        scope: [Scope.Read],
+        oauthClientId: client.id,
+        grantId,
+      });
+
+      // Use the refresh token once (rotation)
+      const res1 = await server.post("/oauth/token", {
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: toFormData({
+          grant_type: "refresh_token",
+          refresh_token: auth1.refreshToken,
+          client_id: client.clientId,
+          client_secret: client.clientSecret,
+        }),
+      });
+      expect(res1.status).toEqual(200);
+      const body1 = await res1.json();
+      const auth2RefreshToken = body1.refresh_token;
+
+      // Immediately replay the OLD refresh token, as a client issuing concurrent
+      // refresh requests would. This is within the reuse interval.
+      const res2 = await server.post("/oauth/token", {
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: toFormData({
+          grant_type: "refresh_token",
+          refresh_token: auth1.refreshToken,
+          client_id: client.clientId,
+          client_secret: client.clientSecret,
+        }),
+      });
+
+      // The replay fails, but the grant won by the first request survives.
+      expect(res2.status).toEqual(400);
+      const foundAuth2 =
+        await OAuthAuthentication.findByRefreshToken(auth2RefreshToken);
+      expect(foundAuth2).not.toBeNull();
     });
   });
 });

--- a/server/utils/oauth/OAuthInterface.test.ts
+++ b/server/utils/oauth/OAuthInterface.test.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "node:crypto";
+import { subSeconds } from "date-fns";
 import { Scope } from "@shared/types";
 import { OAuthInterface } from "./OAuthInterface";
+import { OAuthAuthentication } from "@server/models";
 import {
   buildOAuthAuthentication,
   buildOAuthClient,
@@ -86,6 +88,64 @@ describe("OAuthInterface", () => {
     it("should return false for invalid refresh token", async () => {
       const result = await OAuthInterface.getRefreshToken("invalid_token");
       expect(result).toBe(false);
+    });
+
+    it("should revoke the entire grant when a refresh token is reused outside the reuse interval", async () => {
+      const user = await buildUser();
+      const scope = [Scope.Read];
+      const grantId = randomUUID();
+      const oAuthClient = await buildOAuthClient({ teamId: user.teamId });
+      const rotated = await buildOAuthAuthentication({
+        user,
+        oauthClientId: oAuthClient.id,
+        scope,
+        grantId,
+      });
+      const sibling = await buildOAuthAuthentication({
+        user,
+        oauthClientId: oAuthClient.id,
+        scope,
+        grantId,
+      });
+      const refreshToken = rotated.refreshToken!;
+
+      // Simulate a rotation that happened longer ago than the reuse interval.
+      await rotated.destroy();
+      await OAuthAuthentication.update(
+        { deletedAt: subSeconds(new Date(), 60) },
+        { where: { id: rotated.id }, paranoid: false, silent: true }
+      );
+
+      const result = await OAuthInterface.getRefreshToken(refreshToken);
+      expect(result).toBe(false);
+      expect(await OAuthAuthentication.findByPk(sibling.id)).toBeNull();
+    });
+
+    it("should not revoke the grant when a rotated refresh token is replayed within the reuse interval", async () => {
+      const user = await buildUser();
+      const scope = [Scope.Read];
+      const grantId = randomUUID();
+      const oAuthClient = await buildOAuthClient({ teamId: user.teamId });
+      const rotated = await buildOAuthAuthentication({
+        user,
+        oauthClientId: oAuthClient.id,
+        scope,
+        grantId,
+      });
+      const sibling = await buildOAuthAuthentication({
+        user,
+        oauthClientId: oAuthClient.id,
+        scope,
+        grantId,
+      });
+      const refreshToken = rotated.refreshToken!;
+
+      // Simulate a rotation that just happened, as with a concurrent refresh.
+      await rotated.destroy();
+
+      const result = await OAuthInterface.getRefreshToken(refreshToken);
+      expect(result).toBe(false);
+      expect(await OAuthAuthentication.findByPk(sibling.id)).not.toBeNull();
     });
   });
 

--- a/server/utils/oauth/OAuthInterface.ts
+++ b/server/utils/oauth/OAuthInterface.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import { subSeconds } from "date-fns";
 import type {
   RefreshTokenModel,
   AuthorizationCodeModel,
@@ -13,6 +14,14 @@ import {
   OAuthAuthorizationCode,
 } from "@server/models";
 import { hash, safeEqual } from "@server/utils/crypto";
+
+/**
+ * The number of seconds during which a rotated refresh token may be replayed
+ * without triggering reuse detection. This provides a grace window for clients
+ * that issue concurrent refresh requests, preventing the entire grant from being
+ * revoked due to a benign race.
+ */
+const refreshTokenReuseInterval = 10;
 
 /**
  * Additional configuration for the OAuthInterface, not part of the
@@ -127,7 +136,19 @@ export const OAuthInterface: RefreshTokenModel &
         paranoid: false,
       });
 
-      if (authentication?.grantId) {
+      // A recently rotated token may be replayed by a client that issued
+      // concurrent refresh requests. Treat replays within the reuse interval as
+      // benign and skip revocation, so the grant won by the parallel request
+      // survives. Replays outside the window are treated as genuine reuse.
+      const reuseWindowStart = subSeconds(
+        new Date(),
+        refreshTokenReuseInterval
+      );
+      const withinReuseInterval =
+        authentication?.deletedAt &&
+        authentication.deletedAt > reuseWindowStart;
+
+      if (authentication?.grantId && !withinReuseInterval) {
         await Promise.all([
           OAuthAuthentication.destroy({
             where: {


### PR DESCRIPTION
Adds some leniency as not all OAuth clients are well-adjusted.

- No token is ever issued to the replaying party within the window. A replay of an already-rotated token still yields invalid_grant.
- The window suppresses revocation, not enables access. An attacker holding a stolen, already-rotated token gains nothing new — within 10s the grant survives but the attacker still receives no tokens.
