### PR TITLE
fix: Skip attachment work in exports when includeAttachments is false

### DIFF
--- a/server/queues/tasks/ExportDocumentTreeTask.ts
+++ b/server/queues/tasks/ExportDocumentTreeTask.ts
@@ -166,11 +166,13 @@ export default abstract class ExportDocumentTreeTask extends ExportTask {
     format,
     documentStructure,
     zip,
+    includeAttachments = true,
   }: {
     document: Document;
     format: FileOperationFormat;
     documentStructure: NavigationNode[];
     zip: ZipFile;
+    includeAttachments?: boolean;
   }) {
     const pathMap = new Map<string, string>();
 
@@ -191,7 +193,7 @@ export default abstract class ExportDocumentTreeTask extends ExportTask {
       zip,
       pathMap,
       format,
-      includeAttachments: true,
+      includeAttachments,
     });
 
     return await ZipHelper.toTmpFile(zip);

--- a/server/queues/tasks/ExportHTMLZipTask.ts
+++ b/server/queues/tasks/ExportHTMLZipTask.ts
@@ -22,7 +22,8 @@ export default class ExportHTMLZipTask extends ExportDocumentTreeTask {
 
   public async exportDocument(
     document: Document,
-    documentStructure: NavigationNode[]
+    documentStructure: NavigationNode[],
+    includeAttachments: boolean
   ): Promise<string> {
     const zip = new ZipFile();
 
@@ -31,6 +32,7 @@ export default class ExportHTMLZipTask extends ExportDocumentTreeTask {
       documentStructure,
       format: FileOperationFormat.HTMLZip,
       zip,
+      includeAttachments,
     });
   }
 }

--- a/server/queues/tasks/ExportMarkdownZipTask.ts
+++ b/server/queues/tasks/ExportMarkdownZipTask.ts
@@ -22,7 +22,8 @@ export default class ExportMarkdownZipTask extends ExportDocumentTreeTask {
 
   public async exportDocument(
     document: Document,
-    documentStructure: NavigationNode[]
+    documentStructure: NavigationNode[],
+    includeAttachments: boolean
   ): Promise<string> {
     const zip = new ZipFile();
 
@@ -31,6 +32,7 @@ export default class ExportMarkdownZipTask extends ExportDocumentTreeTask {
       documentStructure,
       format: FileOperationFormat.MarkdownZip,
       zip,
+      includeAttachments,
     });
   }
 }

--- a/server/queues/tasks/ExportTask.ts
+++ b/server/queues/tasks/ExportTask.ts
@@ -140,21 +140,25 @@ export default abstract class ExportTask extends BaseTask<Props> {
         throw new Error("Document not found in collection tree");
       }
 
-      return this.exportDocument(document, documentStructure.children ?? []);
+      return this.exportDocument(
+        document,
+        documentStructure.children ?? [],
+        fileOperation.options?.includeAttachments ?? true
+      );
     }
 
     // ensure attachment size is within limits
-    if (!fileOperation.collectionId) {
+    if (
+      !fileOperation.collectionId &&
+      fileOperation.options?.includeAttachments &&
+      env.MAXIMUM_EXPORT_SIZE
+    ) {
       const totalAttachmentsSize = await Attachment.getTotalSizeForTeam(
         sequelizeReadOnly,
         user.teamId
       );
 
-      if (
-        fileOperation.options?.includeAttachments &&
-        env.MAXIMUM_EXPORT_SIZE &&
-        totalAttachmentsSize > env.MAXIMUM_EXPORT_SIZE
-      ) {
+      if (totalAttachmentsSize > env.MAXIMUM_EXPORT_SIZE) {
         throw ValidationError(
           `${bytesToHumanReadable(
             totalAttachmentsSize
@@ -208,12 +212,13 @@ export default abstract class ExportTask extends BaseTask<Props> {
    *
    * @param document The document to export
    * @param documentStructure Structure of document's children
-   * @param fileOperation File operation associated with the export
+   * @param includeAttachments Whether to include attachments in the export
    * @returns A promise that resolves to a temporary file path
    */
   protected abstract exportDocument(
     document: Document,
-    documentStructure: NavigationNode[]
+    documentStructure: NavigationNode[],
+    includeAttachments: boolean
   ): Promise<string>;
 
   /**


### PR DESCRIPTION
When `includeAttachments: false`, exports performed two pieces of avoidable work. This fixes both.

- For full-workspace exports, the `Attachment.getTotalSizeForTeam` aggregate query is now gated behind `includeAttachments` (and `MAXIMUM_EXPORT_SIZE`), so it no longer runs when attachments are excluded.
- The single-document export path now threads `includeAttachments` through to `addDocumentToArchive` instead of hardcoding `true`, so single-document markdown/HTML exports actually honor the option — it defaults to `true` to preserve existing behavior.