### PR TITLE
fix: Accept unprefixed /authorize, /token, /register, /revoke

### DIFF
--- a/server/middlewares/oauthAliases.ts
+++ b/server/middlewares/oauthAliases.ts
@@ -16,6 +16,9 @@ const ALIASES: Record<string, string> = {
  * GET requests are 302-redirected so the browser's URL bar reflects the
  * canonical path and the consent SPA route matches. Other methods rewrite
  * `ctx.url` in place so existing handlers serve them transparently.
+ *
+ * @returns Koa middleware that rewrites or redirects unprefixed OAuth
+ * paths to their canonical `/oauth/*` counterparts.
  */
 export default function oauthAliases() {
   return async function oauthAliasesMiddleware(ctx: Context, next: Next) {

--- a/server/middlewares/oauthAliases.ts
+++ b/server/middlewares/oauthAliases.ts
@@ -1,0 +1,33 @@
+import type { Context, Next } from "koa";
+
+const ALIASES: Record<string, string> = {
+  "/authorize": "/oauth/authorize",
+  "/token": "/oauth/token",
+  "/register": "/oauth/register",
+  "/revoke": "/oauth/revoke",
+};
+
+/**
+ * Maps the unprefixed OAuth paths some MCP clients construct (e.g.
+ * `<host>/authorize` instead of the canonical `/oauth/authorize` advertised
+ * in the OAuth 2.0 authorization-server metadata) onto Outline's existing
+ * /oauth/* routes.
+ *
+ * GET requests are 302-redirected so the browser's URL bar reflects the
+ * canonical path and the consent SPA route matches. Other methods rewrite
+ * `ctx.url` in place so existing handlers serve them transparently.
+ */
+export default function oauthAliases() {
+  return async function oauthAliasesMiddleware(ctx: Context, next: Next) {
+    const target = ALIASES[ctx.path];
+    if (!target) {
+      return next();
+    }
+    if (ctx.method === "GET") {
+      ctx.redirect(`${target}${ctx.search}`);
+      return;
+    }
+    ctx.url = ctx.url.replace(ctx.path, target);
+    return next();
+  };
+}

--- a/server/routes/oauth/oauth.test.ts
+++ b/server/routes/oauth/oauth.test.ts
@@ -516,3 +516,52 @@ describe("GET /.well-known/oauth-protected-resource", () => {
     }
   });
 });
+
+describe("OAuth path aliases", () => {
+  it("should 302-redirect GET /authorize to /oauth/authorize preserving query", async () => {
+    const res = await server.get(
+      "/authorize?response_type=code&client_id=abc&state=xyz",
+      { redirect: "manual" }
+    );
+
+    expect(res.status).toEqual(302);
+    const location = res.headers.get("location");
+    expect(location).toContain(
+      "/oauth/authorize?response_type=code&client_id=abc&state=xyz"
+    );
+  });
+
+  it("should route POST /token to the canonical /oauth/token handler", async () => {
+    const res = await server.post("/token", {
+      body: { grant_type: "invalid_grant_type" },
+    });
+
+    // The request must reach the OAuth handler stack (not fall through to a
+    // generic 404). The OAuth error handler always wraps failures in an
+    // `error` + `error_description` body, so asserting that shape proves the
+    // alias delivered to /oauth/token specifically.
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(res.status).toBeLessThan(500);
+    const body = await res.json();
+    expect(body.error).toBeTruthy();
+    expect(body.error_description).toBeTruthy();
+  });
+
+  it("should register an OAuth client via POST /register without /oauth prefix", async () => {
+    const subdomain = faker.internet.domainWord();
+    await buildTeam({ subdomain });
+
+    const res = await server.post("/register", {
+      body: {
+        client_name: "Aliased Client",
+        redirect_uris: ["https://example.com/callback"],
+      },
+      headers: { host: `${subdomain}.outline.dev` },
+    });
+
+    expect(res.status).toEqual(201);
+    const body = await res.json();
+    expect(body.client_id).toBeTruthy();
+    expect(body.client_name).toEqual("Aliased Client");
+  });
+});

--- a/server/routes/oauth/oauth.test.ts
+++ b/server/routes/oauth/oauth.test.ts
@@ -564,4 +564,16 @@ describe("OAuth path aliases", () => {
     expect(body.client_id).toBeTruthy();
     expect(body.client_name).toEqual("Aliased Client");
   });
+
+  it("should route POST /revoke to the canonical /oauth/revoke handler", async () => {
+    const res = await server.post("/revoke", {
+      body: { token: "ol_at_unknown_token_value" },
+    });
+
+    // /oauth/revoke is spec'd (RFC 7009) to return 200 regardless of token
+    // validity. Reaching the handler proves the alias delivered correctly.
+    expect(res.status).toEqual(200);
+    const body = await res.json();
+    expect(body.success).toEqual(true);
+  });
 });

--- a/server/services/web.ts
+++ b/server/services/web.ts
@@ -15,6 +15,7 @@ import Logger from "@server/logging/Logger";
 import Metrics from "@server/logging/Metrics";
 import csp from "@server/middlewares/csp";
 import { attachCSRFToken } from "@server/middlewares/csrf";
+import oauthAliases from "@server/middlewares/oauthAliases";
 import ShutdownHelper, { ShutdownOrder } from "@server/utils/ShutdownHelper";
 import { initI18n } from "@server/utils/i18n";
 import routes from "../routes";
@@ -103,6 +104,7 @@ export default function init(app: Koa = new Koa(), server?: Server) {
   );
 
   app.use(mount("/auth", auth));
+  app.use(oauthAliases());
   app.use(mount("/oauth", oauth));
   app.use(mount(routes));
 


### PR DESCRIPTION
Closes #12832.

**PROBLEM**

In practice, MCP desktop clients construct OAuth URLs as \`<mcp-server-host>/<endpoint>\` (no \`/oauth/\` prefix), ignoring the canonical paths advertised in the authorization-server metadata. The browser lands on \`<host>/authorize\` and the SPA returns its not-found page; the token exchange hits \`<host>/token\` and 404s.

**SOLUTION**

A new middleware in \`server/middlewares/oauthAliases.ts\` maps \`/authorize\`, \`/token\`, \`/register\`, \`/revoke\` onto their \`/oauth/*\` equivalents. GET requests are 302-redirected so the URL bar reflects the canonical path and the consent SPA route matches; other methods rewrite \`ctx.url\` in place so the existing \`/oauth/*\` handlers serve them unchanged.

**NOTES**

The alias middleware is a no-op for any path not in the alias map. The four mapped paths (\`/authorize\`, \`/token\`, \`/register\`, \`/revoke\`) were not previously routed at the root — they returned 404 from the SPA — so the new behavior replaces nothing that worked.