### PR TITLE
fix: Handle transient errors in `HealthMonitor`

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -55,7 +55,7 @@ async function master() {
 
   if (env.TELEMETRY && env.isProduction) {
     void checkUpdates();
-    setInterval(checkUpdates, 24 * 3600 * 1000);
+    setInterval(checkUpdates, 24 * 3600 * 1000).unref();
   }
 }
 

--- a/server/queues/HealthMonitor.ts
+++ b/server/queues/HealthMonitor.ts
@@ -23,7 +23,7 @@ export default class HealthMonitor {
       lastActivityTime = Date.now();
     });
 
-    setInterval(async () => {
+    const timer = setInterval(async () => {
       const timeSinceActivity = Date.now() - lastActivityTime;
 
       // If there's been recent activity, the queue is healthy
@@ -31,17 +31,28 @@ export default class HealthMonitor {
         return;
       }
 
-      const waiting = await queue.getWaitingCount();
-      if (waiting > 50) {
-        Logger.fatal(
-          "Queue has stopped processing jobs",
-          new Error(`Jobs are waiting in the ${queue.name} queue`),
-          {
-            queue: queue.name,
-            waiting,
-          }
-        );
+      try {
+        const waiting = await queue.getWaitingCount();
+        if (waiting > 50) {
+          Logger.fatal(
+            "Queue has stopped processing jobs",
+            new Error(`Jobs are waiting in the ${queue.name} queue`),
+            {
+              queue: queue.name,
+              waiting,
+            }
+          );
+        }
+      } catch (err) {
+        // A transient error querying the queue (eg Redis blip or a queue closing
+        // during shutdown) should not take down the process it is meant to guard.
+        Logger.warn("Failed to check queue health", {
+          queue: queue.name,
+          error: err,
+        });
       }
     }, 30 * Second.ms);
+
+    timer.unref();
   }
 }

--- a/server/queues/queue.ts
+++ b/server/queues/queue.ts
@@ -65,14 +65,29 @@ export function createQueue(
     }
   });
 
+  let metricsTimer: NodeJS.Timeout | undefined;
   if (env.ENVIRONMENT !== "test") {
-    setInterval(async () => {
-      Metrics.gauge(`${prefix}.count`, await queue.count());
-      Metrics.gauge(`${prefix}.delayed_count`, await queue.getDelayedCount());
+    metricsTimer = setInterval(async () => {
+      try {
+        Metrics.gauge(`${prefix}.count`, await queue.count());
+        Metrics.gauge(`${prefix}.delayed_count`, await queue.getDelayedCount());
+      } catch (err) {
+        // A transient error querying the queue (eg Redis blip or a queue closing
+        // during shutdown) should not crash the process with an unhandled rejection.
+        Logger.warn("Failed to gather queue metrics", {
+          queue: name,
+          error: err,
+        });
+      }
     }, 5 * Second.ms);
+
+    metricsTimer.unref();
   }
 
   ShutdownHelper.add(name, ShutdownOrder.normal, async () => {
+    if (metricsTimer) {
+      clearInterval(metricsTimer);
+    }
     await queue.close();
   });
 

--- a/server/services/cron.ts
+++ b/server/services/cron.ts
@@ -24,13 +24,13 @@ export default function init() {
     }
   }
 
-  setInterval(() => void run(TaskInterval.Day), Day.ms);
-  setInterval(() => void run(TaskInterval.Hour), Hour.ms);
+  setInterval(() => void run(TaskInterval.Day), Day.ms).unref();
+  setInterval(() => void run(TaskInterval.Hour), Hour.ms).unref();
 
   // Just give everything time to startup before running the first time. Not
   // _technically_ required to function.
   setTimeout(() => {
     void run(TaskInterval.Day);
     void run(TaskInterval.Hour);
-  }, 5 * Second.ms);
+  }, 5 * Second.ms).unref();
 }

--- a/server/services/web.ts
+++ b/server/services/web.ts
@@ -73,7 +73,7 @@ export default function init(app: Koa = new Koa(), server?: Server) {
         }
         Metrics.gaugePerInstance("connections.count", count);
       });
-    }, 5 * Second.ms);
+    }, 5 * Second.ms).unref();
   }
 
   ShutdownHelper.add("connections", ShutdownOrder.normal, async () => {


### PR DESCRIPTION
Also add unref to recurring/background timers whose only job is periodic housekeeping — none should hold the Node event loop open during shutdown