### PR TITLE
fix: Avoid SequelizeEmptyResultError in AvatarProcessor

### DIFF
--- a/server/queues/processors/AvatarProcessor.ts
+++ b/server/queues/processors/AvatarProcessor.ts
@@ -12,11 +12,10 @@ export default class AvatarProcessor extends BaseProcessor {
     // case of failures as it involves network calls to third party services.
 
     if (event.name === "users.create") {
-      const user = await User.findByPk(event.userId, {
-        rejectOnEmpty: true,
-      });
+      // The user may have been deleted before this processor runs.
+      const user = await User.findByPk(event.userId);
 
-      if (user.avatarUrl) {
+      if (user?.avatarUrl) {
         await new UploadUserAvatarTask().schedule({
           userId: event.userId,
           avatarUrl: user.avatarUrl,
@@ -25,11 +24,10 @@ export default class AvatarProcessor extends BaseProcessor {
     }
 
     if (event.name === "teams.create") {
-      const team = await Team.findByPk(event.teamId, {
-        rejectOnEmpty: true,
-      });
+      // The team may have been deleted before this processor runs.
+      const team = await Team.findByPk(event.teamId);
 
-      if (team.avatarUrl) {
+      if (team?.avatarUrl) {
         await new UploadTeamAvatarTask().schedule({
           teamId: event.teamId,
           avatarUrl: team.avatarUrl,


### PR DESCRIPTION
The `AvatarProcessor` handles `users.create` / `teams.create` events asynchronously, but the team or user can be deleted before the queued processor runs, causing `findByPk` with `rejectOnEmpty: true` to throw `SequelizeEmptyResultError` (Sentry: OUTLINE-CLOUD-CMW). Since the avatar upload is non-critical, this drops `rejectOnEmpty` and uses optional chaining to gracefully skip the upload when the record no longer exists.

Fixes #12829

🤖 Generated with [Claude Code](https://claude.com/claude-code)