### PR TITLE
Fix image overflow in table cells using CSS min()

### DIFF
--- a/shared/editor/components/Image.tsx
+++ b/shared/editor/components/Image.tsx
@@ -100,7 +100,7 @@ const Image = (props: Props) => {
 
   const widthStyle = isFullWidth
     ? { width: "var(--container-width)" }
-    : { width: width || "auto" };
+    : { width: width ? `min(${width}px, 100%)` : "auto" };
 
   const handleImageTouchStart = (ev: React.TouchEvent<HTMLDivElement>) => {
     const currentTime = Date.now();


### PR DESCRIPTION
Fixes #12866

## Problem

Images pasted into table cells render at their full natural pixel resolution (e.g. 1920×1080 screenshot) instead of scaling to fit the column width.

`widthStyle` applies `style="width: 1920px"` as an inline style on both the `.image-wrapper` div and the `img.image-handle` element. Table cells without an explicit `colwidth` attribute cause the browser to use `table-layout: auto`, which expands the cell to the content's preferred width. The `ImageWrapper` styled-component already has `max-width: 100%`, but since the cell has expanded to 1920 px, `100%` of the cell is also 1920 px — the constraint is circular and has no effect.

## Fix

Change the non-full-width branch of `widthStyle` to use the CSS `min()` function:

```tsx
// before
: { width: width || "auto" };

// after
: { width: width ? `min(${width}px, 100%)` : "auto" };
```

`min(1920px, 100%)` breaks the circularity: during auto table layout the browser resolves the `100%` operand against the *table's* available width rather than the already-inflated cell size, so the element's min-content contribution is bounded and the cell no longer expands beyond its natural share of the table. The fix applies to both the wrapper div and the img (both receive `widthStyle`), matching the workaround the reporter confirmed works.

Outside tables the behaviour is unchanged — images still render at their stored pixel size provided the container is wide enough.