### PR TITLE
feat: add MCP tools for importing documents from uploaded files

### DIFF
--- a/server/routes/mcp/index.ts
+++ b/server/routes/mcp/index.ts
@@ -63,6 +63,8 @@ const defaultInstructions = `Document markdown content must not begin with a top
 
 Document and collection markdown support @mentions using the syntax: @[Display Name](mention://user/userId). For example: @[John Doe](mention://user/c9a1b2e3-...). Use the "list_users" tool to find user IDs.
 
+When the user wants to create a document in the document system from an AI-generated or local file, use the same file types accepted by the built-in Import document flow. Use "prepare_document_file_upload" to get a pre-signed upload target, upload the file with the returned uploadUrl and form fields, then use "create_document_from_uploaded_file" with the returned attachment ID and destination. Use "create_attachment" only for files that should be embedded as attachments in documents.
+
 Read images and attachments with the "fetch" tool by setting resource to "attachment" and passing either the attachment ID or an /api/attachments.redirect?id=... URL; the tool will return a signed URL for download.
 
 When asked to create a document that follows a template, use the "list_templates" tool to find a matching template; each result already includes the template body as markdown. To use it unchanged, pass its ID as templateId to "create_document" and the new document is pre-filled from it. To adapt it first, modify the returned body and pass the result as the text parameter to "create_document". Either way no separate fetch is needed.`;

--- a/server/tools/documents.test.ts
+++ b/server/tools/documents.test.ts
@@ -4,12 +4,19 @@ import {
   buildViewer,
   buildCollection,
   buildDocument,
+  buildAttachment,
   buildTemplate,
   buildOAuthAuthentication,
   buildGroup,
 } from "@server/test/factories";
-import { Document, GroupMembership, UserMembership } from "@server/models";
+import {
+  Attachment,
+  Document,
+  GroupMembership,
+  UserMembership,
+} from "@server/models";
 import { getTestServer } from "@server/test/support";
+import DocumentImportTask from "@server/queues/tasks/DocumentImportTask";
 import { buildOAuthUser, callMcpTool } from "@server/test/McpHelper";
 
 const server = getTestServer();
@@ -411,6 +418,285 @@ describe("create_document", () => {
       where: { createdById: user.id },
     });
     expect(documents.length).toEqual(0);
+  });
+});
+
+describe("prepare_document_file_upload", () => {
+  it("creates a temporary upload for a source file", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+
+    const res = await callMcpTool(
+      server,
+      accessToken,
+      "prepare_document_file_upload",
+      {
+        contentType:
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        name: "proposal.docx",
+        size: 1000,
+      }
+    );
+    const data = JSON.parse(res?.result?.content?.[0]?.text ?? "{}");
+
+    expect(res?.result?.isError).toBeUndefined();
+    expect(data.uploadUrl).toMatch(/^https?:\/\//);
+    expect(data.form["Content-Type"]).toEqual(
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    );
+    expect(data.attachment.id).toBeDefined();
+    expect(data.attachment.url).toMatch(/^https?:\/\//);
+    expect(data.curlCommand).toContain(data.uploadUrl);
+
+    const attachment = await Attachment.findByPk(data.attachment.id, {
+      rejectOnEmpty: true,
+    });
+    expect(attachment.name).toEqual("proposal.docx");
+    expect(attachment.contentType).toEqual(
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    );
+    expect(attachment.teamId).toEqual(user.teamId);
+    expect(attachment.userId).toEqual(user.id);
+    expect(attachment.expiresAt).toBeTruthy();
+  });
+
+  it("read-only token does not have document file upload tool", async () => {
+    const user = await buildUser();
+    const auth = await buildOAuthAuthentication({
+      user,
+      scope: [Scope.Read],
+    });
+
+    const res = await callMcpTool(
+      server,
+      auth.accessToken!,
+      "prepare_document_file_upload",
+      {
+        contentType: "text/html",
+        name: "webpage.html",
+        size: 1000,
+      }
+    );
+
+    expect(res?.result?.isError).toBe(true);
+  });
+});
+
+describe("create_document_from_uploaded_file", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not expose legacy document file import tool names", async () => {
+    const { accessToken } = await buildOAuthUser();
+
+    const combinedToolRes = await callMcpTool(
+      server,
+      accessToken,
+      "create_document_from_file",
+      {
+        contentType: "text/html",
+        name: "webpage.html",
+        size: 1000,
+      }
+    );
+    const legacyImportRes = await callMcpTool(
+      server,
+      accessToken,
+      "import_document",
+      {
+        contentType: "text/html",
+        name: "webpage.html",
+        size: 1000,
+      }
+    );
+    const uploadOnlyRes = await callMcpTool(
+      server,
+      accessToken,
+      "create_import_upload",
+      {
+        contentType: "text/html",
+        name: "webpage.html",
+        size: 1000,
+      }
+    );
+
+    expect(combinedToolRes?.result?.isError).toBe(true);
+    expect(legacyImportRes?.result?.isError).toBe(true);
+    expect(uploadOnlyRes?.result?.isError).toBe(true);
+  });
+
+  it("read-only token does not have uploaded file creation tool", async () => {
+    const user = await buildUser();
+    const auth = await buildOAuthAuthentication({
+      user,
+      scope: [Scope.Read],
+    });
+
+    const importRes = await callMcpTool(
+      server,
+      auth.accessToken!,
+      "create_document_from_uploaded_file",
+      {
+        attachmentId: "11111111-1111-4111-8111-111111111111",
+        collectionId: "22222222-2222-4222-8222-222222222222",
+      }
+    );
+
+    expect(importRes?.result?.isError).toBe(true);
+  });
+
+  it("creates a document from an uploaded HTML file in a collection", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const document = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+      title: "Imported Title",
+      text: "Hello from HTML",
+    });
+    const uploadRes = await callMcpTool(
+      server,
+      accessToken,
+      "prepare_document_file_upload",
+      {
+        contentType: "text/html",
+        name: "webpage.html",
+        size: 1000,
+      }
+    );
+    const uploadData = JSON.parse(
+      uploadRes?.result?.content?.[0]?.text ?? "{}"
+    );
+    const attachment = await Attachment.findByPk(uploadData.attachment.id, {
+      rejectOnEmpty: true,
+    });
+    vi.spyOn(DocumentImportTask.prototype, "schedule").mockResolvedValue({
+      finished: vi.fn().mockResolvedValue({ documentId: document.id }),
+    } as unknown as Awaited<ReturnType<DocumentImportTask["schedule"]>>);
+
+    const res = await callMcpTool(
+      server,
+      accessToken,
+      "create_document_from_uploaded_file",
+      {
+        attachmentId: attachment.id,
+        collectionId: collection.id,
+        publish: true,
+      }
+    );
+    const data = JSON.parse(res?.result?.content?.[0]?.text ?? "{}");
+
+    expect(res?.result?.isError).toBeUndefined();
+    expect(data.document.title).toEqual("Imported Title");
+    expect(data.document.collectionId).toEqual(collection.id);
+    expect(data.document.url).toMatch(/^https?:\/\//);
+    expect(res?.result?.content?.[1]?.text).toContain("Hello from HTML");
+  });
+
+  it("queues import for an uploaded document source file", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const document = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+      title: "Queued Import",
+    });
+    const uploadRes = await callMcpTool(
+      server,
+      accessToken,
+      "prepare_document_file_upload",
+      {
+        contentType: "text/html",
+        name: "webpage.html",
+        size: 1000,
+      }
+    );
+    const uploadData = JSON.parse(
+      uploadRes?.result?.content?.[0]?.text ?? "{}"
+    );
+    const attachment = await Attachment.findByPk(uploadData.attachment.id, {
+      rejectOnEmpty: true,
+    });
+    const finished = vi.fn().mockResolvedValue({ documentId: document.id });
+    const schedule = vi
+      .spyOn(DocumentImportTask.prototype, "schedule")
+      .mockResolvedValue({
+        finished,
+      } as unknown as Awaited<ReturnType<DocumentImportTask["schedule"]>>);
+
+    const res = await callMcpTool(
+      server,
+      accessToken,
+      "create_document_from_uploaded_file",
+      {
+        attachmentId: attachment.id,
+        collectionId: collection.id,
+        publish: true,
+      }
+    );
+
+    expect(res?.result?.isError).toBeUndefined();
+    expect(schedule).toHaveBeenCalledWith({
+      key: attachment.key,
+      sourceMetadata: {
+        fileName: attachment.name,
+        mimeType: attachment.contentType,
+      },
+      userId: user.id,
+      collectionId: collection.id,
+      parentDocumentId: undefined,
+      publish: true,
+      ip: expect.any(String),
+    });
+    expect(finished).toHaveBeenCalled();
+  });
+
+  it("rejects regular document attachments as import source files", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const sourceDocument = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+    });
+    const attachment = await buildAttachment(
+      {
+        teamId: user.teamId,
+        userId: user.id,
+        documentId: sourceDocument.id,
+        contentType: "text/html",
+        expiresAt: null,
+      },
+      "webpage.html"
+    );
+    const schedule = vi.spyOn(DocumentImportTask.prototype, "schedule");
+
+    const res = await callMcpTool(
+      server,
+      accessToken,
+      "create_document_from_uploaded_file",
+      {
+        attachmentId: attachment.id,
+        collectionId: collection.id,
+      }
+    );
+
+    expect(res?.result?.isError).toBe(true);
+    expect(res?.result?.content?.[0]?.text).toContain(
+      "must be uploaded with prepare_document_file_upload"
+    );
+    expect(schedule).not.toHaveBeenCalled();
   });
 });
 

--- a/server/tools/documents.ts
+++ b/server/tools/documents.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { z } from "zod";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { type CallToolResult } from "@modelcontextprotocol/sdk/types.js";
@@ -8,15 +9,28 @@ import documentCreator, {
 import documentMover from "@server/commands/documentMover";
 import documentRestorer from "@server/commands/documentRestorer";
 import documentUpdater from "@server/commands/documentUpdater";
-import { Collection, Document, Template } from "@server/models";
+import { ValidationError } from "@server/errors";
+import {
+  Attachment,
+  Collection,
+  Document,
+  Team,
+  Template,
+} from "@server/models";
+import AttachmentHelper from "@server/models/helpers/AttachmentHelper";
 import { sequelize } from "@server/storage/database";
+import FileStorage from "@server/storage/files";
 import { authorize, can } from "@server/policies";
+import presentAttachment from "@server/presenters/attachment";
 import {
   presentDocument as presentDocumentBase,
   presentNavigationNode,
 } from "@server/presenters";
+import type { DocumentImportTaskResponse } from "@server/queues/tasks/DocumentImportTask";
+import DocumentImportTask from "@server/queues/tasks/DocumentImportTask";
 import AuthenticationHelper from "@shared/helpers/AuthenticationHelper";
 import { UrlHelper } from "@shared/utils/UrlHelper";
+import { bytesToHumanReadable } from "@shared/utils/files";
 import {
   error,
   success,
@@ -29,7 +43,7 @@ import {
   pathToUrl,
   withTracing,
 } from "./util";
-import { StatusFilter, TextEditMode } from "@shared/types";
+import { AttachmentPreset, StatusFilter, TextEditMode } from "@shared/types";
 import SearchProviderManager from "@server/utils/SearchProviderManager";
 
 /**
@@ -291,6 +305,227 @@ export function documentTools(server: McpServer, scopes: string[]) {
   }
 
   if (AuthenticationHelper.canAccess("documents.create", scopes)) {
+    server.registerTool(
+      "prepare_document_file_upload",
+      {
+        title: "Prepare document file upload",
+        description:
+          "Creates a temporary pre-signed upload target for a source file that will be imported into the document system. Supports the same file types as the built-in Import document flow.",
+        annotations: {
+          idempotentHint: false,
+          readOnlyHint: false,
+        },
+        inputSchema: {
+          contentType: z.string().describe("The MIME type of the source file."),
+          name: z
+            .string()
+            .describe("The source filename, including extension."),
+          size: z.coerce
+            .number()
+            .int()
+            .nonnegative()
+            .finite()
+            .describe("The source file size in bytes."),
+        },
+      },
+      withTracing(
+        "prepare_document_file_upload",
+        async ({ contentType, name, size }, context) => {
+          try {
+            const ctx = buildAPIContext(context);
+            const { user } = ctx.state.auth;
+            const team = await Team.findByPk(user.teamId, {
+              rejectOnEmpty: true,
+            });
+            authorize(user, "createAttachment", team);
+
+            const preset = AttachmentPreset.Import;
+            const maxUploadSize =
+              AttachmentHelper.presetToMaxUploadSize(preset);
+
+            if (size > maxUploadSize) {
+              throw ValidationError(
+                `Sorry, this file is too large – the maximum size is ${bytesToHumanReadable(
+                  maxUploadSize
+                )}`
+              );
+            }
+
+            const id = randomUUID();
+            const acl = AttachmentHelper.presetToAcl(preset);
+            const key = AttachmentHelper.getKey({
+              id,
+              name,
+              userId: user.id,
+            });
+
+            const attachment = await Attachment.createWithCtx(ctx, {
+              id,
+              key,
+              acl,
+              size,
+              expiresAt: AttachmentHelper.presetToExpiry(preset),
+              contentType,
+              teamId: user.teamId,
+              userId: user.id,
+            });
+
+            const presignedPost = await FileStorage.getPresignedPost(
+              ctx,
+              key,
+              acl,
+              maxUploadSize,
+              contentType
+            );
+
+            const uploadUrl = new URL(FileStorage.getUploadUrl(), team.url)
+              .href;
+            const form = {
+              "Cache-Control": "max-age=31557600",
+              "Content-Type": contentType,
+              ...presignedPost.fields,
+            };
+            const formArgs = Object.entries(form)
+              .map(([k, v]) => `-F '${k}=${v}'`)
+              .join(" ");
+            const curlCommand = `curl -X POST ${formArgs} -F 'file=@/path/to/file' '${uploadUrl}'`;
+
+            return success({
+              uploadUrl,
+              form,
+              maxUploadSize,
+              curlCommand,
+              attachment: pathToUrl(team, {
+                ...presentAttachment(attachment),
+                url: attachment.redirectUrl,
+              }),
+            });
+          } catch (message) {
+            return error(message);
+          }
+        }
+      )
+    );
+
+    server.registerTool(
+      "create_document_from_uploaded_file",
+      {
+        title: "Create document from uploaded file",
+        description:
+          "Creates a document in the document system from a source file uploaded with prepare_document_file_upload. Uses the same import pipeline as the built-in Import document flow.",
+        annotations: {
+          idempotentHint: false,
+          readOnlyHint: false,
+        },
+        inputSchema: {
+          attachmentId: z
+            .string()
+            .describe(
+              "The temporary upload attachment ID returned by prepare_document_file_upload."
+            ),
+          collectionId: optionalString().describe(
+            "The collection to create the document in."
+          ),
+          parentDocumentId: optionalString().describe(
+            "The parent document ID to nest the created document under."
+          ),
+          publish: z
+            .boolean()
+            .optional()
+            .describe(
+              "Whether to publish the created document. Defaults to true."
+            ),
+        },
+      },
+      withTracing(
+        "create_document_from_uploaded_file",
+        async (input, context) => {
+          try {
+            const ctx = buildAPIContext(context);
+            const { user } = ctx.state.auth;
+            const { attachmentId, collectionId, parentDocumentId } = input;
+
+            if (!collectionId && !parentDocumentId) {
+              return error(
+                "Either collectionId or parentDocumentId is required"
+              );
+            }
+
+            const { collection, parentDocument } =
+              await authorizeDocumentCreate(ctx, {
+                collectionId,
+                parentDocumentId,
+              });
+            const attachment = await Attachment.findByPk(attachmentId, {
+              rejectOnEmpty: true,
+            });
+            authorize(user, "read", attachment);
+
+            if (
+              attachment.userId !== user.id ||
+              attachment.documentId ||
+              !attachment.expiresAt ||
+              attachment.expiresAt <= new Date()
+            ) {
+              return error(
+                "attachmentId must be uploaded with prepare_document_file_upload"
+              );
+            }
+
+            const job = await new DocumentImportTask().schedule({
+              key: attachment.key,
+              sourceMetadata: {
+                fileName: attachment.name,
+                mimeType: attachment.contentType,
+              },
+              userId: user.id,
+              collectionId: collection?.id ?? parentDocument?.collectionId,
+              parentDocumentId,
+              publish: input.publish !== false,
+              ip: ctx.context.ip ?? "",
+            });
+            const taskResponse: DocumentImportTaskResponse =
+              await job.finished();
+
+            if ("error" in taskResponse) {
+              return error(taskResponse.error);
+            }
+
+            const document = await Document.findByPk(taskResponse.documentId, {
+              userId: user.id,
+              rejectOnEmpty: true,
+            });
+            const [{ text, ...attributes }, breadcrumb] = await Promise.all([
+              presentDocument(document, {
+                includeData: false,
+                includeText: true,
+                includeUpdatedAt: true,
+              }),
+              getDocumentBreadcrumb(document, user),
+            ]);
+
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: JSON.stringify({
+                    document: pathToUrl(user.team, attributes),
+                    ...(breadcrumb !== undefined && { breadcrumb }),
+                  }),
+                },
+                {
+                  type: "text" as const,
+                  text: typeof text === "string" ? text : "",
+                },
+              ],
+            } satisfies CallToolResult;
+          } catch (message) {
+            return error(message);
+          }
+        }
+      )
+    );
+
     server.registerTool(
       "create_document",
       {


### PR DESCRIPTION
## Summary

Adds MCP tools for creating documents from uploaded source files using Outline’s existing Import document pipeline.

This introduces:
- `prepare_document_file_upload` to create a temporary pre-signed upload target for a document source file.
- `create_document_from_uploaded_file` to create a document from that uploaded source file.
- MCP guidance that tells clients to use this flow for file-based document creation instead of manually converting supported files to markdown.

## Motivation

MCP clients and AI agents often generate rich documents as files, such as HTML or Word documents. Today, the MCP `create_document` tool only accepts markdown-like document content, so agents either need to inline converted text or perform their own HTML/Word-to-markdown conversion.

That conversion can be lossy, especially for documents containing images, media, tables, or other rich structure. Outline already has a built-in Import document flow for these source files, but that flow was not available through MCP.

This change exposes that existing import path to MCP clients so generated or local document files can be uploaded and imported through the same pipeline as the product UI.
