### PR TITLE
fix: mermaid Ctrl+Enter edit shortcut not working on Windows

### DIFF
--- a/shared/editor/extensions/Mermaid.ts
+++ b/shared/editor/extensions/Mermaid.ts
@@ -18,6 +18,7 @@ import type { Editor } from "../../../app/editor";
 import { LightboxImageFactory } from "../lib/Lightbox";
 import { hashString } from "../../utils/string";
 import { sanitizeUrl } from "../../utils/urls";
+import { isModKey } from "../../utils/keyboard";
 
 export const pluginKey = new PluginKey("mermaid");
 
@@ -523,7 +524,7 @@ export default function Mermaid({
         return this.getState(state)?.decorationSet;
       },
       handleKeyDown(view, event) {
-        if (event.key === "Enter" && event.metaKey && !editor.props.readOnly) {
+        if (event.key === "Enter" && isModKey(event) && !editor.props.readOnly) {
           const { selection } = view.state;
           const isNodeSel = selection instanceof NodeSelection;
           const isMermaidNode =


### PR DESCRIPTION
The keydown handler that enters mermaid edit mode only checked
event.metaKey, which corresponds to Cmd on macOS but the Windows/Super
key on other platforms. On Windows the shortcut is Ctrl+Enter, which
sets event.ctrlKey instead, so the handler never fired.

Use the platform-aware isModKey helper so the check matches Cmd on
macOS and Ctrl elsewhere, consistent with the displayed shortcut.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HEPoMq8Pdc7d1vW4rZE8b7