### PR TITLE
fix: Comments sidebar opens on document load when draft comment exists

### DIFF
--- a/app/components/Editor.tsx
+++ b/app/components/Editor.tsx
@@ -199,42 +199,50 @@ function Editor(props: Props, ref: React.RefObject<SharedEditor> | null) {
     []
   );
 
-  const updateComments = React.useCallback(() => {
-    if (onCreateCommentMark && onDeleteCommentMark && localRef.current) {
-      const commentMarks = localRef.current.getComments();
-      const commentIds = comments.orderedData.map((c) => c.id);
-      const commentMarkIds = commentMarks?.map((c) => c.id);
-      const focus = previousCommentIds.current !== undefined;
-      const newCommentIds = difference(
-        commentMarkIds,
-        previousCommentIds.current ?? [],
-        commentIds
-      );
+  const updateComments = React.useCallback(
+    (event?: { remote: boolean }) => {
+      if (onCreateCommentMark && onDeleteCommentMark && localRef.current) {
+        const commentMarks = localRef.current.getComments();
+        const commentIds = comments.orderedData.map((c) => c.id);
+        const commentMarkIds = commentMarks?.map((c) => c.id);
 
-      newCommentIds.forEach((commentId) => {
-        const mark = commentMarks.find((c) => c.id === commentId);
-        if (mark) {
-          onCreateCommentMark(mark.id, mark.userId, { focus });
-        }
-      });
+        // Comment marks that arrive through a remote or sync transaction, such
+        // as the initial load of a collaborative document containing a draft
+        // comment, should not steal focus – only marks created locally should.
+        const focus =
+          previousCommentIds.current !== undefined && !event?.remote;
+        const newCommentIds = difference(
+          commentMarkIds,
+          previousCommentIds.current ?? [],
+          commentIds
+        );
 
-      const removedCommentIds = difference(
-        previousCommentIds.current ?? [],
-        commentMarkIds ?? []
-      );
+        newCommentIds.forEach((commentId) => {
+          const mark = commentMarks.find((c) => c.id === commentId);
+          if (mark) {
+            onCreateCommentMark(mark.id, mark.userId, { focus });
+          }
+        });
 
-      removedCommentIds.forEach((commentId) => {
-        onDeleteCommentMark(commentId);
-      });
+        const removedCommentIds = difference(
+          previousCommentIds.current ?? [],
+          commentMarkIds ?? []
+        );
 
-      previousCommentIds.current = commentMarkIds;
-    }
-  }, [onCreateCommentMark, onDeleteCommentMark, comments.orderedData]);
+        removedCommentIds.forEach((commentId) => {
+          onDeleteCommentMark(commentId);
+        });
 
-  const handleChange = React.useCallback(
-    (event) => {
-      onChange?.(event);
-      updateComments();
+        previousCommentIds.current = commentMarkIds;
+      }
+    },
+    [onCreateCommentMark, onDeleteCommentMark, comments.orderedData]
+  );
+
+  const handleChange = React.useCallback<NonNullable<EditorProps["onChange"]>>(
+    (value, event) => {
+      onChange?.(value, event);
+      updateComments(event);
     },
     [onChange, updateComments]
   );

--- a/app/editor/index.tsx
+++ b/app/editor/index.tsx
@@ -32,6 +32,7 @@ import type { CommandFactory, WidgetProps } from "@shared/editor/lib/Extension";
 import type { AnyExtension, AnyExtensionClass } from "@shared/editor/lib/types";
 import ExtensionManager from "@shared/editor/lib/ExtensionManager";
 import type { MarkdownSerializer } from "@shared/editor/lib/markdown/serializer";
+import { isRemoteTransaction } from "@shared/editor/lib/multiplayer";
 import textBetween from "@shared/editor/lib/textBetween";
 import { basicExtensions as extensions } from "@shared/editor/nodes";
 import type ReactNode from "@shared/editor/nodes/ReactNode";
@@ -118,8 +119,11 @@ export type Props = {
   /** Callback when user uses cancel key combo */
   onCancel?: () => void;
   /** Callback when user changes editor content */
-  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-  onChange?: (value: (asString?: boolean, trim?: boolean) => any) => void;
+  onChange?: (
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    value: (asString?: boolean, trim?: boolean) => any,
+    event?: { remote: boolean }
+  ) => void;
   /** Callback when a comment mark is clicked */
   onClickCommentMark?: (commentId: string) => void;
   /**
@@ -537,7 +541,11 @@ export class Editor extends React.PureComponent<
             (self.props.canUpdate && transactions.some(isEditingCheckbox)) ||
             (self.props.canComment && transactions.some(isEditingComment)))
         ) {
-          self.handleChange();
+          self.handleChange({
+            remote: transactions.some(
+              (tr) => tr.docChanged && isRemoteTransaction(tr)
+            ),
+          });
         }
 
         self.handleEditorInit();
@@ -848,13 +856,15 @@ export class Editor extends React.PureComponent<
     this.view.dispatch(this.view.state.tr.setMeta("theme", event.detail));
   };
 
-  private handleChange = () => {
+  private handleChange = (event?: { remote: boolean }) => {
     if (!this.props.onChange) {
       return;
     }
 
-    this.props.onChange((asString = true, trim = false) =>
-      this.view ? this.value(asString, trim) : undefined
+    this.props.onChange(
+      (asString = true, trim = false) =>
+        this.view ? this.value(asString, trim) : undefined,
+      event
     );
   };
 


### PR DESCRIPTION
When a document containing an unsent draft comment mark is loaded, the initial collaborative sync applies the content in a transaction after the editor has mounted. The comment mark diffing treated these marks as newly created and focused them, which in turn opened the comments sidebar.

Thread the transaction origin through the editor onChange callback and skip focusing comment marks that arrive via remote or sync transactions, so only locally created comment marks focus and open the sidebar.