### PR TITLE
fix: Settings appear behind sidebar

### DIFF
--- a/app/components/AuthenticatedLayout.tsx
+++ b/app/components/AuthenticatedLayout.tsx
@@ -107,7 +107,12 @@ const AuthenticatedLayout: React.FC = ({ children }: Props) => {
       <RightSidebarProvider>
         <PortalContext.Provider value={layoutRef.current}>
           <DndProvider backend={EditorAwareHTML5Backend}>
-            <Layout title={team.name} sidebar={sidebar} ref={layoutRef}>
+            <Layout
+              title={team.name}
+              sidebar={sidebar}
+              sidebarCanCollapse={!isSettings}
+              ref={layoutRef}
+            >
               <RegisterKeyDown trigger="n" handler={goToNewDocument} />
               <RegisterKeyDown trigger="t" handler={goToSearch} />
               <RegisterKeyDown trigger="/" handler={goToSearch} />

--- a/app/components/Layout.tsx
+++ b/app/components/Layout.tsx
@@ -21,14 +21,17 @@ type Props = {
   title?: string;
   /** Left sidebar content. */
   sidebar?: React.ReactNode;
+  /** Whether the sidebar can be collapsed, defaults to true. */
+  sidebarCanCollapse?: boolean;
 };
 
 const Layout = React.forwardRef(function Layout_(
-  { title, children, sidebar }: Props,
+  { title, children, sidebar, sidebarCanCollapse = true }: Props,
   ref: React.RefObject<HTMLDivElement>
 ) {
   const { ui } = useStores();
-  const sidebarCollapsed = !sidebar || ui.sidebarIsClosed;
+  const sidebarCollapsed =
+    !sidebar || (ui.sidebarIsClosed && sidebarCanCollapse);
   const sidebarRight = useRightSidebarContent();
 
   return (

--- a/app/scenes/Shared/index.tsx
+++ b/app/scenes/Shared/index.tsx
@@ -266,6 +266,7 @@ function SharedScene() {
             <Layout
               title={pageTitle}
               sidebar={hasSidebar ? <Sidebar share={share} /> : null}
+              sidebarCanCollapse={false}
             >
               {model instanceof Document ? (
                 <DocumentScene document={model} />


### PR DESCRIPTION
Fixes an issue where the main app sidebar is collapsed the settings content appears behind it