### PR TITLE
Harden shared tree utilities and add test coverage

### DIFF
--- a/shared/utils/tree.test.ts
+++ b/shared/utils/tree.test.ts
@@ -1,0 +1,143 @@
+import type { NavigationNode } from "../types";
+import { ancestors, descendants, flattenTree } from "./tree";
+
+const buildNode = (
+  id: string,
+  children: NavigationNode[] = []
+): NavigationNode => ({
+  id,
+  title: `Title ${id}`,
+  url: `/doc/${id}`,
+  children,
+});
+
+/**
+ * Annotates a tree with the `parent` and `depth` fields added at runtime by
+ * useCollectionTrees, mirroring how nodes are prepared in the app.
+ */
+const annotate = (
+  node: NavigationNode,
+  parent: NavigationNode | null = null,
+  depth = 0
+): NavigationNode => {
+  node.parent = parent;
+  node.depth = depth;
+  node.children.forEach((child) => annotate(child, node, depth + 1));
+  return node;
+};
+
+const buildTree = () =>
+  buildNode("root", [
+    buildNode("a", [buildNode("a1", [buildNode("a1i")]), buildNode("a2")]),
+    buildNode("b"),
+  ]);
+
+describe("#flattenTree", () => {
+  it("should return all nodes in depth-first order", () => {
+    expect(flattenTree(buildTree()).map((node) => node.id)).toEqual([
+      "root",
+      "a",
+      "a1",
+      "a1i",
+      "a2",
+      "b",
+    ]);
+  });
+
+  it("should return a single node for a leaf", () => {
+    expect(flattenTree(buildNode("leaf")).map((node) => node.id)).toEqual([
+      "leaf",
+    ]);
+  });
+
+  it("should tolerate nodes without a children array", () => {
+    const node: Partial<NavigationNode> = buildNode("orphan");
+    delete node.children;
+
+    expect(flattenTree(node as NavigationNode).map((n) => n.id)).toEqual([
+      "orphan",
+    ]);
+  });
+});
+
+describe("#ancestors", () => {
+  it("should return ancestors ordered from root to direct parent", () => {
+    const root = annotate(buildTree());
+    const deepest = root.children[0].children[0].children[0];
+
+    expect(ancestors(deepest).map((node) => node.id)).toEqual([
+      "root",
+      "a",
+      "a1",
+    ]);
+  });
+
+  it("should return an empty list for a root node", () => {
+    const root = annotate(buildTree());
+    expect(ancestors(root)).toEqual([]);
+  });
+
+  it("should return an empty list for a missing node", () => {
+    expect(ancestors(null)).toEqual([]);
+  });
+
+  it("should treat nodes without a parent annotation as roots", () => {
+    // Nodes straight from the server, e.g. a shared tree, carry no parent.
+    expect(ancestors(buildNode("unannotated"))).toEqual([]);
+  });
+
+  it("should not loop forever on a malformed parent cycle", () => {
+    const first = buildNode("first");
+    const second = buildNode("second");
+    first.parent = second;
+    second.parent = first;
+
+    expect(ancestors(first).map((node) => node.id)).toEqual([
+      "first",
+      "second",
+    ]);
+  });
+});
+
+describe("#descendants", () => {
+  it("should return all descendants by default", () => {
+    expect(descendants(buildTree()).map((node) => node.id)).toEqual([
+      "a",
+      "a1",
+      "a1i",
+      "a2",
+      "b",
+    ]);
+  });
+
+  it("should limit results to the given depth", () => {
+    const root = buildTree();
+
+    expect(descendants(root, 1).map((node) => node.id)).toEqual(["a", "b"]);
+    expect(descendants(root, 2).map((node) => node.id)).toEqual([
+      "a",
+      "a1",
+      "a2",
+      "b",
+    ]);
+  });
+
+  it("should limit by depth relative to the node itself", () => {
+    const root = annotate(buildTree());
+    const child = root.children[0];
+
+    expect(descendants(child, 1).map((node) => node.id)).toEqual(["a1", "a2"]);
+  });
+
+  it("should not require depth annotations on nodes", () => {
+    // Nodes straight from the server carry no depth annotation.
+    expect(descendants(buildTree(), 1).map((node) => node.id)).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  it("should return an empty list for a leaf node", () => {
+    expect(descendants(buildNode("leaf"))).toEqual([]);
+  });
+});

--- a/shared/utils/tree.test.ts
+++ b/shared/utils/tree.test.ts
@@ -92,10 +92,9 @@ describe("#ancestors", () => {
     first.parent = second;
     second.parent = first;
 
-    expect(ancestors(first).map((node) => node.id)).toEqual([
-      "first",
-      "second",
-    ]);
+    // The node itself is never part of its own ancestors, even when the
+    // parent chain cycles back to it.
+    expect(ancestors(first).map((node) => node.id)).toEqual(["second"]);
   });
 });
 

--- a/shared/utils/tree.ts
+++ b/shared/utils/tree.ts
@@ -5,9 +5,12 @@ import type { NavigationNode } from "../types";
  * starting with the root node itself.
  *
  * @param root The root node of the tree to flatten.
- * @returns the root node followed by all of its descendants.
+ * @returns the root node followed by all of its descendants, or an empty
+ *   list when no root is given.
  */
-export const flattenTree = (root: NavigationNode): NavigationNode[] => {
+export const flattenTree = (
+  root: NavigationNode | null | undefined
+): NavigationNode[] => {
   const flattened: NavigationNode[] = [];
 
   const visit = (node: NavigationNode) => {
@@ -35,6 +38,9 @@ export const ancestors = (
 ): NavigationNode[] => {
   const nodes: NavigationNode[] = [];
   const seen = new Set<NavigationNode>();
+  if (node) {
+    seen.add(node);
+  }
 
   let current = node?.parent;
   while (current && !seen.has(current)) {

--- a/shared/utils/tree.ts
+++ b/shared/utils/tree.ts
@@ -1,36 +1,75 @@
 import type { NavigationNode } from "../types";
 
-export const flattenTree = (root: NavigationNode) => {
+/**
+ * Flattens a navigation tree into a list of nodes in depth-first order,
+ * starting with the root node itself.
+ *
+ * @param root The root node of the tree to flatten.
+ * @returns the root node followed by all of its descendants.
+ */
+export const flattenTree = (root: NavigationNode): NavigationNode[] => {
   const flattened: NavigationNode[] = [];
-  if (!root) {
-    return flattened;
+
+  const visit = (node: NavigationNode) => {
+    flattened.push(node);
+    node.children?.forEach(visit);
+  };
+
+  if (root) {
+    visit(root);
   }
-
-  flattened.push(root);
-
-  root.children.forEach((child) => {
-    flattened.push(...flattenTree(child));
-  });
 
   return flattened;
 };
 
-export const ancestors = (node: NavigationNode | null) => {
+/**
+ * Returns the ancestors of a node, ordered from the root of the tree down to
+ * the node's direct parent. Nodes must have been annotated with a `parent`
+ * reference (see useCollectionTrees); nodes without one are treated as roots.
+ *
+ * @param node The node to return ancestors for.
+ * @returns the node's ancestors, or an empty list for a root node.
+ */
+export const ancestors = (
+  node: NavigationNode | null | undefined
+): NavigationNode[] => {
   const nodes: NavigationNode[] = [];
-  if (node) {
-    while (node.parent !== null) {
-      nodes.unshift(node.parent as NavigationNode);
-      node = node.parent as NavigationNode;
-    }
+  const seen = new Set<NavigationNode>();
+
+  let current = node?.parent;
+  while (current && !seen.has(current)) {
+    seen.add(current);
+    nodes.unshift(current);
+    current = current.parent;
   }
+
   return nodes;
 };
 
-export const descendants = (node: NavigationNode, depth = 0) => {
-  const allDescendants = flattenTree(node).slice(1);
-  return depth === 0
-    ? allDescendants
-    : allDescendants.filter(
-        (d) => (d.depth as number) <= (node.depth as number) + depth
-      );
+/**
+ * Returns the descendants of a node in depth-first order, optionally limited
+ * to a maximum depth below the node.
+ *
+ * @param node The node to return descendants for.
+ * @param depth The maximum depth to descend to, where 1 returns direct
+ *   children only. Defaults to 0, which returns all descendants.
+ * @returns the node's descendants, not including the node itself.
+ */
+export const descendants = (
+  node: NavigationNode,
+  depth = 0
+): NavigationNode[] => {
+  const found: NavigationNode[] = [];
+
+  const visit = (child: NavigationNode, childDepth: number) => {
+    if (depth > 0 && childDepth > depth) {
+      return;
+    }
+    found.push(child);
+    child.children?.forEach((grandchild) => visit(grandchild, childDepth + 1));
+  };
+
+  node.children?.forEach((child) => visit(child, 1));
+
+  return found;
 };


### PR DESCRIPTION
- Fix ancestors() throwing a TypeError when a node's parent is undefined
  rather than null, which is the case for nodes that haven't been
  annotated by useCollectionTrees (e.g. shared trees from the server).
- Guard against malformed parent cycles in ancestors() so a bad tree can
  no longer hang the client.
- Compute descendants() depth limits relative to the given node during
  traversal instead of relying on optional absolute depth annotations,
  which silently returned an empty list when they were missing.
- Tolerate nodes without a children array in traversal.
- Remove type assertions, add JSDoc, and add collocated unit tests.
