### PR TITLE
MCP: omit document body from create/update tool results

### DIFF
--- a/server/tools/documents.ts
+++ b/server/tools/documents.ts
@@ -393,7 +393,7 @@ export function documentTools(server: McpServer, scopes: string[]) {
           const [{ text, ...attributes }, breadcrumb] = await Promise.all([
             presentDocument(document, {
               includeData: false,
-              includeText: true,
+              includeText: false,
               includeUpdatedAt: true,
             }),
             getDocumentBreadcrumb(document, user),
@@ -660,7 +660,7 @@ export function documentTools(server: McpServer, scopes: string[]) {
           const [{ text, ...attributes }, breadcrumb] = await Promise.all([
             presentDocument(updated, {
               includeData: false,
-              includeText: true,
+              includeText: false,
               includeUpdatedAt: true,
             }),
             getDocumentBreadcrumb(updated, user),


### PR DESCRIPTION
### What

`create_document` and `update_document` MCP tools present their result with `includeText: true`, so every write — even a one-line `append`/`patch` — returns the **entire document body** in the tool result.

This flips those two handlers to `includeText: false`, matching what the read/list tools already do (`search_documents`, `list_*` use `includeText: false`). `restore_document` is intentionally left unchanged (the caller didn't supply the content there).

```diff
 // create_document
   presentDocument(document, {
     includeData: false,
-    includeText: true,
+    includeText: false,
     includeUpdatedAt: true,
   }),
 // update_document
   presentDocument(updated, {
     includeData: false,
-    includeText: true,
+    includeText: false,
     includeUpdatedAt: true,
   }),
```

The handlers already destructure `const [{ text, ...attributes }, breadcrumb]` and place `text` separately, so with `includeText: false` it is simply `undefined` and drops out of the response — no other change needed. Title, url, id, revision, `updatedAt` and the breadcrumb are still returned for workspace awareness.

### Why

On a write, the caller **just supplied the text** — echoing the full body back is pure redundancy that inflates the agent's context. For agents that edit large/long-lived docs (runbooks, task queues), each append re-emits the whole document; across a fleet of agent sessions this adds up to a large, silent context/token tax (measured ~1.3M tokens/month in one deployment) and offers no new information the client doesn't already have. Read tools already made this choice; this just makes writes consistent.

### Note

If you'd rather preserve the current default, I'm happy to change this to an opt-in input parameter (e.g. `minimal` / `includeText`) on the write tools instead of flipping the default — just let me know your preference.