### PR TITLE
fix(i18n): improve Brazilian Portuguese translation

### DIFF
--- a/shared/i18n/locales/pt_BR/translation.json
+++ b/shared/i18n/locales/pt_BR/translation.json
@@ -272,7 +272,7 @@
   "Document moved": "Documento movido",
   "Couldn’t move the document, try again?": "Não foi possível mover o documento, tentar novamente?",
   "Move to <em>{{ location }}</em>": "Mover para <em>{{ location }}</em>",
-  "Couldn’t move the template, try again?": "Couldn’t move the template, try again?",
+  "Couldn’t move the template, try again?": "Não foi possível mover o template, tentar novamente?",
   "New": "Novo",
   "Only visible to you": "Visível apenas para você",
   "Draft": "Rascunho",


### PR DESCRIPTION
## Summary

Improves the Brazilian Portuguese (`pt-BR`) translation for the template move error message to make it properly localized.

### Changed

- Updated the `pt-BR` translation for:
  - `Couldn't move the template, try again?`