### PR TITLE
fix: `useIdle` never triggered without user activity

### DIFF
--- a/app/hooks/useIdle.ts
+++ b/app/hooks/useIdle.ts
@@ -53,7 +53,16 @@ export default function useIdle(
     events.forEach((eventName) =>
       window.addEventListener(eventName, handleUserActivityEvent)
     );
+
+    // Start the countdown immediately, otherwise the user is never considered
+    // idle unless activity occurs after mount.
+    onActivity();
+
     return () => {
+      handleUserActivityEvent.cancel();
+      if (timeout.current) {
+        clearTimeout(timeout.current);
+      }
       events.forEach((eventName) =>
         window.removeEventListener(eventName, handleUserActivityEvent)
       );


### PR DESCRIPTION
The idle countdown only ever started from a user-activity event after mount, so a user who never interacted was never considered idle, the pending timer and throttled handler also leaked on unmount.