### PR TITLE
fix: Serialize API and imported markdown hard breaks as double spaces

### DIFF
--- a/server/commands/documentImporter.test.ts
+++ b/server/commands/documentImporter.test.ts
@@ -214,6 +214,24 @@ describe("documentImporter", () => {
     expect(response.title).toEqual("Title");
   });
 
+  it("should preserve hard breaks as trailing double spaces in markdown imports", async () => {
+    const user = await buildUser();
+    const fileName = "markdown.md";
+    const content = "# Title\n\nLine one  \nLine two";
+    const response = await sequelize.transaction((transaction) =>
+      documentImporter({
+        user,
+        mimeType: "text/plain",
+        fileName,
+        content,
+        ctx: createContext({ user, transaction }),
+      })
+    );
+
+    expect(response.text).toEqual("Line one  \nLine two");
+    expect(response.title).toEqual("Title");
+  });
+
   it("should convert frontmatter to yaml codeblock", async () => {
     const user = await buildUser();
     const fileName = "markdown-frontmatter.md";

--- a/server/commands/documentImporter.ts
+++ b/server/commands/documentImporter.ts
@@ -83,7 +83,11 @@ async function documentImporter({
   );
 
   // Serialize final text and handle empty documents
-  let text = serializer.serialize(processedDoc).trim();
+  let text = serializer
+    .serialize(processedDoc, {
+      commonMark: true,
+    })
+    .trim();
   // Empty paragraphs serialize to escaped newlines/backslashes, treat as empty
   if (/^[\\\s]*$/.test(text)) {
     text = "";

--- a/server/models/helpers/DocumentHelper.test.ts
+++ b/server/models/helpers/DocumentHelper.test.ts
@@ -561,6 +561,37 @@ This is a [test paragraph](https://example.net)`,
       expect(result).toContain("2. second");
     });
 
+    it("should export hard breaks as trailing double spaces", async () => {
+      const document = await buildDocument({
+        content: {
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "text",
+                  text: "Line one",
+                },
+                {
+                  type: "br",
+                },
+                {
+                  type: "text",
+                  text: "Line two",
+                },
+              ],
+            },
+          ],
+        },
+      });
+      const result = await DocumentHelper.toMarkdown(document, {
+        includeTitle: false,
+      });
+
+      expect(result).toBe("Line one  \nLine two");
+    });
+
     it("should pad table cells to match header width", async () => {
       const document = await buildDocument({
         content: {

--- a/server/models/helpers/DocumentHelper.tsx
+++ b/server/models/helpers/DocumentHelper.tsx
@@ -209,7 +209,9 @@ export class DocumentHelper {
     }
 
     const text = serializer
-      .serialize(node)
+      .serialize(node, {
+        commonMark: true,
+      })
       .replace(/(^|\n)\\(\n|$)/g, "\n\n")
       .trim();
 

--- a/server/utils/DocumentConverter.ts
+++ b/server/utils/DocumentConverter.ts
@@ -62,7 +62,11 @@ export class DocumentConverter {
     doc = docWithoutEmoji;
 
     // Serialize to markdown and trim whitespace
-    const text = serializer.serialize(doc).trim();
+    const text = serializer
+      .serialize(doc, {
+        commonMark: true,
+      })
+      .trim();
 
     return {
       text,


### PR DESCRIPTION
Fix to a finding highlighted during .md export/import testing. 

## Summary
- When exporting/pulling a document or importing a Markdown file, hard breaks currently serialize as an internal escaped backslash (`\n`) rather than a standard CommonMark hard break.
- This updates `DocumentHelper`, `DocumentConverter`, and `documentImporter` to serialize with `commonMark: true`, so hard breaks materialize as standard CommonMark trailing double spaces instead.

## Test plan
- [x] `yarn tsc --noEmit`
- [x] `yarn lint`
- [x] `yarn test server/commands/documentImporter.test.ts server/models/helpers/DocumentHelper.test.ts`