### PR TITLE
fix(mermaid): use opacity:0 render container to fix foreignObject sizing

### DIFF
--- a/shared/editor/extensions/Mermaid.ts
+++ b/shared/editor/extensions/Mermaid.ts
@@ -28,9 +28,9 @@ export type MermaidState = {
   editingId?: string;
 };
 
-// The `v2` namespace discards entries cached before the #11782 fix, so
+// The `v3` namespace discards entries cached before the foreignObject fix, so
 // previously mis-sized diagrams are re-rendered instead of served from cache.
-const STORAGE_PREFIX = "mermaid:v2:";
+const STORAGE_PREFIX = "mermaid:v3:";
 const MAX_STORAGE_ENTRIES = 20;
 
 class Cache {
@@ -160,16 +160,22 @@ class MermaidRenderer {
       return;
     }
 
-    // Create a temporary element for rendering. We use visibility:hidden instead of
-    // offscreen positioning so the browser computes correct bounding boxes for SVG
-    // elements — offscreen elements can produce incorrect getBBox() results, leading
-    // to wrong viewBox dimensions (see mermaid-js/mermaid#6146).
+    // Create a temporary element for rendering. We use opacity:0 instead of
+    // visibility:hidden because browsers skip layout of <foreignObject> content
+    // inside visibility:hidden SVGs, causing mermaid's layout engine to measure
+    // zero-size nodes and produce inflated viewBox dimensions for diagram types
+    // that use foreignObject-based text (classDiagram, erDiagram,
+    // requirementDiagram). opacity:0 keeps the element in the render tree and
+    // fully laid out without being visible to the user. We previously used
+    // offscreen positioning (left:-9999px) which broke getBBox() in Chromium
+    // (mermaid-js/mermaid#6146); opacity:0 avoids both problems.
     const renderElement = document.createElement("div");
     const tempId =
       "offscreen-mermaid-" + Math.random().toString(36).substr(2, 9);
     renderElement.id = tempId;
     renderElement.style.position = "fixed";
-    renderElement.style.visibility = "hidden";
+    renderElement.style.opacity = "0";
+    renderElement.style.pointerEvents = "none";
     renderElement.style.top = "0";
     renderElement.style.left = "0";
     const width = this.editor.view?.dom.clientWidth ?? window.innerWidth;


### PR DESCRIPTION
Fixes #12812

## Root cause

`classDiagram`, `erDiagram`, and `requirementDiagram` render node labels using `<foreignObject>` elements. Browsers skip layout computation for `<foreignObject>` content inside a `visibility:hidden` SVG — when mermaid calls `getBBox()` on those nodes to drive the dagre/ELK layout, it gets zero-size boxes and the layout engine distributes elements across a canvas that is orders of magnitude too large.

The symptom is a viewBox like `0 0 7401 5966` for a three-class diagram that should fit in ~400×300.

## Fix

Replace `visibility: hidden` with `opacity: 0` + `pointer-events: none` on the render container.

`opacity: 0` keeps the element fully in the render tree — layout, paint, and `getBBox()` all run normally for both regular SVG shapes and `<foreignObject>` content. The user sees nothing because the element is transparent and behind everything (z-index: -1).

The previous switch from `position: absolute; left: -9999px` → `visibility: hidden` fixed Chromium's `getBBox()` bug for off-screen elements (mermaid-js/mermaid#6146). `opacity: 0` avoids both that bug and the `foreignObject` layout-skip issue.

The session-storage cache prefix is bumped from `v2` → `v3` so any incorrectly-sized diagrams cached by the previous render path are discarded and re-rendered with the fix.