### PR TITLE
fix: Refactor find logic for non-ascii characters

### DIFF
--- a/app/editor/extensions/FindAndReplace.test.ts
+++ b/app/editor/extensions/FindAndReplace.test.ts
@@ -1,0 +1,70 @@
+import { deburrWithMap } from "./FindAndReplace";
+
+describe("deburrWithMap", () => {
+  it("leaves plain ASCII text unchanged and maps indices 1:1", () => {
+    const { deburred, map } = deburrWithMap("abc");
+    expect(deburred).toBe("abc");
+    expect(map).toEqual([0, 1, 2, 3]);
+  });
+
+  it("strips diacritics while keeping the original length", () => {
+    const { deburred, map } = deburrWithMap("café");
+    expect(deburred).toBe("cafe");
+    // Each deburred code unit maps back to the original index it came from,
+    // plus a sentinel for the end position.
+    expect(map).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it("maps decomposed (longer) output back to original indices for Hangul", () => {
+    const text = "강의";
+    const { deburred, map } = deburrWithMap(text);
+
+    // NFD decomposition expands each precomposed syllable into jamo, so the
+    // deburred string is longer than the original.
+    expect(deburred.length).toBeGreaterThan(text.length);
+
+    // The final sentinel must be the original length, not the deburred length.
+    expect(map[map.length - 1]).toBe(text.length);
+
+    // Every deburred code unit maps to a valid original index.
+    for (let i = 0; i < deburred.length; i++) {
+      expect(map[i]).toBeGreaterThanOrEqual(0);
+      expect(map[i]).toBeLessThan(text.length);
+    }
+  });
+
+  it("recovers correct original positions for an ASCII match surrounded by CJK", () => {
+    const text = "강의a평가";
+    const { deburred, map } = deburrWithMap(text);
+
+    const index = deburred.indexOf("a");
+    expect(index).toBeGreaterThanOrEqual(0);
+
+    // The mapped start/end must point at the real "a" in the original text.
+    const from = map[index];
+    const to = map[index + 1];
+    expect(text.slice(from, to)).toBe("a");
+  });
+
+  it("maps a deburred match for CJK text back to the original code unit", () => {
+    const text = "abc평가";
+    const { deburred, map } = deburrWithMap(text);
+
+    // "abc" appears at the start of both the original and deburred strings.
+    expect(map[0]).toBe(0);
+    expect(map[3]).toBe(3);
+    expect(text.slice(map[0], map[3])).toBe("abc");
+  });
+
+  it("handles surrogate pairs without splitting them", () => {
+    const text = "a😀b";
+    const { deburred, map } = deburrWithMap(text);
+
+    // The emoji occupies two UTF-16 code units in the original string.
+    expect(map[map.length - 1]).toBe(text.length);
+    expect(map[0]).toBe(0);
+    // The index following the emoji should account for both code units.
+    const bIndex = deburred.indexOf("b");
+    expect(text.slice(map[bIndex], map[bIndex + 1])).toBe("b");
+  });
+});

--- a/app/editor/extensions/FindAndReplace.tsx
+++ b/app/editor/extensions/FindAndReplace.tsx
@@ -414,6 +414,14 @@ export default class FindAndReplaceExtension extends Extension<FindAndReplaceOpt
             const from = type === "inline" ? pos + start : pos;
             const to = type === "inline" ? pos + end : pos + node.nodeSize;
 
+            // A match against the deburred text can cover only part of a
+            // decomposed sequence (e.g. a single jamo of a Hangul syllable),
+            // which maps back to a zero-length range in the original text.
+            // Skip these so replace operations don't degenerate into inserts.
+            if (to <= from) {
+              continue;
+            }
+
             // Check if already exists in results, possible because we search
             // over both the deburred and the original text.
             const key = `${from}:${to}`;

--- a/app/editor/extensions/FindAndReplace.tsx
+++ b/app/editor/extensions/FindAndReplace.tsx
@@ -429,16 +429,19 @@ export default class FindAndReplaceExtension extends Extension<FindAndReplaceOpt
         }
       };
 
-      // Search the diacritics-stripped text so that, for example, "cafe"
+      // Search the original text so that queries containing diacritics (e.g.
+      // "café") match, and to cover any text that deburring alters.
+      collect(text, (index) => index);
+
+      // Also search the diacritics-stripped text so that, for example, "cafe"
       // matches "café". Because deburring can change the string length (e.g. it
       // decomposes CJK/Hangul characters), match indices are translated back to
-      // the original text through the index map rather than assumed equal.
-      const { deburred, map } = deburrWithMap(text);
-      collect(deburred, (index) => map[index]);
-
-      // Also search the original text so that queries containing diacritics
-      // (e.g. "café") still match, and to cover any text that deburring alters.
-      collect(text, (index) => index);
+      // the original text rather than assumed equal. Skip it when deburring was
+      // a no-op, since it would only re-find the matches already collected.
+      const { deburred, toOriginalIndex } = deburrWithMap(text);
+      if (deburred !== text) {
+        collect(deburred, toOriginalIndex);
+      }
     });
   }
 

--- a/app/editor/extensions/FindAndReplace.tsx
+++ b/app/editor/extensions/FindAndReplace.tsx
@@ -18,6 +18,44 @@ const supportsHighlightAPI =
   typeof CSS !== "undefined" && CSS.highlights !== undefined;
 
 /**
+ * Build a diacritics-stripped version of a string together with a mapping from
+ * each index in the stripped string back to the corresponding index in the
+ * original string.
+ *
+ * `deburr` normalizes to NFD form, which can change the length of the string –
+ * most notably it decomposes precomposed CJK/Hangul syllables (e.g. "강" is a
+ * single UTF-16 code unit but decomposes into three jamo). Because of this the
+ * stripped string cannot be aligned to the original by assuming equal lengths,
+ * so we record the source index of every emitted code unit instead.
+ *
+ * @param text The original text to deburr.
+ * @returns the deburred text and an index map of length `deburred.length + 1`,
+ * where `map[i]` is the original index of the deburred code unit at `i` and the
+ * final entry is the original text length (a sentinel for end positions).
+ */
+export function deburrWithMap(text: string): {
+  deburred: string;
+  map: number[];
+} {
+  let deburred = "";
+  const map: number[] = [];
+  let originalIndex = 0;
+
+  // Iterate by code point so surrogate pairs are deburred as a unit.
+  for (const char of text) {
+    const stripped = deburr(char);
+    for (let i = 0; i < stripped.length; i++) {
+      map.push(originalIndex);
+    }
+    deburred += stripped;
+    originalIndex += char.length;
+  }
+
+  map.push(text.length);
+  return { deburred, map };
+}
+
+/**
  * Options for the FindAndReplace extension.
  */
 type FindAndReplaceOptions = {
@@ -382,47 +420,62 @@ export default class FindAndReplaceExtension extends Extension<FindAndReplaceOpt
     });
 
     // Tracks already-seen match positions so duplicate matches (possible because
-    // we search the deburred text concatenated with the original) can be skipped
-    // in constant time rather than rescanning the entire results array.
+    // we search both the deburred and the original text) can be skipped in
+    // constant time rather than rescanning the entire results array.
     const seen = new Set<string>();
 
     mergedTextNodes.forEach((node) => {
       const { text = "", pos, type } = node;
-      try {
-        let m;
-        const search = this.findRegExp;
 
-        // We construct a string with the text stripped of diacritics plus the original text for
-        // search  allowing to search for diacritics-insensitive matches easily.
-        while ((m = search.exec(deburr(text) + text))) {
-          if (m[0] === "") {
-            break;
+      // Collects matches found in `haystack`, translating string indices into
+      // original-text indices via `toOriginalIndex`.
+      const collect = (
+        haystack: string,
+        toOriginalIndex: (index: number) => number | undefined
+      ) => {
+        try {
+          let m;
+          const search = this.findRegExp;
+
+          while ((m = search.exec(haystack))) {
+            if (m[0] === "") {
+              break;
+            }
+
+            const start = toOriginalIndex(m.index);
+            const end = toOriginalIndex(m.index + m[0].length);
+            if (start === undefined || end === undefined) {
+              continue;
+            }
+
+            const from = type === "inline" ? pos + start : pos;
+            const to = type === "inline" ? pos + end : pos + node.nodeSize;
+
+            // Check if already exists in results, possible because we search
+            // over both the deburred and the original text.
+            const key = `${from}:${to}`;
+            if (seen.has(key)) {
+              continue;
+            }
+            seen.add(key);
+
+            this.results.push({ from, to, type });
           }
-
-          // Reconstruct the correct match position
-          const i = m.index >= text.length ? m.index - text.length : m.index;
-          const from = type === "inline" ? pos + i : pos;
-          const to = from + (type === "inline" ? m[0].length : node.nodeSize);
-
-          // Prevent wrap around matches when the regex matches at the end of the deburred
-          // string and continues matching at the start of the original string
-          if (i + m[0].length > text.length) {
-            continue;
-          }
-
-          // Check if already exists in results, possible because we search
-          // over `deburr(text) + text`
-          const key = `${from}:${to}`;
-          if (seen.has(key)) {
-            continue;
-          }
-          seen.add(key);
-
-          this.results.push({ from, to, type });
+        } catch (_err) {
+          // Invalid RegExp
         }
-      } catch (_err) {
-        // Invalid RegExp
-      }
+      };
+
+      // Search the diacritics-stripped text so that, for example, "cafe"
+      // matches "café". Because deburring can change the string length (e.g. it
+      // decomposes CJK/Hangul characters), match indices are translated back to
+      // the original text through the index map rather than assumed equal.
+      const { deburred, map } = deburrWithMap(text);
+      collect(deburred, (index) => map[index]);
+
+      // Also search the original text so that queries containing diacritics
+      // (e.g. "café") still match, and to cover any text that deburring alters.
+      collect(text, (index) => index);
     });
   }
 

--- a/app/editor/extensions/FindAndReplace.tsx
+++ b/app/editor/extensions/FindAndReplace.tsx
@@ -1,4 +1,4 @@
-import { deburr, escapeRegExp } from "es-toolkit/compat";
+import { escapeRegExp } from "es-toolkit/compat";
 import { observable } from "mobx";
 import type { Node } from "prosemirror-model";
 import type { Command } from "prosemirror-state";
@@ -12,48 +12,11 @@ import { isToggleBlock } from "@shared/editor/queries/toggleBlock";
 import { ancestors } from "@shared/editor/utils";
 import isTextInput from "~/utils/isTextInput";
 import FindAndReplace from "../components/FindAndReplace";
+import { deburrWithMap } from "./deburrWithMap";
 
 const pluginKey = new PluginKey("find-and-replace");
 const supportsHighlightAPI =
   typeof CSS !== "undefined" && CSS.highlights !== undefined;
-
-/**
- * Build a diacritics-stripped version of a string together with a mapping from
- * each index in the stripped string back to the corresponding index in the
- * original string.
- *
- * `deburr` normalizes to NFD form, which can change the length of the string –
- * most notably it decomposes precomposed CJK/Hangul syllables (e.g. "강" is a
- * single UTF-16 code unit but decomposes into three jamo). Because of this the
- * stripped string cannot be aligned to the original by assuming equal lengths,
- * so we record the source index of every emitted code unit instead.
- *
- * @param text The original text to deburr.
- * @returns the deburred text and an index map of length `deburred.length + 1`,
- * where `map[i]` is the original index of the deburred code unit at `i` and the
- * final entry is the original text length (a sentinel for end positions).
- */
-export function deburrWithMap(text: string): {
-  deburred: string;
-  map: number[];
-} {
-  let deburred = "";
-  const map: number[] = [];
-  let originalIndex = 0;
-
-  // Iterate by code point so surrogate pairs are deburred as a unit.
-  for (const char of text) {
-    const stripped = deburr(char);
-    for (let i = 0; i < stripped.length; i++) {
-      map.push(originalIndex);
-    }
-    deburred += stripped;
-    originalIndex += char.length;
-  }
-
-  map.push(text.length);
-  return { deburred, map };
-}
 
 /**
  * Options for the FindAndReplace extension.

--- a/app/editor/extensions/deburrWithMap.test.ts
+++ b/app/editor/extensions/deburrWithMap.test.ts
@@ -2,69 +2,73 @@ import { deburrWithMap } from "./deburrWithMap";
 
 describe("deburrWithMap", () => {
   it("leaves plain ASCII text unchanged and maps indices 1:1", () => {
-    const { deburred, map } = deburrWithMap("abc");
+    const { deburred, toOriginalIndex } = deburrWithMap("abc");
     expect(deburred).toBe("abc");
-    expect(map).toEqual([0, 1, 2, 3]);
+    expect(toOriginalIndex(0)).toBe(0);
+    expect(toOriginalIndex(3)).toBe(3);
   });
 
-  it("strips diacritics while keeping the original length", () => {
-    const { deburred, map } = deburrWithMap("café");
+  it("strips diacritics while keeping the original length (fast path)", () => {
+    const { deburred, toOriginalIndex } = deburrWithMap("café");
     expect(deburred).toBe("cafe");
-    // Each deburred code unit maps back to the original index it came from,
-    // plus a sentinel for the end position.
-    expect(map).toEqual([0, 1, 2, 3, 4]);
+    // Length is preserved, so indices line up one-to-one with the original.
+    for (let i = 0; i <= deburred.length; i++) {
+      expect(toOriginalIndex(i)).toBe(i);
+    }
   });
 
   it("maps decomposed (longer) output back to original indices for Hangul", () => {
     const text = "강의";
-    const { deburred, map } = deburrWithMap(text);
+    const { deburred, toOriginalIndex } = deburrWithMap(text);
 
     // NFD decomposition expands each precomposed syllable into jamo, so the
     // deburred string is longer than the original.
     expect(deburred.length).toBeGreaterThan(text.length);
 
-    // The final sentinel must be the original length, not the deburred length.
-    expect(map[map.length - 1]).toBe(text.length);
+    // The end position must map to the original length, not the deburred length.
+    expect(toOriginalIndex(deburred.length)).toBe(text.length);
 
     // Every deburred code unit maps to a valid original index.
     for (let i = 0; i < deburred.length; i++) {
-      expect(map[i]).toBeGreaterThanOrEqual(0);
-      expect(map[i]).toBeLessThan(text.length);
+      expect(toOriginalIndex(i)).toBeGreaterThanOrEqual(0);
+      expect(toOriginalIndex(i)).toBeLessThan(text.length);
     }
   });
 
   it("recovers correct original positions for an ASCII match surrounded by CJK", () => {
     const text = "강의a평가";
-    const { deburred, map } = deburrWithMap(text);
+    const { deburred, toOriginalIndex } = deburrWithMap(text);
 
     const index = deburred.indexOf("a");
     expect(index).toBeGreaterThanOrEqual(0);
 
     // The mapped start/end must point at the real "a" in the original text.
-    const from = map[index];
-    const to = map[index + 1];
+    const from = toOriginalIndex(index);
+    const to = toOriginalIndex(index + 1);
     expect(text.slice(from, to)).toBe("a");
   });
 
   it("maps a deburred match for CJK text back to the original code unit", () => {
     const text = "abc평가";
-    const { deburred, map } = deburrWithMap(text);
+    const { toOriginalIndex } = deburrWithMap(text);
 
     // "abc" appears at the start of both the original and deburred strings.
-    expect(map[0]).toBe(0);
-    expect(map[3]).toBe(3);
-    expect(text.slice(map[0], map[3])).toBe("abc");
+    expect(toOriginalIndex(0)).toBe(0);
+    expect(toOriginalIndex(3)).toBe(3);
+    expect(text.slice(toOriginalIndex(0), toOriginalIndex(3))).toBe("abc");
   });
 
   it("handles surrogate pairs without splitting them", () => {
     const text = "a😀b";
-    const { deburred, map } = deburrWithMap(text);
+    const { deburred, toOriginalIndex } = deburrWithMap(text);
 
     // The emoji occupies two UTF-16 code units in the original string.
-    expect(map[map.length - 1]).toBe(text.length);
-    expect(map[0]).toBe(0);
+    expect(toOriginalIndex(deburred.length)).toBe(text.length);
+    expect(toOriginalIndex(0)).toBe(0);
     // The index following the emoji should account for both code units.
     const bIndex = deburred.indexOf("b");
-    expect(text.slice(map[bIndex], map[bIndex + 1])).toBe("b");
+    expect(
+      text.slice(toOriginalIndex(bIndex), toOriginalIndex(bIndex + 1))
+    ).toBe("b");
   });
 });

--- a/app/editor/extensions/deburrWithMap.test.ts
+++ b/app/editor/extensions/deburrWithMap.test.ts
@@ -58,6 +58,26 @@ describe("deburrWithMap", () => {
     expect(text.slice(toOriginalIndex(0), toOriginalIndex(3))).toBe("abc");
   });
 
+  it("keeps the map consistent across interleaved ASCII and Hangul", () => {
+    const text = "a강b의c";
+    const { deburred, toOriginalIndex } = deburrWithMap(text);
+
+    // Every ASCII character must still resolve to its exact original code unit,
+    // even though the Hangul characters between them expand under NFD.
+    for (const ascii of ["a", "b", "c"]) {
+      const index = deburred.indexOf(ascii);
+      expect(text.slice(toOriginalIndex(index), toOriginalIndex(index + 1))).toBe(
+        ascii
+      );
+    }
+
+    // Indices are non-decreasing and the end maps to the original length.
+    for (let i = 0; i < deburred.length; i++) {
+      expect(toOriginalIndex(i + 1)).toBeGreaterThanOrEqual(toOriginalIndex(i));
+    }
+    expect(toOriginalIndex(deburred.length)).toBe(text.length);
+  });
+
   it("handles surrogate pairs without splitting them", () => {
     const text = "a😀b";
     const { deburred, toOriginalIndex } = deburrWithMap(text);

--- a/app/editor/extensions/deburrWithMap.test.ts
+++ b/app/editor/extensions/deburrWithMap.test.ts
@@ -1,4 +1,4 @@
-import { deburrWithMap } from "./FindAndReplace";
+import { deburrWithMap } from "./deburrWithMap";
 
 describe("deburrWithMap", () => {
   it("leaves plain ASCII text unchanged and maps indices 1:1", () => {

--- a/app/editor/extensions/deburrWithMap.test.ts
+++ b/app/editor/extensions/deburrWithMap.test.ts
@@ -78,6 +78,22 @@ describe("deburrWithMap", () => {
     expect(toOriginalIndex(deburred.length)).toBe(text.length);
   });
 
+  it("maps a partial decomposed sequence to a zero-length original range", () => {
+    // A precomposed Hangul syllable decomposes into multiple jamo that all
+    // originate from the same single original code unit. Matching only part of
+    // that sequence therefore collapses to an empty range in the original text,
+    // which consumers must detect and skip.
+    const text = "강";
+    const { deburred, toOriginalIndex } = deburrWithMap(text);
+
+    expect(deburred.length).toBeGreaterThan(1);
+    // The first jamo alone maps back to a zero-length range (start === end).
+    expect(toOriginalIndex(0)).toBe(toOriginalIndex(1));
+    // The full sequence still spans the whole original character.
+    expect(toOriginalIndex(0)).toBe(0);
+    expect(toOriginalIndex(deburred.length)).toBe(text.length);
+  });
+
   it("handles surrogate pairs without splitting them", () => {
     const text = "a😀b";
     const { deburred, toOriginalIndex } = deburrWithMap(text);

--- a/app/editor/extensions/deburrWithMap.ts
+++ b/app/editor/extensions/deburrWithMap.ts
@@ -1,0 +1,39 @@
+import { deburr } from "es-toolkit/compat";
+
+/**
+ * Build a diacritics-stripped version of a string together with a mapping from
+ * each index in the stripped string back to the corresponding index in the
+ * original string.
+ *
+ * `deburr` normalizes to NFD form, which can change the length of the string –
+ * most notably it decomposes precomposed CJK/Hangul syllables (e.g. "강" is a
+ * single UTF-16 code unit but decomposes into three jamo). Because of this the
+ * stripped string cannot be aligned to the original by assuming equal lengths,
+ * so we record the source index of every emitted code unit instead.
+ *
+ * @param text The original text to deburr.
+ * @returns the deburred text and an index map of length `deburred.length + 1`,
+ * where `map[i]` is the original index of the deburred code unit at `i` and the
+ * final entry is the original text length (a sentinel for end positions).
+ */
+export function deburrWithMap(text: string): {
+  deburred: string;
+  map: number[];
+} {
+  let deburred = "";
+  const map: number[] = [];
+  let originalIndex = 0;
+
+  // Iterate by code point so surrogate pairs are deburred as a unit.
+  for (const char of text) {
+    const stripped = deburr(char);
+    for (let i = 0; i < stripped.length; i++) {
+      map.push(originalIndex);
+    }
+    deburred += stripped;
+    originalIndex += char.length;
+  }
+
+  map.push(text.length);
+  return { deburred, map };
+}

--- a/app/editor/extensions/deburrWithMap.ts
+++ b/app/editor/extensions/deburrWithMap.ts
@@ -1,39 +1,63 @@
 import { deburr } from "es-toolkit/compat";
 
 /**
- * Build a diacritics-stripped version of a string together with a mapping from
- * each index in the stripped string back to the corresponding index in the
+ * Build a diacritics-stripped version of a string together with a way to map
+ * any index in the stripped string back to the corresponding index in the
  * original string.
  *
  * `deburr` normalizes to NFD form, which can change the length of the string –
  * most notably it decomposes precomposed CJK/Hangul syllables (e.g. "강" is a
- * single UTF-16 code unit but decomposes into three jamo). Because of this the
- * stripped string cannot be aligned to the original by assuming equal lengths,
- * so we record the source index of every emitted code unit instead.
+ * single UTF-16 code unit but decomposes into three jamo). When that happens a
+ * naive offset no longer lines up with the original, so the source index of
+ * every emitted code unit is recorded instead.
+ *
+ * When deburring does not change the length – the common case for ASCII and
+ * ordinary accented Latin text – indices line up one-to-one and the cheap
+ * identity mapping is returned without building any per-character table.
  *
  * @param text The original text to deburr.
- * @returns the deburred text and an index map of length `deburred.length + 1`,
- * where `map[i]` is the original index of the deburred code unit at `i` and the
- * final entry is the original text length (a sentinel for end positions).
+ * @returns the deburred text and a `toOriginalIndex` function translating a
+ * deburred index (0…deburred.length) into the corresponding original index.
  */
 export function deburrWithMap(text: string): {
   deburred: string;
-  map: number[];
+  toOriginalIndex: (index: number) => number;
 } {
-  let deburred = "";
+  const deburred = deburr(text);
+
+  // Fast path: deburring preserved the length, so indices line up one-to-one
+  // with the original string and no per-character table is needed.
+  if (deburred.length === text.length) {
+    return { deburred, toOriginalIndex: (index) => index };
+  }
+
+  // Slow path: deburring changed the length (e.g. NFD decomposed a CJK/Hangul
+  // syllable or expanded a ligature). Rebuild the deburred string per code
+  // point so it stays consistent with the index map, recording the original
+  // index of every emitted code unit plus a sentinel for the end position.
+  let rebuilt = "";
   const map: number[] = [];
   let originalIndex = 0;
 
   // Iterate by code point so surrogate pairs are deburred as a unit.
   for (const char of text) {
+    // ASCII characters are never altered or decomposed by deburr, so emit them
+    // directly and skip the comparatively expensive normalization.
+    if (char.charCodeAt(0) < 0x80) {
+      map.push(originalIndex);
+      rebuilt += char;
+      originalIndex += 1;
+      continue;
+    }
+
     const stripped = deburr(char);
     for (let i = 0; i < stripped.length; i++) {
       map.push(originalIndex);
     }
-    deburred += stripped;
+    rebuilt += stripped;
     originalIndex += char.length;
   }
-
   map.push(text.length);
-  return { deburred, map };
+
+  return { deburred: rebuilt, toOriginalIndex: (index) => map[index] };
 }

--- a/app/editor/extensions/deburrWithMap.ts
+++ b/app/editor/extensions/deburrWithMap.ts
@@ -35,7 +35,7 @@ export function deburrWithMap(text: string): {
   // syllable or expanded a ligature). Rebuild the deburred string per code
   // point so it stays consistent with the index map, recording the original
   // index of every emitted code unit plus a sentinel for the end position.
-  let rebuilt = "";
+  const parts: string[] = [];
   const map: number[] = [];
   let originalIndex = 0;
 
@@ -45,7 +45,7 @@ export function deburrWithMap(text: string): {
     // directly and skip the comparatively expensive normalization.
     if (char.charCodeAt(0) < 0x80) {
       map.push(originalIndex);
-      rebuilt += char;
+      parts.push(char);
       originalIndex += 1;
       continue;
     }
@@ -54,10 +54,10 @@ export function deburrWithMap(text: string): {
     for (let i = 0; i < stripped.length; i++) {
       map.push(originalIndex);
     }
-    rebuilt += stripped;
+    parts.push(stripped);
     originalIndex += char.length;
   }
   map.push(text.length);
 
-  return { deburred: rebuilt, toOriginalIndex: (index) => map[index] };
+  return { deburred: parts.join(""), toOriginalIndex: (index) => map[index] };
 }


### PR DESCRIPTION
The previous approach concatenating the search and deburred search string always had a lot of edge cases and relied on handling "wrap around" which caused several bugs.

It also turns out that `deburr` also _changes the length_ of the string - obvious in hindsight, but this newly sized string was not mapped back to original document positions.

closes #12807