### PR TITLE
fix: `revisions.list` response too large

### DIFF
--- a/app/scenes/Document/components/History/History.tsx
+++ b/app/scenes/Document/components/History/History.tsx
@@ -173,6 +173,16 @@ function History() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [document, revisions.orderedData, revisionsOffset]);
 
+  // The revisions list is lightweight and omits document content, so load the
+  // content of the latest revision on demand to compare it against the current
+  // document below.
+  const latestRevisionEvent = revisionEvents[0];
+  React.useEffect(() => {
+    if (latestRevisionEvent && !latestRevisionEvent.data) {
+      void revisions.fetch(latestRevisionEvent.id);
+    }
+  }, [revisions, latestRevisionEvent]);
+
   const nonRevisionEvents = React.useMemo(
     () =>
       document
@@ -188,8 +198,6 @@ function History() {
       "createdAt",
       "desc"
     );
-
-    const latestRevisionEvent = revisionEvents[0];
 
     if (latestRevisionEvent && document) {
       const latestRevision = revisions.get(latestRevisionEvent.id);
@@ -215,7 +223,13 @@ function History() {
     }
 
     return merged;
-  }, [revisions, document, revisionEvents, nonRevisionEvents]);
+  }, [
+    revisions,
+    document,
+    revisionEvents,
+    nonRevisionEvents,
+    latestRevisionEvent,
+  ]);
 
   const onCloseHistory = React.useCallback(() => {
     if (isMobile) {

--- a/app/scenes/Document/components/History/History.tsx
+++ b/app/scenes/Document/components/History/History.tsx
@@ -177,11 +177,27 @@ function History() {
   // content of the latest revision on demand to compare it against the current
   // document below.
   const latestRevisionEvent = revisionEvents[0];
+  const latestRevision = latestRevisionEvent
+    ? revisions.get(latestRevisionEvent.id)
+    : undefined;
+
   React.useEffect(() => {
-    if (latestRevisionEvent && !latestRevisionEvent.data) {
-      void revisions.fetch(latestRevisionEvent.id);
+    if (latestRevision && !latestRevision.data) {
+      void revisions.fetch(latestRevision.id);
     }
-  }, [revisions, latestRevisionEvent]);
+  }, [revisions, latestRevision]);
+
+  // Whether the current document has unsaved changes beyond its latest
+  // revision, in which case a "Current version" entry is shown. Computed in the
+  // render body (rather than the memo below) so the observer re-evaluates it
+  // once the lazily-loaded revision content arrives. The content-aware check is
+  // deferred until the content has loaded to avoid showing an entry that would
+  // then vanish.
+  const isDocUpdated =
+    !!latestRevision &&
+    !!document &&
+    (latestRevision.title !== document.title ||
+      (!!latestRevision.data && !isEqual(latestRevision.data, document.data)));
 
   const nonRevisionEvents = React.useMemo(
     () =>
@@ -199,37 +215,23 @@ function History() {
       "desc"
     );
 
-    if (latestRevisionEvent && document) {
-      const latestRevision = revisions.get(latestRevisionEvent.id);
-
-      const isDocUpdated =
-        latestRevision?.title !== document.title ||
-        !isEqual(latestRevision.data, document.data);
-
-      if (isDocUpdated) {
-        const createdById = document.updatedBy?.id ?? "";
-        merged.unshift(
-          new Revision(
-            {
-              id: RevisionHelper.latestId(document.id),
-              createdAt: document.updatedAt,
-              createdById,
-              collaboratorIds: [createdById],
-            },
-            revisions
-          )
-        );
-      }
+    if (isDocUpdated && document) {
+      const createdById = document.updatedBy?.id ?? "";
+      merged.unshift(
+        new Revision(
+          {
+            id: RevisionHelper.latestId(document.id),
+            createdAt: document.updatedAt,
+            createdById,
+            collaboratorIds: [createdById],
+          },
+          revisions
+        )
+      );
     }
 
     return merged;
-  }, [
-    revisions,
-    document,
-    revisionEvents,
-    nonRevisionEvents,
-    latestRevisionEvent,
-  ]);
+  }, [revisions, document, revisionEvents, nonRevisionEvents, isDocUpdated]);
 
   const onCloseHistory = React.useCallback(() => {
     if (isMobile) {

--- a/app/scenes/Document/components/RevisionViewer.tsx
+++ b/app/scenes/Document/components/RevisionViewer.tsx
@@ -62,6 +62,18 @@ function RevisionViewer(props: Props, ref: React.Ref<TEditor>) {
     ? compareToRevision?.data
     : revision.before?.data;
 
+  // Revisions are listed without their content, so when diffing against the
+  // previous revision ensure its content has been loaded. The directly viewed
+  // and `compareTo` revisions are loaded by the document DataLoader.
+  const beforeRevisionId = compareToRevisionId
+    ? undefined
+    : revision.before?.id;
+  React.useEffect(() => {
+    if (showChanges && beforeRevisionId) {
+      void revisions.fetch(beforeRevisionId);
+    }
+  }, [showChanges, beforeRevisionId, revisions]);
+
   /**
    * Create editor extensions with the Diff extension configured to render
    * the calculated changes as decorations in the editor.

--- a/app/stores/RevisionsStore.ts
+++ b/app/stores/RevisionsStore.ts
@@ -1,3 +1,4 @@
+import { type JSONObject } from "@shared/types";
 import type RootStore from "~/stores/RootStore";
 import Store from "~/stores/base/Store";
 import Revision from "~/models/Revision";
@@ -6,6 +7,23 @@ import { client } from "~/utils/ApiClient";
 export default class RevisionsStore extends Store<Revision> {
   constructor(rootStore: RootStore) {
     super(rootStore, Revision);
+  }
+
+  /**
+   * Fetches a single revision by ID, including its full document content.
+   *
+   * Revisions returned by `revisions.list` are lightweight and omit the
+   * document content to keep the response small, so this forces a fetch when
+   * the cached revision is missing its content.
+   *
+   * @param id - The ID of the revision to fetch.
+   * @param options - Options to pass through to the underlying fetch.
+   * @returns A promise that resolves to the fetched revision.
+   */
+  async fetch(id: string, options: JSONObject = {}): Promise<Revision> {
+    const item = this.get(id);
+    const force = Boolean(options.force) || (!!item && !item.data);
+    return super.fetch(id, { ...options, force });
   }
 
   /**

--- a/app/stores/RevisionsStore.ts
+++ b/app/stores/RevisionsStore.ts
@@ -12,10 +12,6 @@ export default class RevisionsStore extends Store<Revision> {
   /**
    * Fetches a single revision by ID, including its full document content.
    *
-   * Revisions returned by `revisions.list` are lightweight and omit the
-   * document content to keep the response small, so this forces a fetch when
-   * the cached revision is missing its content.
-   *
    * @param id - The ID of the revision to fetch.
    * @param options - Options to pass through to the underlying fetch.
    * @returns A promise that resolves to the fetched revision.

--- a/server/presenters/revision.ts
+++ b/server/presenters/revision.ts
@@ -4,13 +4,28 @@ import type { Revision } from "@server/models";
 import { DocumentHelper } from "@server/models/helpers/DocumentHelper";
 import presentUser from "./user";
 
-async function presentRevision(revision: Revision) {
+type PresentRevisionOptions = {
+  /**
+   * Whether to include the (potentially large) document content, both as
+   * Prosemirror `data` and Markdown `text`. Defaults to true. This should be
+   * disabled when presenting many revisions at once (e.g. in a list) to avoid
+   * generating an excessively large response.
+   */
+  includeContent?: boolean;
+};
+
+async function presentRevision(
+  revision: Revision,
+  options: PresentRevisionOptions = {}
+) {
+  const { includeContent = true } = options;
+
   // TODO: Remove this fallback once all revisions have been migrated
   const { emoji, strippedTitle } = parseTitle(revision.title);
 
   const [data, text, collaborators] = await Promise.all([
-    DocumentHelper.toJSON(revision),
-    DocumentHelper.toMarkdown(revision),
+    includeContent ? DocumentHelper.toJSON(revision) : undefined,
+    includeContent ? DocumentHelper.toMarkdown(revision) : undefined,
     revision.collaborators,
   ]);
 

--- a/server/presenters/revision.ts
+++ b/server/presenters/revision.ts
@@ -6,10 +6,7 @@ import presentUser from "./user";
 
 type PresentRevisionOptions = {
   /**
-   * Whether to include the (potentially large) document content, both as
-   * Prosemirror `data` and Markdown `text`. Defaults to true. This should be
-   * disabled when presenting many revisions at once (e.g. in a list) to avoid
-   * generating an excessively large response.
+   * Whether to include the document content. Defaults to true.
    */
   includeContent?: boolean;
 };

--- a/server/routes/api/revisions/revisions.test.ts
+++ b/server/routes/api/revisions/revisions.test.ts
@@ -30,6 +30,9 @@ describe("#revisions.info", () => {
     expect(res.status).toEqual(200);
     expect(body.data.id).not.toEqual(document.id);
     expect(body.data.title).toEqual(document.title);
+    // The single revision endpoint includes the full document content.
+    expect(body.data.data).toBeDefined();
+    expect(body.data.text).toBeDefined();
   });
 
   it("should require authorization", async () => {
@@ -178,6 +181,27 @@ describe("#revisions.list", () => {
     expect(body.data.length).toEqual(1);
     expect(body.data[0].id).not.toEqual(document.id);
     expect(body.data[0].title).toEqual(document.title);
+  });
+
+  it("should not include document content for listed revisions", async () => {
+    const user = await buildUser();
+    const document = await buildDocument({
+      userId: user.id,
+      teamId: user.teamId,
+    });
+    await Revision.createFromDocument(createContext({ user }), document);
+    const res = await server.post("/api/revisions.list", user, {
+      body: {
+        documentId: document.id,
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.data.length).toEqual(1);
+    // The (potentially large) content is omitted from the list response and
+    // only loaded when a single revision is opened via revisions.info.
+    expect(body.data[0].data).toBeUndefined();
+    expect(body.data[0].text).toBeUndefined();
   });
 
   it("should not return revisions for document in collection not a member of", async () => {

--- a/server/routes/api/revisions/revisions.ts
+++ b/server/routes/api/revisions/revisions.ts
@@ -251,8 +251,14 @@ router.post(
       limit: ctx.state.pagination.limit,
       paranoid: false,
     });
+    // Avoid serializing the (potentially very large) document content for every
+    // revision in the list as this can result in a response large enough to
+    // fail mid-stream for big documents. The content is loaded on demand when a
+    // single revision is opened via revisions.info.
     const data = await Promise.all(
-      revisions.map((revision) => presentRevision(revision))
+      revisions.map((revision) =>
+        presentRevision(revision, { includeContent: false })
+      )
     );
 
     ctx.body = {

--- a/server/routes/api/revisions/revisions.ts
+++ b/server/routes/api/revisions/revisions.ts
@@ -251,10 +251,7 @@ router.post(
       limit: ctx.state.pagination.limit,
       paranoid: false,
     });
-    // Avoid serializing the (potentially very large) document content for every
-    // revision in the list as this can result in a response large enough to
-    // fail mid-stream for big documents. The content is loaded on demand when a
-    // single revision is opened via revisions.info.
+
     const data = await Promise.all(
       revisions.map((revision) =>
         presentRevision(revision, { includeContent: false })


### PR DESCRIPTION
closes #12810