### PR TITLE
fix: Add query parameter to `templates.list` endpoint

### DIFF
--- a/server/routes/api/templates/schema.ts
+++ b/server/routes/api/templates/schema.ts
@@ -29,6 +29,9 @@ export const TemplatesListSchema = BaseSchema.extend({
   body: TemplatesSortParamsSchema.extend({
     /** Id of the collection to which the template belongs */
     collectionId: z.string().uuid().optional(),
+
+    /** Search query to filter templates by title */
+    query: z.string().optional(),
   }),
 });
 

--- a/server/routes/api/templates/templates.test.ts
+++ b/server/routes/api/templates/templates.test.ts
@@ -53,6 +53,32 @@ describe("#templates.list", () => {
     expect(body.data[0].id).toEqual(template.id);
   });
 
+  it("should filter templates by query", async () => {
+    const user = await buildUser();
+    const template = await buildTemplate({
+      userId: user.id,
+      teamId: user.teamId,
+      title: "Meeting notes",
+    });
+    await buildTemplate({
+      userId: user.id,
+      teamId: user.teamId,
+      title: "Project plan",
+    });
+
+    const res = await server.post("/api/templates.list", user, {
+      body: {
+        query: "meeting",
+      },
+    });
+
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.data.length).toEqual(1);
+    expect(body.data[0].id).toEqual(template.id);
+    expect(body.pagination.total).toEqual(1);
+  });
+
   it("should require authentication", async () => {
     const res = await server.post("/api/templates.list");
     expect(res.status).toEqual(401);

--- a/server/routes/api/templates/templates.ts
+++ b/server/routes/api/templates/templates.ts
@@ -1,6 +1,6 @@
 import Router from "koa-router";
 import type { WhereOptions } from "sequelize";
-import { Op } from "sequelize";
+import { Op, Sequelize } from "sequelize";
 import auth from "@server/middlewares/authentication";
 import { rateLimiter } from "@server/middlewares/rateLimiter";
 import { transaction } from "@server/middlewares/transaction";
@@ -72,7 +72,7 @@ router.post(
   pagination(),
   validate(T.TemplatesListSchema),
   async (ctx: APIContext<T.TemplatesListReq>) => {
-    const { sort, direction, collectionId } = ctx.input.body;
+    const { sort, direction, collectionId, query } = ctx.input.body;
     const { user } = ctx.state.auth;
     const where: WhereOptions<Template> & {
       [Op.and]: WhereOptions<Template>[];
@@ -109,6 +109,16 @@ router.post(
       });
     }
 
+    if (query) {
+      where[Op.and].push(
+        Sequelize.literal(
+          `unaccent(LOWER("template"."title")) like unaccent(LOWER(:query))`
+        )
+      );
+    }
+
+    const replacements = { query: `%${query}%` };
+
     const [templates, total] = await Promise.all([
       Template.scope([
         "defaultScope",
@@ -117,11 +127,16 @@ router.post(
         },
       ]).findAll({
         where,
+        replacements,
         order: [[sort, direction]],
         offset: ctx.state.pagination.offset,
         limit: ctx.state.pagination.limit,
       }),
-      Template.count({ where }),
+      Template.count({
+        where,
+        // @ts-expect-error Types are incorrect for count
+        replacements,
+      }),
     ]);
 
     const data = templates.map((template) => presentTemplate(template));


### PR DESCRIPTION
Fixes infinite loop when filtering template list in settings