### PR TITLE
fix: Various unlabeled and undescribed interactive elements

### DIFF
--- a/app/components/CircularProgressBar.tsx
+++ b/app/components/CircularProgressBar.tsx
@@ -43,19 +43,37 @@ const Circle = ({
   );
 };
 
+/**
+ * Renders a small circular progress indicator.
+ *
+ * @param percentage - the progress to display, clamped to the range 0–100.
+ * @param size - the width and height of the indicator in pixels.
+ * @param label - an accessible name announced by assistive technology.
+ * @returns the rendered progress bar element.
+ */
 const CircularProgressBar = ({
   percentage,
   size = 16,
+  label,
 }: {
   percentage: number;
   size?: number;
+  label?: string;
 }) => {
   const theme = useTheme();
   percentage = cleanPercentage(percentage);
   const offset = Math.floor(size / 2);
 
   return (
-    <SVG width={size} height={size}>
+    <SVG
+      width={size}
+      height={size}
+      role="progressbar"
+      aria-label={label}
+      aria-valuenow={Math.round(percentage)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+    >
       <g transform={`rotate(-90 ${offset} ${offset})`}>
         <Circle color={theme.progressBarBackground} offset={offset} />
         {percentage > 0 && (

--- a/app/components/DocumentTasks.tsx
+++ b/app/components/DocumentTasks.tsx
@@ -50,7 +50,7 @@ function DocumentTasks({ document }: Props) {
           $animated={done && previousDone === false}
         />
       ) : (
-        <CircularProgressBar percentage={tasksPercentage} />
+        <CircularProgressBar percentage={tasksPercentage} label={message} />
       )}
       {message}
     </Flex>

--- a/app/components/IconPicker/components/EmojiPanel.tsx
+++ b/app/components/IconPicker/components/EmojiPanel.tsx
@@ -184,7 +184,10 @@ const EmojiPanel = ({
         data={templateData}
         onIconSelect={handleEmojiSelection}
         empty={
-          <IconButton onClick={handleUploadClick}>
+          <IconButton
+            onClick={handleUploadClick}
+            aria-label={t("Upload emoji")}
+          >
             <PlusIcon />
           </IconButton>
         }

--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -103,7 +103,7 @@ const Modal: React.FC<Props> = ({
                     <Text size="large">{resolvedTitle}</Text>
                   </Dialog.Title>
                   <Tooltip content={t("Close")} shortcut="Esc">
-                    <NudeButton onClick={onClose}>
+                    <NudeButton onClick={onClose} aria-label={t("Close")}>
                       <CloseIcon />
                     </NudeButton>
                   </Tooltip>

--- a/app/components/Sharing/components/ShareSettingsPopover.tsx
+++ b/app/components/Sharing/components/ShareSettingsPopover.tsx
@@ -295,7 +295,7 @@ function ShareSettingsPopover({ share, children }: Props) {
                   "Display the last modified timestamp on the shared page"
                 )}
               >
-                <NudeButton size={18}>
+                <NudeButton size={18} aria-label={t("More information")}>
                   <QuestionMarkIcon size={18} />
                 </NudeButton>
               </Tooltip>
@@ -320,7 +320,7 @@ function ShareSettingsPopover({ share, children }: Props) {
                   "Display the table of contents on documents by default"
                 )}
               >
-                <NudeButton size={18}>
+                <NudeButton size={18} aria-label={t("More information")}>
                   <QuestionMarkIcon size={18} />
                 </NudeButton>
               </Tooltip>
@@ -348,7 +348,7 @@ function ShareSettingsPopover({ share, children }: Props) {
                   "Disable this setting to discourage search engines from indexing the page"
                 )}
               >
-                <NudeButton size={18}>
+                <NudeButton size={18} aria-label={t("More information")}>
                   <QuestionMarkIcon size={18} />
                 </NudeButton>
               </Tooltip>

--- a/app/components/Sharing/components/ShareSettingsPopover.tsx
+++ b/app/components/Sharing/components/ShareSettingsPopover.tsx
@@ -374,7 +374,7 @@ function ShareSettingsPopover({ share, children }: Props) {
                     "Allow viewers to subscribe and receive email notifications when documents are updated"
                   )}
                 >
-                  <NudeButton size={18}>
+                  <NudeButton size={18} aria-label={t("More information")}>
                     <QuestionMarkIcon size={18} />
                   </NudeButton>
                 </Tooltip>

--- a/app/components/Table.tsx
+++ b/app/components/Table.tsx
@@ -183,7 +183,7 @@ function Table<TData>({
                 const handleSortKeyDown = (
                   ev: React.KeyboardEvent<HTMLDivElement>
                 ) => {
-                  if (ev.key === "Enter" || ev.key === " ") {
+                  if (!ev.repeat && (ev.key === "Enter" || ev.key === " ")) {
                     ev.preventDefault();
                     toggleSorting?.(ev);
                   }

--- a/app/components/Table.tsx
+++ b/app/components/Table.tsx
@@ -176,28 +176,57 @@ function Table<TData>({
         <THead role="rowgroup" $topPos={stickyOffset}>
           {table.getHeaderGroups().map((headerGroup) => (
             <TR role="row" key={headerGroup.id} $columns={gridColumns}>
-              {headerGroup.headers.map((header) => (
-                <TH role="columnheader" key={header.id}>
-                  <SortWrapper
-                    align="center"
-                    gap={4}
-                    onClick={header.column.getToggleSortingHandler()}
-                    $sortable={header.column.getCanSort()}
+              {headerGroup.headers.map((header) => {
+                const sorted = header.column.getIsSorted();
+                const canSort = header.column.getCanSort();
+                const toggleSorting = header.column.getToggleSortingHandler();
+                const handleSortKeyDown = (
+                  ev: React.KeyboardEvent<HTMLDivElement>
+                ) => {
+                  if (ev.key === "Enter" || ev.key === " ") {
+                    ev.preventDefault();
+                    toggleSorting?.(ev);
+                  }
+                };
+
+                return (
+                  <TH
+                    role="columnheader"
+                    key={header.id}
+                    aria-sort={
+                      !canSort
+                        ? undefined
+                        : sorted === "asc"
+                          ? "ascending"
+                          : sorted === "desc"
+                            ? "descending"
+                            : "none"
+                    }
                   >
-                    {flexRender(
-                      header.column.columnDef.header,
-                      header.getContext()
-                    )}
-                    {header.column.getIsSorted() === "asc" ? (
-                      <AscSortIcon />
-                    ) : header.column.getIsSorted() === "desc" ? (
-                      <DescSortIcon />
-                    ) : (
-                      <div />
-                    )}
-                  </SortWrapper>
-                </TH>
-              ))}
+                    <SortWrapper
+                      align="center"
+                      gap={4}
+                      onClick={toggleSorting}
+                      onKeyDown={canSort ? handleSortKeyDown : undefined}
+                      role={canSort ? "button" : undefined}
+                      tabIndex={canSort ? 0 : undefined}
+                      $sortable={canSort}
+                    >
+                      {flexRender(
+                        header.column.columnDef.header,
+                        header.getContext()
+                      )}
+                      {sorted === "asc" ? (
+                        <AscSortIcon />
+                      ) : sorted === "desc" ? (
+                        <DescSortIcon />
+                      ) : (
+                        <div />
+                      )}
+                    </SortWrapper>
+                  </TH>
+                );
+              })}
             </TR>
           ))}
         </THead>
@@ -322,6 +351,11 @@ const SortWrapper = styled(Flex)<{ $sortable: boolean }>`
     background: ${(props) =>
       props.$sortable ? props.theme.backgroundSecondary : "none"};
   }
+
+  &:focus-visible {
+    outline: 2px solid ${(props) => props.theme.accent};
+    outline-offset: 2px;
+  }
 `;
 
 const InnerTable = styled.div`
@@ -416,6 +450,7 @@ const TD = styled.span`
       background: ${s("sidebarControlHoverBackground")};
     }
 
+    &:focus-visible,
     &[aria-expanded="true"] {
       opacity: 1;
     }

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -468,6 +468,7 @@
   "Site title": "Site title",
   "Show last modified": "Show last modified",
   "Display the last modified timestamp on the shared page": "Display the last modified timestamp on the shared page",
+  "More information": "More information",
   "Show table of contents": "Show table of contents",
   "Display the table of contents on documents by default": "Display the table of contents on documents by default",
   "Behavior": "Behavior",


### PR DESCRIPTION
- `CircularProgressBar` — added progressbar role with aria-valuenow/min/max and an optional label so screen readers can perceive the indicator.
- `Modal` — gave the icon-only close button an aria-label so it’s announced (the tooltip only supplied a description, not a name).
- `EmojiPanel` — labeled the empty-state upload button to match its already-labeled toolbar twin.
- `ShareSettingsPopover` — added an accessible name to the four unlabeled question-mark help buttons.
- `Table` (sort headers) — exposed aria-sort state and made sorting keyboard-operable with role="button", tabIndex, and an Enter/Space handler.
- `Table` (sort focus) — added a :focus-visible outline so the now-focusable sort control shows visible keyboard focus.
- `Table` (overflow action) — revealed the row overflow menu button on keyboard focus, not just on hover.