### PR TITLE
Auto-reload on repeated chunk failure

### DIFF
--- a/app/utils/lazyWithRetry.ts
+++ b/app/utils/lazyWithRetry.ts
@@ -73,8 +73,9 @@ function reloadIfStaleChunk(error: unknown): boolean {
     }
     sessionStorage.setItem(reloadSessionKey, "1");
   } catch {
-    // sessionStorage may be unavailable (e.g. Safari private mode); reload
-    // anyway, accepting the small risk of a single extra reload.
+    // sessionStorage may be unavailable (e.g. Safari private mode). Without it
+    // we can't guard against a reload loop, so fail safe and don't reload.
+    return false;
   }
 
   window.location.reload();

--- a/app/utils/lazyWithRetry.ts
+++ b/app/utils/lazyWithRetry.ts
@@ -32,6 +32,11 @@ function retry<T extends React.ComponentType<any>>(
       .catch((error) => {
         setTimeout(() => {
           if (retriesLeft === 1) {
+            // Retrying a removed chunk is futile, the only recovery is to
+            // reload and fetch a fresh index.html with current chunk URLs.
+            if (reloadIfStaleChunk(error)) {
+              return;
+            }
             reject(error);
             return;
           }
@@ -39,4 +44,39 @@ function retry<T extends React.ComponentType<any>>(
         }, interval);
       });
   });
+}
+
+const reloadSessionKey = "chunkReload";
+
+/**
+ * Reloads the page when a dynamic import fails because the chunk no longer
+ * exists, typically after a deploy left an open tab referencing stale URLs.
+ * Guarded so it only reloads once per session to avoid reload loops.
+ *
+ * @param error The error thrown by the failed dynamic import.
+ * @returns Whether a reload was triggered.
+ */
+function reloadIfStaleChunk(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  const isChunkError =
+    /Failed to fetch dynamically imported module|Importing a module script failed/i.test(
+      message
+    );
+
+  if (!isChunkError) {
+    return false;
+  }
+
+  try {
+    if (sessionStorage.getItem(reloadSessionKey)) {
+      return false;
+    }
+    sessionStorage.setItem(reloadSessionKey, "1");
+  } catch {
+    // sessionStorage may be unavailable (e.g. Safari private mode); reload
+    // anyway, accepting the small risk of a single extra reload.
+  }
+
+  window.location.reload();
+  return true;
 }

--- a/app/utils/sentry.ts
+++ b/app/utils/sentry.ts
@@ -36,6 +36,7 @@ export function initSentry(history: History) {
     tracesSampleRate: env.ENVIRONMENT === "production" ? 0.1 : 1,
     ignoreErrors: [
       "Failed to fetch dynamically imported module",
+      "Importing a module script failed",
       "ResizeObserver loop completed with undelivered notifications",
       "ResizeObserver loop limit exceeded",
       "Object Not Found Matching Id",


### PR DESCRIPTION
It is possible for outdated index to not be able to load previous chunks, particularly in cloud hosted with continuous deployment - this adds an improved recovery path with guard against reload loop