### PR TITLE
fix: Decode percent-encoded filenames from URLs

### DIFF
--- a/shared/utils/files.test.ts
+++ b/shared/utils/files.test.ts
@@ -82,4 +82,22 @@ describe("getFileNameFromUrl", () => {
     ).toBe("file.txt");
     expect(getFileNameFromUrl("https://example.com/")).toBe("");
   });
+
+  it("decodes percent-encoded filenames", () => {
+    expect(getFileNameFromUrl("https://example.com/My%20Report.pdf")).toBe(
+      "My Report.pdf"
+    );
+    expect(getFileNameFromUrl("https://example.com/caf%C3%A9%20menu.png")).toBe(
+      "café menu.png"
+    );
+    expect(
+      getFileNameFromUrl("https://example.com/report%20final.pdf?v=2#top")
+    ).toBe("report final.pdf");
+  });
+
+  it("falls back to the raw filename on malformed encoding", () => {
+    expect(getFileNameFromUrl("https://example.com/bad%name.txt")).toBe(
+      "bad%name.txt"
+    );
+  });
 });

--- a/shared/utils/files.ts
+++ b/shared/utils/files.ts
@@ -157,7 +157,14 @@ export function getFileNameFromUrl(url: string) {
     const urlObj = new URL(url);
     const pathname = urlObj.pathname;
     const filename = pathname.substring(pathname.lastIndexOf("/") + 1);
-    return filename;
+
+    try {
+      // Decode percent-encoding so the name is human readable (e.g. "My%20File.pdf" → "My File.pdf").
+      return decodeURIComponent(filename);
+    } catch (_err) {
+      // Malformed percent-encoding, fall back to the raw filename.
+      return filename;
+    }
   } catch (_err) {
     return null;
   }


### PR DESCRIPTION
`getFileNameFromUrl` returned the raw URL path segment, so attachments created via the `attachments.createFromUrl` endpoint were stored with percent-encoded names (e.g. `My%20Report.pdf` instead of `My Report.pdf`, and mangled non-ASCII names). This decodes the filename with `decodeURIComponent`, falling back to the raw value when the encoding is malformed so a bad URL degrades gracefully rather than losing the name. Added test coverage for decoding, query/hash stripping, and the malformed-encoding fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)