### PR TITLE
fix: Debounce search query persistence

### DIFF
--- a/server/models/SearchQuery.test.ts
+++ b/server/models/SearchQuery.test.ts
@@ -1,0 +1,168 @@
+import { buildTeam, buildUser } from "@server/test/factories";
+import SearchQuery from "./SearchQuery";
+
+describe("SearchQuery.record", () => {
+  it("updates the existing record when a query extends a recent one", async () => {
+    const user = await buildUser();
+    const teamId = user.teamId;
+
+    const first = await SearchQuery.record({
+      userId: user.id,
+      teamId,
+      source: "app",
+      query: "conf",
+      results: 3,
+      duration: 10,
+    });
+
+    const second = await SearchQuery.record({
+      userId: user.id,
+      teamId,
+      source: "app",
+      query: "conflue",
+      results: 5,
+      duration: 12,
+    });
+
+    expect(second.id).toEqual(first.id);
+    expect(second.query).toEqual("conflue");
+    expect(second.results).toEqual(5);
+    expect(await SearchQuery.count({ where: { teamId } })).toEqual(1);
+  });
+
+  it("updates the existing record when a query is shortened", async () => {
+    const user = await buildUser();
+    const teamId = user.teamId;
+
+    const first = await SearchQuery.record({
+      userId: user.id,
+      teamId,
+      source: "app",
+      query: "conflue",
+      results: 5,
+      duration: 12,
+    });
+
+    const second = await SearchQuery.record({
+      userId: user.id,
+      teamId,
+      source: "app",
+      query: "conf",
+      results: 3,
+      duration: 10,
+    });
+
+    expect(second.id).toEqual(first.id);
+    expect(second.query).toEqual("conf");
+    expect(await SearchQuery.count({ where: { teamId } })).toEqual(1);
+  });
+
+  it("creates a new record for an unrelated query", async () => {
+    const user = await buildUser();
+    const teamId = user.teamId;
+
+    await SearchQuery.record({
+      userId: user.id,
+      teamId,
+      source: "app",
+      query: "conflue",
+      results: 5,
+      duration: 12,
+    });
+
+    await SearchQuery.record({
+      userId: user.id,
+      teamId,
+      source: "app",
+      query: "database",
+      results: 2,
+      duration: 8,
+    });
+
+    expect(await SearchQuery.count({ where: { teamId } })).toEqual(2);
+  });
+
+  it("does not collapse queries from different scopes", async () => {
+    const team = await buildTeam();
+    const userA = await buildUser({ teamId: team.id });
+    const userB = await buildUser({ teamId: team.id });
+
+    await SearchQuery.record({
+      userId: userA.id,
+      teamId: team.id,
+      source: "app",
+      query: "conf",
+      results: 1,
+      duration: 5,
+    });
+
+    await SearchQuery.record({
+      userId: userB.id,
+      teamId: team.id,
+      source: "app",
+      query: "conflue",
+      results: 1,
+      duration: 5,
+    });
+
+    expect(await SearchQuery.count({ where: { teamId: team.id } })).toEqual(2);
+  });
+
+  it("does not collapse when there is no user or share to scope by", async () => {
+    const team = await buildTeam();
+
+    await SearchQuery.record({
+      teamId: team.id,
+      source: "api",
+      query: "conf",
+      results: 1,
+      duration: 5,
+    });
+
+    await SearchQuery.record({
+      teamId: team.id,
+      source: "api",
+      query: "conflue",
+      results: 1,
+      duration: 5,
+    });
+
+    expect(await SearchQuery.count({ where: { teamId: team.id } })).toEqual(2);
+  });
+
+  it("creates a new record once the recency window has passed", async () => {
+    const user = await buildUser();
+    const teamId = user.teamId;
+
+    const first = await SearchQuery.record({
+      userId: user.id,
+      teamId,
+      source: "app",
+      query: "conf",
+      results: 1,
+      duration: 5,
+    });
+
+    // Backdate the first record beyond the recency window.
+    await SearchQuery.sequelize!.query(
+      `UPDATE search_queries SET "createdAt" = :createdAt WHERE id = :id`,
+      {
+        replacements: {
+          createdAt: new Date(Date.now() - SearchQuery.recencyWindow - 1000),
+          id: first.id,
+        },
+      }
+    );
+
+    await SearchQuery.record({
+      userId: user.id,
+      teamId,
+      source: "app",
+      query: "conflue",
+      results: 1,
+      duration: 5,
+    });
+
+    expect(await SearchQuery.count({ where: { teamId } })).toEqual(2);
+  });
+});

--- a/server/models/SearchQuery.ts
+++ b/server/models/SearchQuery.ts
@@ -1,3 +1,4 @@
+import { Op } from "sequelize";
 import type { InferAttributes, InferCreationAttributes } from "sequelize";
 import {
   Table,
@@ -10,6 +11,7 @@ import {
   DataType,
   Default,
 } from "sequelize-typescript";
+import { Second } from "@shared/utils/time";
 import Share from "@server/models/Share";
 import Team from "@server/models/Team";
 import User from "@server/models/User";
@@ -26,6 +28,73 @@ class SearchQuery extends Model<
   InferAttributes<SearchQuery>,
   Partial<InferCreationAttributes<SearchQuery>>
 > {
+  /**
+   * The window during which a follow-up query for the same scope is treated as
+   * a continuation of the same "search as you type" session rather than a new
+   * search.
+   */
+  public static recencyWindow = Second.ms * 30;
+
+  /**
+   * Records a search query, collapsing rapid "search as you type" keystrokes
+   * into a single record. If a query was recorded for the same scope within the
+   * recency window and one query is a prefix of the other (i.e. the visitor kept
+   * typing or edited their term), the existing record is updated in place rather
+   * than inserting a new row.
+   *
+   * @param attrs the attributes of the search to record.
+   * @returns the created or updated search query record.
+   */
+  public static async record(attrs: {
+    userId?: string | null;
+    teamId: string;
+    shareId?: string | null;
+    source: string;
+    query: string;
+    results: number;
+    duration: number;
+  }): Promise<SearchQuery> {
+    const { userId, teamId, shareId, source, query, results, duration } = attrs;
+
+    // Without a user or share to scope by, collapsing would merge unrelated
+    // searches across the team, so only ever record a new row.
+    const existing =
+      userId || shareId
+        ? await this.findOne({
+            where: {
+              teamId,
+              userId: userId ?? null,
+              shareId: shareId ?? null,
+              source,
+              createdAt: {
+                [Op.gte]: new Date(Date.now() - SearchQuery.recencyWindow),
+              },
+            },
+            order: [["createdAt", "DESC"]],
+          })
+        : null;
+
+    if (
+      existing &&
+      (query.startsWith(existing.query) || existing.query.startsWith(query))
+    ) {
+      existing.query = query;
+      existing.results = results;
+      existing.duration = duration;
+      return existing.save();
+    }
+
+    return this.create({
+      userId,
+      teamId,
+      shareId,
+      source,
+      query,
+      results,
+      duration,
+    });
+  }
+
   @IsUUID(4)
   @PrimaryKey
   @Default(DataType.UUIDV4)

--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -1173,11 +1173,11 @@ router.post(
     // duplicate search query records
     if (query && offset === 0) {
       const duration = Date.now() - searchStartedAt;
-      await SearchQuery.create({
+      await SearchQuery.record({
         userId: user?.id,
         teamId,
         shareId: share?.id,
-        source: ctx.state.auth.type || "app", // we'll consider anything that isn't "api" to be "app"
+        source: ctx.state.auth.type || "app", // anything that isn't explicitly set is "app"
         query,
         results: total,
         duration,


### PR DESCRIPTION
Searching in cmd+k sends a query for each character typed (particularly on public shares), this then gets recorded in the db as separate searches.