### PR TITLE
ci: fix invalid secrets expression in RelativeCI step condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,9 @@ jobs:
         run: echo "NODE_ENV=production" >> $GITHUB_ENV
       - run: yarn vite:build
       - name: Send bundle stats to RelativeCI
-        if: ${{ secrets.RELATIVE_CI_KEY != '' }}
+        if: ${{ env.RELATIVE_CI_KEY != '' }}
+        env:
+          RELATIVE_CI_KEY: ${{ secrets.RELATIVE_CI_KEY }}
         uses: relative-ci/agent-action@38328454d6a23942175eba485fca4fbb807b1f03 # v2
         with:
           key: ${{ secrets.RELATIVE_CI_KEY }}


### PR DESCRIPTION
The `secrets` context is not available in step-level `if` conditions, which made the CI workflow file invalid ("Unrecognized named-value: 'secrets'"). This maps `RELATIVE_CI_KEY` to a step-level env var and tests `env.RELATIVE_CI_KEY` instead, preserving the original intent of skipping the RelativeCI step when the key is unset.