### PR TITLE
fix: Incorrect typing of passport request handlers

### DIFF
--- a/plugins/azure/server/auth/azure.ts
+++ b/plugins/azure/server/auth/azure.ts
@@ -1,7 +1,7 @@
 import passport from "@outlinewiki/koa-passport";
 import { Strategy as AzureStrategy } from "@outlinewiki/passport-azure-ad-oauth2";
 import jwt from "jsonwebtoken";
-import type { Context } from "koa";
+import type { Request } from "koa";
 import Router from "koa-router";
 import type { Profile } from "passport";
 import { toError } from "@shared/utils/error";
@@ -86,7 +86,7 @@ if (env.AZURE_CLIENT_ID && env.AZURE_CLIENT_SECRET) {
       scope: scopes,
     },
     async function (
-      context: Context,
+      req: Request,
       accessToken: string,
       refreshToken: string,
       params: { expires_in: number; id_token: string },
@@ -97,6 +97,7 @@ if (env.AZURE_CLIENT_ID && env.AZURE_CLIENT_SECRET) {
         result?: AuthenticationResult
       ) => void
     ) {
+      const context = req.ctx;
       try {
         // see docs for what the fields in profile represent here:
         // https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens

--- a/plugins/discord/server/auth/discord.ts
+++ b/plugins/discord/server/auth/discord.ts
@@ -5,7 +5,7 @@ import type {
   RESTGetAPICurrentUserResult,
   RESTGetCurrentUserGuildMemberResult,
 } from "discord-api-types/v10";
-import type { Context } from "koa";
+import type { Request } from "koa";
 import Router from "koa-router";
 
 import { Strategy } from "passport-oauth2";
@@ -59,7 +59,7 @@ if (env.DISCORD_CLIENT_ID && env.DISCORD_CLIENT_SECRET) {
         pkce: false,
       },
       async function (
-        context: Context,
+        req: Request,
         accessToken: string,
         refreshToken: string,
         params: { expires_in: number },
@@ -70,6 +70,7 @@ if (env.DISCORD_CLIENT_ID && env.DISCORD_CLIENT_SECRET) {
           result?: AuthenticationResult
         ) => void
       ) {
+        const context = req.ctx;
         try {
           const team = await getTeamFromContext(context);
           const client = getClientFromOAuthState(context);

--- a/plugins/google/server/auth/google.ts
+++ b/plugins/google/server/auth/google.ts
@@ -1,5 +1,5 @@
 import passport from "@outlinewiki/koa-passport";
-import type { Context } from "koa";
+import type { Request } from "koa";
 import Router from "koa-router";
 import { capitalize } from "es-toolkit/compat";
 import type { Profile } from "passport";
@@ -55,7 +55,7 @@ if (env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET) {
         scope: scopes,
       },
       async function (
-        context: Context,
+        req: Request,
         accessToken: string,
         refreshToken: string,
         params: { expires_in: number; scope?: string },
@@ -66,6 +66,7 @@ if (env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET) {
           result?: AuthenticationResult
         ) => void
       ) {
+        const context = req.ctx;
         try {
           // "domain" is the Google Workspaces domain
           const domain = profile._json.hd;

--- a/plugins/oidc/server/auth/oidcRouter.ts
+++ b/plugins/oidc/server/auth/oidcRouter.ts
@@ -1,7 +1,7 @@
 import passport from "@outlinewiki/koa-passport";
 import { addMonths, subMinutes } from "date-fns";
 import JWT from "jsonwebtoken";
-import type { Context } from "koa";
+import type { Context, Request } from "koa";
 import type Router from "koa-router";
 import { get } from "es-toolkit/compat";
 import { toError } from "@shared/utils/error";
@@ -73,7 +73,7 @@ export function createOIDCRouter(
       // Any claim supplied in response to the userinfo request will be
       // available on the `profile` parameter
       async function (
-        context: Context,
+        req: Request,
         accessToken: string,
         refreshToken: string,
         params: { expires_in: number; id_token: string; scope?: string },
@@ -84,6 +84,7 @@ export function createOIDCRouter(
           result?: AuthenticationResult
         ) => void
       ) {
+        const context = req.ctx;
         try {
           // Some providers require a POST request to the userinfo endpoint, add them as exceptions here.
           const usePostMethod = [

--- a/plugins/slack/server/auth/slack.ts
+++ b/plugins/slack/server/auth/slack.ts
@@ -1,5 +1,5 @@
 import passport from "@outlinewiki/koa-passport";
-import type { Context } from "koa";
+import type { Request } from "koa";
 import Router from "koa-router";
 import type { Profile } from "passport";
 import { Strategy as SlackStrategy } from "passport-slack-oauth2";
@@ -76,7 +76,7 @@ if (env.SLACK_CLIENT_ID && env.SLACK_CLIENT_SECRET) {
       scope: scopes,
     },
     async function (
-      context: Context,
+      req: Request,
       accessToken: string,
       refreshToken: string,
       params: { expires_in: number },
@@ -87,6 +87,7 @@ if (env.SLACK_CLIENT_ID && env.SLACK_CLIENT_SECRET) {
         result?: AuthenticationResult
       ) => void
     ) {
+      const context = req.ctx;
       try {
         const team = await getTeamFromContext(context);
         const client = getClientFromOAuthState(context);


### PR DESCRIPTION
The previous logic worked mostly incidentally. Only OIDC could actually crash (it was the only one reaching .request.hostname); the other four “worked” by relying on koa-passport’s property delegation.

closes https://github.com/outline/outline/issues/12881
related https://github.com/outline/outline/pull/12804