### PR TITLE
fix(notion): recover from expired search cursor in large workspaces

### DIFF
--- a/plugins/notion/server/notion.ts
+++ b/plugins/notion/server/notion.ts
@@ -207,24 +207,52 @@ export class NotionClient {
 
   async fetchRootPages() {
     const pages: Page[] = [];
+    const seen = new Set<string>();
+    const maxRestarts = 3;
 
     let cursor: string | undefined;
     let hasMore = true;
+    let restarts = 0;
 
     while (hasMore) {
-      const response = await this.fetchWithRetry(() =>
-        this.client.search({
-          start_cursor: cursor,
-          page_size: this.pageSize,
-        })
-      );
+      let response;
+      try {
+        response = await this.fetchWithRetry(() =>
+          this.client.search({
+            start_cursor: cursor,
+            page_size: this.pageSize,
+          })
+        );
+      } catch (error) {
+        // The Notion search cursor has an undocumented TTL. For large workspaces
+        // (10 000+ pages) pagination can take long enough that the cursor expires
+        // mid-way through, producing a ValidationError. Restart from the
+        // beginning and skip IDs we have already collected.
+        if (
+          error instanceof APIResponseError &&
+          error.code === APIErrorCode.ValidationError &&
+          cursor !== undefined &&
+          restarts < maxRestarts
+        ) {
+          restarts++;
+          Logger.info(
+            "task",
+            `Notion search cursor expired, restarting from the beginning (restart ${restarts}/${maxRestarts})`
+          );
+          cursor = undefined;
+          hasMore = true;
+          continue;
+        }
+        throw error;
+      }
 
       response.results.forEach((item) => {
         if (!isFullPageOrDatabase(item)) {
           return;
         }
 
-        if (item.parent.type === "workspace") {
+        if (item.parent.type === "workspace" && !seen.has(item.id)) {
+          seen.add(item.id);
           pages.push({
             type: item.object === "page" ? PageType.Page : PageType.Database,
             id: item.id,


### PR DESCRIPTION
Fixes #11573

## Problem

The Notion search API cursor has an undocumented TTL. For workspaces with 10 000+ pages, `fetchRootPages()` paginates through every page in the workspace to find workspace-level items (because Notion has no server-side `parent.type === "workspace"` filter). At 3 req/s with `pageSize: 100`, a 15k-page workspace takes ~50 seconds — long enough for the cursor to expire mid-way through:

```
Failed: The start_cursor provided is invalid: 4d49987c-a64c-4ab8-916e-d9aeaffa265b
```

`fetchWithRetry` handles rate limits and timeouts but not cursor expiration, so the import fails with no recovery path.

## Fix

When `fetchRootPages()` receives a `ValidationError` with a non-null cursor (cursor-expired signature), it:

1. Logs the restart event for observability.
2. Resets `cursor` to `undefined` and restarts the search from the beginning.
3. Uses a `Set<string>` of already-seen IDs to skip duplicates and avoid regressing pages already collected before the cursor expired.
4. Allows up to 3 restarts before surfacing the error — enough to cover cursor TTL variance while bounding worst-case time.

No changes to the `fetchWithRetry` machinery; the cursor-expiry case is handled inline in `fetchRootPages` where the context (the `seen` set) lives.