### PR TITLE
fix: MCP OAuth interop fixes for desktop clients

### DIFF
--- a/server/middlewares/oauthAliases.ts
+++ b/server/middlewares/oauthAliases.ts
@@ -1,0 +1,33 @@
+import type { Context, Next } from "koa";
+
+const ALIASES: Record<string, string> = {
+  "/authorize": "/oauth/authorize",
+  "/token": "/oauth/token",
+  "/register": "/oauth/register",
+  "/revoke": "/oauth/revoke",
+};
+
+/**
+ * Maps the unprefixed OAuth paths some MCP clients construct (e.g.
+ * `<host>/authorize` instead of the canonical `/oauth/authorize` advertised
+ * in the OAuth 2.0 authorization-server metadata) onto Outline's existing
+ * /oauth/* routes.
+ *
+ * GET requests are 302-redirected so the browser's URL bar reflects the
+ * canonical path and the consent SPA route matches. Other methods rewrite
+ * `ctx.url` in place so existing handlers serve them transparently.
+ */
+export default function oauthAliases() {
+  return async function oauthAliasesMiddleware(ctx: Context, next: Next) {
+    const target = ALIASES[ctx.path];
+    if (!target) {
+      return next();
+    }
+    if (ctx.method === "GET") {
+      ctx.redirect(`${target}${ctx.search}`);
+      return;
+    }
+    ctx.url = ctx.url.replace(ctx.path, target);
+    return next();
+  };
+}

--- a/server/routes/mcp/index.test.ts
+++ b/server/routes/mcp/index.test.ts
@@ -29,6 +29,20 @@ describe("POST /mcp/", () => {
       expect(res.status).toEqual(401);
     });
 
+    it("should include WWW-Authenticate header on 401 responses", async () => {
+      const { body } = mcpRequest("tools/list");
+      const res = await server.post("/mcp/", {
+        headers: { Accept: "application/json, text/event-stream" },
+        body,
+      });
+      expect(res.status).toEqual(401);
+      const wwwAuth = res.headers.get("www-authenticate");
+      expect(wwwAuth).toBeTruthy();
+      expect(wwwAuth).toContain("Bearer");
+      expect(wwwAuth).toContain("resource_metadata=");
+      expect(wwwAuth).toContain("/.well-known/oauth-protected-resource/mcp");
+    });
+
     it("should reject JWT authentication", async () => {
       const user = await buildUser();
       const { body } = mcpRequest("tools/list");

--- a/server/routes/mcp/index.ts
+++ b/server/routes/mcp/index.ts
@@ -8,6 +8,7 @@ import { ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { toError } from "@shared/utils/error";
 import { TeamPreference } from "@shared/types";
 import { NotFoundError } from "@server/errors";
+import env from "@server/env";
 import Logger from "@server/logging/Logger";
 import auth from "@server/middlewares/authentication";
 import { rateLimiter } from "@server/middlewares/rateLimiter";
@@ -26,6 +27,27 @@ import { version } from "../../../package.json";
 
 const app = new Koa();
 const router = new Router();
+
+// RFC 9728 / MCP auth spec: 401 responses from the /mcp endpoint must include
+// a WWW-Authenticate header pointing at the OAuth protected resource metadata
+// document so clients can bootstrap the authorization flow via discovery.
+app.use(async (ctx, next) => {
+  try {
+    await next();
+  } catch (err: unknown) {
+    const error = err as { status?: number };
+    if (error?.status === 401) {
+      const origin = env.isCloudHosted
+        ? ctx.request.URL.origin
+        : new URL(env.URL).origin;
+      (err as { headers?: Record<string, string> }).headers = {
+        ...((err as { headers?: Record<string, string> }).headers ?? {}),
+        "WWW-Authenticate": `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource/mcp"`,
+      };
+    }
+    throw err;
+  }
+});
 
 const defaultInstructions = `Document markdown content must not begin with a top-level heading (H1) — the title is stored as a separate field, so set it via the title parameter and start the content with body text or a lower-level heading instead.
 

--- a/server/routes/oauth/index.ts
+++ b/server/routes/oauth/index.ts
@@ -209,7 +209,9 @@ router.post(
         : "public";
 
     const client = await OAuthClient.createWithCtx(ctx, {
-      name: client_name,
+      // RFC 7591 makes client_name optional; fall back to a generic label so
+      // dynamic-registration clients that omit it still register cleanly.
+      name: client_name ?? "Untitled application",
       redirectUris: redirect_uris,
       clientType,
       developerUrl: client_uri ?? null,

--- a/server/routes/oauth/oauth.test.ts
+++ b/server/routes/oauth/oauth.test.ts
@@ -539,11 +539,15 @@ describe("OAuth path aliases", () => {
       body: { grant_type: "invalid_grant_type" },
     });
 
-    // The request reaches /oauth/token's handler, which rejects unknown grant
-    // types with the same OAuth2 error response a direct /oauth/token call
-    // would produce.
+    // The request must reach the OAuth handler stack (not fall through to a
+    // generic 404). The OAuth error handler always wraps failures in an
+    // `error` + `error_description` body, so asserting that shape proves the
+    // alias delivered to /oauth/token specifically.
     expect(res.status).toBeGreaterThanOrEqual(400);
     expect(res.status).toBeLessThan(500);
+    const body = await res.json();
+    expect(body.error).toBeTruthy();
+    expect(body.error_description).toBeTruthy();
   });
 
   it("should register an OAuth client via POST /register without /oauth prefix", async () => {

--- a/server/routes/oauth/oauth.test.ts
+++ b/server/routes/oauth/oauth.test.ts
@@ -94,19 +94,6 @@ describe("#oauth.register", () => {
     expect(body.logo_uri).toEqual("https://example.com/logo.png");
   });
 
-  it("should reject missing client_name", async () => {
-    const res = await server.post("/oauth/register", {
-      body: {
-        redirect_uris: ["https://example.com/callback"],
-      },
-      headers: {
-        host: `${subdomain}.outline.dev`,
-      },
-    });
-
-    expect(res.status).toEqual(400);
-  });
-
   it("should reject missing redirect_uris", async () => {
     const res = await server.post("/oauth/register", {
       body: {
@@ -118,6 +105,22 @@ describe("#oauth.register", () => {
     });
 
     expect(res.status).toEqual(400);
+  });
+
+  it("should accept registration without client_name", async () => {
+    const res = await server.post("/oauth/register", {
+      body: {
+        redirect_uris: ["https://example.com/callback"],
+      },
+      headers: {
+        host: `${subdomain}.outline.dev`,
+      },
+    });
+
+    expect(res.status).toEqual(201);
+    const body = await res.json();
+    expect(body.client_id).toBeTruthy();
+    expect(body.client_name).toEqual("Untitled application");
   });
 
   it("should reject invalid redirect_uris", async () => {
@@ -514,5 +517,50 @@ describe("GET /.well-known/oauth-protected-resource", () => {
     } finally {
       env.URL = sharedEnv.URL = originalUrl;
     }
+  });
+});
+
+describe("OAuth path aliases", () => {
+  it("should 302-redirect GET /authorize to /oauth/authorize preserving query", async () => {
+    const res = await server.get(
+      "/authorize?response_type=code&client_id=abc&state=xyz",
+      { redirect: "manual" }
+    );
+
+    expect(res.status).toEqual(302);
+    const location = res.headers.get("location");
+    expect(location).toContain(
+      "/oauth/authorize?response_type=code&client_id=abc&state=xyz"
+    );
+  });
+
+  it("should route POST /token to the canonical /oauth/token handler", async () => {
+    const res = await server.post("/token", {
+      body: { grant_type: "invalid_grant_type" },
+    });
+
+    // The request reaches /oauth/token's handler, which rejects unknown grant
+    // types with the same OAuth2 error response a direct /oauth/token call
+    // would produce.
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(res.status).toBeLessThan(500);
+  });
+
+  it("should register an OAuth client via POST /register without /oauth prefix", async () => {
+    const subdomain = faker.internet.domainWord();
+    await buildTeam({ subdomain });
+
+    const res = await server.post("/register", {
+      body: {
+        client_name: "Aliased Client",
+        redirect_uris: ["https://example.com/callback"],
+      },
+      headers: { host: `${subdomain}.outline.dev` },
+    });
+
+    expect(res.status).toEqual(201);
+    const body = await res.json();
+    expect(body.client_id).toBeTruthy();
+    expect(body.client_name).toEqual("Aliased Client");
   });
 });

--- a/server/routes/oauth/schema.ts
+++ b/server/routes/oauth/schema.ts
@@ -27,7 +27,14 @@ export type TokenRevokeReq = z.infer<typeof TokenRevokeSchema>;
 
 export const RegisterSchema = BaseSchema.extend({
   body: z.object({
-    client_name: z.string().min(1).max(OAuthClientValidation.maxNameLength),
+    // RFC 7591 §2 marks every metadata field as OPTIONAL; some MCP clients
+    // omit `client_name` on dynamic registration and currently get rejected.
+    // A default is filled in by the handler when the field is absent.
+    client_name: z
+      .string()
+      .min(1)
+      .max(OAuthClientValidation.maxNameLength)
+      .optional(),
     redirect_uris: z
       .array(z.url().max(OAuthClientValidation.maxRedirectUriLength))
       .min(1)

--- a/server/services/web.ts
+++ b/server/services/web.ts
@@ -15,6 +15,7 @@ import Logger from "@server/logging/Logger";
 import Metrics from "@server/logging/Metrics";
 import csp from "@server/middlewares/csp";
 import { attachCSRFToken } from "@server/middlewares/csrf";
+import oauthAliases from "@server/middlewares/oauthAliases";
 import ShutdownHelper, { ShutdownOrder } from "@server/utils/ShutdownHelper";
 import { initI18n } from "@server/utils/i18n";
 import routes from "../routes";
@@ -103,6 +104,7 @@ export default function init(app: Koa = new Koa(), server?: Server) {
   );
 
   app.use(mount("/auth", auth));
+  app.use(oauthAliases());
   app.use(mount("/oauth", oauth));
   app.use(mount(routes));
 


### PR DESCRIPTION
Three small fixes that, together, make a stock Outline serve OAuth-based MCP desktop clients end-to-end. They surfaced from trying to add a self-hosted Outline as an MCP connector in Claude Desktop:

- The connector setup fails silently at the auth step — Outline's `/mcp` 401 has no `WWW-Authenticate` header, so the client has nothing to follow into the OAuth discovery chain.
- Claude Desktop builds OAuth URLs as `<host>/authorize` and `<host>/token` (no `/oauth/` prefix); the browser lands on the SPA's not-found page and the token exchange 404s.
- Dynamic client registration is rejected with `client_name: Invalid input` because Claude Desktop omits the field and Outline's schema treats it as required.

Each fix is independent and could be split if preferred; they're grouped because they all surfaced from the same connect-to-Outline flow.

---

**PROBLEM** — Missing `WWW-Authenticate` header on `/mcp` 401

The `/mcp` endpoint returns 401 without a `WWW-Authenticate` header. Desktop MCP clients use that header to discover the OAuth authorization server via the protected-resource metadata document — without it, they have no entry point into the discovery chain (RFC 9728 and the MCP authorization spec both require it), the OAuth flow can't bootstrap, and the connector silently fails to authenticate.

**SOLUTION**

A small Koa middleware on the `/mcp` app catches `err.status === 401` and attaches `WWW-Authenticate: Bearer resource_metadata="<origin>/.well-known/oauth-protected-resource/mcp"` to `err.headers`, which `server/onerror.ts` already copies to the response. Origin uses `ctx.request.URL.origin` when cloud-hosted and `env.URL` otherwise — same convention the well-known routes follow. The metadata document is already served; this just points clients at it.

---

**PROBLEM** — MCP clients hit `<host>/authorize` and `<host>/token`, not the canonical `/oauth/*`

In practice, MCP desktop clients construct OAuth URLs as `<mcp-server-host>/<endpoint>` (no `/oauth/` prefix), ignoring the canonical paths advertised in the authorization-server metadata. The browser lands on `<host>/authorize` and the SPA returns its not-found page; the token exchange hits `<host>/token` and 404s.

**SOLUTION**

A new middleware in `server/middlewares/oauthAliases.ts` maps `/authorize`, `/token`, `/register`, `/revoke` onto their `/oauth/*` equivalents. GET requests are 302-redirected so the URL bar reflects the canonical path and the consent SPA route matches; other methods rewrite `ctx.url` in place so the existing `/oauth/*` handlers serve them unchanged.

---

**PROBLEM** — `/oauth/register` rejects requests with no `client_name`

RFC 7591 §2 states every client metadata field is OPTIONAL, including `client_name`. Outline's schema currently requires it (`z.string().min(1)`), so MCP clients that omit `client_name` during dynamic registration are rejected with a 400 and fall back to "please paste a Client ID manually" UX in the connector setup.

**SOLUTION**

`client_name` becomes optional in `RegisterSchema`. When absent, the handler stores a generic `"Untitled application"` label so the DB constraint on `name` still has a value and the workspace's OAuth-applications list stays readable. Callers that send `client_name` keep working unchanged.

---

**NOTES**

None of the three changes alters existing client behavior:

- The `WWW-Authenticate` middleware only adds a header to 401s that previously had none. Clients that don't read the header see the same status/body as before; spec-compliant ones now get the discovery pointer they expect.
- The alias middleware is a no-op for any path not in the alias map. The four mapped paths (`/authorize`, `/token`, `/register`, `/revoke`) were not previously routed at the root — they returned 404 from the SPA — so the new behavior replaces nothing that worked.
- `client_name` becoming optional widens the accepted input set. Every request that worked before (i.e. ones that included a `client_name`) continues to work identically; only previously-rejected requests now succeed with a default label. The `OAuthClient.name` column still receives a non-null value.

Full server test suite is green locally (180 files, 2544 tests) — `yarn lint --quiet`, `yarn tsc`, `yarn format:check`, and `yarn test:server` all pass on this branch.