### PR TITLE
perf: optimize sidebar dragging

### DIFF
--- a/app/components/Menu/ContextMenu.tsx
+++ b/app/components/Menu/ContextMenu.tsx
@@ -31,17 +31,26 @@ export const ContextMenu = observer(
       isMenu: true,
     });
 
+    const [open, setOpen] = React.useState(false);
+
+    // Menu items must only be built while the menu is open. Resolving every
+    // action's title, icon and visibility (including translations) is
+    // expensive, and the closed branch reads no observables so store changes
+    // don't invalidate it.
     const menuItems = useComputed(
       () =>
-        ((action?.children as ActionVariant[]) ?? []).map((childAction) =>
-          actionToMenuItem(childAction, actionContext)
-        ),
-      [action?.children, actionContext]
+        open
+          ? ((action?.children as ActionVariant[]) ?? []).map((childAction) =>
+              actionToMenuItem(childAction, actionContext)
+            )
+          : [],
+      [open, action?.children, actionContext]
     );
 
     const handleOpenChange = React.useCallback(
-      (open: boolean) => {
-        if (open) {
+      (nextOpen: boolean) => {
+        setOpen(nextOpen);
+        if (nextOpen) {
           onOpen?.();
         } else {
           onClose?.();
@@ -62,7 +71,14 @@ export const ContextMenu = observer(
       }
     }, []);
 
-    if (isMobile || !action || menuItems.length === 0) {
+    // actionToMenuItem is length-preserving, so the raw children count decides
+    // emptiness without resolving any items.
+    const childActions = action?.children;
+    const isEmpty = Array.isArray(childActions)
+      ? childActions.length === 0
+      : !childActions;
+
+    if (isMobile || !action || isEmpty) {
       return <>{children}</>;
     }
 

--- a/app/components/Sidebar/components/DocumentLink.tsx
+++ b/app/components/Sidebar/components/DocumentLink.tsx
@@ -15,6 +15,7 @@ import type GroupMembership from "~/models/GroupMembership";
 import type UserMembership from "~/models/UserMembership";
 import type { RefHandle } from "~/components/EditableTitle";
 import useBoolean from "~/hooks/useBoolean";
+import { useComputed } from "~/hooks/useComputed";
 import useCurrentUser from "~/hooks/useCurrentUser";
 import { useDocumentMenuAction } from "~/hooks/useDocumentMenuAction";
 import useOnScreen from "~/hooks/useOnScreen";
@@ -282,7 +283,12 @@ const DocumentLinkInner = observer(function DocumentLinkInner({
   );
 
   const [menuOpen, handleMenuOpen, handleMenuClose] = useBoolean();
-  const isMoving = documents.movingDocumentId === node.id;
+  // Computed so that a change to movingDocumentId only re-renders the rows
+  // whose boolean actually flips, not every observer of the store field.
+  const isMoving = useComputed(
+    () => documents.movingDocumentId === node.id,
+    [documents, node.id]
+  );
   const icon = document?.icon || node.icon || node.emoji;
   const color = document?.color || node.color;
   const initial = document?.initial || node.title.charAt(0).toUpperCase();
@@ -301,8 +307,11 @@ const DocumentLinkInner = observer(function DocumentLinkInner({
   );
 
   const parentRef = React.useRef<HTMLDivElement>(null);
-  const [{ isOverReparent, canDropToReparent }, dropToReparent] =
-    useDropToReparentDocument(node, handleExpand, parentRef);
+  const [{ isOverReparent }, dropToReparent] = useDropToReparentDocument(
+    node,
+    handleExpand,
+    parentRef
+  );
 
   // Fall back so document-only access (e.g. "Manage" on a parent) can reorder.
   const moveCollectionId = collection?.id ?? document?.collectionId;
@@ -320,7 +329,7 @@ const DocumentLinkInner = observer(function DocumentLinkInner({
       };
     });
 
-  const [{ isOverReorder, isDraggingAnyDocument }, dropToReorder] =
+  const [{ isOverReorder }, dropToReorder] =
     useDropToReorderDocument(node, collection, (item) => {
       if (!moveCollectionId) {
         return;
@@ -381,16 +390,17 @@ const DocumentLinkInner = observer(function DocumentLinkInner({
     onRename: handleRename,
   });
 
-  const showMenuActions = !isDraggingAnyDocument;
-  const menu =
-    showMenuActions && document ? (
-      <DocumentMenu
-        document={document}
-        onRename={handleRename}
-        onOpen={handleMenuOpen}
-        onClose={handleMenuClose}
-      />
-    ) : undefined;
+  // The menu must stay mounted during drags. Unmounting it for every row at
+  // drag start and remounting at drop is expensive. The actions slot is
+  // hidden via CSS (see Actions in SidebarLink) while a drag is active.
+  const menu = document ? (
+    <DocumentMenu
+      document={document}
+      onRename={handleRename}
+      onOpen={handleMenuOpen}
+      onClose={handleMenuClose}
+    />
+  ) : undefined;
 
   // Without a collection we can't read isManualSort; fall back to the shared
   // membership's permission, which is the same for every descendant.
@@ -399,8 +409,11 @@ const DocumentLinkInner = observer(function DocumentLinkInner({
     : membership?.permission === DocumentPermission.Admin ||
       membership?.permission === DocumentPermission.ReadWrite;
 
+  // Cursors stay mounted between drags so that drag start/end doesn't change
+  // the tree for every row. DropCursor is inert and invisible while no drag
+  // is active.
   const cursorBefore =
-    isDraggingAnyDocument && canReorderHere && index === 0 ? (
+    canReorderHere && index === 0 ? (
       <DropCursor
         isActiveDrop={isOverReorderAbove}
         innerRef={dropToReorderAbove}
@@ -408,10 +421,9 @@ const DocumentLinkInner = observer(function DocumentLinkInner({
       />
     ) : undefined;
 
-  const cursorAfter =
-    isDraggingAnyDocument && canReorderHere ? (
-      <DropCursor isActiveDrop={isOverReorder} innerRef={dropToReorder} />
-    ) : undefined;
+  const cursorAfter = canReorderHere ? (
+    <DropCursor isActiveDrop={isOverReorder} innerRef={dropToReorder} />
+  ) : undefined;
 
   return (
     <DocumentRow
@@ -437,12 +449,12 @@ const DocumentLinkInner = observer(function DocumentLinkInner({
       isMoving={isMoving}
       parentRef={parentRef}
       dropToReparentRef={dropToReparent}
-      isActiveDropTarget={isOverReparent && canDropToReparent}
+      isActiveDropTarget={isOverReparent}
       cursorBefore={cursorBefore}
       cursorAfter={cursorAfter}
       menu={menu}
       menuOpen={menuOpen}
-      canCreateChild={showMenuActions && can.createChildDocument}
+      canCreateChild={can.createChildDocument}
       onCreateChild={handleNewDoc}
       contextAction={contextMenuAction}
       isActiveOverride={isActiveCheck}

--- a/app/components/Sidebar/components/DragActiveContext.tsx
+++ b/app/components/Sidebar/components/DragActiveContext.tsx
@@ -32,6 +32,15 @@ export function DragActiveProvider({
   children: React.ReactNode;
 }) {
   const isDragging = useDragLayer((monitor) => monitor.isDragging());
+
+  // Expose drag state to CSS so per-row UI (e.g. the hover actions slot) can
+  // be hidden for the duration of a drag without re-rendering or unmounting
+  // anything in each row.
+  React.useEffect(() => {
+    document.body.toggleAttribute("data-drag-active", isDragging);
+    return () => document.body.removeAttribute("data-drag-active");
+  }, [isDragging]);
+
   return (
     <DragActiveContext.Provider value={isDragging}>
       {children}

--- a/app/components/Sidebar/components/DropCursor.tsx
+++ b/app/components/Sidebar/components/DropCursor.tsx
@@ -21,6 +21,15 @@ const Cursor = styled.div<{
   position: absolute;
   z-index: 1;
 
+  /* Cursors stay mounted between drags so drag start/end doesn't re-render
+     rows. They are only interactive while a drag is active (attribute set by
+     DragActiveProvider) so the invisible strips never intercept clicks. */
+  pointer-events: none;
+
+  [data-drag-active] & {
+    pointer-events: auto;
+  }
+
   width: 100%;
   height: 14px;
   background: transparent;

--- a/app/components/Sidebar/components/DropToImport.tsx
+++ b/app/components/Sidebar/components/DropToImport.tsx
@@ -32,7 +32,17 @@ function DropToImport({ disabled, children, collectionId, documentId }: Props) {
     collectionId || documentId,
     "Must provide either collectionId or documentId"
   );
-  useEventListener("dragenter", () => setPreRendered(true));
+  // Only prepare the dropzone for OS file drags. Internal react-dnd drags
+  // fire native dragenter too, and prerendering a dropzone in every sidebar
+  // row at once is expensive.
+  useEventListener("dragenter", (event: Event) => {
+    if (
+      event instanceof DragEvent &&
+      event.dataTransfer?.types.includes("Files")
+    ) {
+      setPreRendered(true);
+    }
+  });
 
   const canCollection = usePolicy(collectionId);
   const canDocument = usePolicy(documentId);

--- a/app/components/Sidebar/components/DropToImport.tsx
+++ b/app/components/Sidebar/components/DropToImport.tsx
@@ -34,11 +34,14 @@ function DropToImport({ disabled, children, collectionId, documentId }: Props) {
   );
   // Only prepare the dropzone for OS file drags. Internal react-dnd drags
   // fire native dragenter too, and prerendering a dropzone in every sidebar
-  // row at once is expensive.
+  // row at once is expensive. DragEvent may be undefined in test
+  // environments, and types is a DOMStringList in older browsers, hence the
+  // extra guards.
   useEventListener("dragenter", (event: Event) => {
     if (
+      typeof DragEvent !== "undefined" &&
       event instanceof DragEvent &&
-      event.dataTransfer?.types.includes("Files")
+      Array.from(event.dataTransfer?.types ?? []).includes("Files")
     ) {
       setPreRendered(true);
     }

--- a/app/components/Sidebar/components/SharedWithMeLink.tsx
+++ b/app/components/Sidebar/components/SharedWithMeLink.tsx
@@ -119,8 +119,11 @@ function SharedWithMeLink({ membership, depth = 0 }: Props) {
     () => document?.asNavigationNode,
     [document]
   );
-  const [{ isOverReparent, canDropToReparent }, dropToReparent] =
-    useDropToReparentDocument(reparentableNode, setExpanded, parentRef);
+  const [{ isOverReparent }, dropToReparent] = useDropToReparentDocument(
+    reparentableNode,
+    setExpanded,
+    parentRef
+  );
 
   const { icon } = useSidebarLabelAndIcon(membership);
   const [{ isDragging }, draggableRef] = useDragMembership(membership);
@@ -192,7 +195,7 @@ function SharedWithMeLink({ membership, depth = 0 }: Props) {
       isDragging={isDragging}
       parentRef={parentRef}
       dropToReparentRef={dropToReparent}
-      isActiveDropTarget={isOverReparent && canDropToReparent}
+      isActiveDropTarget={isOverReparent}
       menu={menu}
       menuOpen={menuOpen}
       isActiveOverride={isActive}

--- a/app/components/Sidebar/components/SidebarLink.tsx
+++ b/app/components/Sidebar/components/SidebarLink.tsx
@@ -237,6 +237,12 @@ const Content = styled.span`
 const Actions = styled(EventBoundary)<{ $showActions?: boolean }>`
   display: inline-flex;
   visibility: ${(props) => (props.$showActions ? "visible" : "hidden")};
+
+  /* Hidden while a sidebar drag is in progress (attribute set by
+     DragActiveProvider) so action menus stay mounted but out of the way. */
+  [data-drag-active] & {
+    display: none;
+  }
   position: absolute;
   top: 3px;
   inset-inline-end: 4px;

--- a/app/components/Sidebar/hooks/useDragAndDrop.tsx
+++ b/app/components/Sidebar/hooks/useDragAndDrop.tsx
@@ -321,11 +321,7 @@ export function useDropToReparentDocument(
 
   const startHover = useHover(parentRef, setExpanded);
 
-  return useDrop<
-    DragObject,
-    Promise<void>,
-    { isOverReparent: boolean; canDropToReparent: boolean }
-  >({
+  return useDrop<DragObject, Promise<void>, { isOverReparent: boolean }>({
     accept: "document",
     drop: async (item, monitor) => {
       if (monitor.didDrop() || !node) {
@@ -400,9 +396,11 @@ export function useDropToReparentDocument(
         startHover();
       }
     },
+    // Collected values must stay unchanged while the target is not hovered.
+    // Collecting global drag state (e.g. a bare canDrop) re-renders every
+    // sidebar row at drag start and drop.
     collect: (monitor) => ({
-      isOverReparent: monitor.isOver({ shallow: true }),
-      canDropToReparent: monitor.canDrop(),
+      isOverReparent: monitor.isOver({ shallow: true }) && monitor.canDrop(),
     }),
   });
 }
@@ -431,11 +429,7 @@ export function useDropToReorderDocument(
 
   const document = documents.get(node.id);
 
-  return useDrop<
-    DragObject,
-    Promise<void>,
-    { isOverReorder: boolean; isDraggingAnyDocument: boolean }
-  >({
+  return useDrop<DragObject, Promise<void>, { isOverReorder: boolean }>({
     accept: "document",
     canDrop: (item: DragObject) => {
       if (item.id === node.id || (document && !document.isActive)) {
@@ -490,9 +484,11 @@ export function useDropToReorderDocument(
         }
       }
     },
+    // Collected values must stay unchanged while the target is not hovered.
+    // Collecting global drag state (e.g. a bare canDrop) re-renders every
+    // sidebar row at drag start and drop.
     collect: (monitor) => ({
-      isOverReorder: monitor.isOver(),
-      isDraggingAnyDocument: monitor.canDrop(),
+      isOverReorder: monitor.isOver() && monitor.canDrop(),
     }),
   });
 }


### PR DESCRIPTION
Improved performance of dragging items in the sidebar. Previously it was noticeably laggy. In firefox, just starting the drag could take 500ms (hierarchy of a few hundred pages)
This PR improves things by:
* Minimizing changes to the DOM
* Skipping some callbacks when dragging pages
* Avoids re-drawing most items that don't need any redrawing
* Making ContextMenu skip materializing its sub-items until it is opened
* And a few other fixes

After this PR it is still not really fast, but it's significantly faster than before!