### PR TITLE
feat: Add HTML input support to MCP create_document

### DIFF
--- a/server/tools/documents.test.ts
+++ b/server/tools/documents.test.ts
@@ -8,7 +8,12 @@ import {
   buildOAuthAuthentication,
   buildGroup,
 } from "@server/test/factories";
-import { Document, GroupMembership, UserMembership } from "@server/models";
+import {
+  Attachment,
+  Document,
+  GroupMembership,
+  UserMembership,
+} from "@server/models";
 import { getTestServer } from "@server/test/support";
 import { buildOAuthUser, callMcpTool } from "@server/test/McpHelper";
 
@@ -257,6 +262,40 @@ describe("create_document", () => {
     expect(data.document.collectionId).toEqual(collection.id);
     expect(data.document.id).toBeDefined();
     expect(data.document.url).toMatch(/^https?:\/\//);
+  });
+
+  it("creates from HTML and preserves images as attachments", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const image =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+
+    const res = await callMcpTool(server, accessToken, "create_document", {
+      title: "HTML Document",
+      text: `<p>Hello <strong>HTML</strong></p><img alt="chart" src="data:image/png;base64,${image}" width="1" height="1">`,
+      format: "html",
+      collectionId: collection.id,
+    });
+    const data = JSON.parse(res?.result?.content?.[0]?.text ?? "{}");
+    const attachmentCount = await Attachment.count({
+      where: {
+        teamId: user.teamId,
+        userId: user.id,
+        contentType: "image/png",
+      },
+    });
+
+    expect(res?.result?.isError).toBeUndefined();
+    expect(data.document.title).toEqual("HTML Document");
+    expect(data.document.collectionId).toEqual(collection.id);
+    expect(res?.result?.content?.[1]?.text).toContain("Hello **HTML**");
+    expect(res?.result?.content?.[1]?.text).toContain(
+      "/api/attachments.redirect?id="
+    );
+    expect(attachmentCount).toEqual(1);
   });
 
   it("creates nested under parent document", async () => {

--- a/server/tools/documents.ts
+++ b/server/tools/documents.ts
@@ -5,6 +5,7 @@ import documentCreator, {
   authorizeDocumentCreate,
   authorizeDocumentPublish,
 } from "@server/commands/documentCreator";
+import documentImporter from "@server/commands/documentImporter";
 import documentMover from "@server/commands/documentMover";
 import documentRestorer from "@server/commands/documentRestorer";
 import documentUpdater from "@server/commands/documentUpdater";
@@ -296,7 +297,7 @@ export function documentTools(server: McpServer, scopes: string[]) {
       {
         title: "Create document",
         description:
-          "Creates a new document. Requires a collectionId to place the document in a collection, or parentDocumentId to nest it under an existing document. Pass a templateId (from list_templates) to pre-fill the document from a template; the template's content is used unless text is also provided.",
+          "Creates a new document from markdown or HTML content. Requires a collectionId to place the document in a collection, or parentDocumentId to nest it under an existing document. Pass a templateId (from list_templates) to pre-fill the document from a template; the template's content is used unless text is also provided.",
         annotations: {
           idempotentHint: false,
           readOnlyHint: false,
@@ -308,7 +309,15 @@ export function documentTools(server: McpServer, scopes: string[]) {
           text: z
             .string()
             .optional()
-            .describe("The markdown content of the document."),
+            .describe(
+              'The content of the document. Interpreted as markdown unless format is set to "html".'
+            ),
+          format: z
+            .enum(["markdown", "html"])
+            .optional()
+            .describe(
+              'The format of the text content. Defaults to "markdown"; use "html" for rich HTML input.'
+            ),
           collectionId: optionalString().describe(
             "The collection to place the document in."
           ),
@@ -334,7 +343,7 @@ export function documentTools(server: McpServer, scopes: string[]) {
             .boolean()
             .optional()
             .describe(
-              "Whether the document should occupy full width of the screen. Defaults to false."
+              "Whether the document should occupy full width of the screen. Defaults to false. Do not set this to true for HTML input unless the user explicitly asks for a full-width document layout."
             ),
         },
       },
@@ -357,15 +366,27 @@ export function documentTools(server: McpServer, scopes: string[]) {
             authorize(user, "read", template);
           }
 
+          const imported =
+            input.format === "html"
+              ? await documentImporter({
+                  user,
+                  fileName: "document.html",
+                  mimeType: "text/html",
+                  content: input.text ?? "",
+                  ctx,
+                })
+              : undefined;
+
           const document = await documentCreator(ctx, {
-            title: input.title,
-            text: input.text,
-            icon: input.icon,
+            title: input.title ?? imported?.title,
+            text: imported?.text ?? input.text,
+            state: imported?.state,
+            icon: input.icon ?? imported?.icon,
             color: input.color,
             parentDocumentId: parentDocumentId,
             publish: input.publish !== false,
             collectionId: collection?.id,
-            template,
+            template: imported ? undefined : template,
             fullWidth: input.fullWidth,
           });
 


### PR DESCRIPTION
close https://github.com/outline/outline/issues/12901


## Summary

Adds optional HTML input support to the MCP `create_document` tool.

- Adds a `format` option to `create_document`, defaulting to markdown.
- When `format: "html"` is provided, the tool reuses the existing document import pipeline to convert HTML into document state.
- Preserves supported embedded media, such as images, as attachments instead of leaving raw HTML/media sources in the document.
- Keeps markdown behavior unchanged when `format` is omitted.
