### PR TITLE
fix: Comments menu item does nothing when triggered from a document list

### DIFF
--- a/app/actions/definitions/documents.tsx
+++ b/app/actions/definitions/documents.tsx
@@ -1473,7 +1473,7 @@ export const openDocumentComments = createAction({
       !!activeDocumentId && can.comment && !!stores.auth.team?.commentingEnabled
     );
   },
-  perform: ({ activeDocumentId, stores }) => {
+  perform: ({ activeDocumentId, sidebarContext, stores }) => {
     const document = activeDocumentId
       ? stores.documents.get(activeDocumentId)
       : undefined;
@@ -1485,7 +1485,7 @@ export const openDocumentComments = createAction({
     // document list), as the comments sidebar is only rendered there.
     const path = documentPath(document);
     if (!history.location.pathname.startsWith(path)) {
-      history.push(path);
+      history.push(path, { sidebarContext });
     }
 
     stores.ui.set({ rightSidebar: "comments" });

--- a/app/actions/definitions/documents.tsx
+++ b/app/actions/definitions/documents.tsx
@@ -1474,8 +1474,18 @@ export const openDocumentComments = createAction({
     );
   },
   perform: ({ activeDocumentId, stores }) => {
-    if (!activeDocumentId) {
+    const document = activeDocumentId
+      ? stores.documents.get(activeDocumentId)
+      : undefined;
+    if (!document) {
       return;
+    }
+
+    // Navigate to the document when triggered from outside its scene (e.g. a
+    // document list), as the comments sidebar is only rendered there.
+    const path = documentPath(document);
+    if (!history.location.pathname.startsWith(path)) {
+      history.push(path);
     }
 
     stores.ui.set({ rightSidebar: "comments" });


### PR DESCRIPTION
The **Comments** item in the document menu did nothing when triggered from a document list. `openDocumentComments` only set `ui.rightSidebar = "comments"`, which is consumed exclusively by the Document scene's sidebar — a scene that isn't mounted when the menu is opened from a list, so the click had no visible effect. This changes the action's `perform` to navigate to the document first (unless already viewing it) before opening the comments sidebar, matching the behaviour of the sibling History action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)