### PR TITLE
fix: all `_FILE` suffix secrets in env are cemented at startup

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,8 +7,7 @@ NODE_ENV=production
 # Any environment variable read by Outline can be loaded from a file by
 # appending _FILE to the variable name and setting the value to the path of the
 # file. This is useful for Docker secrets and other file-based secret
-# management systems. _FILE variables consumed by other software, such as the
-# AWS SDK's AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE, are left untouched.
+# management systems.
 #
 # For example, instead of:
 #   SECRET_KEY=your_secret_key

--- a/.env.sample
+++ b/.env.sample
@@ -4,9 +4,11 @@ NODE_ENV=production
 # –––––––––––  FILE-BASED SECRETS  ––––––––
 # –––––––––––––––––––––––––––––––––––––––––
 #
-# Any environment variable can be loaded from a file by appending _FILE to the
-# variable name and setting the value to the path of the file. This is useful
-# for Docker secrets and other file-based secret management systems.
+# Any environment variable read by Outline can be loaded from a file by
+# appending _FILE to the variable name and setting the value to the path of the
+# file. This is useful for Docker secrets and other file-based secret
+# management systems. _FILE variables consumed by other software, such as the
+# AWS SDK's AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE, are left untouched.
 #
 # For example, instead of:
 #   SECRET_KEY=your_secret_key

--- a/server/utils/environment.test.ts
+++ b/server/utils/environment.test.ts
@@ -1,9 +1,9 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { resolveFileSecrets } from "./environment";
+import { withFileSecrets } from "./environment";
 
-describe("resolveFileSecrets", () => {
+describe("withFileSecrets", () => {
   let tmpDir: string;
 
   beforeEach(() => {
@@ -18,11 +18,9 @@ describe("resolveFileSecrets", () => {
     const secretFile = path.join(tmpDir, "secret");
     fs.writeFileSync(secretFile, "my-secret-value");
 
-    const env: Record<string, string | undefined> = {
+    const env = withFileSecrets({
       TEST_SECRET_FILE: secretFile,
-    };
-
-    resolveFileSecrets(env);
+    });
 
     expect(env.TEST_SECRET).toBe("my-secret-value");
   });
@@ -31,11 +29,9 @@ describe("resolveFileSecrets", () => {
     const secretFile = path.join(tmpDir, "secret");
     fs.writeFileSync(secretFile, "  my-secret-value\n\n");
 
-    const env: Record<string, string | undefined> = {
+    const env = withFileSecrets({
       TEST_TRIM_FILE: secretFile,
-    };
-
-    resolveFileSecrets(env);
+    });
 
     expect(env.TEST_TRIM).toBe("my-secret-value");
   });
@@ -44,12 +40,10 @@ describe("resolveFileSecrets", () => {
     const secretFile = path.join(tmpDir, "secret");
     fs.writeFileSync(secretFile, "file-value");
 
-    const env: Record<string, string | undefined> = {
+    const env = withFileSecrets({
       TEST_OVERRIDE: "direct-value",
       TEST_OVERRIDE_FILE: secretFile,
-    };
-
-    resolveFileSecrets(env);
+    });
 
     expect(env.TEST_OVERRIDE).toBe("direct-value");
   });
@@ -58,63 +52,133 @@ describe("resolveFileSecrets", () => {
     const secretFile = path.join(tmpDir, "secret");
     fs.writeFileSync(secretFile, "file-value");
 
-    const env: Record<string, string | undefined> = {
+    const env = withFileSecrets({
       TEST_OVERRIDE_EMPTY: "",
       TEST_OVERRIDE_EMPTY_FILE: secretFile,
-    };
-
-    resolveFileSecrets(env);
+    });
 
     expect(env.TEST_OVERRIDE_EMPTY).toBe("");
   });
 
-  it("should skip a bare _FILE key with no base name", () => {
+  it("should return the file path when reading the _FILE variable itself", () => {
     const secretFile = path.join(tmpDir, "secret");
-    fs.writeFileSync(secretFile, "value");
+    fs.writeFileSync(secretFile, "my-secret-value");
 
-    const env: Record<string, string | undefined> = {
-      _FILE: secretFile,
+    const env = withFileSecrets({
+      TEST_PATH_FILE: secretFile,
+    });
+
+    expect(env.TEST_PATH_FILE).toBe(secretFile);
+  });
+
+  it("should not materialize base variables that are never read", () => {
+    const tokenFile = path.join(tmpDir, "token");
+    fs.writeFileSync(tokenFile, "rotating-token");
+
+    const record: Record<string, string | undefined> = {
+      AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE: tokenFile,
     };
+    withFileSecrets(record);
 
-    resolveFileSecrets(env);
+    expect(record.AWS_CONTAINER_AUTHORIZATION_TOKEN).toBeUndefined();
+    expect(
+      Object.keys(record).includes("AWS_CONTAINER_AUTHORIZATION_TOKEN")
+    ).toBe(false);
+  });
 
-    expect(env[""]).toBeUndefined();
+  it("should not resolve reserved third-party _FILE variables", () => {
+    const bundleFile = path.join(tmpDir, "ca-bundle.crt");
+    fs.writeFileSync(bundleFile, "-----BEGIN CERTIFICATE-----");
+
+    const record: Record<string, string | undefined> = {
+      SSL_CERT_FILE: bundleFile,
+    };
+    const env = withFileSecrets(record);
+
+    expect(env.SSL_CERT).toBeUndefined();
+    expect(record.SSL_CERT).toBeUndefined();
+  });
+
+  it("should cache the resolved value on the underlying record", () => {
+    const secretFile = path.join(tmpDir, "secret");
+    fs.writeFileSync(secretFile, "first-value");
+
+    const record: Record<string, string | undefined> = {
+      TEST_CACHE_FILE: secretFile,
+    };
+    const env = withFileSecrets(record);
+
+    expect(env.TEST_CACHE).toBe("first-value");
+    expect(record.TEST_CACHE).toBe("first-value");
+
+    // Subsequent reads must not hit the filesystem again.
+    fs.rmSync(secretFile);
+    expect(env.TEST_CACHE).toBe("first-value");
   });
 
   it("should handle missing file gracefully", () => {
-    const env: Record<string, string | undefined> = {
+    const env = withFileSecrets({
       TEST_MISSING_FILE: path.join(tmpDir, "nonexistent"),
-    };
-
-    resolveFileSecrets(env);
+    });
 
     expect(env.TEST_MISSING).toBeUndefined();
   });
 
   it("should skip _FILE entries with empty path", () => {
-    const env: Record<string, string | undefined> = {
+    const env = withFileSecrets({
       TEST_EMPTY_FILE: "",
-    };
-
-    resolveFileSecrets(env);
+    });
 
     expect(env.TEST_EMPTY).toBeUndefined();
   });
 
-  it("should process multiple _FILE entries", () => {
+  it("should ignore a bare _FILE key with no base name", () => {
+    const secretFile = path.join(tmpDir, "secret");
+    fs.writeFileSync(secretFile, "value");
+
+    const record: Record<string, string | undefined> = {
+      _FILE: secretFile,
+    };
+    const env = withFileSecrets(record);
+
+    expect(env[""]).toBeUndefined();
+    expect(record[""]).toBeUndefined();
+  });
+
+  it("should resolve multiple _FILE entries independently", () => {
     const file1 = path.join(tmpDir, "secret1");
     const file2 = path.join(tmpDir, "secret2");
     fs.writeFileSync(file1, "value1");
     fs.writeFileSync(file2, "value2");
 
-    const env: Record<string, string | undefined> = {
+    const env = withFileSecrets({
       SECRET_KEY_FILE: file1,
       DATABASE_PASSWORD_FILE: file2,
-    };
-
-    resolveFileSecrets(env);
+    });
 
     expect(env.SECRET_KEY).toBe("value1");
     expect(env.DATABASE_PASSWORD).toBe("value2");
+  });
+
+  it("should resolve Outline _FILE secrets through Environment while leaving AWS SDK variables untouched", async () => {
+    const tokenFile = path.join(tmpDir, "eks-pod-identity-token");
+    const secretFile = path.join(tmpDir, "smtp-password");
+    fs.writeFileSync(tokenFile, "rotating-jwt-token");
+    fs.writeFileSync(secretFile, "smtp-secret-value\n");
+
+    process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI =
+      "http://169.254.170.23/v1/credentials";
+    process.env.AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE = tokenFile;
+    process.env.SMTP_PASSWORD_FILE = secretFile;
+
+    vi.resetModules();
+    const env = (await import("../env")).default;
+
+    // Outline's own variable is resolved from the file.
+    expect(env.SMTP_PASSWORD).toBe("smtp-secret-value");
+
+    // The AWS SDK's token variable is never materialized, so the SDK keeps
+    // re-reading the rotated token file on every credential refresh.
+    expect(process.env.AWS_CONTAINER_AUTHORIZATION_TOKEN).toBeUndefined();
   });
 });

--- a/server/utils/environment.test.ts
+++ b/server/utils/environment.test.ts
@@ -86,19 +86,6 @@ describe("withFileSecrets", () => {
     ).toBe(false);
   });
 
-  it("should not resolve reserved third-party _FILE variables", () => {
-    const bundleFile = path.join(tmpDir, "ca-bundle.crt");
-    fs.writeFileSync(bundleFile, "-----BEGIN CERTIFICATE-----");
-
-    const record: Record<string, string | undefined> = {
-      SSL_CERT_FILE: bundleFile,
-    };
-    const env = withFileSecrets(record);
-
-    expect(env.SSL_CERT).toBeUndefined();
-    expect(record.SSL_CERT).toBeUndefined();
-  });
-
   it("should cache the resolved value on the underlying record", () => {
     const secretFile = path.join(tmpDir, "secret");
     fs.writeFileSync(secretFile, "first-value");

--- a/server/utils/environment.ts
+++ b/server/utils/environment.ts
@@ -37,14 +37,6 @@ process.env = {
 };
 
 /**
- * `_FILE` environment variables that have a well-known meaning to other
- * software and so are never treated as Outline file secrets, even though the
- * base name matches a configuration variable. `SSL_CERT_FILE` is OpenSSL's
- * CA bundle path and is commonly present in container environments.
- */
-const RESERVED_FILE_VARIABLES = new Set(["SSL_CERT_FILE"]);
-
-/**
  * Wraps an environment record so that Docker-style file secrets are resolved
  * lazily. When a variable is read through the proxy and has no value, but a
  * corresponding `<NAME>_FILE` variable is set, the referenced file is read and
@@ -76,12 +68,7 @@ export function withFileSecrets(
         return value;
       }
 
-      const fileKey = `${prop}_FILE`;
-      if (RESERVED_FILE_VARIABLES.has(fileKey)) {
-        return undefined;
-      }
-
-      const filePath = target[fileKey];
+      const filePath = target[`${prop}_FILE`];
       if (!filePath) {
         return undefined;
       }
@@ -91,7 +78,7 @@ export function withFileSecrets(
       } catch (err) {
         // oxlint-disable-next-line no-console
         console.error(
-          `Failed to read file for ${fileKey} (${filePath}): ${(err as Error).message}`
+          `Failed to read file for ${prop}_FILE (${filePath}): ${(err as Error).message}`
         );
       }
       return target[prop];

--- a/server/utils/environment.ts
+++ b/server/utils/environment.ts
@@ -37,10 +37,10 @@ process.env = {
 };
 
 /**
- * Well-known `_FILE` environment variables consumed by third-party software,
- * where the suffix does not indicate an Outline file secret. `SSL_CERT_FILE`
- * is the standard OpenSSL variable pointing at a CA bundle and must not be
- * resolved into Outline's `SSL_CERT` setting.
+ * `_FILE` environment variables that have a well-known meaning to other
+ * software and so are never treated as Outline file secrets, even though the
+ * base name matches a configuration variable. `SSL_CERT_FILE` is OpenSSL's
+ * CA bundle path and is commonly present in container environments.
  */
 const RESERVED_FILE_VARIABLES = new Set(["SSL_CERT_FILE"]);
 

--- a/server/utils/environment.ts
+++ b/server/utils/environment.ts
@@ -37,44 +37,66 @@ process.env = {
 };
 
 /**
- * Process environment variables with _FILE suffix by reading the referenced
- * file and setting the base variable. If the base variable is already set, the
- * file is not read. File contents are trimmed of leading/trailing whitespace.
- *
- * @param env - the environment record to process.
+ * Well-known `_FILE` environment variables consumed by third-party software,
+ * where the suffix does not indicate an Outline file secret. `SSL_CERT_FILE`
+ * is the standard OpenSSL variable pointing at a CA bundle and must not be
+ * resolved into Outline's `SSL_CERT` setting.
  */
-export function resolveFileSecrets(
+const RESERVED_FILE_VARIABLES = new Set(["SSL_CERT_FILE"]);
+
+/**
+ * Wraps an environment record so that Docker-style file secrets are resolved
+ * lazily. When a variable is read through the proxy and has no value, but a
+ * corresponding `<NAME>_FILE` variable is set, the referenced file is read and
+ * its contents – trimmed of leading/trailing whitespace – are cached on the
+ * underlying record and returned. If the base variable is already set, the
+ * file is not read.
+ *
+ * Resolution only happens for variables that are actually read through the
+ * proxy, which limits it to the variables declared on the Environment classes.
+ * `_FILE` variables consumed directly by third-party libraries – such as the
+ * AWS SDK's `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`, which must be re-read
+ * from disk on every credential refresh – are never copied into their base
+ * variable.
+ *
+ * @param env - the environment record to wrap.
+ * @returns a proxy over the record that resolves `_FILE` secrets on read.
+ */
+export function withFileSecrets(
   env: Record<string, string | undefined>
-): void {
-  for (const key of Object.keys(env)) {
-    if (key.endsWith("_FILE")) {
-      const baseKey = key.slice(0, -5);
-      if (!baseKey.length) {
-        continue;
+): Record<string, string | undefined> {
+  return new Proxy(env, {
+    get(target, prop, receiver) {
+      if (typeof prop !== "string" || !prop.length || prop.endsWith("_FILE")) {
+        return Reflect.get(target, prop, receiver);
       }
 
-      const filePath = env[key];
+      const value = target[prop];
+      if (value !== undefined) {
+        return value;
+      }
 
+      const fileKey = `${prop}_FILE`;
+      if (RESERVED_FILE_VARIABLES.has(fileKey)) {
+        return undefined;
+      }
+
+      const filePath = target[fileKey];
       if (!filePath) {
-        continue;
-      }
-
-      if (env[baseKey] !== undefined) {
-        continue;
+        return undefined;
       }
 
       try {
-        env[baseKey] = fs.readFileSync(filePath, "utf8").trim();
+        target[prop] = fs.readFileSync(filePath, "utf8").trim();
       } catch (err) {
         // oxlint-disable-next-line no-console
         console.error(
-          `Failed to read file for ${key} (${filePath}): ${(err as Error).message}`
+          `Failed to read file for ${fileKey} (${filePath}): ${(err as Error).message}`
         );
       }
-    }
-  }
+      return target[prop];
+    },
+  });
 }
 
-resolveFileSecrets(process.env);
-
-export default process.env;
+export default withFileSecrets(process.env);

--- a/server/utils/environment.ts
+++ b/server/utils/environment.ts
@@ -44,13 +44,6 @@ process.env = {
  * underlying record and returned. If the base variable is already set, the
  * file is not read.
  *
- * Resolution only happens for variables that are actually read through the
- * proxy, which limits it to the variables declared on the Environment classes.
- * `_FILE` variables consumed directly by third-party libraries – such as the
- * AWS SDK's `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`, which must be re-read
- * from disk on every credential refresh – are never copied into their base
- * variable.
- *
  * @param env - the environment record to wrap.
  * @returns a proxy over the record that resolves `_FILE` secrets on read.
  */

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,12 @@ import path from "node:path";
 import swc from "unplugin-swc";
 import { defineConfig } from "vitest/config";
 
+// SSL_CERT_FILE is OpenSSL's CA bundle variable and may be present in the
+// host environment running the tests; clear it so it is not resolved into
+// Outline's SSL_CERT setting. The config is evaluated before the global setup
+// and before workers spawn, so this covers every test process.
+delete process.env.SSL_CERT_FILE;
+
 const aliases = {
   "@server": path.resolve(__dirname, "./server"),
   "@shared": path.resolve(__dirname, "./shared"),


### PR DESCRIPTION
closes #12885