### PR TITLE
fix: Avoid SequelizeEmptyResultError when team is missing in CollectionsProcessor

### DIFF
--- a/server/queues/processors/CollectionsProcessor.ts
+++ b/server/queues/processors/CollectionsProcessor.ts
@@ -21,7 +21,6 @@ export default class CollectionsProcessor extends BaseProcessor {
 
     await sequelize.transaction(async (transaction) => {
       const team = await Team.findByPk(event.teamId, {
-        rejectOnEmpty: true,
         transaction,
         lock: transaction.LOCK.UPDATE,
       });


### PR DESCRIPTION
Fixes #12828.

`CollectionsProcessor` loaded the team with `rejectOnEmpty: true`, which threw `SequelizeEmptyResultError` when the team had been deleted between the `collections.delete`/`collections.archive` event being queued and the job running. The following line already guards with optional chaining (`team?.defaultCollectionId`), so it expected `team` to possibly be null.

Removing `rejectOnEmpty` lets a missing team resolve to `null`, the existing guard short-circuits, and the transaction completes as a no-op instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)