### PR TITLE
fix: Remove separate editing guard on Rename action

### DIFF
--- a/app/hooks/useDocumentMenuAction.tsx
+++ b/app/hooks/useDocumentMenuAction.tsx
@@ -91,7 +91,7 @@ export function useDocumentMenuAction({
         name: `${t("Rename")}…`,
         section: ActiveDocumentSection,
         icon: <InputIcon />,
-        visible: !!can.update && !user.separateEditMode && !!onRename,
+        visible: !!can.update && !!onRename,
         perform: () => requestAnimationFrame(() => onRename?.()),
       }),
       shareDocument,


### PR DESCRIPTION
Related #12845