### PR TITLE
fix: Flash in collaborator facepile while multiplayer connecting

### DIFF
--- a/app/components/Collaborators.tsx
+++ b/app/components/Collaborators.tsx
@@ -41,11 +41,15 @@ function Collaborators(props: Props) {
     [documentPresence]
   );
 
-  // Use Set for O(1) lookups and stable references
-  const presentIds = useMemo(
-    () => new Set(documentPresenceArray.map((p) => p.userId)),
-    [documentPresenceArray]
-  );
+  // Use Set for O(1) lookups and stable references. The current user is
+  // always included to avoid a flash while the multiplayer connection forms.
+  const presentIds = useMemo(() => {
+    const ids = new Set(documentPresenceArray.map((p) => p.userId));
+    if (currentUserId) {
+      ids.add(currentUserId);
+    }
+    return ids;
+  }, [documentPresenceArray, currentUserId]);
   const editingIds = useMemo(
     () =>
       new Set(


### PR DESCRIPTION
The current user is now injected into the presence set in `Collaborators`, so their avatar renders as actively viewing from the first paint instead of flashing into the present state once the multiplayer connection is established.