### PR TITLE
fix(mcp): return text content for empty list tool results

### DIFF
--- a/server/test/McpHelper.ts
+++ b/server/test/McpHelper.ts
@@ -120,3 +120,25 @@ export async function callMcpTool(
       }
     | undefined;
 }
+
+/**
+ * Parses list-style MCP tool content blocks into an array of items.
+ * Zero-result list tools return a single `[]` sentinel block instead of
+ * an empty content array.
+ *
+ * @param content - the content blocks from an MCP tool result.
+ * @returns the parsed list items.
+ */
+export function parseMcpListContent<T = unknown>(
+  content: { text?: string }[] | undefined
+): T[] {
+  if (!content?.length) {
+    return [];
+  }
+
+  if (content.length === 1 && content[0]?.text === "[]") {
+    return [];
+  }
+
+  return content.map((c) => JSON.parse(c.text ?? "{}") as T);
+}

--- a/server/tools/collections.test.ts
+++ b/server/tools/collections.test.ts
@@ -13,16 +13,17 @@ describe("collection tools", () => {
     });
 
     const res = await callMcpTool(server, accessToken, "list_collections");
-    const data = parseMcpListContent<{ id: string }>(res?.result?.content);
+    const data = parseMcpListContent<{ id: string; url: string }>(
+      res?.result?.content
+    );
 
     expect(data.length).toBeGreaterThanOrEqual(1);
-    const ids = data.map((c: { id: string }) => c.id);
+    const ids = data.map((c) => c.id);
     expect(ids).toContain(collection.id);
 
-    const match = data.find((c: { id: string }) => c.id === collection.id) as {
-      url: string;
-    };
-    expect(match.url).toMatch(/^https?:\/\//);
+    const match = data.find((c) => c.id === collection.id);
+    expect(match).toBeDefined();
+    expect(match!.url).toMatch(/^https?:\/\//);
   });
 
   it("list_collections does not return collections from another team", async () => {

--- a/server/tools/collections.test.ts
+++ b/server/tools/collections.test.ts
@@ -1,6 +1,6 @@
 import { buildCollection, buildUser } from "@server/test/factories";
 import { getTestServer } from "@server/test/support";
-import { buildOAuthUser, callMcpTool } from "@server/test/McpHelper";
+import { buildOAuthUser, callMcpTool, parseMcpListContent } from "@server/test/McpHelper";
 
 const server = getTestServer();
 
@@ -13,9 +13,7 @@ describe("collection tools", () => {
     });
 
     const res = await callMcpTool(server, accessToken, "list_collections");
-    const data = (res?.result?.content ?? []).map((c: { text: string }) =>
-      JSON.parse(c.text)
-    );
+    const data = parseMcpListContent<{ id: string }>(res?.result?.content);
 
     expect(data.length).toBeGreaterThanOrEqual(1);
     const ids = data.map((c: { id: string }) => c.id);
@@ -36,9 +34,7 @@ describe("collection tools", () => {
     });
 
     const res = await callMcpTool(server, accessToken, "list_collections");
-    const data = (res?.result?.content ?? []).map((c: { text: string }) =>
-      JSON.parse(c.text)
-    );
+    const data = parseMcpListContent<{ id: string }>(res?.result?.content);
 
     const ids = data.map((c: { id: string }) => c.id);
     expect(ids).not.toContain(otherCollection.id);

--- a/server/tools/documents.test.ts
+++ b/server/tools/documents.test.ts
@@ -10,7 +10,7 @@ import {
 } from "@server/test/factories";
 import { Document, GroupMembership, UserMembership } from "@server/models";
 import { getTestServer } from "@server/test/support";
-import { buildOAuthUser, callMcpTool } from "@server/test/McpHelper";
+import { buildOAuthUser, callMcpTool, parseMcpListContent } from "@server/test/McpHelper";
 
 const server = getTestServer();
 
@@ -198,12 +198,15 @@ describe("list_documents", () => {
       query: privateDocument.urlId,
     });
 
-    const data = (res?.result?.content ?? []).map((c: { text?: string }) =>
-      JSON.parse(c.text ?? "{}")
+    expect(res?.result?.content).toEqual([{ type: "text", text: "[]" }]);
+
+    const data = parseMcpListContent<{ document: { id: string } }>(
+      res?.result?.content
     );
-    const ids = data.map((d: { document: { id: string } }) => d.document.id);
+    const ids = data.map((d) => d.document.id);
 
     expect(res?.result?.isError).not.toBe(true);
+    expect(ids).toHaveLength(0);
     expect(ids).not.toContain(privateDocument.id);
   });
 

--- a/server/tools/util.test.ts
+++ b/server/tools/util.test.ts
@@ -9,6 +9,7 @@ import {
   buildBreadcrumb,
   getBreadcrumbsForDocuments,
   optionalString,
+  success,
 } from "./util";
 
 const node = (
@@ -20,6 +21,29 @@ const node = (
   title,
   url: `/doc/${id}`,
   children,
+});
+
+describe("success", () => {
+  it("returns a text block for empty list results", () => {
+    expect(success([])).toEqual({
+      content: [{ type: "text", text: "[]" }],
+    });
+  });
+
+  it("returns one text block per list item", () => {
+    expect(success([{ id: "a" }, { id: "b" }])).toEqual({
+      content: [
+        { type: "text", text: JSON.stringify({ id: "a" }) },
+        { type: "text", text: JSON.stringify({ id: "b" }) },
+      ],
+    });
+  });
+
+  it("wraps a single object in one text block", () => {
+    expect(success({ success: true })).toEqual({
+      content: [{ type: "text", text: JSON.stringify({ success: true }) }],
+    });
+  });
 });
 
 describe("buildBreadcrumb", () => {

--- a/server/tools/util.ts
+++ b/server/tools/util.ts
@@ -74,6 +74,12 @@ export function optionalString() {
 export function success<T>(data: T | T[]): CallToolResult {
   const payload = Array.isArray(data) ? data : [data];
 
+  if (payload.length === 0) {
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify([]) }],
+    };
+  }
+
   return {
     content: payload.map((item) => ({
       type: "text" as const,

--- a/server/tools/util.ts
+++ b/server/tools/util.ts
@@ -68,6 +68,9 @@ export function optionalString() {
 /**
  * Helper function to format successful MCP tool responses.
  *
+ * Empty arrays return a single `[]` text block so MCP clients that reject
+ * `content: []` can still distinguish zero results from a broken response.
+ *
  * @param data - the data to include in the response.
  * @returns a formatted response object for MCP tools.
  */


### PR DESCRIPTION
## Summary

When MCP list tools return zero items, `success([])` previously produced `{ content: [] }`. Anthropic's MCP connector rejects that format and surfaces a misleading API error instead of "no results."

This change returns a single JSON text block (`[]`) for empty list payloads so clients can distinguish zero results from a broken tool response.

## Motivation

Fixes #12858. The issue author confirmed the preferred approach is a shared guard in `success()` rather than per-tool handling.

## Changes

- Guard empty arrays in `server/tools/util.ts` `success()` helper
- Add unit tests for empty, multi-item, and single-object responses
- Add `parseMcpListContent` test helper for the `[]` sentinel block
- Update integration tests that can receive zero list results

## Tests

- `yarn test:server server/tools/util.test.ts` — 13 passed (3 new `success` tests + existing unit tests; DB integration tests require PostgreSQL)
- `yarn lint server/tools/util.ts server/tools/util.test.ts` — no new issues in changed files

## Notes

- Applies to all list-style MCP tools (`list_documents`, `list_collections`, `list_collection_documents`, `list_users`, `list_templates`, etc.)
- Non-empty list responses are unchanged (one text block per item)
- Empty collection trees still return a single `[]` block, which is the machine-readable equivalent of zero items