### PR TITLE
fix: Notion import crash on empty table ("Index 0 out of range")

### DIFF
--- a/plugins/notion/server/utils/NotionConverter.test.ts
+++ b/plugins/notion/server/utils/NotionConverter.test.ts
@@ -37,7 +37,7 @@ describe("NotionConverter", () => {
     expect(ProsemirrorHelper.toProsemirror(response)).toBeInstanceOf(Node);
   });
 
-  it("converts a page with an empty table", () => {
+  it("drops an empty table", () => {
     const response = NotionConverter.page({
       children: [
         {
@@ -54,7 +54,7 @@ describe("NotionConverter", () => {
       ],
     } as unknown as NotionPage);
 
-    expect(response.content).toEqual([{ type: "table", content: [] }]);
+    expect(response.content).toEqual([]);
     expect(ProsemirrorHelper.toProsemirror(response)).toBeInstanceOf(Node);
   });
 });

--- a/plugins/notion/server/utils/NotionConverter.ts
+++ b/plugins/notion/server/utils/NotionConverter.ts
@@ -595,9 +595,14 @@ export class NotionConverter {
       }>;
     }
   ) {
+    // A table with no rows is invalid content, skip it entirely.
+    if (!item.children?.length) {
+      return undefined;
+    }
+
     return {
       type: "table",
-      content: (item.children ?? []).map((tr, y) => ({
+      content: item.children.map((tr, y) => ({
         type: "tr",
         content: tr.table_row.cells.map((td, x) => ({
           type:

--- a/server/models/helpers/DocumentHelper.test.ts
+++ b/server/models/helpers/DocumentHelper.test.ts
@@ -360,6 +360,23 @@ This is a [test paragraph](https://example.net)`,
       expect(result).toBe("the cat’s “meow”");
     });
 
+    it("should not crash serializing a table with no rows", async () => {
+      const document = await buildDocument({
+        content: {
+          type: "doc",
+          content: [
+            { type: "paragraph", content: [{ type: "text", text: "before" }] },
+            { type: "table", content: [] },
+            { type: "paragraph", content: [{ type: "text", text: "after" }] },
+          ],
+        },
+      });
+      const result = await DocumentHelper.toMarkdown(document, {
+        includeTitle: false,
+      });
+      expect(result).toBe("before\n\nafter");
+    });
+
     it("should not escape standalone square brackets", async () => {
       const document = await buildDocument({
         content: {

--- a/shared/editor/lib/markdown/serializer.ts
+++ b/shared/editor/lib/markdown/serializer.ts
@@ -463,6 +463,11 @@ export class MarkdownSerializerState {
   }
 
   renderTable(node) {
+    // A table with no rows is not valid Markdown and has nothing to serialize.
+    if (node.childCount === 0) {
+      return;
+    }
+
     this.flushClose(1);
 
     const prevTable = this.inTable;


### PR DESCRIPTION
Notion imports were sometimes failing with only the message `Index 0 out of range for <>`. The cause is an empty Notion table being converted to a schema-invalid table node with zero rows: `Node.fromJSON` accepts it, but Markdown serialization then crashes in `renderTable`'s `node.child(0)`. This drops empty tables in the Notion converter so we never persist an invalid node, and also guards `renderTable` against tables with no rows so the crash is handled regardless of source. Added regression tests for both the converter and the Markdown serializer.
