### PR TITLE
perf: `findAllChildDocumentIds`

### DIFF
--- a/server/models/Document.test.ts
+++ b/server/models/Document.test.ts
@@ -227,6 +227,34 @@ describe("#findAllChildDocumentIds", () => {
     // descendants are not traversed.
     expect(results).toEqual([publishedChild.id]);
   });
+
+  test("should include soft-deleted children when paranoid is false", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const collection = await buildCollection({
+      userId: user.id,
+      teamId: team.id,
+    });
+    const document = await buildDocument({
+      userId: user.id,
+      teamId: team.id,
+      collectionId: collection.id,
+      title: "test",
+    });
+    const child = await buildDocument({
+      userId: user.id,
+      teamId: team.id,
+      collectionId: collection.id,
+      parentDocumentId: document.id,
+      title: "child",
+    });
+    await child.destroy();
+
+    expect(await document.findAllChildDocumentIds()).toEqual([]);
+    expect(
+      await document.findAllChildDocumentIds(undefined, { paranoid: false })
+    ).toEqual([child.id]);
+  });
 });
 
 describe("#findByPk", () => {

--- a/server/models/Document.test.ts
+++ b/server/models/Document.test.ts
@@ -1,4 +1,4 @@
-import { EmptyResultError } from "sequelize";
+import { EmptyResultError, Op } from "sequelize";
 import { CollectionPermission } from "@shared/types";
 import slugify from "@shared/utils/slugify";
 import { parser } from "@server/editor";
@@ -180,6 +180,52 @@ describe("#findAllChildDocumentIds", () => {
     expect(results.length).toBe(2);
     expect(results[0]).toBe(document2.id);
     expect(results[1]).toBe(document3.id);
+  });
+
+  test("should apply where filter and prune unmatched branches", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const collection = await buildCollection({
+      userId: user.id,
+      teamId: team.id,
+    });
+    const document = await buildDocument({
+      userId: user.id,
+      teamId: team.id,
+      collectionId: collection.id,
+      title: "test",
+    });
+    const publishedChild = await buildDocument({
+      userId: user.id,
+      teamId: team.id,
+      collectionId: collection.id,
+      parentDocumentId: document.id,
+      title: "published",
+    });
+    // A draft (unpublished) child, with its own nested child.
+    const draftChild = await buildDraftDocument({
+      userId: user.id,
+      teamId: team.id,
+      collectionId: collection.id,
+      parentDocumentId: document.id,
+      title: "draft",
+    });
+    await buildDocument({
+      userId: user.id,
+      teamId: team.id,
+      collectionId: collection.id,
+      parentDocumentId: draftChild.id,
+      title: "published under draft",
+    });
+
+    const results = await document.findAllChildDocumentIds({
+      publishedAt: {
+        [Op.ne]: null,
+      },
+    });
+    // Only the published child is returned; the draft branch is pruned so its
+    // descendants are not traversed.
+    expect(results).toEqual([publishedChild.id]);
   });
 });
 

--- a/server/models/Document.ts
+++ b/server/models/Document.ts
@@ -1004,11 +1004,14 @@ class Document extends ArchivableModel<
     const queryGenerator = this.sequelize!.getQueryInterface()
       .queryGenerator as QueryGeneratorWithWhere;
 
+    const paranoid = options?.paranoid ?? true;
     const whereConditions = queryGenerator.getWhereConditions(
-      { deletedAt: null, ...where },
+      { ...(paranoid ? { deletedAt: null } : {}), ...where },
       "documents",
       model
     );
+    const anchorFilter = whereConditions ? `AND (${whereConditions})` : "";
+    const recursiveFilter = whereConditions ? `WHERE (${whereConditions})` : "";
 
     // A single recursive CTE walks the entire subtree in one round-trip rather
     // than issuing one query per level of nesting (N+1). Rows are ordered by
@@ -1020,12 +1023,12 @@ class Document extends ArchivableModel<
         SELECT documents.id, 1 AS depth
         FROM documents
         WHERE documents."parentDocumentId" = :parentDocumentId
-          AND (${whereConditions})
+          ${anchorFilter}
         UNION ALL
         SELECT documents.id, children.depth + 1
         FROM documents
         INNER JOIN children ON documents."parentDocumentId" = children.id
-        WHERE (${whereConditions})
+        ${recursiveFilter}
       )
       SELECT id FROM children ORDER BY depth
       `,

--- a/server/models/Document.ts
+++ b/server/models/Document.ts
@@ -10,7 +10,13 @@ import type {
   FindOptions,
   WhereOptions,
 } from "sequelize";
-import { Transaction, Op, EmptyResultError, Sequelize } from "sequelize";
+import {
+  Transaction,
+  Op,
+  EmptyResultError,
+  Sequelize,
+  QueryTypes,
+} from "sequelize";
 import {
   ForeignKey,
   BelongsTo,
@@ -984,34 +990,51 @@ class Document extends ArchivableModel<
     where?: Omit<WhereOptions<Document>, "parentDocumentId">,
     options?: FindOptions<Document>
   ): Promise<string[]> => {
-    const findAllChildDocumentIds = async (
-      ...parentDocumentId: string[]
-    ): Promise<string[]> => {
-      // Unscoped as this method only ever reads the id column
-      const childDocuments = await (this.constructor as typeof Document)
-        .unscoped()
-        .findAll({
-          attributes: ["id"],
-          where: {
-            parentDocumentId,
-            ...where,
-          },
-          ...options,
-        });
+    const model = this.constructor as typeof Document;
 
-      const childDocumentIds = childDocuments.map((doc) => doc.id);
-
-      if (childDocumentIds.length > 0) {
-        return [
-          ...childDocumentIds,
-          ...(await findAllChildDocumentIds(...childDocumentIds)),
-        ];
-      }
-
-      return childDocumentIds;
+    // Sequelize types the query generator as unknown; narrow to the single
+    // method used to build the shared filter fragment.
+    const queryGenerator = model.sequelize!.getQueryInterface()
+      .queryGenerator as {
+      getWhereConditions(
+        where: WhereOptions<Document>,
+        tableName: string,
+        factory: typeof Document
+      ): string;
     };
 
-    return findAllChildDocumentIds(this.id);
+    const whereConditions = queryGenerator.getWhereConditions(
+      { deletedAt: null, ...where },
+      "documents",
+      model
+    );
+
+    // A single recursive CTE walks the entire subtree in one round-trip rather
+    // than issuing one query per level of nesting (N+1). Rows are ordered by
+    // depth to ensure breadth-first result ordering.
+    const rows = await model.sequelize!.query<{ id: string }>(
+      `
+      WITH RECURSIVE children AS (
+        SELECT documents.id, 1 AS depth
+        FROM documents
+        WHERE documents."parentDocumentId" = :parentDocumentId
+          AND (${whereConditions})
+        UNION
+        SELECT documents.id, children.depth + 1
+        FROM documents
+        INNER JOIN children ON documents."parentDocumentId" = children.id
+        WHERE (${whereConditions})
+      )
+      SELECT id FROM children ORDER BY depth
+      `,
+      {
+        replacements: { parentDocumentId: this.id },
+        transaction: options?.transaction,
+        type: QueryTypes.SELECT,
+      }
+    );
+
+    return rows.map((row) => row.id);
   };
 
   publish = async (

--- a/server/models/Document.ts
+++ b/server/models/Document.ts
@@ -102,6 +102,16 @@ type AdditionalFindOptions = {
   rejectOnEmpty?: boolean | Error;
 };
 
+/** Sequelize types the query generator as unknown; this narrows to the single
+ * method used to build a raw SQL filter fragment. */
+interface QueryGeneratorWithWhere {
+  getWhereConditions(
+    where: WhereOptions<Document>,
+    tableName: string,
+    factory: typeof Document
+  ): string;
+}
+
 // @ts-expect-error Type 'Literal' is not assignable to type 'string | ProjectionAlias'.
 @DefaultScope(() => ({
   include: [
@@ -991,17 +1001,8 @@ class Document extends ArchivableModel<
     options?: FindOptions<Document>
   ): Promise<string[]> => {
     const model = this.constructor as typeof Document;
-
-    // Sequelize types the query generator as unknown; narrow to the single
-    // method used to build the shared filter fragment.
-    const queryGenerator = model.sequelize!.getQueryInterface()
-      .queryGenerator as {
-      getWhereConditions(
-        where: WhereOptions<Document>,
-        tableName: string,
-        factory: typeof Document
-      ): string;
-    };
+    const queryGenerator = this.sequelize!.getQueryInterface()
+      .queryGenerator as QueryGeneratorWithWhere;
 
     const whereConditions = queryGenerator.getWhereConditions(
       { deletedAt: null, ...where },
@@ -1011,15 +1012,16 @@ class Document extends ArchivableModel<
 
     // A single recursive CTE walks the entire subtree in one round-trip rather
     // than issuing one query per level of nesting (N+1). Rows are ordered by
-    // depth to ensure breadth-first result ordering.
-    const rows = await model.sequelize!.query<{ id: string }>(
+    // depth to ensure breadth-first result ordering. UNION ALL is safe as the
+    // tree is acyclic, so each descendant id is reached exactly once.
+    const rows = await this.sequelize!.query<{ id: string }>(
       `
       WITH RECURSIVE children AS (
         SELECT documents.id, 1 AS depth
         FROM documents
         WHERE documents."parentDocumentId" = :parentDocumentId
           AND (${whereConditions})
-        UNION
+        UNION ALL
         SELECT documents.id, children.depth + 1
         FROM documents
         INNER JOIN children ON documents."parentDocumentId" = children.id


### PR DESCRIPTION
Removes recursive queries in `findAllChildDocumentIds`, pushing down into db layer.

As this is a hot path inside membership and search it is worth escaping the ORM with a raw query in this case.