### PR TITLE
fix: Vertically center empty state in notifications popover

### DIFF
--- a/app/actions/definitions/developer.tsx
+++ b/app/actions/definitions/developer.tsx
@@ -161,6 +161,18 @@ export const createTestUsers = createAction({
   },
 });
 
+export const createTestNotifications = createAction({
+  name: "Create 10 notifications",
+  icon: <BeakerIcon />,
+  section: DeveloperSection,
+  visible: () => env.ENVIRONMENT === "development",
+  perform: async () => {
+    const count = 10;
+    await client.post("/developer.create_test_notifications", { count });
+    toast.message(`${count} test notifications created`);
+  },
+});
+
 export const createToast = createAction({
   name: "Create toast",
   section: DeveloperSection,
@@ -239,6 +251,7 @@ export const developer = createActionWithChildren({
     toggleFeatureFlag,
     createToast,
     createTestUsers,
+    createTestNotifications,
     clearIndexedDB,
     clearStorage,
     startTyping,

--- a/app/components/Notifications/Notifications.tsx
+++ b/app/components/Notifications/Notifications.tsx
@@ -145,7 +145,7 @@ function Notifications(
             <NotificationMenu />
           </HStack>
         </Header>
-        <Scrollable ref={ref} flex topShadow hiddenScrollbars>
+        <StyledScrollable ref={ref} flex topShadow hiddenScrollbars>
           <React.Suspense fallback={null}>
             <PaginatedList<Notification>
               fetch={notifications.fetchPage}
@@ -165,7 +165,7 @@ function Notifications(
               )}
             />
           </React.Suspense>
-        </Scrollable>
+        </StyledScrollable>
       </Flex>
     </ErrorBoundary>
   );
@@ -183,11 +183,16 @@ const StyledInputSelect = styled(InputSelect)`
   }
 `;
 
+const StyledScrollable = styled(Scrollable)`
+  flex: 1;
+  min-height: 0;
+`;
+
 const EmptyNotifications = styled(Empty)`
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 100%;
+  flex: 1;
 `;
 
 const Button = styled(NudeButton)`

--- a/server/routes/api/developer/developer.ts
+++ b/server/routes/api/developer/developer.ts
@@ -1,12 +1,16 @@
 import type { Context, Next } from "koa";
 import Router from "koa-router";
-import { randomString } from "@shared/random";
+import { Op } from "sequelize";
+import { randomString, randomElement } from "@shared/random";
+import { NotificationEventType } from "@shared/types";
 import type { Invite } from "@server/commands/userInviter";
 import userInviter from "@server/commands/userInviter";
 import env from "@server/env";
 import Logger from "@server/logging/Logger";
 import auth from "@server/middlewares/authentication";
 import validate from "@server/middlewares/validate";
+import { Document, Notification, User } from "@server/models";
+import presentNotification from "@server/presenters/notification";
 import { presentUser } from "@server/presenters";
 import type { APIContext } from "@server/types";
 import * as T from "./schema";
@@ -55,6 +59,66 @@ router.post(
     ctx.body = {
       data: {
         users: response.users.map((user) => presentUser(user)),
+      },
+    };
+  }
+);
+
+router.post(
+  "developer.create_test_notifications",
+  dev(),
+  auth(),
+  validate(T.CreateTestNotificationsSchema),
+  async (ctx: APIContext<T.CreateTestNotificationsReq>) => {
+    const { count } = ctx.input.body;
+    const { user } = ctx.state.auth;
+
+    const events = [
+      NotificationEventType.UpdateDocument,
+      NotificationEventType.CreateComment,
+      NotificationEventType.MentionedInDocument,
+      NotificationEventType.MentionedInComment,
+      NotificationEventType.AddUserToDocument,
+    ];
+
+    const [documents, actors] = await Promise.all([
+      Document.findAll({
+        where: { teamId: user.teamId },
+        limit: 25,
+      }),
+      User.findAll({
+        where: { teamId: user.teamId, id: { [Op.ne]: user.id } },
+        limit: 25,
+      }),
+    ]);
+
+    const notifications = await Promise.all(
+      Array(Math.min(count, 100))
+        .fill(0)
+        .map(() => {
+          const document = documents.length
+            ? randomElement(documents)
+            : undefined;
+
+          return Notification.create({
+            event: randomElement(events),
+            userId: user.id,
+            actorId: actors.length ? randomElement(actors).id : user.id,
+            teamId: user.teamId,
+            documentId: document?.id,
+          });
+        })
+    );
+
+    Logger.info("utils", `Creating ${count} test notifications`);
+
+    ctx.body = {
+      data: {
+        notifications: await Promise.all(
+          notifications.map((notification) =>
+            presentNotification(ctx, notification)
+          )
+        ),
       },
     };
   }

--- a/server/routes/api/developer/schema.ts
+++ b/server/routes/api/developer/schema.ts
@@ -8,3 +8,13 @@ export const CreateTestUsersSchema = BaseSchema.extend({
 });
 
 export type CreateTestUsersReq = z.infer<typeof CreateTestUsersSchema>;
+
+export const CreateTestNotificationsSchema = BaseSchema.extend({
+  body: z.object({
+    count: z.coerce.number().prefault(10),
+  }),
+});
+
+export type CreateTestNotificationsReq = z.infer<
+  typeof CreateTestNotificationsSchema
+>;


### PR DESCRIPTION
The empty state relied on percentage heights to center, but the height chain was broken by the outer container only setting min/max height. Switch to flexbox growth so the scroll region fills the available space and the empty message centers reliably.

Add utility to create test notifications in development for debugging