### PR TITLE
fix: Floating toolbar in template settings overlaps sidebar

### DIFF
--- a/app/components/CenteredContent.tsx
+++ b/app/components/CenteredContent.tsx
@@ -10,6 +10,7 @@ type Props = {
 };
 
 const Container = styled.div<Props>`
+  position: relative;
   width: 100%;
   max-width: 100vw;
   padding: ${(props) => (props.withStickyHeader ? "4px 16px" : "60px 16px")};


### PR DESCRIPTION
closes #12983