### PR TITLE
feat: Add support for `rgb`, `hsl` swatches

### DIFF
--- a/app/editor/components/ComponentView.tsx
+++ b/app/editor/components/ComponentView.tsx
@@ -72,8 +72,8 @@ export default class ComponentView {
     this.dom.classList.add(this.className);
     this.renderer = new NodeViewRenderer(this.dom, this.component, this.props);
 
-    // Add the renderer to the editor's set of renderers so that it is included in the React tree.
-    this.editor.renderers.add(this.renderer);
+    // Add the renderer to the editor's set of node renderers so that it is included in the React tree.
+    this.editor.nodeRenderers.add(this.renderer);
 
     // Apply decoration classes to the DOM element.
     this.applyDecorationClasses();
@@ -156,7 +156,7 @@ export default class ComponentView {
   }
 
   destroy() {
-    this.editor.renderers.delete(this.renderer);
+    this.editor.nodeRenderers.delete(this.renderer);
     this.dom = null;
   }
 

--- a/app/editor/components/NodeViewRenderer.tsx
+++ b/app/editor/components/NodeViewRenderer.tsx
@@ -1,14 +1,22 @@
 import { isEqual } from "es-toolkit/compat";
 import { action, computed, observable } from "mobx";
-import type { FunctionComponent } from "react";
+import type { FunctionComponent, ReactNode } from "react";
 import { createPortal } from "react-dom";
 
-export class NodeViewRenderer<T extends object> {
+/**
+ * The minimal shape the editor needs to include a renderer's React content in
+ * its shared tree. Both node views and decoration widgets satisfy this.
+ */
+export interface PortalRenderer {
+  readonly content: ReactNode;
+}
+
+export class NodeViewRenderer<T extends object> implements PortalRenderer {
   @observable public props: T;
 
   public constructor(
     public element: HTMLElement,
-    private Component: FunctionComponent,
+    private Component: FunctionComponent<T>,
     props: T
   ) {
     this.props = props;

--- a/app/editor/extensions/CommentGutter.tsx
+++ b/app/editor/extensions/CommentGutter.tsx
@@ -2,8 +2,6 @@ import type { Node } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
 import { Plugin, PluginKey } from "prosemirror-state";
 import { Decoration, DecorationSet } from "prosemirror-view";
-import ReactDOM from "react-dom";
-import { ThemeProvider } from "styled-components";
 import Extension from "@shared/editor/lib/Extension";
 import { changedDescendants } from "@shared/editor/lib/changedDescendants";
 import { isRemoteTransaction } from "@shared/editor/lib/multiplayer";
@@ -182,14 +180,12 @@ export default class CommentGutter extends Extension {
           () => {
             // The mount point is layout-neutral; the rendered gutter is
             // absolutely positioned relative to the editor instead.
-            const element = document.createElement("div");
-            element.style.display = "contents";
-            ReactDOM.render(
-              <ThemeProvider theme={this.editor.props.theme}>
-                <CommentGutterComponent commentIds={commentIds} {...handlers} />
-              </ThemeProvider>,
-              element
+            const element = this.editor.renderToPortal(
+              CommentGutterComponent,
+              { commentIds, ...handlers },
+              false
             );
+            element.style.display = "contents";
             return element;
           },
           {
@@ -201,7 +197,7 @@ export default class CommentGutter extends Extension {
               commentIds.forEach((commentId) =>
                 handlers.onHoverCommentMark(commentId, false)
               );
-              ReactDOM.unmountComponentAtNode(node);
+              this.editor.destroyPortal(node);
             },
           }
         )

--- a/app/editor/index.tsx
+++ b/app/editor/index.tsx
@@ -54,7 +54,8 @@ import type { Properties } from "~/types";
 import Logger from "~/utils/Logger";
 import ComponentView from "./components/ComponentView";
 import EditorContext from "./components/EditorContext";
-import type { NodeViewRenderer } from "./components/NodeViewRenderer";
+import { NodeViewRenderer } from "./components/NodeViewRenderer";
+import type { PortalRenderer } from "./components/NodeViewRenderer";
 
 import WithTheme from "./components/WithTheme";
 import { isArray, isNull, map } from "es-toolkit/compat";
@@ -231,7 +232,9 @@ export class Editor extends React.PureComponent<
   };
 
   widgets: { [name: string]: React.FC<WidgetProps> };
-  renderers = observable.set<NodeViewRenderer<ComponentProps>>();
+  nodeRenderers = observable.set<NodeViewRenderer<ComponentProps>>();
+  decorationRenderers = observable.set<PortalRenderer>();
+  private portalDestroyers = new WeakMap<HTMLElement, () => void>();
   nodes: { [name: string]: NodeSpec };
   marks: { [name: string]: MarkSpec };
   commands: Record<string, CommandFactory>;
@@ -287,7 +290,7 @@ export class Editor extends React.PureComponent<
 
       // NodeView will not automatically render when editable changes so we must trigger an update
       // manually, see: https://discuss.prosemirror.net/t/re-render-custom-nodeview-when-view-editable-changes/6441
-      Array.from(this.renderers).forEach((view) =>
+      Array.from(this.nodeRenderers).forEach((view) =>
         view.setProp("isEditable", false)
       );
     }
@@ -894,6 +897,42 @@ export class Editor extends React.PureComponent<
     return false;
   };
 
+  /**
+   * Renders a React component into the editor's shared React tree and returns a
+   * DOM element to mount it into — for example from a ProseMirror decoration
+   * widget. Because it joins the editor tree via a portal, the component
+   * inherits all editor context (theme, translations, stores) with no separate
+   * React root. Pair every call with destroyPortal in the widget's teardown.
+   *
+   * @param Component - The React component to render.
+   * @param props - The props to pass to the component.
+   * @param inline - Whether to mount into an inline element (default true).
+   * @returns the DOM element the component is rendered into.
+   */
+  public renderToPortal<P extends object>(
+    Component: React.FunctionComponent<P>,
+    props: P,
+    inline = true
+  ): HTMLElement {
+    const element = document.createElement(inline ? "span" : "div");
+    const renderer = new NodeViewRenderer(element, Component, props);
+    this.decorationRenderers.add(renderer);
+    this.portalDestroyers.set(element, () =>
+      this.decorationRenderers.delete(renderer)
+    );
+    return element;
+  }
+
+  /**
+   * Unmounts a component previously rendered with renderToPortal.
+   *
+   * @param element - The element returned by renderToPortal.
+   */
+  public destroyPortal(element: HTMLElement) {
+    this.portalDestroyers.get(element)?.();
+    this.portalDestroyers.delete(element);
+  }
+
   public render() {
     const { readOnly, canUpdate, grow, style, className, onKeyDown } =
       this.props;
@@ -936,7 +975,11 @@ export class Editor extends React.PureComponent<
               ))}
             <Observer>
               {() => (
-                <>{Array.from(this.renderers).map((view) => view.content)}</>
+                <>
+                  {[...this.nodeRenderers, ...this.decorationRenderers].map(
+                    (view) => view.content
+                  )}
+                </>
               )}
             </Observer>
           </Flex>

--- a/shared/editor/components/ColorSwatch.tsx
+++ b/shared/editor/components/ColorSwatch.tsx
@@ -1,0 +1,55 @@
+import copy from "copy-to-clipboard";
+import type { MouseEvent } from "react";
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { EditorStyleHelper } from "../styles/EditorStyleHelper";
+
+interface Props {
+  /** The CSS color the swatch represents, in its original notation. */
+  color: string;
+  /** The relative luminance of the color, used to pick an outline. */
+  luminance: number;
+}
+
+/**
+ * A small colored circle rendered after a CSS color inside inline code. Clicking
+ * it copies the color to the clipboard.
+ */
+export function ColorSwatch({ color, luminance }: Props) {
+  const { t } = useTranslation();
+
+  const handleMouseDown = useCallback((event: MouseEvent) => {
+    // Prevent the editor from moving the cursor into the code mark on click.
+    event.preventDefault();
+  }, []);
+
+  const handleClick = useCallback(
+    (event: MouseEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      copy(color);
+      toast.message(t("Copied to clipboard"));
+    },
+    [color, t]
+  );
+
+  const className = [
+    EditorStyleHelper.colorSwatch,
+    luminance > 0.85 && EditorStyleHelper.colorSwatchLight,
+    luminance < 0.1 && EditorStyleHelper.colorSwatchDark,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <span
+      className={className}
+      aria-hidden="true"
+      title={t("Click to copy")}
+      style={{ backgroundColor: color }}
+      onMouseDown={handleMouseDown}
+      onClick={handleClick}
+    />
+  );
+}

--- a/shared/editor/components/ColorSwatch.tsx
+++ b/shared/editor/components/ColorSwatch.tsx
@@ -3,7 +3,7 @@ import type { MouseEvent } from "react";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
-import { EditorStyleHelper } from "../styles/EditorStyleHelper";
+import styled, { css } from "styled-components";
 
 interface Props {
   /** The CSS color the swatch represents, in its original notation. */
@@ -34,22 +34,41 @@ export function ColorSwatch({ color, luminance }: Props) {
     [color, t]
   );
 
-  const className = [
-    EditorStyleHelper.colorSwatch,
-    luminance > 0.85 && EditorStyleHelper.colorSwatchLight,
-    luminance < 0.1 && EditorStyleHelper.colorSwatchDark,
-  ]
-    .filter(Boolean)
-    .join(" ");
-
   return (
-    <span
-      className={className}
+    <Swatch
       aria-hidden="true"
       title={t("Click to copy")}
+      $luminance={luminance}
       style={{ backgroundColor: color }}
       onMouseDown={handleMouseDown}
       onClick={handleClick}
     />
   );
 }
+
+const Swatch = styled.span<{ $luminance: number }>`
+  display: inline-block;
+  width: 0.75em;
+  height: 0.75em;
+  margin-left: 0.3em;
+  vertical-align: -0.05em;
+  border-radius: 50%;
+  background-clip: padding-box;
+  cursor: var(--pointer);
+  transition: transform 100ms ease;
+
+  /* Outline colors that would otherwise blend into the current background. */
+  ${(props) =>
+    (props.theme.isDark ? props.$luminance < 0.1 : props.$luminance > 0.85) &&
+    css`
+      outline: 1px solid ${props.theme.codeBorder};
+    `}
+
+  &:hover {
+    transform: scale(1.1);
+  }
+
+  &:active {
+    transform: scale(0.9);
+  }
+`;

--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -1721,25 +1721,6 @@ code {
   }
 }
 
-.${EditorStyleHelper.colorSwatch} {
-  display: inline-block;
-  width: 0.75em;
-  height: 0.75em;
-  margin-left: 0.3em;
-  vertical-align: -0.05em;
-  border-radius: 50%;
-  background-clip: padding-box;
-  cursor: var(--pointer);
-}
-
-.${
-  props.theme.isDark
-    ? EditorStyleHelper.colorSwatchDark
-    : EditorStyleHelper.colorSwatchLight
-} {
-  outline: 1px solid ${props.theme.codeBorder};
-}
-
 mark {
   border-radius: 1px;
   padding: 2px 0;

--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -1721,7 +1721,7 @@ code {
   }
 }
 
-.${EditorStyleHelper.hexColorSwatch} {
+.${EditorStyleHelper.colorSwatch} {
   display: inline-block;
   width: 0.75em;
   height: 0.75em;
@@ -1734,8 +1734,8 @@ code {
 
 .${
   props.theme.isDark
-    ? EditorStyleHelper.hexColorSwatchDark
-    : EditorStyleHelper.hexColorSwatchLight
+    ? EditorStyleHelper.colorSwatchDark
+    : EditorStyleHelper.colorSwatchLight
 } {
   outline: 1px solid ${props.theme.codeBorder};
 }

--- a/shared/editor/extensions/ColorSwatchPreview.ts
+++ b/shared/editor/extensions/ColorSwatchPreview.ts
@@ -1,12 +1,9 @@
-import copy from "copy-to-clipboard";
-import { t } from "i18next";
 import { getLuminance } from "polished";
 import type { EditorState } from "prosemirror-state";
 import { Plugin, PluginKey } from "prosemirror-state";
 import { Decoration, DecorationSet } from "prosemirror-view";
-import { toast } from "sonner";
+import { ColorSwatch } from "../components/ColorSwatch";
 import Extension from "../lib/Extension";
-import { EditorStyleHelper } from "../styles/EditorStyleHelper";
 
 // Matches a CSS color in hex (#RGB, #RGBA, #RRGGBB, #RRGGBBAA), rgb()/rgba(),
 // or hsl()/hsla() notation. Functional matches are loose here and validated by
@@ -32,6 +29,10 @@ const pluginKey = new PluginKey<ColorPluginState>("color_swatch_preview");
 export default class ColorSwatchPreview extends Extension {
   get name() {
     return "color_swatch_preview";
+  }
+
+  get allowInReadOnly() {
+    return true;
   }
 
   get plugins() {
@@ -94,14 +95,19 @@ export default class ColorSwatchPreview extends Extension {
 
         const end = pos + match.index + color.length;
 
+        // Key on the color value rather than the document position, so editing
+        // elsewhere doesn't change the key and force ProseMirror to destroy and
+        // remount the swatch's React portal. Identical colors are interchangeable
+        // so a shared key between them is harmless.
         decorations.push(
           Decoration.widget(end, () => this.createSwatch(color, luminance), {
             // Use side: -1 so the swatch renders before the fake-cursor widget
             // from prosemirror-codemark, which uses side 0/-1 to represent the
             // "inside"/"outside" cursor positions at mark boundaries.
             side: -1,
-            key: `color-${end}-${color}`,
+            key: `color-${color.toLowerCase()}`,
             marks: [codeMark],
+            destroy: (node: HTMLElement) => this.editor.destroyPortal(node),
           })
         );
       }
@@ -111,28 +117,12 @@ export default class ColorSwatchPreview extends Extension {
   }
 
   private createSwatch(color: string, luminance: number): HTMLElement {
-    const swatch = document.createElement("span");
-    swatch.className = EditorStyleHelper.colorSwatch;
-    swatch.setAttribute("aria-hidden", "true");
-    swatch.style.backgroundColor = color;
-
-    if (luminance > 0.85) {
-      swatch.classList.add(EditorStyleHelper.colorSwatchLight);
-    } else if (luminance < 0.1) {
-      swatch.classList.add(EditorStyleHelper.colorSwatchDark);
-    }
-
-    swatch.addEventListener("mousedown", (event) => {
-      // Prevent the editor from moving the cursor into the code mark on click.
-      event.preventDefault();
+    const element = this.editor.renderToPortal(ColorSwatch, {
+      color,
+      luminance,
     });
-    swatch.addEventListener("click", (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      copy(color);
-      toast.message(t("Copied to clipboard"));
-    });
-
-    return swatch;
+    // Keep the mount point layout-neutral; the swatch styles itself.
+    element.style.display = "contents";
+    return element;
   }
 }

--- a/shared/editor/extensions/ColorSwatchPreview.ts
+++ b/shared/editor/extensions/ColorSwatchPreview.ts
@@ -1,5 +1,6 @@
 import copy from "copy-to-clipboard";
 import { t } from "i18next";
+import { getLuminance } from "polished";
 import type { EditorState } from "prosemirror-state";
 import { Plugin, PluginKey } from "prosemirror-state";
 import { Decoration, DecorationSet } from "prosemirror-view";
@@ -7,26 +8,35 @@ import { toast } from "sonner";
 import Extension from "../lib/Extension";
 import { EditorStyleHelper } from "../styles/EditorStyleHelper";
 
-const HEX_COLOR_REGEX = /#(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6})\b/g;
+// Matches a CSS color in hex (#RGB, #RGBA, #RRGGBB, #RRGGBBAA), rgb()/rgba(),
+// or hsl()/hsla() notation. Functional matches are loose here and validated by
+// getLuminance, which throws for anything that isn't a real color.
+const COLOR_REGEX = new RegExp(
+  [
+    "#(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{4}|[0-9a-fA-F]{3})\\b",
+    "(?:rgba?|hsla?)\\([^)]*\\)",
+  ].join("|"),
+  "gi"
+);
 
-type HexPluginState = {
+type ColorPluginState = {
   decorations: DecorationSet;
 };
 
-const pluginKey = new PluginKey<HexPluginState>("hex_color_preview");
+const pluginKey = new PluginKey<ColorPluginState>("color_swatch_preview");
 
 /**
- * An editor extension that renders a small colored circle after any valid hex
- * color code found inside an inline code mark.
+ * An editor extension that renders a small colored circle after any valid CSS
+ * color (hex, rgb/rgba, or hsl/hsla) found inside an inline code mark.
  */
-export default class HexColorPreview extends Extension {
+export default class ColorSwatchPreview extends Extension {
   get name() {
-    return "hex_color_preview";
+    return "color_swatch_preview";
   }
 
   get plugins() {
     return [
-      new Plugin<HexPluginState>({
+      new Plugin<ColorPluginState>({
         key: pluginKey,
         state: {
           init: (_, state) => ({
@@ -67,20 +77,30 @@ export default class HexColorPreview extends Extension {
       }
 
       const text = node.text;
-      HEX_COLOR_REGEX.lastIndex = 0;
+      COLOR_REGEX.lastIndex = 0;
       let match: RegExpExecArray | null;
 
-      while ((match = HEX_COLOR_REGEX.exec(text)) !== null) {
-        const hex = match[0];
-        const end = pos + match.index + hex.length;
+      while ((match = COLOR_REGEX.exec(text)) !== null) {
+        const color = match[0];
+
+        // getLuminance throws for anything that isn't a real color, which also
+        // filters out false-positive regex matches like "rgb(foo)".
+        let luminance: number;
+        try {
+          luminance = getLuminance(color);
+        } catch {
+          continue;
+        }
+
+        const end = pos + match.index + color.length;
 
         decorations.push(
-          Decoration.widget(end, () => this.createSwatch(hex), {
+          Decoration.widget(end, () => this.createSwatch(color, luminance), {
             // Use side: -1 so the swatch renders before the fake-cursor widget
             // from prosemirror-codemark, which uses side 0/-1 to represent the
             // "inside"/"outside" cursor positions at mark boundaries.
             side: -1,
-            key: `hex-${hex}`,
+            key: `color-${end}-${color}`,
             marks: [codeMark],
           })
         );
@@ -90,17 +110,16 @@ export default class HexColorPreview extends Extension {
     return DecorationSet.create(state.doc, decorations);
   }
 
-  private createSwatch(color: string): HTMLElement {
+  private createSwatch(color: string, luminance: number): HTMLElement {
     const swatch = document.createElement("span");
-    swatch.className = EditorStyleHelper.hexColorSwatch;
+    swatch.className = EditorStyleHelper.colorSwatch;
     swatch.setAttribute("aria-hidden", "true");
     swatch.style.backgroundColor = color;
 
-    const luminance = this.getRelativeLuminance(color);
     if (luminance > 0.85) {
-      swatch.classList.add(EditorStyleHelper.hexColorSwatchLight);
+      swatch.classList.add(EditorStyleHelper.colorSwatchLight);
     } else if (luminance < 0.1) {
-      swatch.classList.add(EditorStyleHelper.hexColorSwatchDark);
+      swatch.classList.add(EditorStyleHelper.colorSwatchDark);
     }
 
     swatch.addEventListener("mousedown", (event) => {
@@ -115,14 +134,5 @@ export default class HexColorPreview extends Extension {
     });
 
     return swatch;
-  }
-
-  private getRelativeLuminance(hex: string): number {
-    const r = parseInt(hex.slice(1, 3), 16) / 255;
-    const g = parseInt(hex.slice(3, 5), 16) / 255;
-    const b = parseInt(hex.slice(5, 7), 16) / 255;
-    const channel = (c: number) =>
-      c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
-    return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
   }
 }

--- a/shared/editor/nodes/index.ts
+++ b/shared/editor/nodes/index.ts
@@ -1,6 +1,6 @@
+import ColorSwatchPreview from "../extensions/ColorSwatchPreview";
 import DateTime from "../extensions/DateTime";
 import DeleteNearAtom from "../extensions/DeleteNearAtom";
-import HexColorPreview from "../extensions/HexColorPreview";
 import History from "../extensions/History";
 import InputRuleUndo from "../extensions/InputRuleUndo";
 import MaxLength from "../extensions/MaxLength";
@@ -71,7 +71,7 @@ export const inlineExtensions: Nodes = [
   DateTime,
   HardBreak,
   DeleteNearAtom,
-  HexColorPreview,
+  ColorSwatchPreview,
 ];
 
 export const listExtensions: Nodes = [

--- a/shared/editor/styles/EditorStyleHelper.ts
+++ b/shared/editor/styles/EditorStyleHelper.ts
@@ -42,12 +42,6 @@ export class EditorStyleHelper {
 
   static readonly codeWord = "code-word";
 
-  static readonly colorSwatch = "color-swatch";
-
-  static readonly colorSwatchLight = "color-swatch-light";
-
-  static readonly colorSwatchDark = "color-swatch-dark";
-
   /** Toggle button for collapsible code blocks */
   static readonly codeBlockToggle = "code-block-toggle";
 

--- a/shared/editor/styles/EditorStyleHelper.ts
+++ b/shared/editor/styles/EditorStyleHelper.ts
@@ -42,11 +42,11 @@ export class EditorStyleHelper {
 
   static readonly codeWord = "code-word";
 
-  static readonly hexColorSwatch = "hex-color-swatch";
+  static readonly colorSwatch = "color-swatch";
 
-  static readonly hexColorSwatchLight = "hex-color-swatch-light";
+  static readonly colorSwatchLight = "color-swatch-light";
 
-  static readonly hexColorSwatchDark = "hex-color-swatch-dark";
+  static readonly colorSwatchDark = "color-swatch-dark";
 
   /** Toggle button for collapsible code blocks */
   static readonly codeBlockToggle = "code-block-toggle";

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -1812,6 +1812,7 @@
   "Sorry, an error occurred uploading the file": "Sorry, an error occurred uploading the file",
   "Sorry, that type of link is not supported": "Sorry, that type of link is not supported",
   "Caption": "Caption",
+  "Click to copy": "Click to copy",
   "Empty diagram": "Empty diagram",
   "Double click to edit": "Double click to edit",
   "Open": "Open",


### PR DESCRIPTION
- Refactors rendering of React decorations
- Adds wider color swatch support

<img width="238" height="133" alt="image" src="https://github.com/user-attachments/assets/dd094f02-342c-45b8-9453-ccb49886f352" />

ref https://github.com/outline/outline/discussions/12969