### PR TITLE
fix: Remove empty header bar on search page

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -41,6 +41,10 @@ function Header(
   const [internalMeasureRef, size] = useMeasure();
   const [breadcrumbsMeasureRef, breadcrumbsSize] = useMeasure();
   const passThrough = !actions && !left && !title;
+  const insetTitleAdjust = ui.sidebarIsClosed && Desktop.hasInsetTitlebar();
+  // Collapse the empty bar when there is no content to display, unless space is
+  // still required for the desktop inset titlebar (OS window controls).
+  const collapsed = passThrough && !insetTitleAdjust;
 
   const [isScrolled, setScrolled] = React.useState(false);
   const handleScroll = React.useMemo(
@@ -82,7 +86,8 @@ function Header(
         shrink={false}
         className={className}
         $passThrough={passThrough}
-        $insetTitleAdjust={ui.sidebarIsClosed && Desktop.hasInsetTitlebar()}
+        $collapsed={collapsed}
+        $insetTitleAdjust={insetTitleAdjust}
       >
         {left || hasMobileSidebar ? (
           <Breadcrumbs ref={setBreadcrumbRef}>
@@ -141,6 +146,7 @@ const Actions = styled(Flex)`
 
 type WrapperProps = {
   $passThrough?: boolean;
+  $collapsed?: boolean;
   $insetTitleAdjust?: boolean;
 };
 
@@ -161,9 +167,9 @@ const Wrapper = styled(Flex)<WrapperProps>`
       backdrop-filter: blur(20px);
       `};
 
-  padding: 12px 16px;
+  padding: ${(props) => (props.$collapsed ? "0" : "12px 16px")};
   transform: translate3d(0, 0, 0);
-  min-height: ${HEADER_HEIGHT}px;
+  min-height: ${(props) => (props.$collapsed ? 0 : `${HEADER_HEIGHT}px`)};
   justify-content: flex-start;
   ${draggableOnDesktop()}
 
@@ -182,7 +188,7 @@ const Wrapper = styled(Flex)<WrapperProps>`
   }
 
   ${breakpoint("tablet")`
-    padding: 16px;
+    ${(props: WrapperProps) => !props.$collapsed && `padding: 16px;`}
     ${(props: WrapperProps) => props.$insetTitleAdjust && `padding-left: 64px;`}
     `};
 `;

--- a/app/scenes/Search/Search.tsx
+++ b/app/scenes/Search/Search.tsx
@@ -18,6 +18,7 @@ import ArrowKeyNavigation from "~/components/ArrowKeyNavigation";
 import DocumentListItem from "~/components/DocumentListItem";
 import Fade from "~/components/Fade";
 import Flex from "~/components/Flex";
+import { HEADER_HEIGHT } from "~/components/Header";
 import LoadingIndicator from "~/components/LoadingIndicator";
 import RegisterKeyDown from "~/components/RegisterKeyDown";
 import Scene from "~/components/Scene";
@@ -390,7 +391,7 @@ const Centered = styled(Flex)`
 
 const ResultsWrapper = styled(Flex)`
   ${breakpoint("tablet")`
-    margin-top: 40px;
+    margin-top: ${40 + HEADER_HEIGHT}px;
   `};
 `;
 


### PR DESCRIPTION
Search pages has an empty bar at the top that contents scrolls behind – a consequence of no header content in the `Layout` component