### PR TITLE
fix: Add WWW-Authenticate header to /mcp 401 responses

### DIFF
--- a/server/routes/mcp/index.test.ts
+++ b/server/routes/mcp/index.test.ts
@@ -29,6 +29,20 @@ describe("POST /mcp/", () => {
       expect(res.status).toEqual(401);
     });
 
+    it("should include WWW-Authenticate header on 401 responses", async () => {
+      const { body } = mcpRequest("tools/list");
+      const res = await server.post("/mcp/", {
+        headers: { Accept: "application/json, text/event-stream" },
+        body,
+      });
+      expect(res.status).toEqual(401);
+      const wwwAuth = res.headers.get("www-authenticate");
+      expect(wwwAuth).toBeTruthy();
+      expect(wwwAuth).toContain("Bearer");
+      expect(wwwAuth).toContain("resource_metadata=");
+      expect(wwwAuth).toContain("/.well-known/oauth-protected-resource/mcp");
+    });
+
     it("should reject JWT authentication", async () => {
       const user = await buildUser();
       const { body } = mcpRequest("tools/list");

--- a/server/routes/mcp/index.ts
+++ b/server/routes/mcp/index.ts
@@ -8,6 +8,7 @@ import { ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { toError } from "@shared/utils/error";
 import { TeamPreference } from "@shared/types";
 import { NotFoundError } from "@server/errors";
+import env from "@server/env";
 import Logger from "@server/logging/Logger";
 import auth from "@server/middlewares/authentication";
 import { rateLimiter } from "@server/middlewares/rateLimiter";
@@ -26,6 +27,27 @@ import { version } from "../../../package.json";
 
 const app = new Koa();
 const router = new Router();
+
+// RFC 9728 / MCP auth spec: 401 responses from the /mcp endpoint must include
+// a WWW-Authenticate header pointing at the OAuth protected resource metadata
+// document so clients can bootstrap the authorization flow via discovery.
+app.use(async (ctx, next) => {
+  try {
+    await next();
+  } catch (err: unknown) {
+    const error = err as { status?: number };
+    if (error?.status === 401) {
+      const origin = env.isCloudHosted
+        ? ctx.request.URL.origin
+        : new URL(env.URL).origin;
+      (err as { headers?: Record<string, string> }).headers = {
+        ...((err as { headers?: Record<string, string> }).headers ?? {}),
+        "WWW-Authenticate": `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource/mcp"`,
+      };
+    }
+    throw err;
+  }
+});
 
 const defaultInstructions = `Document markdown content must not begin with a top-level heading (H1) — the title is stored as a separate field, so set it via the title parameter and start the content with body text or a lower-level heading instead.
 

--- a/server/routes/mcp/index.ts
+++ b/server/routes/mcp/index.ts
@@ -35,15 +35,25 @@ app.use(async (ctx, next) => {
   try {
     await next();
   } catch (err: unknown) {
-    const error = err as { status?: number };
-    if (error?.status === 401) {
-      const origin = env.isCloudHosted
-        ? ctx.request.URL.origin
-        : new URL(env.URL).origin;
-      (err as { headers?: Record<string, string> }).headers = {
-        ...((err as { headers?: Record<string, string> }).headers ?? {}),
-        "WWW-Authenticate": `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource/mcp"`,
-      };
+    if (
+      typeof err === "object" &&
+      err !== null &&
+      (err as { status?: number }).status === 401
+    ) {
+      const headersHost = err as { headers?: Record<string, string> };
+      const existingHeaders = headersHost.headers ?? {};
+      const hasWwwAuth = Object.keys(existingHeaders).some(
+        (k) => k.toLowerCase() === "www-authenticate"
+      );
+      if (!hasWwwAuth) {
+        const origin = env.isCloudHosted
+          ? ctx.request.URL.origin
+          : new URL(env.URL).origin;
+        headersHost.headers = {
+          ...existingHeaders,
+          "WWW-Authenticate": `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource/mcp"`,
+        };
+      }
     }
     throw err;
   }


### PR DESCRIPTION
Closes #12831.

**PROBLEM**

The \`/mcp\` endpoint returns 401 without a \`WWW-Authenticate\` header. Desktop MCP clients use that header to discover the OAuth authorization server via the protected-resource metadata document — without it, they have no entry point into the discovery chain (RFC 9728 and the MCP authorization spec both require it), the OAuth flow can't bootstrap, and the connector silently fails to authenticate.

**SOLUTION**

A small Koa middleware on the \`/mcp\` app catches \`err.status === 401\` and attaches \`WWW-Authenticate: Bearer resource_metadata="<origin>/.well-known/oauth-protected-resource/mcp"\` to \`err.headers\`, which \`server/onerror.ts\` already copies to the response. Origin uses \`ctx.request.URL.origin\` when cloud-hosted and \`env.URL\` otherwise — same convention the well-known routes follow. The metadata document is already served; this just points clients at it.

**NOTES**

The middleware only adds a header to 401s that previously had none. Clients that don't read the header see the same status/body as before; spec-compliant ones now get the discovery pointer they expect.