### PR TITLE
fix: Wrap inline code in comments

### DIFF
--- a/app/scenes/Document/components/Comments/CommentThreadItem.tsx
+++ b/app/scenes/Document/components/Comments/CommentThreadItem.tsx
@@ -9,6 +9,7 @@ import { toast } from "sonner";
 import styled, { css } from "styled-components";
 import breakpoint from "styled-components-breakpoint";
 import EventBoundary from "@shared/components/EventBoundary";
+import { EditorStyleHelper } from "@shared/editor/styles/EditorStyleHelper";
 import { s, hover } from "@shared/styles";
 import type { ProsemirrorData } from "@shared/types";
 import { dateToRelative } from "@shared/utils/date";
@@ -345,6 +346,14 @@ const StyledCommentEditor = styled(CommentEditor)`
 
   .mention {
     background: ${(props) => darken(0.05, props.theme.mentionBackground)};
+  }
+
+  code.inline {
+    overflow-wrap: anywhere;
+
+    .${EditorStyleHelper.codeWord} {
+      white-space: inherit;
+    }
   }
 `;
 


### PR DESCRIPTION
Follow-up to #12735. Inline code in comments can still overflow narrower comment bubbles because the shared editor decorates inline code words with `.code-word` spans, and that class uses `white-space: nowrap` at tablet widths. The existing max word length guard handles very long tokens, but shorter domain-like tokens can still exceed the comment bubble width.

- Scope the wrapping change to comment rendering only.
- Allow `code.inline` to wrap anywhere inside comments.
- Let `.code-word` inherit the comment inline code wrapping behavior without changing normal document editor styling.

Verification:
- `yarn oxlint --type-aware app/scenes/Document/components/Comments/CommentThreadItem.tsx`
- `yarn oxfmt --check app/scenes/Document/components/Comments/CommentThreadItem.tsx`
- `yarn tsc --noEmit --pretty false`
- Ran Outline locally with a seeded comment and verified the inline code wraps inside the comments panel (`codeOverflowThread=false`).

Screenshot:

Before
<img width="302" height="276" alt="file-c5d9f6f3db5a1cb25e0f7e4dea445c63" src="https://github.com/user-attachments/assets/7f474f72-9c9c-4bff-ad4f-6b3803b29571" />

After
<img width="302" height="276" alt="file-fb86f5b6abe63082743e653c4021951d" src="https://github.com/user-attachments/assets/b1b573e6-404e-415d-ab0c-cd21e6f4161c" />
