### PR TITLE
correctly paste doc links with hash

### DIFF
--- a/app/editor/extensions/PasteHandler.tsx
+++ b/app/editor/extensions/PasteHandler.tsx
@@ -140,6 +140,8 @@ export default class PasteHandler extends Extension {
                         if (document) {
                           if (state.schema.nodes.mention) {
                             const { hash } = new URL(trimmedText);
+                            const trimmedHash = hash.substring(1);
+
                             view.dispatch(
                               view.state.tr.replaceWith(
                                 state.selection.from,
@@ -149,8 +151,8 @@ export default class PasteHandler extends Extension {
                                   modelId: document.id,
                                   label: document.titleWithDefault,
                                   id: uuidv4(),
-                                  anchorId: hash.length
-                                    ? hash.substring(1)
+                                  anchorId: trimmedHash.length
+                                    ? trimmedHash
                                     : undefined,
                                 })
                               )
@@ -161,9 +163,9 @@ export default class PasteHandler extends Extension {
                               determineIconType(document.icon) ===
                               IconType.Emoji;
 
-                            const title = `${
-                              hasEmoji ? document.icon + " " : ""
-                            }${document.titleWithDefault}`;
+                            const title = `${hasEmoji ? document.icon + " " : ""}${
+                              document.titleWithDefault
+                            }`;
 
                             this.insertLink(`${document.path}${hash}`, title);
                           }
@@ -206,9 +208,9 @@ export default class PasteHandler extends Extension {
                               determineIconType(collection.icon) ===
                               IconType.Emoji;
 
-                            const title = `${
-                              hasEmoji ? collection.icon + " " : ""
-                            }${collection.name}`;
+                            const title = `${hasEmoji ? collection.icon + " " : ""}${
+                              collection.name
+                            }`;
 
                             this.insertLink(`${collection.path}${hash}`, title);
                           }

--- a/app/editor/extensions/PasteHandler.tsx
+++ b/app/editor/extensions/PasteHandler.tsx
@@ -138,7 +138,8 @@ export default class PasteHandler extends Extension {
                           return;
                         }
                         if (document) {
-                          if (state.schema.nodes.mention && !containsHash) {
+                          if (state.schema.nodes.mention) {
+                            const { hash } = new URL(trimmedText);
                             view.dispatch(
                               view.state.tr.replaceWith(
                                 state.selection.from,
@@ -148,6 +149,9 @@ export default class PasteHandler extends Extension {
                                   modelId: document.id,
                                   label: document.titleWithDefault,
                                   id: uuidv4(),
+                                  anchorId: hash.length
+                                    ? hash.substring(1)
+                                    : undefined,
                                 })
                               )
                             );

--- a/shared/editor/components/Mentions.tsx
+++ b/shared/editor/components/Mentions.tsx
@@ -102,6 +102,7 @@ export const MentionDocument = observer(function MentionDocument_(
   const { documents } = useStores();
   const doc = documents.get(node.attrs.modelId);
   const modelId = node.attrs.modelId;
+  const anchorId = node.attrs.anchorId;
   const { className, unfurl, ...attrs } = getAttributesFromNode(node);
 
   React.useEffect(() => {
@@ -110,13 +111,15 @@ export const MentionDocument = observer(function MentionDocument_(
     }
   }, [modelId, documents]);
 
+  const documentPath = doc?.path ?? `/doc/${node.attrs.modelId}`;
+
   return (
     <Link
       {...attrs}
       className={cn(className, {
         "ProseMirror-selectednode": isSelected,
       })}
-      to={doc?.path ?? `/doc/${node.attrs.modelId}`}
+      to={anchorId ? `${documentPath}#${anchorId}` : documentPath}
     >
       {doc?.icon ? (
         <Icon

--- a/shared/editor/nodes/Mention.tsx
+++ b/shared/editor/nodes/Mention.tsx
@@ -58,6 +58,9 @@ export default class Mention extends Node {
         id: {
           default: undefined,
         },
+        anchorId: {
+          default: undefined,
+        },
         href: {
           default: undefined,
         },
@@ -87,6 +90,8 @@ export default class Mention extends Node {
               actorId: dom.dataset.actorid,
               label: dom.innerText,
               id: dom.id,
+              anchorId:
+                dom.dataset.anchorId ?? dom.getAttribute("href")?.split("#")[1],
               href: dom.getAttribute("href"),
               unfurl: dom.dataset.unfurl
                 ? JSON.parse(dom.dataset.unfurl)
@@ -113,13 +118,16 @@ export default class Mention extends Node {
             node.attrs.type === MentionType.Date
               ? undefined
               : node.attrs.type === MentionType.Document
-                ? `${env.URL}/doc/${node.attrs.modelId}`
+                ? `${env.URL}/doc/${node.attrs.modelId}${
+                    node.attrs.anchorId ? `#${node.attrs.anchorId}` : ""
+                  }`
                 : node.attrs.type === MentionType.Collection
                   ? `${env.URL}/collection/${node.attrs.modelId}`
                   : sanitizeUrl(node.attrs.href),
           "data-type": node.attrs.type,
           "data-id": node.attrs.modelId,
           "data-actorid": node.attrs.actorId,
+          "data-anchor-id": node.attrs.anchorId,
           "data-url":
             node.attrs.type === MentionType.PullRequest ||
             node.attrs.type === MentionType.Issue ||
@@ -252,7 +260,11 @@ export default class Mention extends Node {
                 ? "doc"
                 : "collection";
 
-            link = `/${linkType}/${modelId}`;
+            link = `/${linkType}/${modelId}${
+              selection.node.attrs.anchorId
+                ? `#${selection.node.attrs.anchorId}`
+                : ""
+            }`;
           }
 
           this.editor.props.onClickLink?.(link);
@@ -334,7 +346,11 @@ export default class Mention extends Node {
 
     // Use regular links for document and collection mentions
     if (mType === MentionType.Document) {
-      state.write(`[${label}](/doc/${mId})`);
+      state.write(
+        `[${label}](/doc/${mId}${
+          node.attrs.anchorId ? `#${node.attrs.anchorId}` : ""
+        })`
+      );
     } else if (mType === MentionType.Collection) {
       state.write(`[${label}](/collection/${mId})`);
     } else {


### PR DESCRIPTION
This allows the editor to correctly handle doc links with a hash when they are pasted.

### Demo

https://github.com/user-attachments/assets/a59db7f8-7b04-441b-8305-c4abc52af292

