### PR TITLE
fix: Make client_name optional on /oauth/register

### DIFF
--- a/server/routes/oauth/index.ts
+++ b/server/routes/oauth/index.ts
@@ -209,7 +209,9 @@ router.post(
         : "public";
 
     const client = await OAuthClient.createWithCtx(ctx, {
-      name: client_name,
+      // RFC 7591 makes client_name optional; fall back to a generic label so
+      // dynamic-registration clients that omit it still register cleanly.
+      name: client_name ?? "Untitled application",
       redirectUris: redirect_uris,
       clientType,
       developerUrl: client_uri ?? null,

--- a/server/routes/oauth/oauth.test.ts
+++ b/server/routes/oauth/oauth.test.ts
@@ -94,7 +94,7 @@ describe("#oauth.register", () => {
     expect(body.logo_uri).toEqual("https://example.com/logo.png");
   });
 
-  it("should reject missing client_name", async () => {
+  it("should accept registration without client_name", async () => {
     const res = await server.post("/oauth/register", {
       body: {
         redirect_uris: ["https://example.com/callback"],
@@ -104,7 +104,10 @@ describe("#oauth.register", () => {
       },
     });
 
-    expect(res.status).toEqual(400);
+    expect(res.status).toEqual(201);
+    const body = await res.json();
+    expect(body.client_id).toBeTruthy();
+    expect(body.client_name).toEqual("Untitled application");
   });
 
   it("should reject missing redirect_uris", async () => {

--- a/server/routes/oauth/schema.ts
+++ b/server/routes/oauth/schema.ts
@@ -27,7 +27,14 @@ export type TokenRevokeReq = z.infer<typeof TokenRevokeSchema>;
 
 export const RegisterSchema = BaseSchema.extend({
   body: z.object({
-    client_name: z.string().min(1).max(OAuthClientValidation.maxNameLength),
+    // RFC 7591 §2 marks every metadata field as OPTIONAL; some MCP clients
+    // omit `client_name` on dynamic registration and currently get rejected.
+    // A default is filled in by the handler when the field is absent.
+    client_name: z
+      .string()
+      .min(1)
+      .max(OAuthClientValidation.maxNameLength)
+      .optional(),
     redirect_uris: z
       .array(z.url().max(OAuthClientValidation.maxRedirectUriLength))
       .min(1)


### PR DESCRIPTION
Closes #12833.

**PROBLEM**

RFC 7591 §2 states every client metadata field is OPTIONAL, including \`client_name\`. Outline's schema currently requires it (\`z.string().min(1)\`), so MCP clients that omit \`client_name\` during dynamic registration are rejected with a 400 and fall back to "please paste a Client ID manually" UX in the connector setup.

**SOLUTION**

\`client_name\` becomes optional in \`RegisterSchema\`. When absent, the handler stores a generic \`"Untitled application"\` label so the DB constraint on \`name\` still has a value and the workspace's OAuth-applications list stays readable. Callers that send \`client_name\` keep working unchanged.

**NOTES**

\`client_name\` becoming optional widens the accepted input set. Every request that worked before (i.e. ones that included a \`client_name\`) continues to work identically; only previously-rejected requests now succeed with a default label. The \`OAuthClient.name\` column still receives a non-null value.