### PR TITLE
fix: Complete RP-initiated logout against Keycloak 17

### DIFF
--- a/app/scenes/Logout.tsx
+++ b/app/scenes/Logout.tsx
@@ -1,3 +1,5 @@
+import { observer } from "mobx-react";
+import { useEffect } from "react";
 import { Redirect } from "react-router-dom";
 import env from "~/env";
 import useStores from "~/hooks/useStores";
@@ -6,10 +8,21 @@ import { logoutPath } from "~/utils/routeHelpers";
 const Logout = () => {
   const { auth } = useStores();
 
-  void auth.logout({
-    userInitiated: true,
-    clearCache: true,
-  });
+  useEffect(() => {
+    void auth.logout({
+      userInitiated: true,
+      clearCache: true,
+    });
+  }, [auth]);
+
+  // This scene is rendered outside of `Authenticated`, so the redirect to the
+  // provider logout URI must be performed here once the local session is
+  // cleared.
+  useEffect(() => {
+    if (auth.logoutRedirectUri) {
+      window.location.href = auth.logoutRedirectUri;
+    }
+  }, [auth.logoutRedirectUri]);
 
   if (env.OIDC_LOGOUT_URI || auth.lastSignedIn === "oidc") {
     return null; // user will be redirected to logout URI after logout
@@ -17,4 +30,4 @@ const Logout = () => {
   return <Redirect to={logoutPath()} />;
 };
 
-export default Logout;
+export default observer(Logout);

--- a/plugins/oidc/server/auth/keycloak.test.ts
+++ b/plugins/oidc/server/auth/keycloak.test.ts
@@ -1,0 +1,45 @@
+import { deriveKeycloakLogoutUrl } from "./keycloak";
+
+describe("deriveKeycloakLogoutUrl", () => {
+  it("should derive the logout endpoint from a Keycloak authorization endpoint", () => {
+    expect(
+      deriveKeycloakLogoutUrl(
+        "https://sso.example.com/realms/myrealm/protocol/openid-connect/auth"
+      )
+    ).toEqual(
+      "https://sso.example.com/realms/myrealm/protocol/openid-connect/logout"
+    );
+  });
+
+  it("should support the legacy /auth relative path", () => {
+    expect(
+      deriveKeycloakLogoutUrl(
+        "https://sso.example.com/auth/realms/myrealm/protocol/openid-connect/auth"
+      )
+    ).toEqual(
+      "https://sso.example.com/auth/realms/myrealm/protocol/openid-connect/logout"
+    );
+  });
+
+  it("should strip query strings and fragments", () => {
+    expect(
+      deriveKeycloakLogoutUrl(
+        "https://sso.example.com/realms/myrealm/protocol/openid-connect/auth?kc_idp_hint=github#top"
+      )
+    ).toEqual(
+      "https://sso.example.com/realms/myrealm/protocol/openid-connect/logout"
+    );
+  });
+
+  it("should return undefined for non-Keycloak endpoints", () => {
+    expect(
+      deriveKeycloakLogoutUrl("https://accounts.google.com/o/oauth2/v2/auth")
+    ).toBeUndefined();
+    expect(deriveKeycloakLogoutUrl("https://example.com/auth")).toBeUndefined();
+  });
+
+  it("should return undefined for missing or invalid input", () => {
+    expect(deriveKeycloakLogoutUrl(undefined)).toBeUndefined();
+    expect(deriveKeycloakLogoutUrl("not a url")).toBeUndefined();
+  });
+});

--- a/plugins/oidc/server/auth/keycloak.ts
+++ b/plugins/oidc/server/auth/keycloak.ts
@@ -1,0 +1,36 @@
+const KEYCLOAK_AUTH_ENDPOINT_SUFFIX = "/protocol/openid-connect/auth";
+
+/**
+ * Derives the Keycloak end-session endpoint from its authorization endpoint.
+ *
+ * Keycloak exposes all OIDC endpoints under a common
+ * `…/realms/{realm}/protocol/openid-connect/` path, so when a logout endpoint
+ * has not been explicitly configured it can be derived by swapping the last
+ * path segment of the authorization endpoint.
+ *
+ * @param authorizationURL the configured OIDC authorization endpoint.
+ * @returns the corresponding end-session endpoint, or undefined when the URL
+ * does not match the Keycloak endpoint layout.
+ */
+export function deriveKeycloakLogoutUrl(
+  authorizationURL: string | undefined
+): string | undefined {
+  if (!authorizationURL) {
+    return undefined;
+  }
+
+  try {
+    const url = new URL(authorizationURL);
+
+    if (!url.pathname.endsWith(KEYCLOAK_AUTH_ENDPOINT_SUFFIX)) {
+      return undefined;
+    }
+
+    url.pathname = url.pathname.replace(/\/auth$/, "/logout");
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch (_err) {
+    return undefined;
+  }
+}

--- a/plugins/oidc/server/auth/oidc.test.ts
+++ b/plugins/oidc/server/auth/oidc.test.ts
@@ -31,6 +31,17 @@ describe("oidc", () => {
       ).toEqual("http://localhost:3000");
     });
 
+    it("should include the legacy redirect_uri for Keycloak 17 and earlier", async () => {
+      const res = await server.get("/auth/oidc.logout", {
+        redirect: "manual",
+      });
+      expect(res.status).toEqual(302);
+      const redirectLocation = new URL(res.headers.get("location")!);
+      expect(redirectLocation.searchParams.get("redirect_uri")).toEqual(
+        "http://localhost:3000"
+      );
+    });
+
     it("should include the id_token_hint when present", async () => {
       const res = await server.get("/auth/oidc.logout", {
         redirect: "manual",

--- a/plugins/oidc/server/auth/oidc.ts
+++ b/plugins/oidc/server/auth/oidc.ts
@@ -3,6 +3,7 @@ import { toError } from "@shared/utils/error";
 import Logger from "@server/logging/Logger";
 import env from "../env";
 import { fetchOIDCConfiguration } from "../oidcDiscovery";
+import { deriveKeycloakLogoutUrl } from "./keycloak";
 import { createOIDCRouter } from "./oidcRouter";
 
 const router = new Router();
@@ -25,7 +26,14 @@ const hasIssuerConfig = !!(
 );
 
 if (hasManualConfig) {
-  // Mount endpoints immediately with manual configuration
+  // Mount endpoints immediately with manual configuration. When no logout
+  // endpoint is configured, attempt to derive it from the authorization
+  // endpoint for providers with a known layout, such as Keycloak – otherwise
+  // the provider session would outlive the Outline session and users would be
+  // silently signed back in.
+  env.OIDC_LOGOUT_URI =
+    env.OIDC_LOGOUT_URI ?? deriveKeycloakLogoutUrl(env.OIDC_AUTH_URI);
+
   createOIDCRouter(router, {
     authorizationURL: env.OIDC_AUTH_URI!,
     tokenURL: env.OIDC_TOKEN_URI!,
@@ -46,12 +54,17 @@ if (hasManualConfig) {
       env.OIDC_TOKEN_URI = oidcConfig.token_endpoint;
       env.OIDC_USERINFO_URI = oidcConfig.userinfo_endpoint;
 
+      // An explicitly configured logout endpoint takes precedence over the
+      // discovered end_session_endpoint.
+      env.OIDC_LOGOUT_URI =
+        env.OIDC_LOGOUT_URI ?? oidcConfig.end_session_endpoint;
+
       // Mount endpoints into the existing router
       createOIDCRouter(router, {
         authorizationURL: oidcConfig.authorization_endpoint,
         tokenURL: oidcConfig.token_endpoint,
         userInfoURL: oidcConfig.userinfo_endpoint,
-        logoutURL: oidcConfig.end_session_endpoint,
+        logoutURL: env.OIDC_LOGOUT_URI,
         pkce: oidcConfig.code_challenge_methods_supported?.includes("S256"),
       });
 

--- a/plugins/oidc/server/auth/oidcRouter.ts
+++ b/plugins/oidc/server/auth/oidcRouter.ts
@@ -297,6 +297,11 @@ export function createOIDCRouter(
       }
       url.searchParams.set("post_logout_redirect_uri", env.URL);
 
+      // Keycloak 17 and earlier do not implement the RP-initiated logout
+      // spec and only redirect back when the legacy `redirect_uri` parameter
+      // is present. Spec-compliant providers ignore unrecognized parameters.
+      url.searchParams.set("redirect_uri", env.URL);
+
       return ctx.redirect(url.toString());
     } catch (err) {
       Logger.warn("Invalid OIDC logout URL", {


### PR DESCRIPTION
Pressing the logout button previously only cleared the local Outline session in several configurations, leaving the Keycloak SSO session alive so the user was silently signed back in:

- The provider logout URL now falls back to being derived from the authorization endpoint when OIDC_LOGOUT_URI is not set and the provider uses the Keycloak endpoint layout, instead of skipping the provider logout entirely.
- The logout redirect now includes the legacy `redirect_uri` parameter in addition to `post_logout_redirect_uri`, as Keycloak 17 and earlier do not implement the RP-initiated logout spec and ignore the latter. Spec-compliant providers ignore the extra parameter.
- The /logout scene now performs the redirect to the provider logout URI itself. It renders outside of `Authenticated`, which was the only place handling `logoutRedirectUri`, so navigating to /logout stalled on a blank page without ever reaching the provider.
- An explicitly configured OIDC_LOGOUT_URI now takes precedence over the discovered end_session_endpoint.


Claude-Session: https://claude.ai/code/session_01EB4uUyaHAtDnoX3DBVYH6m