### PR TITLE
fix: Ensure mention in doc emails always include context

### DIFF
--- a/server/models/helpers/ProseMirrorHelper.test.ts
+++ b/server/models/helpers/ProseMirrorHelper.test.ts
@@ -399,7 +399,7 @@ describe("ProsemirrorHelper", () => {
       expect(newDoc?.toJSON()).toEqual(expectedDoc.toJSON());
     });
 
-    it("should return the whole checkbox list containing the mention", () => {
+    it("should trim a checkbox list to the mentioned item and one either side", () => {
       const mentionAttrs: MentionAttrs = {
         id: "31d5899f-e544-4ff6-b6d3-c49dd6b81901",
         type: MentionType.User,
@@ -408,25 +408,19 @@ describe("ProsemirrorHelper", () => {
         modelId: "9a17c1c8-d178-4350-9001-203a73070fcb",
       };
 
+      const checkboxItem = (text: string): DeepPartial<ProsemirrorData> => ({
+        type: "checkbox_item",
+        content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+      });
+
       const mentionedItem: DeepPartial<ProsemirrorData> = {
         type: "checkbox_item",
         content: [
           {
             type: "paragraph",
             content: [
-              {
-                type: "text",
-                text: "task B ",
-              },
-              {
-                type: "paragraph",
-                content: [
-                  {
-                    type: "mention",
-                    attrs: mentionAttrs,
-                  },
-                ],
-              },
+              { type: "text", text: "task C " },
+              { type: "mention", attrs: mentionAttrs },
             ],
           },
         ],
@@ -434,55 +428,26 @@ describe("ProsemirrorHelper", () => {
 
       const doc = buildProseMirrorDoc([
         {
-          type: "paragraph",
-          content: [
-            {
-              type: "text",
-              text: "some content in a paragraph",
-            },
-          ],
-        },
-        {
           type: "checkbox_list",
           content: [
-            {
-              type: "checkbox_item",
-              content: [
-                {
-                  type: "paragraph",
-                  content: [
-                    {
-                      type: "text",
-                      text: "task A",
-                    },
-                  ],
-                },
-              ],
-            },
+            checkboxItem("task A"),
+            checkboxItem("task B"),
             mentionedItem,
+            checkboxItem("task D"),
+            checkboxItem("task E"),
           ],
         },
       ]);
 
+      // The mention is in the third item, so the snippet keeps items two
+      // through four.
       const expectedDoc = buildProseMirrorDoc([
         {
           type: "checkbox_list",
           content: [
-            {
-              type: "checkbox_item",
-              content: [
-                {
-                  type: "paragraph",
-                  content: [
-                    {
-                      type: "text",
-                      text: "task A",
-                    },
-                  ],
-                },
-              ],
-            },
+            checkboxItem("task B"),
             mentionedItem,
+            checkboxItem("task D"),
           ],
         },
       ]);
@@ -495,7 +460,7 @@ describe("ProsemirrorHelper", () => {
       expect(newDoc?.toJSON()).toEqual(expectedDoc.toJSON());
     });
 
-    it("should return the whole bullet list containing the mention", () => {
+    it("should trim a bullet list to the mentioned item and one either side", () => {
       const mentionAttrs: MentionAttrs = {
         id: "31d5899f-e544-4ff6-b6d3-c49dd6b81901",
         type: MentionType.User,
@@ -504,20 +469,19 @@ describe("ProsemirrorHelper", () => {
         modelId: "9a17c1c8-d178-4350-9001-203a73070fcb",
       };
 
+      const listItem = (text: string): DeepPartial<ProsemirrorData> => ({
+        type: "list_item",
+        content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+      });
+
       const mentionedItem: DeepPartial<ProsemirrorData> = {
         type: "list_item",
         content: [
           {
             type: "paragraph",
             content: [
-              {
-                type: "text",
-                text: "item B ",
-              },
-              {
-                type: "mention",
-                attrs: mentionAttrs,
-              },
+              { type: "text", text: "item A " },
+              { type: "mention", attrs: mentionAttrs },
             ],
           },
         ],
@@ -525,56 +489,17 @@ describe("ProsemirrorHelper", () => {
 
       const doc = buildProseMirrorDoc([
         {
-          type: "paragraph",
-          content: [
-            {
-              type: "text",
-              text: "some content in a paragraph",
-            },
-          ],
-        },
-        {
           type: "bullet_list",
-          content: [
-            {
-              type: "list_item",
-              content: [
-                {
-                  type: "paragraph",
-                  content: [
-                    {
-                      type: "text",
-                      text: "item A",
-                    },
-                  ],
-                },
-              ],
-            },
-            mentionedItem,
-          ],
+          content: [mentionedItem, listItem("item B"), listItem("item C")],
         },
       ]);
 
+      // The mention is in the first item, so the window is clamped to the
+      // mentioned item and the one that follows.
       const expectedDoc = buildProseMirrorDoc([
         {
           type: "bullet_list",
-          content: [
-            {
-              type: "list_item",
-              content: [
-                {
-                  type: "paragraph",
-                  content: [
-                    {
-                      type: "text",
-                      text: "item A",
-                    },
-                  ],
-                },
-              ],
-            },
-            mentionedItem,
-          ],
+          content: [mentionedItem, listItem("item B")],
         },
       ]);
 

--- a/server/models/helpers/ProseMirrorHelper.test.ts
+++ b/server/models/helpers/ProseMirrorHelper.test.ts
@@ -295,7 +295,7 @@ describe("ProsemirrorHelper", () => {
       expect(newDoc?.toJSON()).toEqual(expectedDoc.toJSON());
     });
 
-    it("should return the whole table containing the mention", () => {
+    it("should trim a table to the mentioned row", () => {
       const mentionAttrs: MentionAttrs = {
         id: "31d5899f-e544-4ff6-b6d3-c49dd6b81901",
         type: MentionType.User,
@@ -304,23 +304,29 @@ describe("ProsemirrorHelper", () => {
         modelId: "9a17c1c8-d178-4350-9001-203a73070fcb",
       };
 
+      const row = (text: string): DeepPartial<ProsemirrorData> => ({
+        type: "tr",
+        content: [
+          {
+            type: "td",
+            attrs: { colspan: 1, rowspan: 1 },
+            content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+          },
+        ],
+      });
+
       const mentionedRow: DeepPartial<ProsemirrorData> = {
         type: "tr",
         content: [
           {
             type: "td",
-            attrs: {
-              colspan: 1,
-              rowspan: 1,
-            },
+            attrs: { colspan: 1, rowspan: 1 },
             content: [
               {
                 type: "paragraph",
                 content: [
-                  {
-                    type: "mention",
-                    attrs: mentionAttrs,
-                  },
+                  { type: "text", text: "row B " },
+                  { type: "mention", attrs: mentionAttrs },
                 ],
               },
             ],
@@ -330,64 +336,15 @@ describe("ProsemirrorHelper", () => {
 
       const doc = buildProseMirrorDoc([
         {
-          type: "paragraph",
-          content: [
-            {
-              type: "text",
-              text: "some content in a paragraph",
-            },
-          ],
-        },
-        {
           type: "table",
-          content: [
-            {
-              type: "td",
-              attrs: {
-                colspan: 1,
-                rowspan: 1,
-              },
-              content: [
-                {
-                  type: "paragraph",
-                  content: [
-                    {
-                      type: "text",
-                      text: "cell content",
-                    },
-                  ],
-                },
-              ],
-            },
-            mentionedRow,
-          ],
+          content: [row("row A"), mentionedRow, row("row C")],
         },
       ]);
 
       const expectedDoc = buildProseMirrorDoc([
         {
           type: "table",
-          content: [
-            {
-              type: "td",
-              attrs: {
-                colspan: 1,
-                rowspan: 1,
-              },
-              content: [
-                {
-                  type: "paragraph",
-                  content: [
-                    {
-                      type: "text",
-                      text: "cell content",
-                    },
-                  ],
-                },
-              ],
-            },
-            mentionedRow,
-          ],
+          content: [mentionedRow],
         },
       ]);
 
@@ -500,6 +457,65 @@ describe("ProsemirrorHelper", () => {
         {
           type: "bullet_list",
           content: [mentionedItem, listItem("item B")],
+        },
+      ]);
+
+      const newDoc = ProsemirrorHelper.getNodeForMentionEmail(
+        doc,
+        mentionAttrs
+      );
+
+      expect(newDoc?.toJSON()).toEqual(expectedDoc.toJSON());
+    });
+
+    it("should advance an ordered list's start to keep numbering aligned", () => {
+      const mentionAttrs: MentionAttrs = {
+        id: "31d5899f-e544-4ff6-b6d3-c49dd6b81901",
+        type: MentionType.User,
+        label: "test.user",
+        actorId: "ccec260a-e060-4925-ade8-17cfabaf2cac",
+        modelId: "9a17c1c8-d178-4350-9001-203a73070fcb",
+      };
+
+      const listItem = (text: string): DeepPartial<ProsemirrorData> => ({
+        type: "list_item",
+        content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+      });
+
+      const mentionedItem: DeepPartial<ProsemirrorData> = {
+        type: "list_item",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              { type: "text", text: "item D " },
+              { type: "mention", attrs: mentionAttrs },
+            ],
+          },
+        ],
+      };
+
+      const doc = buildProseMirrorDoc([
+        {
+          type: "ordered_list",
+          attrs: { order: 1, listStyle: "number" },
+          content: [
+            listItem("item A"),
+            listItem("item B"),
+            listItem("item C"),
+            mentionedItem,
+            listItem("item E"),
+          ],
+        },
+      ]);
+
+      // The mention is in the fourth item, so items three through five are kept
+      // and the list starts at three to preserve the original numbering.
+      const expectedDoc = buildProseMirrorDoc([
+        {
+          type: "ordered_list",
+          attrs: { order: 3, listStyle: "number" },
+          content: [listItem("item C"), mentionedItem, listItem("item E")],
         },
       ]);
 

--- a/server/models/helpers/ProseMirrorHelper.test.ts
+++ b/server/models/helpers/ProseMirrorHelper.test.ts
@@ -459,6 +459,141 @@ describe("ProsemirrorHelper", () => {
       expect(newDoc?.toJSON()).toEqual(expectedDoc.toJSON());
     });
 
+    it("should return the bullet list with the mentioned item only", () => {
+      const mentionAttrs: MentionAttrs = {
+        id: "31d5899f-e544-4ff6-b6d3-c49dd6b81901",
+        type: MentionType.User,
+        label: "test.user",
+        actorId: "ccec260a-e060-4925-ade8-17cfabaf2cac",
+        modelId: "9a17c1c8-d178-4350-9001-203a73070fcb",
+      };
+
+      const mentionedItem: DeepPartial<ProsemirrorData> = {
+        type: "list_item",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "text",
+                text: "item B ",
+              },
+              {
+                type: "mention",
+                attrs: mentionAttrs,
+              },
+            ],
+          },
+        ],
+      };
+
+      const doc = buildProseMirrorDoc([
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "some content in a paragraph",
+            },
+          ],
+        },
+        {
+          type: "bullet_list",
+          content: [
+            {
+              type: "list_item",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [
+                    {
+                      type: "text",
+                      text: "item A",
+                    },
+                  ],
+                },
+              ],
+            },
+            mentionedItem,
+          ],
+        },
+      ]);
+
+      const expectedDoc = buildProseMirrorDoc([
+        {
+          type: "bullet_list",
+          content: [mentionedItem],
+        },
+      ]);
+
+      const newDoc = ProsemirrorHelper.getNodeForMentionEmail(
+        doc,
+        mentionAttrs
+      );
+
+      expect(newDoc?.toJSON()).toEqual(expectedDoc.toJSON());
+    });
+
+    it("should return the blockquote with the mentioned paragraph only", () => {
+      const mentionAttrs: MentionAttrs = {
+        id: "31d5899f-e544-4ff6-b6d3-c49dd6b81901",
+        type: MentionType.User,
+        label: "test.user",
+        actorId: "ccec260a-e060-4925-ade8-17cfabaf2cac",
+        modelId: "9a17c1c8-d178-4350-9001-203a73070fcb",
+      };
+
+      const mentionedParagraph: DeepPartial<ProsemirrorData> = {
+        type: "paragraph",
+        content: [
+          {
+            type: "text",
+            text: "a quote with ",
+          },
+          {
+            type: "mention",
+            attrs: mentionAttrs,
+          },
+          {
+            type: "text",
+            text: " mentioned",
+          },
+        ],
+      };
+
+      const doc = buildProseMirrorDoc([
+        {
+          type: "blockquote",
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "text",
+                  text: "some other line",
+                },
+              ],
+            },
+            mentionedParagraph,
+          ],
+        },
+      ]);
+
+      const expectedDoc = buildProseMirrorDoc([
+        {
+          type: "blockquote",
+          content: [mentionedParagraph],
+        },
+      ]);
+
+      const newDoc = ProsemirrorHelper.getNodeForMentionEmail(
+        doc,
+        mentionAttrs
+      );
+
+      expect(newDoc?.toJSON()).toEqual(expectedDoc.toJSON());
+    });
+
     it("should not return anything when the mention attrs could not be found", () => {
       const mentionAttrs: MentionAttrs = {
         id: "31d5899f-e544-4ff6-b6d3-c49dd6b81901",

--- a/server/models/helpers/ProseMirrorHelper.test.ts
+++ b/server/models/helpers/ProseMirrorHelper.test.ts
@@ -295,7 +295,7 @@ describe("ProsemirrorHelper", () => {
       expect(newDoc?.toJSON()).toEqual(expectedDoc.toJSON());
     });
 
-    it("should return the table node with the mentioned row only", () => {
+    it("should return the whole table containing the mention", () => {
       const mentionAttrs: MentionAttrs = {
         id: "31d5899f-e544-4ff6-b6d3-c49dd6b81901",
         type: MentionType.User,
@@ -367,7 +367,27 @@ describe("ProsemirrorHelper", () => {
       const expectedDoc = buildProseMirrorDoc([
         {
           type: "table",
-          content: [mentionedRow],
+          content: [
+            {
+              type: "td",
+              attrs: {
+                colspan: 1,
+                rowspan: 1,
+              },
+              content: [
+                {
+                  type: "paragraph",
+                  content: [
+                    {
+                      type: "text",
+                      text: "cell content",
+                    },
+                  ],
+                },
+              ],
+            },
+            mentionedRow,
+          ],
         },
       ]);
 
@@ -379,7 +399,7 @@ describe("ProsemirrorHelper", () => {
       expect(newDoc?.toJSON()).toEqual(expectedDoc.toJSON());
     });
 
-    it("should return the checkbox list with the mentioned item only", () => {
+    it("should return the whole checkbox list containing the mention", () => {
       const mentionAttrs: MentionAttrs = {
         id: "31d5899f-e544-4ff6-b6d3-c49dd6b81901",
         type: MentionType.User,
@@ -447,7 +467,23 @@ describe("ProsemirrorHelper", () => {
       const expectedDoc = buildProseMirrorDoc([
         {
           type: "checkbox_list",
-          content: [mentionedItem],
+          content: [
+            {
+              type: "checkbox_item",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [
+                    {
+                      type: "text",
+                      text: "task A",
+                    },
+                  ],
+                },
+              ],
+            },
+            mentionedItem,
+          ],
         },
       ]);
 
@@ -459,7 +495,7 @@ describe("ProsemirrorHelper", () => {
       expect(newDoc?.toJSON()).toEqual(expectedDoc.toJSON());
     });
 
-    it("should return the bullet list with the mentioned item only", () => {
+    it("should return the whole bullet list containing the mention", () => {
       const mentionAttrs: MentionAttrs = {
         id: "31d5899f-e544-4ff6-b6d3-c49dd6b81901",
         type: MentionType.User,
@@ -522,7 +558,23 @@ describe("ProsemirrorHelper", () => {
       const expectedDoc = buildProseMirrorDoc([
         {
           type: "bullet_list",
-          content: [mentionedItem],
+          content: [
+            {
+              type: "list_item",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [
+                    {
+                      type: "text",
+                      text: "item A",
+                    },
+                  ],
+                },
+              ],
+            },
+            mentionedItem,
+          ],
         },
       ]);
 
@@ -534,7 +586,7 @@ describe("ProsemirrorHelper", () => {
       expect(newDoc?.toJSON()).toEqual(expectedDoc.toJSON());
     });
 
-    it("should return the blockquote with the mentioned paragraph only", () => {
+    it("should return the whole blockquote containing the mention", () => {
       const mentionAttrs: MentionAttrs = {
         id: "31d5899f-e544-4ff6-b6d3-c49dd6b81901",
         type: MentionType.User,
@@ -582,9 +634,77 @@ describe("ProsemirrorHelper", () => {
       const expectedDoc = buildProseMirrorDoc([
         {
           type: "blockquote",
-          content: [mentionedParagraph],
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "text",
+                  text: "some other line",
+                },
+              ],
+            },
+            mentionedParagraph,
+          ],
         },
       ]);
+
+      const newDoc = ProsemirrorHelper.getNodeForMentionEmail(
+        doc,
+        mentionAttrs
+      );
+
+      expect(newDoc?.toJSON()).toEqual(expectedDoc.toJSON());
+    });
+
+    it("should stop climbing when the container exceeds the size budget", () => {
+      const mentionAttrs: MentionAttrs = {
+        id: "31d5899f-e544-4ff6-b6d3-c49dd6b81901",
+        type: MentionType.User,
+        label: "test.user",
+        actorId: "ccec260a-e060-4925-ade8-17cfabaf2cac",
+        modelId: "9a17c1c8-d178-4350-9001-203a73070fcb",
+      };
+
+      const mentionedParagraph: DeepPartial<ProsemirrorData> = {
+        type: "paragraph",
+        content: [
+          {
+            type: "text",
+            text: "a quote with ",
+          },
+          {
+            type: "mention",
+            attrs: mentionAttrs,
+          },
+          {
+            type: "text",
+            text: " mentioned",
+          },
+        ],
+      };
+
+      const doc = buildProseMirrorDoc([
+        {
+          type: "blockquote",
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "text",
+                  text: "x".repeat(ProsemirrorHelper.mentionEmailMaxChars + 1),
+                },
+              ],
+            },
+            mentionedParagraph,
+          ],
+        },
+      ]);
+
+      // The blockquote overflows the budget, so the snippet falls back to the
+      // mention's own paragraph rather than the surrounding container.
+      const expectedDoc = buildProseMirrorDoc([mentionedParagraph]);
 
       const newDoc = ProsemirrorHelper.getNodeForMentionEmail(
         doc,

--- a/server/models/helpers/ProsemirrorHelper.tsx
+++ b/server/models/helpers/ProsemirrorHelper.tsx
@@ -228,8 +228,9 @@ export class ProsemirrorHelper extends SharedProsemirrorHelper {
   }
 
   /**
-   * Build an email snippet around a mention by keeping the largest complete
-   * block surrounding it that still fits within the size budget.
+   * Build an email snippet around a mention. A surrounding list is trimmed to
+   * the mentioned item plus one sibling on either side; otherwise the largest
+   * complete block that still fits the size budget is kept.
    *
    * @param doc The top-level doc node of a document / revision.
    * @param mention The mention to build the snippet around.
@@ -256,6 +257,26 @@ export class ProsemirrorHelper extends SharedProsemirrorHelper {
     }
 
     const $pos = doc.resolve(mentionPos);
+
+    // Lists can be long, so rather than show the whole list, trim it to the
+    // mentioned item plus one sibling on either side. Use the nearest list
+    // ancestor so nested lists show the items closest to the mention.
+    const listTypes = ["bullet_list", "ordered_list", "checkbox_list"];
+    for (let d = $pos.depth - 1; d >= 1; d--) {
+      const list = $pos.node(d);
+      if (listTypes.includes(list.type.name)) {
+        const index = $pos.index(d);
+        const start = Math.max(0, index - 1);
+        const end = Math.min(list.childCount, index + 2);
+        const items: Node[] = [];
+        for (let i = start; i < end; i++) {
+          items.push(list.child(i));
+        }
+        return doc.copy(
+          Fragment.fromArray([list.copy(Fragment.fromArray(items))])
+        );
+      }
+    }
 
     // Always include at least the textblock the mention sits in, then climb the
     // ancestor chain outward keeping the largest complete block that still fits

--- a/server/models/helpers/ProsemirrorHelper.tsx
+++ b/server/models/helpers/ProsemirrorHelper.tsx
@@ -105,7 +105,7 @@ export class ProsemirrorHelper extends SharedProsemirrorHelper {
    * Maximum amount of visible text, in characters, to grow a mention email
    * snippet outward to when climbing toward surrounding context.
    */
-  static mentionEmailMaxChars = 1000;
+  static readonly mentionEmailMaxChars = 1000;
 
   /**
    * Returns the input text as a Y.Doc.
@@ -229,8 +229,9 @@ export class ProsemirrorHelper extends SharedProsemirrorHelper {
 
   /**
    * Build an email snippet around a mention. A surrounding list is trimmed to
-   * the mentioned item plus one sibling on either side; otherwise the largest
-   * complete block that still fits the size budget is kept.
+   * the mentioned item plus one sibling on either side, a table to the
+   * mentioned row; otherwise the largest complete block that still fits the
+   * size budget is kept.
    *
    * @param doc The top-level doc node of a document / revision.
    * @param mention The mention to build the snippet around.
@@ -258,22 +259,44 @@ export class ProsemirrorHelper extends SharedProsemirrorHelper {
 
     const $pos = doc.resolve(mentionPos);
 
-    // Lists can be long, so rather than show the whole list, trim it to the
-    // mentioned item plus one sibling on either side. Use the nearest list
-    // ancestor so nested lists show the items closest to the mention.
+    // Lists and tables can be long, so rather than show the whole container,
+    // trim a list to the mentioned item plus one sibling on either side, and a
+    // table to the mentioned row. Use the nearest such ancestor so nested
+    // structures show the content closest to the mention.
     const listTypes = ["bullet_list", "ordered_list", "checkbox_list"];
     for (let d = $pos.depth - 1; d >= 1; d--) {
-      const list = $pos.node(d);
-      if (listTypes.includes(list.type.name)) {
+      const container = $pos.node(d);
+      const name = container.type.name;
+
+      if (listTypes.includes(name)) {
         const index = $pos.index(d);
         const start = Math.max(0, index - 1);
-        const end = Math.min(list.childCount, index + 2);
+        const end = Math.min(container.childCount, index + 2);
         const items: Node[] = [];
         for (let i = start; i < end; i++) {
-          items.push(list.child(i));
+          items.push(container.child(i));
         }
+        // Keep an ordered list's numbering aligned with the original document
+        // by advancing its start to match the first item shown.
+        const attrs =
+          name === "ordered_list" && start > 0
+            ? {
+                ...container.attrs,
+                order: (container.attrs.order ?? 1) + start,
+              }
+            : container.attrs;
+        const trimmed = container.type.create(
+          attrs,
+          Fragment.fromArray(items),
+          container.marks
+        );
+        return doc.copy(Fragment.fromArray([trimmed]));
+      }
+
+      if (name === "table") {
+        const row = container.child($pos.index(d));
         return doc.copy(
-          Fragment.fromArray([list.copy(Fragment.fromArray(items))])
+          Fragment.fromArray([container.copy(Fragment.fromArray([row]))])
         );
       }
     }

--- a/server/models/helpers/ProsemirrorHelper.tsx
+++ b/server/models/helpers/ProsemirrorHelper.tsx
@@ -102,6 +102,12 @@ function isDecorationSource(value: unknown): value is DecorationSource {
 @trace()
 export class ProsemirrorHelper extends SharedProsemirrorHelper {
   /**
+   * Maximum amount of visible text, in characters, to grow a mention email
+   * snippet outward to when climbing toward surrounding context.
+   */
+  static mentionEmailMaxChars = 1000;
+
+  /**
    * Returns the input text as a Y.Doc.
    *
    * @param markdown The text to parse
@@ -222,11 +228,13 @@ export class ProsemirrorHelper extends SharedProsemirrorHelper {
   }
 
   /**
-   * Find the nearest ancestor block node which contains the mention.
+   * Build an email snippet around a mention by keeping the largest complete
+   * block surrounding it that still fits within the size budget.
    *
    * @param doc The top-level doc node of a document / revision.
-   * @param mention The mention for which the ancestor node is needed.
-   * @returns A new top-level doc node with the ancestor node as the only child.
+   * @param mention The mention to build the snippet around.
+   * @returns A new top-level doc node with the chosen block as its only child,
+   * or undefined if the mention could not be found.
    */
   static getNodeForMentionEmail(doc: Node, mention: MentionAttrs) {
     // A mention is an inline node, so it always lives inside a textblock
@@ -249,33 +257,20 @@ export class ProsemirrorHelper extends SharedProsemirrorHelper {
 
     const $pos = doc.resolve(mentionPos);
 
-    // Walk the ancestor chain outward and keep the outermost container worth
-    // showing as context, falling back to the textblock the mention sits in.
-    const minifiableContainers = [
-      "table",
-      "checkbox_list",
-      "bullet_list",
-      "ordered_list",
-      "blockquote",
-      "container_notice",
-    ];
-
-    let depth = $pos.depth;
-    for (let d = 1; d < $pos.depth; d++) {
-      if (minifiableContainers.includes($pos.node(d).type.name)) {
-        depth = d;
+    // Always include at least the textblock the mention sits in, then climb the
+    // ancestor chain outward keeping the largest complete block that still fits
+    // the size budget. Each ancestor strictly contains the previous, so sizes
+    // grow monotonically and we can stop at the first that overflows.
+    let node = $pos.node($pos.depth);
+    for (let d = $pos.depth - 1; d >= 1; d--) {
+      const ancestor = $pos.node(d);
+      if (
+        ancestor.textContent.length > ProsemirrorHelper.mentionEmailMaxChars
+      ) {
         break;
       }
+      node = ancestor;
     }
-
-    const blockNode = $pos.node(depth);
-
-    // For a container, minify to just the child on the path to the mention so
-    // the snippet keeps its structure without unrelated siblings.
-    const node =
-      depth < $pos.depth
-        ? blockNode.copy(Fragment.fromArray([$pos.node(depth + 1)]))
-        : blockNode;
 
     // Return a new top-level "doc" node to maintain structure during serialization.
     return doc.copy(Fragment.fromArray([node]));

--- a/server/models/helpers/ProsemirrorHelper.tsx
+++ b/server/models/helpers/ProsemirrorHelper.tsx
@@ -229,73 +229,56 @@ export class ProsemirrorHelper extends SharedProsemirrorHelper {
    * @returns A new top-level doc node with the ancestor node as the only child.
    */
   static getNodeForMentionEmail(doc: Node, mention: MentionAttrs) {
-    let blockNode: Node | undefined;
-    const potentialBlockNodes = [
+    // A mention is an inline node, so it always lives inside a textblock
+    // (paragraph or heading). Locate it once and resolve its position.
+    let mentionPos: number | undefined;
+    doc.descendants((node: Node, pos: number) => {
+      if (mentionPos !== undefined) {
+        return false;
+      }
+      if (node.type.name === "mention" && isMatch(node.attrs, mention)) {
+        mentionPos = pos;
+        return false;
+      }
+      return true;
+    });
+
+    if (mentionPos === undefined) {
+      return undefined;
+    }
+
+    const $pos = doc.resolve(mentionPos);
+
+    // Walk the ancestor chain outward and keep the outermost container worth
+    // showing as context, falling back to the textblock the mention sits in.
+    const minifiableContainers = [
       "table",
       "checkbox_list",
       "bullet_list",
       "ordered_list",
       "blockquote",
       "container_notice",
-      "heading",
-      "paragraph",
     ];
 
-    const isNodeContainingMention = (node: Node) => {
-      let foundMention = false;
-
-      node.descendants((childNode: Node) => {
-        if (
-          childNode.type.name === "mention" &&
-          isMatch(childNode.attrs, mention)
-        ) {
-          foundMention = true;
-          return false;
-        }
-
-        // No need to traverse other descendants once we find the mention.
-        if (foundMention) {
-          return false;
-        }
-
-        return true;
-      });
-
-      return foundMention;
-    };
-
-    doc.descendants((node: Node) => {
-      // No need to traverse other descendants once we find the containing block node.
-      if (blockNode) {
-        return false;
+    let depth = $pos.depth;
+    for (let d = 1; d < $pos.depth; d++) {
+      if (minifiableContainers.includes($pos.node(d).type.name)) {
+        depth = d;
+        break;
       }
-
-      if (potentialBlockNodes.includes(node.type.name)) {
-        if (isNodeContainingMention(node)) {
-          blockNode = node;
-        }
-        return false;
-      }
-
-      return true;
-    });
-
-    // Use the containing block node to maintain structure during serialization.
-    // Minify to include mentioned child only.
-    if (blockNode && !["heading", "paragraph"].includes(blockNode.type.name)) {
-      const children: Node[] = [];
-
-      blockNode.forEach((child: Node) => {
-        if (isNodeContainingMention(child)) {
-          children.push(child);
-        }
-      });
-
-      blockNode = blockNode.copy(Fragment.fromArray(children));
     }
 
+    const blockNode = $pos.node(depth);
+
+    // For a container, minify to just the child on the path to the mention so
+    // the snippet keeps its structure without unrelated siblings.
+    const node =
+      depth < $pos.depth
+        ? blockNode.copy(Fragment.fromArray([$pos.node(depth + 1)]))
+        : blockNode;
+
     // Return a new top-level "doc" node to maintain structure during serialization.
-    return blockNode ? doc.copy(Fragment.fromArray([blockNode])) : undefined;
+    return doc.copy(Fragment.fromArray([node]));
   }
 
   static async replaceInternalUrls(

--- a/server/models/helpers/ProsemirrorHelper.tsx
+++ b/server/models/helpers/ProsemirrorHelper.tsx
@@ -103,7 +103,7 @@ function isDecorationSource(value: unknown): value is DecorationSource {
 export class ProsemirrorHelper extends SharedProsemirrorHelper {
   /**
    * Maximum amount of visible text, in characters, to grow a mention email
-   * snippet outward to when climbing toward surrounding context.
+   * snippet outward when climbing toward surrounding context.
    */
   static readonly mentionEmailMaxChars = 1000;
 
@@ -308,9 +308,10 @@ export class ProsemirrorHelper extends SharedProsemirrorHelper {
     let node = $pos.node($pos.depth);
     for (let d = $pos.depth - 1; d >= 1; d--) {
       const ancestor = $pos.node(d);
-      if (
-        ancestor.textContent.length > ProsemirrorHelper.mentionEmailMaxChars
-      ) {
+      // textBetween rather than textContent so leaf text (mentions, etc.) is
+      // counted towards the budget.
+      const length = textBetween(ancestor, 0, ancestor.content.size).length;
+      if (length > ProsemirrorHelper.mentionEmailMaxChars) {
         break;
       }
       node = ancestor;

--- a/server/models/helpers/ProsemirrorHelper.tsx
+++ b/server/models/helpers/ProsemirrorHelper.tsx
@@ -233,6 +233,10 @@ export class ProsemirrorHelper extends SharedProsemirrorHelper {
     const potentialBlockNodes = [
       "table",
       "checkbox_list",
+      "bullet_list",
+      "ordered_list",
+      "blockquote",
+      "container_notice",
       "heading",
       "paragraph",
     ];


### PR DESCRIPTION
The previous approach led to two situations where no context was included because a matching parent node could not be found.

ref #12779