### PR TITLE
fix: Handle deleted user or team in UserCreatedProcessor

### DIFF
--- a/server/queues/processors/UserCreatedProcessor.ts
+++ b/server/queues/processors/UserCreatedProcessor.ts
@@ -11,9 +11,14 @@ export default class UserCreatedProcessor extends BaseProcessor {
 
   async perform(event: UserEvent) {
     const [user, team] = await Promise.all([
-      User.findByPk(event.userId, { rejectOnEmpty: true }),
-      Team.findByPk(event.teamId, { rejectOnEmpty: true }),
+      User.findByPk(event.userId),
+      Team.findByPk(event.teamId),
     ]);
+
+    // The user or team may have been deleted before this event is processed.
+    if (!user || !team) {
+      return;
+    }
 
     // Invited users receive an InviteEmail at invite time, and a WelcomeEmail
     // when they accept the invite and sign in for the first time.


### PR DESCRIPTION
Fixes #12830.

`UserCreatedProcessor` used `rejectOnEmpty: true` when loading the user and team, which threw `SequelizeEmptyResultError` when either record had been deleted before the queued event was processed. Since the processor only sends a welcome email, a missing user or team is expected and benign, so it now returns early instead of throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)