### PR TITLE
fix(test): restore plugin loading under Vite 8

### DIFF
--- a/app/typings/window.d.ts
+++ b/app/typings/window.d.ts
@@ -6,7 +6,16 @@ declare global {
     /**
      * A special feature that allows you to get all matching modules starting from some base directory.
      */
-    glob: (pattern: string, option?: { eager: boolean }) => any;
+    glob: {
+      (
+        pattern: string | string[],
+        option: { eager: true }
+      ): Record<string, unknown>;
+      (
+        pattern: string | string[],
+        option?: { eager?: false }
+      ): Record<string, () => Promise<unknown>>;
+    };
   }
 
   interface Window {

--- a/server/test/setup.ts
+++ b/server/test/setup.ts
@@ -47,8 +47,10 @@ await import("@server/storage/database");
 // files with bare imports (e.g. `@server/...`), so we use Vite's
 // import.meta.glob to load them through the Vite resolver instead.
 const { PluginManager } = await import("@server/utils/PluginManager");
+// Vite 8 dropped support for extglob negation (`!(...)`) in glob patterns, so
+// exclude test and schema files via separate negative patterns instead.
 const pluginModules = import.meta.glob(
-  "../../plugins/*/server/!(*.test|schema).{js,ts}",
+  ["../../plugins/*/server/*.{js,ts}", "!**/*.test.*", "!**/schema.*"],
   { eager: true }
 );
 void pluginModules;

--- a/server/test/setup.ts
+++ b/server/test/setup.ts
@@ -47,8 +47,6 @@ await import("@server/storage/database");
 // files with bare imports (e.g. `@server/...`), so we use Vite's
 // import.meta.glob to load them through the Vite resolver instead.
 const { PluginManager } = await import("@server/utils/PluginManager");
-// Vite 8 dropped support for extglob negation (`!(...)`) in glob patterns, so
-// exclude test and schema files via separate negative patterns instead.
 const pluginModules = import.meta.glob(
   ["../../plugins/*/server/*.{js,ts}", "!**/*.test.*", "!**/schema.*"],
   { eager: true }

--- a/server/test/setupMocks.ts
+++ b/server/test/setupMocks.ts
@@ -14,21 +14,24 @@ import { __setRequireDirectoryCache } from "@server/utils/fs";
 // they live in.
 __setRequireDirectoryCache(
   "emails/templates",
-  import.meta.glob("../emails/templates/!(index|*.test).{js,ts}", {
-    eager: true,
-  })
+  import.meta.glob(
+    ["../emails/templates/*.{js,ts,tsx}", "!**/index.*", "!**/*.test.*"],
+    { eager: true }
+  )
 );
 __setRequireDirectoryCache(
   "queues/processors",
-  import.meta.glob("../queues/processors/!(index|*.test).{js,ts}", {
-    eager: true,
-  })
+  import.meta.glob(
+    ["../queues/processors/*.{js,ts,tsx}", "!**/index.*", "!**/*.test.*"],
+    { eager: true }
+  )
 );
 __setRequireDirectoryCache(
   "queues/tasks",
-  import.meta.glob("../queues/tasks/!(index|*.test).{js,ts}", {
-    eager: true,
-  })
+  import.meta.glob(
+    ["../queues/tasks/*.{js,ts,tsx}", "!**/index.*", "!**/*.test.*"],
+    { eager: true }
+  )
 );
 
 vi.mock("ioredis", async () => {


### PR DESCRIPTION
Vite 8 dropped support for extglob negation (`!(...)`) in glob patterns, so the test setup's plugin glob (`plugins/*/server/!(*.test|schema).{js,ts}`) silently matched **zero** files — no plugin registered its routes, and every plugin API test returned 404.

This switches to Vite's supported array-with-negative-patterns syntax (`["...*.{js,ts}", "!**/*.test.*", "!**/schema.*"]`) to exclude test and schema files.