### PR TITLE
fix: Hand desktop sign-in back to the app on self-hosted deployments

### DIFF
--- a/server/utils/authentication.ts
+++ b/server/utils/authentication.ts
@@ -137,18 +137,16 @@ export async function signIn(
   // stuck on the SSO screen. This must happen regardless of whether the deployment is cloud
   // hosted, otherwise a self-hosted desktop sign-in never hands the token back to the app.
   if (client === Client.Desktop) {
-    ctx.redirect(
-      `${team.url}/desktop-redirect?token=${user.getTransferToken(service)}`
-    );
+    const token = encodeURIComponent(user.getTransferToken(service));
+    ctx.redirect(`${team.url}/desktop-redirect?token=${token}`);
     return;
   }
 
-  // set a transfer cookie for the access token itself and redirect
-  // to the teams subdomain if subdomains are enabled
+  // Redirect to the team subdomain with a short-lived transfer token that the
+  // /auth/redirect handler exchanges for the actual session cookie.
   if (env.isCloudHosted && team.subdomain) {
-    ctx.redirect(
-      `${team.url}/auth/redirect?token=${user.getTransferToken(service)}`
-    );
+    const token = encodeURIComponent(user.getTransferToken(service));
+    ctx.redirect(`${team.url}/auth/redirect?token=${token}`);
   } else {
     ctx.cookies.set("accessToken", user.getSessionToken(expires, service), {
       sameSite: "lax",

--- a/server/utils/authentication.ts
+++ b/server/utils/authentication.ts
@@ -134,8 +134,7 @@ export async function signIn(
   // If the authentication request originally came from the desktop app then we send the user
   // back to a screen in the web app that will immediately redirect to the desktop. The reason
   // to do this from the client is that if you redirect from the server then the browser ends up
-  // stuck on the SSO screen. This must happen regardless of whether the deployment is cloud
-  // hosted, otherwise a self-hosted desktop sign-in never hands the token back to the app.
+  // stuck on the SSO screen.
   if (client === Client.Desktop) {
     const token = encodeURIComponent(user.getTransferToken(service));
     ctx.redirect(`${team.url}/desktop-redirect?token=${token}`);

--- a/server/utils/authentication.ts
+++ b/server/utils/authentication.ts
@@ -108,8 +108,9 @@ export async function signIn(
     domain,
   });
 
-  // set a transfer cookie for the access token itself and redirect
-  // to the teams subdomain if subdomains are enabled
+  // On cloud hosted multi-team deployments, record the signed-in team in the
+  // sessions cookie so the web team switcher stays in sync. This applies to
+  // both web and desktop clients.
   if (env.isCloudHosted && team.subdomain) {
     // get any existing sessions (teams signed in) and add this team
     const existing = getSessionsInCookie(ctx);
@@ -128,20 +129,26 @@ export async function signIn(
       expires,
       domain,
     });
+  }
 
-    // If the authentication request originally came from the desktop app then we send the user
-    // back to a screen in the web app that will immediately redirect to the desktop. The reason
-    // to do this from the client is that if you redirect from the server then the browser ends up
-    // stuck on the SSO screen.
-    if (client === Client.Desktop) {
-      ctx.redirect(
-        `${team.url}/desktop-redirect?token=${user.getTransferToken(service)}`
-      );
-    } else {
-      ctx.redirect(
-        `${team.url}/auth/redirect?token=${user.getTransferToken(service)}`
-      );
-    }
+  // If the authentication request originally came from the desktop app then we send the user
+  // back to a screen in the web app that will immediately redirect to the desktop. The reason
+  // to do this from the client is that if you redirect from the server then the browser ends up
+  // stuck on the SSO screen. This must happen regardless of whether the deployment is cloud
+  // hosted, otherwise a self-hosted desktop sign-in never hands the token back to the app.
+  if (client === Client.Desktop) {
+    ctx.redirect(
+      `${team.url}/desktop-redirect?token=${user.getTransferToken(service)}`
+    );
+    return;
+  }
+
+  // set a transfer cookie for the access token itself and redirect
+  // to the teams subdomain if subdomains are enabled
+  if (env.isCloudHosted && team.subdomain) {
+    ctx.redirect(
+      `${team.url}/auth/redirect?token=${user.getTransferToken(service)}`
+    );
   } else {
     ctx.cookies.set("accessToken", user.getSessionToken(expires, service), {
       sameSite: "lax",


### PR DESCRIPTION
The desktop `/desktop-redirect` handoff — which bounces the transfer token
back into the app via the `outline://` protocol — was nested inside the
`env.isCloudHosted && team.subdomain` branch of `signIn`. On a self-hosted
deployment that branch is never taken, so a desktop OIDC (or any) sign-in fell
through to the single-domain path, which set an `accessToken` cookie in the
browser and redirected to the app's home. The desktop app never received the
token and appeared to hang on the SSO screen.

Move the desktop handoff out of the cloud-hosted guard so it runs for every
deployment. The cloud sessions cookie is still written for cloud-hosted teams
(web and desktop alike), and the web / single-domain redirects are unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Wv8LuN54DQoxofSoWmTPVK