### PR TITLE
feat: Record search query duration in milliseconds

### DIFF
--- a/server/migrations/20260619000000-add-duration-to-search-queries.js
+++ b/server/migrations/20260619000000-add-duration-to-search-queries.js
@@ -1,0 +1,15 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn("search_queries", "duration", {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn("search_queries", "duration");
+  },
+};

--- a/server/models/SearchQuery.ts
+++ b/server/models/SearchQuery.ts
@@ -48,6 +48,12 @@ class SearchQuery extends Model<
   results: number;
 
   /**
+   * How long the search took to execute, in milliseconds.
+   */
+  @Column
+  duration: number;
+
+  /**
    * User score for the results for this query, -1 for negative, 1 for positive, null for neutral.
    */
   @Column

--- a/server/routes/api/documents/documents.test.ts
+++ b/server/routes/api/documents/documents.test.ts
@@ -1951,6 +1951,8 @@ describe("#documents.search", () => {
     expect(searchQuery.length).toBe(1);
     expect(searchQuery[0].results).toBe(0);
     expect(searchQuery[0].source).toBe("app");
+    expect(Number.isInteger(searchQuery[0].duration)).toBe(true);
+    expect(searchQuery[0].duration).toBeGreaterThanOrEqual(0);
   });
 
   it("should include individually shared docs with a user in search results", async () => {

--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -1058,6 +1058,7 @@ router.post(
     let response;
     let share;
     let isPublic = false;
+    const searchStartedAt = Date.now();
 
     if (shareId) {
       const teamFromCtx = await getTeamFromContext(ctx, {
@@ -1171,6 +1172,7 @@ router.post(
     // When requesting subsequent pages of search results we don't want to record
     // duplicate search query records
     if (query && offset === 0) {
+      const duration = Date.now() - searchStartedAt;
       await SearchQuery.create({
         userId: user?.id,
         teamId,
@@ -1178,6 +1180,7 @@ router.post(
         source: ctx.state.auth.type || "app", // we'll consider anything that isn't "api" to be "app"
         query,
         results: total,
+        duration,
       });
     }
 


### PR DESCRIPTION
Adds a `duration` column to the `search_queries` table that records how long each search took, in milliseconds. The timing is captured in the `documents.search` endpoint from just before the search provider call through result presentation, and stored alongside the existing query metadata. A migration adds the nullable INTEGER column so existing rows are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)