### PR TITLE
Show "Signing in" screen for desktop-forced passkey login

### DIFF
--- a/app/scenes/DesktopRedirect.tsx
+++ b/app/scenes/DesktopRedirect.tsx
@@ -1,17 +1,12 @@
 import { useEffect } from "react";
-import { useTranslation } from "react-i18next";
 import styled from "styled-components";
-import { s } from "@shared/styles";
 import Flex from "~/components/Flex";
-import Heading from "~/components/Heading";
-import PageTitle from "~/components/PageTitle";
-import Text from "~/components/Text";
 import useQuery from "~/hooks/useQuery";
+import { SigningIn } from "./Login/components/SigningIn";
 
 const DesktopRedirect = () => {
   const params = useQuery();
   const token = params.get("token");
-  const { t } = useTranslation();
 
   useEffect(() => {
     if (token) {
@@ -28,29 +23,10 @@ const DesktopRedirect = () => {
 
   return (
     <Centered align="center" justify="center" column auto>
-      <PageTitle title={`${t("Signing in")}…`} />
-      <Heading centered>{t("Signing in")}…</Heading>
-      <Note>
-        {t(
-          "You can safely close this window once the Outline desktop app has opened"
-        )}
-        .
-      </Note>
+      <SigningIn />
     </Centered>
   );
 };
-
-const Note = styled(Text)`
-  color: ${s("textTertiary")};
-  text-align: center;
-  font-size: 14px;
-  margin-top: 8px;
-
-  em {
-    font-style: normal;
-    font-weight: 500;
-  }
-`;
 
 const Centered = styled(Flex)`
   user-select: none;

--- a/app/scenes/Login/Login.tsx
+++ b/app/scenes/Login/Login.tsx
@@ -40,6 +40,8 @@ import { BackButton } from "./components/BackButton";
 import { Background } from "./components/Background";
 import { Centered } from "./components/Centered";
 import { Notices } from "./components/Notices";
+import { PasskeyAuthenticationProvider } from "./components/PasskeyAuthenticationProvider";
+import { SigningIn } from "./components/SigningIn";
 import { SwitchHostButton } from "./components/SwitchHostButton";
 import { navigateToSubdomain } from "./urls";
 import lazyWithRetry from "~/utils/lazyWithRetry";
@@ -122,6 +124,14 @@ function Login({ children, onBack }: Props) {
   // ceremony even when this browser already has a session.
   const isPasskeyLogin = query.get("method") === "passkey";
 
+  // When the desktop app forces a passkey login it opens this page in the
+  // system browser, where the ceremony is triggered automatically. Show the
+  // "Signing in" screen rather than the login buttons.
+  const isDesktopPasskeyRedirect =
+    isPasskeyLogin &&
+    query.get("client") === Client.Desktop &&
+    !Desktop.isElectron();
+
   if (auth.authenticated && !isPasskeyLogin) {
     const postLoginPath = spendPostLoginPath();
     if (postLoginPath) {
@@ -167,6 +177,22 @@ function Login({ children, onBack }: Props) {
   // indicator here that's delayed by 250ms
   if (!config) {
     return <LoadingIndicator />;
+  }
+
+  // The passkey ceremony is triggered automatically here, so render the
+  // "Signing in" screen in place of the login buttons. The passkey provider is
+  // still mounted (hidden) to drive the ceremony and form submission, revealing
+  // a retry button if the ceremony fails.
+  if (isDesktopPasskeyRedirect) {
+    return (
+      <Background>
+        <ChangeLanguage locale={detectLanguage()} />
+        <Centered gap={12}>
+          <SigningIn />
+          <PasskeyAuthenticationProvider />
+        </Centered>
+      </Background>
+    );
   }
 
   const isCustomDomain = parseDomain(window.location.origin).custom;

--- a/app/scenes/Login/components/PasskeyAuthenticationProvider.tsx
+++ b/app/scenes/Login/components/PasskeyAuthenticationProvider.tsx
@@ -64,6 +64,7 @@ export function PasskeyAuthenticationProvider(props: Props) {
     null
   );
   const [isAuthenticating, setIsAuthenticating] = React.useState(false);
+  const [hasError, setHasError] = React.useState(false);
 
   // True when this page was opened in the system browser from the desktop app
   // to complete a passkey login (see the /auth/passkey route). In that case the
@@ -72,8 +73,14 @@ export function PasskeyAuthenticationProvider(props: Props) {
   const isDesktopRedirect =
     query.get("method") === "passkey" && query.get("client") === Client.Desktop;
 
+  // When returning to the system browser from the desktop app the ceremony is
+  // triggered automatically, so the button is hidden behind the "Signing in"
+  // screen. It is revealed again if the ceremony fails so the user can retry.
+  const autoStarting = isDesktopRedirect && !Desktop.isElectron();
+
   const runAuthentication = React.useCallback(async (verifyClient: Client) => {
     setIsAuthenticating(true);
+    setHasError(false);
     try {
       const resp = await client.post(
         "/passkeys.generateAuthenticationOptions",
@@ -101,6 +108,7 @@ export function PasskeyAuthenticationProvider(props: Props) {
       // Re-enable the button so the user can retry; on success the form submits
       // and navigates away, so there's no need to reset there.
       setIsAuthenticating(false);
+      setHasError(true);
     }
   }, []);
 
@@ -152,15 +160,17 @@ export function PasskeyAuthenticationProvider(props: Props) {
               readOnly
             />
           ))}
-        <ButtonLarge
-          type="submit"
-          icon={<PluginIcon id="passkeys" color="currentColor" />}
-          fullwidth
-          {...props}
-          disabled={isAuthenticating}
-        >
-          {t("Continue with Passkey")}
-        </ButtonLarge>
+        {(!autoStarting || hasError) && (
+          <ButtonLarge
+            type="submit"
+            icon={<PluginIcon id="passkeys" color="currentColor" />}
+            fullwidth
+            {...props}
+            disabled={isAuthenticating}
+          >
+            {t("Continue with Passkey")}
+          </ButtonLarge>
+        )}
       </Form>
     </Wrapper>
   );

--- a/app/scenes/Login/components/SigningIn.tsx
+++ b/app/scenes/Login/components/SigningIn.tsx
@@ -1,0 +1,42 @@
+import { useTranslation } from "react-i18next";
+import styled from "styled-components";
+import { s } from "@shared/styles";
+import Heading from "~/components/Heading";
+import PageTitle from "~/components/PageTitle";
+import Text from "~/components/Text";
+
+/**
+ * Renders the "Signing in…" screen shown while a login is being completed in
+ * the background, for example after handing a session back to the desktop app
+ * or while a passkey ceremony runs automatically.
+ *
+ * @returns the signing-in screen.
+ */
+export function SigningIn() {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <PageTitle title={`${t("Signing in")}…`} />
+      <Heading centered>{t("Signing in")}…</Heading>
+      <Note>
+        {t(
+          "You can safely close this window once the Outline desktop app has opened"
+        )}
+        .
+      </Note>
+    </>
+  );
+}
+
+const Note = styled(Text)`
+  color: ${s("textTertiary")};
+  text-align: center;
+  font-size: 14px;
+  margin-top: 8px;
+
+  em {
+    font-style: normal;
+    font-weight: 500;
+  }
+`;


### PR DESCRIPTION
When the desktop app forces a passkey login it opens the login page in the system browser, where the passkey ceremony is triggered automatically.

Show the same "Signing in" screen used during desktop redirect instead of the login buttons, since no manual interaction is needed. The passkey provider stays mounted to drive the ceremony and reveals a retry button if it fails.
