### PR TITLE
fix: `useMediaQuery` value incorrect on first render

### DIFF
--- a/app/hooks/useMediaQuery.ts
+++ b/app/hooks/useMediaQuery.ts
@@ -1,5 +1,10 @@
 import { useState, useEffect } from "react";
 
+const getMatches = (query: string): boolean =>
+  typeof window.matchMedia === "function"
+    ? window.matchMedia(query).matches
+    : false;
+
 /**
  * Hook to check if a media query matches the current viewport.
  *
@@ -7,23 +12,28 @@ import { useState, useEffect } from "react";
  * @returns boolean indicating whether the media query matches
  */
 export default function useMediaQuery(query: string): boolean {
-  const [matches, setMatches] = useState<boolean>(false);
+  // Initialize with the real value so the first render is correct and doesn't
+  // flash an incorrect result before the effect runs.
+  const [matches, setMatches] = useState<boolean>(() => getMatches(query));
 
   useEffect(() => {
-    if (window.matchMedia) {
-      const media = window.matchMedia(query);
-      if (media.matches !== matches) {
-        setMatches(media.matches);
-      }
-      const listener = () => {
-        setMatches(media.matches);
-      };
-      media.addListener(listener);
-      return () => media.removeListener(listener);
+    if (typeof window.matchMedia !== "function") {
+      return undefined;
     }
 
-    return undefined;
-  }, [matches, query]);
+    const media = window.matchMedia(query);
+    // Resync in case the query changed, or the viewport moved between the
+    // initial render and this effect, since the initial state is only computed
+    // once on mount.
+    setMatches(media.matches);
+
+    const listener = (event: MediaQueryListEvent) => {
+      setMatches(event.matches);
+    };
+
+    media.addEventListener("change", listener);
+    return () => media.removeEventListener("change", listener);
+  }, [query]);
 
   return matches;
 }

--- a/app/hooks/useMediaQuery.ts
+++ b/app/hooks/useMediaQuery.ts
@@ -1,7 +1,8 @@
 import { useState, useEffect } from "react";
+import { isBrowser } from "@shared/utils/browser";
 
 const getMatches = (query: string): boolean =>
-  typeof window.matchMedia === "function"
+  isBrowser && typeof window.matchMedia === "function"
     ? window.matchMedia(query).matches
     : false;
 
@@ -17,7 +18,7 @@ export default function useMediaQuery(query: string): boolean {
   const [matches, setMatches] = useState<boolean>(() => getMatches(query));
 
   useEffect(() => {
-    if (typeof window.matchMedia !== "function") {
+    if (!isBrowser || typeof window.matchMedia !== "function") {
       return undefined;
     }
 


### PR DESCRIPTION
Dependencies array also included `matches` value, creating unnecessary churn