### PR TITLE
feat(storage): add explicit bucket-bound S3 custom domain support

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -118,6 +118,9 @@ AWS_S3_ACCELERATE_URL=
 AWS_S3_UPLOAD_BUCKET_URL=http://s3:4569
 AWS_S3_UPLOAD_BUCKET_NAME=bucket_name_here
 AWS_S3_FORCE_PATH_STYLE=true
+# Set to true when AWS_S3_UPLOAD_BUCKET_URL is a custom domain bound to a single
+# bucket (e.g. a CDN or COS custom domain). Public URLs omit the bucket path.
+AWS_S3_BUCKET_BOUND_ENDPOINT=false
 AWS_S3_ACL=private
 # Which HTTP method to use for presigned uploads. "post" (default) uses the
 # traditional S3 presigned POST with multipart form data. "put" uses a single

--- a/server/env.ts
+++ b/server/env.ts
@@ -702,6 +702,16 @@ export class Environment {
   );
 
   /**
+   * Whether AWS_S3_UPLOAD_BUCKET_URL is a custom domain bound to a single bucket.
+   * When true, public URLs omit the bucket path prefix and presigned GET URLs are
+   * signed against the domain root.
+   */
+  @IsOptional()
+  public AWS_S3_BUCKET_BOUND_ENDPOINT = this.toBoolean(
+    environment.AWS_S3_BUCKET_BOUND_ENDPOINT ?? "false"
+  );
+
+  /**
    * Set default AWS S3 ACL for file attachments.
    */
   @IsOptional()

--- a/server/storage/files/S3Storage.bucketBoundEndpoint.test.ts
+++ b/server/storage/files/S3Storage.bucketBoundEndpoint.test.ts
@@ -1,0 +1,181 @@
+import type S3Storage from "./S3Storage";
+
+const {
+  mockEnv,
+  mockS3ClientConstructor,
+  mockGetSignedUrl,
+  customDomainUrl,
+  bucketName,
+  objectKey,
+} = vi.hoisted(() => {
+  const customDomainUrl = "https://files.example.com";
+  const bucketName = "attachments";
+  const objectKey = "uploads/user-id/attachment-id/photo.png";
+
+  return {
+    customDomainUrl,
+    bucketName,
+    objectKey,
+    mockEnv: {
+      AWS_CLOUDFRONT_URL: undefined as string | undefined,
+      AWS_CLOUDFRONT_KEY_PAIR_ID: undefined as string | undefined,
+      AWS_CLOUDFRONT_PRIVATE_KEY: undefined as string | undefined,
+      AWS_S3_UPLOAD_BUCKET_URL: customDomainUrl,
+      AWS_S3_UPLOAD_BUCKET_NAME: bucketName,
+      AWS_S3_ACCELERATE_URL: "",
+      AWS_S3_BUCKET_BOUND_ENDPOINT: false,
+      AWS_REGION: "us-east-1",
+      AWS_S3_FORCE_PATH_STYLE: false,
+      AWS_S3_ACL: "private",
+    },
+    mockS3ClientConstructor: vi.fn(),
+    mockGetSignedUrl: vi.fn().mockResolvedValue(`${customDomainUrl}/key`),
+  };
+});
+
+vi.mock("@server/env", () => ({
+  default: mockEnv,
+}));
+
+vi.mock("@aws-sdk/signature-v4-crt", () => ({}));
+
+vi.mock("@aws-sdk/s3-request-presigner", () => ({
+  getSignedUrl: mockGetSignedUrl,
+}));
+
+vi.mock("@aws-sdk/s3-presigned-post", () => ({
+  createPresignedPost: vi.fn().mockResolvedValue({ url: "", fields: {} }),
+}));
+
+vi.mock("@aws-sdk/client-s3", () => ({
+  S3Client: class MockS3Client {
+    constructor(config: unknown) {
+      mockS3ClientConstructor(config);
+    }
+    send = vi.fn();
+  },
+  DeleteObjectCommand: vi.fn(),
+  GetObjectCommand: vi.fn(),
+  HeadObjectCommand: vi.fn(),
+  CopyObjectCommand: vi.fn(),
+  PutObjectCommand: vi.fn(),
+}));
+
+const defaultEnv = {
+  AWS_S3_UPLOAD_BUCKET_URL: customDomainUrl,
+  AWS_S3_UPLOAD_BUCKET_NAME: bucketName,
+  AWS_S3_ACCELERATE_URL: "",
+  AWS_S3_BUCKET_BOUND_ENDPOINT: false,
+  AWS_S3_FORCE_PATH_STYLE: false,
+};
+
+async function loadStorage(
+  overrides: Partial<typeof mockEnv> = {}
+): Promise<typeof S3Storage> {
+  vi.resetModules();
+  mockS3ClientConstructor.mockReset();
+  Object.assign(mockEnv, defaultEnv, overrides);
+  return (await import("./S3Storage")).default;
+}
+
+describe("S3Storage bucket-bound endpoint", () => {
+  let Storage: typeof S3Storage;
+
+  beforeEach(async () => {
+    mockGetSignedUrl.mockReset();
+    mockGetSignedUrl.mockResolvedValue(`${customDomainUrl}/key`);
+    Storage = await loadStorage({ AWS_S3_BUCKET_BOUND_ENDPOINT: true });
+  });
+
+  it("should use path-style API calls with the real bucket name", () => {
+    new Storage();
+
+    expect(mockS3ClientConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bucketEndpoint: false,
+        forcePathStyle: true,
+        endpoint: customDomainUrl,
+        region: "us-east-1",
+      })
+    );
+  });
+
+  it("should build path-style upload URLs on bucket-bound endpoints", () => {
+    const storage = new Storage();
+
+    expect(storage.getUploadUrl()).toBe(`${customDomainUrl}/${bucketName}`);
+  });
+
+  it("should sign download URLs at the domain root", async () => {
+    const { GetObjectCommand } = await import("@aws-sdk/client-s3");
+    const storage = new Storage();
+
+    await storage.getSignedUrl(objectKey);
+
+    expect(mockS3ClientConstructor).toHaveBeenCalledTimes(2);
+    expect(mockS3ClientConstructor).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        bucketEndpoint: false,
+        forcePathStyle: true,
+      })
+    );
+    expect(mockS3ClientConstructor).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        bucketEndpoint: true,
+        forcePathStyle: false,
+        endpoint: customDomainUrl,
+      })
+    );
+    expect(GetObjectCommand).toHaveBeenCalledWith({
+      Bucket: customDomainUrl,
+      Key: objectKey,
+    });
+    expect(mockGetSignedUrl).toHaveBeenCalled();
+  });
+
+  it("should build public object URLs without a bucket path prefix", () => {
+    const storage = new Storage();
+
+    expect(storage.getUrlForKey(objectKey)).toBe(
+      `${customDomainUrl}/${objectKey}`
+    );
+  });
+
+  it("should use standard path-style URLs when bucket-bound is disabled", async () => {
+    Storage = await loadStorage({
+      AWS_S3_BUCKET_BOUND_ENDPOINT: false,
+      AWS_S3_UPLOAD_BUCKET_URL: "https://abc123.r2.cloudflarestorage.com",
+      AWS_S3_FORCE_PATH_STYLE: true,
+    });
+    const storage = new Storage();
+
+    expect(mockS3ClientConstructor).toHaveBeenCalledTimes(1);
+    expect(mockS3ClientConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bucketEndpoint: false,
+        forcePathStyle: true,
+      })
+    );
+    expect(storage.getUploadUrl()).toBe(
+      `https://abc123.r2.cloudflarestorage.com/${bucketName}`
+    );
+  });
+
+  it("should enable bucketEndpoint only for AWS transfer acceleration", async () => {
+    Storage = await loadStorage({
+      AWS_S3_BUCKET_BOUND_ENDPOINT: false,
+      AWS_S3_ACCELERATE_URL: "https://bucket.s3-accelerate.amazonaws.com",
+    });
+    new Storage();
+
+    expect(mockS3ClientConstructor).toHaveBeenCalledTimes(1);
+    expect(mockS3ClientConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bucketEndpoint: true,
+        endpoint: "https://bucket.s3-accelerate.amazonaws.com",
+      })
+    );
+  });
+});

--- a/server/storage/files/S3Storage.ts
+++ b/server/storage/files/S3Storage.ts
@@ -33,12 +33,24 @@ export default class S3Storage extends BaseStorage {
     // https://github.com/aws/aws-sdk-js-v3#functionality-requiring-aws-common-runtime-crt
     require("@aws-sdk/signature-v4-crt");
 
+    const bucketBound = env.AWS_S3_BUCKET_BOUND_ENDPOINT;
+
     this.client = new S3Client({
-      bucketEndpoint: env.AWS_S3_ACCELERATE_URL ? true : false,
-      forcePathStyle: env.AWS_S3_FORCE_PATH_STYLE,
+      bucketEndpoint: !!env.AWS_S3_ACCELERATE_URL,
+      forcePathStyle: bucketBound ? true : env.AWS_S3_FORCE_PATH_STYLE,
       region: env.AWS_REGION,
       endpoint: this.getEndpoint(),
     });
+
+    // bucket-bound custom domains need bucketEndpoint for presigned GET URLs
+    if (bucketBound) {
+      this.downloadSigningClient = new S3Client({
+        bucketEndpoint: true,
+        forcePathStyle: false,
+        region: env.AWS_REGION,
+        endpoint: this.getEndpoint(),
+      });
+    }
   }
 
   public async getPresignedPost(
@@ -127,6 +139,10 @@ export default class S3Storage extends BaseStorage {
       "AWS_S3_UPLOAD_BUCKET_NAME is required"
     );
 
+    if (env.AWS_S3_BUCKET_BOUND_ENDPOINT) {
+      return this.getBucketUrl().base;
+    }
+
     // lose trailing slash if there is one and convert fake-s3 url to localhost
     // for access outside of docker containers in local development
     const isDocker = env.AWS_S3_UPLOAD_BUCKET_URL.match(/http:\/\/s3:/);
@@ -138,9 +154,10 @@ export default class S3Storage extends BaseStorage {
 
     // support old path-style S3 uploads and new virtual host uploads by checking
     // for the bucket name in the endpoint url before appending.
-    const isVirtualHost = host.includes(env.AWS_S3_UPLOAD_BUCKET_NAME);
+    const hostname = new URL(host.startsWith("http") ? host : `https://${host}`)
+      .hostname;
 
-    if (isVirtualHost) {
+    if (this.isVirtualHostBucketUrl(hostname)) {
       return host;
     }
 
@@ -150,6 +167,10 @@ export default class S3Storage extends BaseStorage {
   }
 
   public getUploadUrl(isServerUpload?: boolean) {
+    if (env.AWS_S3_BUCKET_BOUND_ENDPOINT) {
+      return `${this.getBucketUrl().base}/${env.AWS_S3_UPLOAD_BUCKET_NAME}`;
+    }
+
     return this.getPublicEndpoint(isServerUpload);
   }
 
@@ -323,6 +344,8 @@ export default class S3Storage extends BaseStorage {
 
   private client: S3Client;
 
+  private downloadSigningClient?: S3Client;
+
   private getCloudFrontUrlForKey(key: string): string {
     if (!env.AWS_CLOUDFRONT_URL) {
       throw new Error("CloudFront URL is not configured");
@@ -350,7 +373,7 @@ export default class S3Storage extends BaseStorage {
   ) => {
     const isDocker = env.AWS_S3_UPLOAD_BUCKET_URL.match(/http:\/\/s3:/);
     const params = {
-      Bucket: this.getBucket(),
+      Bucket: this.getBucket({ forSigning: true }),
       Key: key,
     };
 
@@ -362,9 +385,13 @@ export default class S3Storage extends BaseStorage {
     const clampedExpiresIn = Math.min(expiresIn, S3Storage.maxSignedUrlExpires);
 
     const command = new GetObjectCommand(params);
-    const url = await getSignedUrl(this.client, command, {
-      expiresIn: clampedExpiresIn,
-    });
+    const url = await getSignedUrl(
+      this.downloadSigningClient ?? this.client,
+      command,
+      {
+        expiresIn: clampedExpiresIn,
+      }
+    );
 
     if (env.AWS_S3_ACCELERATE_URL) {
       return url.replace(
@@ -400,7 +427,27 @@ export default class S3Storage extends BaseStorage {
     return env.AWS_S3_UPLOAD_BUCKET_URL;
   }
 
-  private getBucket() {
-    return env.AWS_S3_ACCELERATE_URL || env.AWS_S3_UPLOAD_BUCKET_NAME || "";
+  private getBucket(options?: { forSigning?: boolean }) {
+    if (env.AWS_S3_ACCELERATE_URL) {
+      return env.AWS_S3_ACCELERATE_URL;
+    }
+
+    if (options?.forSigning && env.AWS_S3_BUCKET_BOUND_ENDPOINT) {
+      return this.getBucketUrl().base;
+    }
+
+    return env.AWS_S3_UPLOAD_BUCKET_NAME || "";
+  }
+
+  private getBucketUrl() {
+    const base = env.AWS_S3_UPLOAD_BUCKET_URL.replace(/\/$/, "");
+    return { base, hostname: new URL(base).hostname };
+  }
+
+  private isVirtualHostBucketUrl(hostname: string) {
+    return (
+      !!env.AWS_S3_UPLOAD_BUCKET_NAME &&
+      hostname.startsWith(`${env.AWS_S3_UPLOAD_BUCKET_NAME}.`)
+    );
   }
 }


### PR DESCRIPTION
## Background

Outline's S3 storage layer was designed around standard AWS S3 and common S3-compatible endpoints (path-style or virtual-hosted bucket URLs). Many teams instead serve files through a **custom domain bound to a single bucket**—for example a Tencent COS CNAME or a CDN origin hostname.

With that setup, upload and download do not follow the same URL shape:

| Operation | Expected URL on a bucket-bound custom domain |
|-----------|-----------------------------------------------|
| Presigned POST upload | `https://files.example.com/{bucket}` (path-style API) |
| Public / presigned GET | `https://files.example.com/{key}` (object at domain root) |

The existing implementation always treats `AWS_S3_UPLOAD_BUCKET_URL` like a generic S3 endpoint. When pointed at a custom domain:

- **Presigned GET URLs** are signed with path-style semantics (`/{bucket}/{key}`), which returns **404** on a CNAME that serves objects at `/{key}`.
- **Public URLs** from `getUrlForKey()` incorrectly include the bucket name in the path.

This breaks private attachments end-to-end: uploads may succeed, but images fail to load after redirect.

An explicit opt-in flag is preferable to hostname heuristics so existing deployments (AWS S3, Cloudflare R2, DigitalOcean Spaces, MinIO, etc.) remain unchanged.

## What changed

- Add `AWS_S3_BUCKET_BOUND_ENDPOINT` (default `false`).
- When enabled:
  - API calls (upload, delete, copy, etc.) use path-style with the real bucket name.
  - Public URLs omit the bucket path prefix.
  - Presigned GET URLs use a dedicated signing client with `bucketEndpoint: true` so objects are addressed at the domain root.
- Document the flag in `.env.sample`.
- Add unit tests in `S3Storage.bucketBoundEndpoint.test.ts` covering bucket-bound behavior, unchanged R2-style endpoints with the flag off, and AWS Transfer Acceleration.

### Example configuration (COS custom domain)

```env
AWS_S3_UPLOAD_BUCKET_URL=https://files.example.com
AWS_S3_UPLOAD_BUCKET_NAME=my-bucket
AWS_S3_FORCE_PATH_STYLE=true
AWS_S3_BUCKET_BOUND_ENDPOINT=true
```

## Test plan

- [x] `yarn test server/storage/files/S3Storage.bucketBoundEndpoint.test.ts`
- [x] Set `AWS_S3_BUCKET_BOUND_ENDPOINT=true` with a COS/CDN custom domain; verify upload returns 204 and images load via `attachments.redirect`
- [x] Confirm R2/Spaces/AWS deployments with the flag unset behave as before