### PR TITLE
fix: Ensure accessible name to search and text inputs

### DIFF
--- a/app/components/Input.tsx
+++ b/app/components/Input.tsx
@@ -296,6 +296,16 @@ function Input(
 
   const wrappedLabel = <LabelText>{label}</LabelText>;
 
+  // Ensure the control always has an accessible name. When no visible or
+  // visually-hidden label is provided, fall back to the placeholder text so
+  // that screen readers announce a persistent name for the field. A caller
+  // supplied aria-label/aria-labelledby (spread via rest) still takes
+  // precedence over this fallback.
+  const fallbackAriaLabel =
+    !label && typeof props.placeholder === "string"
+      ? props.placeholder
+      : undefined;
+
   return (
     <Wrapper className={className} short={short} flex={flex}>
       <label>
@@ -321,6 +331,7 @@ function Input(
               $autoSize={autoSize}
               $minHeight={minHeight}
               $maxHeight={maxHeight}
+              aria-label={fallbackAriaLabel}
               {...rest}
               // set it after "rest" to override props from spread.
               maxLength={maxLength}
@@ -338,6 +349,7 @@ function Input(
               hasIcon={!!icon}
               hasPrefix={!!prefix}
               type={type}
+              aria-label={fallbackAriaLabel}
               {...rest}
               // set it after "rest" to override "onKeyDown" and "onChange" from prop.
               maxLength={maxLength}

--- a/app/components/Sharing/components/SearchInput.tsx
+++ b/app/components/Sharing/components/SearchInput.tsx
@@ -60,6 +60,7 @@ export const SearchInput = React.forwardRef(function SearchInput_(
         <NativeInput
           key="input"
           ref={mergeRefs([inputRef, ref])}
+          aria-label={`${t("Add or invite")}…`}
           placeholder={`${t("Add or invite")}…`}
           value={query}
           onChange={onChange}


### PR DESCRIPTION
The global search field and other inputs relied solely on a placeholder for their label. Placeholder text disappears on focus and is not reliably announced as a persistent field name by screen readers, failing WCAG 1.3.1 (Info and Relationships).

closes #12868