### PR TITLE
chore: TSC caching

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "incremental": true,
+    "tsBuildInfoFile": "./node_modules/.cache/tsc/tsconfig.tsbuildinfo",
     "strict": false,
     "allowSyntheticDefaultImports": true,
     "alwaysStrict": true,


### PR DESCRIPTION
The cache rebuilds from cold after yarn install blows away node_modules, and is per-workspace