### PR TITLE
fix: `validateUrlNotPrivate` hardening

### DIFF
--- a/server/utils/url.test.ts
+++ b/server/utils/url.test.ts
@@ -7,9 +7,8 @@ describe("validateUrlNotPrivate", () => {
   let lookupSpy: MockInstance;
 
   beforeEach(() => {
-    lookupSpy = vi
-      .spyOn(dns.promises, "lookup")
-      .mockResolvedValue({ address: "93.184.216.34", family: 4 });
+    lookupSpy = vi.spyOn(dns.promises, "lookup");
+    lookupSpy.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
   });
 
   afterEach(() => {
@@ -18,7 +17,7 @@ describe("validateUrlNotPrivate", () => {
   });
 
   it("should allow public IP addresses", async () => {
-    lookupSpy.mockResolvedValue({ address: "93.184.216.34", family: 4 });
+    lookupSpy.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
     await expect(
       validateUrlNotPrivate("https://example.com")
     ).resolves.toBeUndefined();
@@ -31,10 +30,39 @@ describe("validateUrlNotPrivate", () => {
   });
 
   it("should reject URL resolving to private IP", async () => {
-    lookupSpy.mockResolvedValue({ address: "192.168.1.1", family: 4 });
+    lookupSpy.mockResolvedValue([{ address: "192.168.1.1", family: 4 }]);
     await expect(
       validateUrlNotPrivate("https://internal.example.com")
     ).rejects.toThrow("is not allowed");
+  });
+
+  it("should reject when any of multiple records is private", async () => {
+    lookupSpy.mockResolvedValue([
+      { address: "93.184.216.34", family: 4 },
+      { address: "169.254.169.254", family: 4 },
+    ]);
+    await expect(
+      validateUrlNotPrivate("https://internal.example.com")
+    ).rejects.toThrow("is not allowed");
+  });
+
+  it("should allow when all records are public", async () => {
+    lookupSpy.mockResolvedValue([
+      { address: "93.184.216.34", family: 4 },
+      { address: "2606:2800:220:1:248:1893:25c8:1946", family: 6 },
+    ]);
+    await expect(
+      validateUrlNotPrivate("https://example.com")
+    ).resolves.toBeUndefined();
+  });
+
+  it("should reject when the hostname cannot be resolved", async () => {
+    lookupSpy.mockRejectedValue(
+      Object.assign(new Error("getaddrinfo ENOTFOUND"), { code: "ENOTFOUND" })
+    );
+    await expect(
+      validateUrlNotPrivate("https://does-not-exist.example.com")
+    ).rejects.toThrow("DNS lookup for does-not-exist.example.com failed.");
   });
 
   it("should reject loopback address", async () => {
@@ -44,7 +72,7 @@ describe("validateUrlNotPrivate", () => {
   });
 
   it("should reject link-local address", async () => {
-    lookupSpy.mockResolvedValue({ address: "169.254.169.254", family: 4 });
+    lookupSpy.mockResolvedValue([{ address: "169.254.169.254", family: 4 }]);
     await expect(
       validateUrlNotPrivate("https://metadata.internal")
     ).rejects.toThrow("is not allowed");
@@ -64,10 +92,9 @@ describe("validateUrlNotPrivate", () => {
   });
 
   it("should reject IPv4-mapped IPv6 address resolved via DNS", async () => {
-    lookupSpy.mockResolvedValue({
-      address: "::ffff:169.254.169.254",
-      family: 6,
-    });
+    lookupSpy.mockResolvedValue([
+      { address: "::ffff:169.254.169.254", family: 6 },
+    ]);
     await expect(
       validateUrlNotPrivate("https://metadata.example.com")
     ).rejects.toThrow("is not allowed");
@@ -95,7 +122,7 @@ describe("validateUrlNotPrivate", () => {
 
     it("should allow IP within CIDR range", async () => {
       env.ALLOWED_PRIVATE_IP_ADDRESSES = ["192.168.1.0/24"];
-      lookupSpy.mockResolvedValue({ address: "192.168.1.50", family: 4 });
+      lookupSpy.mockResolvedValue([{ address: "192.168.1.50", family: 4 }]);
       await expect(
         validateUrlNotPrivate("https://gitlab.internal")
       ).resolves.toBeUndefined();
@@ -103,7 +130,7 @@ describe("validateUrlNotPrivate", () => {
 
     it("should reject IP outside CIDR range", async () => {
       env.ALLOWED_PRIVATE_IP_ADDRESSES = ["192.168.1.0/24"];
-      lookupSpy.mockResolvedValue({ address: "192.168.2.1", family: 4 });
+      lookupSpy.mockResolvedValue([{ address: "192.168.2.1", family: 4 }]);
       await expect(
         validateUrlNotPrivate("https://gitlab.internal")
       ).rejects.toThrow("is not allowed");
@@ -111,7 +138,7 @@ describe("validateUrlNotPrivate", () => {
 
     it("should allow resolved hostname matching allowlist", async () => {
       env.ALLOWED_PRIVATE_IP_ADDRESSES = ["10.0.0.5"];
-      lookupSpy.mockResolvedValue({ address: "10.0.0.5", family: 4 });
+      lookupSpy.mockResolvedValue([{ address: "10.0.0.5", family: 4 }]);
       await expect(
         validateUrlNotPrivate("https://gitlab.internal")
       ).resolves.toBeUndefined();
@@ -126,7 +153,7 @@ describe("validateUrlNotPrivate", () => {
 
     it("should support multiple entries in allowlist", async () => {
       env.ALLOWED_PRIVATE_IP_ADDRESSES = ["10.0.0.1", "172.16.0.0/12"];
-      lookupSpy.mockResolvedValue({ address: "172.20.5.10", family: 4 });
+      lookupSpy.mockResolvedValue([{ address: "172.20.5.10", family: 4 }]);
       await expect(
         validateUrlNotPrivate("https://gitlab.internal")
       ).resolves.toBeUndefined();

--- a/server/utils/url.ts
+++ b/server/utils/url.ts
@@ -126,7 +126,7 @@ export async function validateUrlNotPrivate(url: string) {
   // Resolve every record for the hostname — with multiple A/AAAA records the
   // connection may use any of them, so a single private record hidden among
   // public ones must still fail validation.
-  let addresses;
+  let addresses: dns.LookupAddress[];
   try {
     addresses = await dns.promises.lookup(hostname, { all: true });
   } catch {

--- a/server/utils/url.ts
+++ b/server/utils/url.ts
@@ -88,11 +88,28 @@ function isAllowedPrivateIP(ip: string): boolean {
 }
 
 /**
+ * Builds the error thrown when a URL resolves to a disallowed private IP.
+ *
+ * @param ip - the private IP address that was rejected.
+ * @param hostname - the hostname that resolved to the IP, if any.
+ * @returns the error to throw.
+ */
+function privateIpError(ip: string, hostname?: string) {
+  return InvalidRequestError(
+    `DNS lookup ${ip}${hostname ? ` (${hostname})` : ""} is not allowed.` +
+      (env.isCloudHosted
+        ? ""
+        : " To allow this request, add the IP address or CIDR range to the ALLOWED_PRIVATE_IP_ADDRESSES environment variable.")
+  );
+}
+
+/**
  * Validates that a URL does not resolve to a private or internal IP address.
  * Respects the ALLOWED_PRIVATE_IP_ADDRESSES environment variable.
  *
  * @param url - the URL to validate.
- * @throws InternalError if the URL resolves to a private IP that is not allowed.
+ * @throws InvalidRequestError if the URL resolves to a private IP that is not
+ * allowed, or if the hostname cannot be resolved.
  */
 export async function validateUrlNotPrivate(url: string) {
   // URL.hostname keeps the square brackets around IPv6 literals (e.g.
@@ -101,23 +118,24 @@ export async function validateUrlNotPrivate(url: string) {
 
   if (net.isIP(hostname)) {
     if (isPrivateIP(hostname) && !isAllowedPrivateIP(hostname)) {
-      throw InvalidRequestError(
-        `DNS lookup ${hostname} is not allowed.` +
-          (env.isCloudHosted
-            ? ""
-            : " To allow this request, add the IP address or CIDR range to the ALLOWED_PRIVATE_IP_ADDRESSES environment variable.")
-      );
+      throw privateIpError(hostname);
     }
     return;
   }
 
-  const { address } = await dns.promises.lookup(hostname);
-  if (isPrivateIP(address) && !isAllowedPrivateIP(address)) {
-    throw InvalidRequestError(
-      `DNS lookup ${address} (${hostname}) is not allowed.` +
-        (env.isCloudHosted
-          ? ""
-          : " To allow this request, add the IP address or CIDR range to the ALLOWED_PRIVATE_IP_ADDRESSES environment variable.")
-    );
+  // Resolve every record for the hostname — with multiple A/AAAA records the
+  // connection may use any of them, so a single private record hidden among
+  // public ones must still fail validation.
+  let addresses;
+  try {
+    addresses = await dns.promises.lookup(hostname, { all: true });
+  } catch {
+    throw InvalidRequestError(`DNS lookup for ${hostname} failed.`);
+  }
+
+  for (const { address } of addresses) {
+    if (isPrivateIP(address) && !isAllowedPrivateIP(address)) {
+      throw privateIpError(address, hostname);
+    }
   }
 }


### PR DESCRIPTION
A hostname with multiple A/AAAA records would pass validation as long as the first record returned was public, even if another record pointed at a private or link-local address the connection could actually use. Resolve with { all: true } and reject if any record is private and not allowlisted.

Also wrap DNS resolution failures in `InvalidRequestError` so an unresolvable hostname returns a clean 400 instead of an unhandled `ENOTFOUND`.
