### PR TITLE
fix: Deflake DocumentInsight rollupPeriod no-activity test

### DIFF
--- a/server/models/DocumentInsight.test.ts
+++ b/server/models/DocumentInsight.test.ts
@@ -15,14 +15,16 @@ const dayStr = (d: Date) => format(d, "yyyy-MM-dd");
 describe("DocumentInsight.rollupPeriod", () => {
   it("writes nothing when no source activity exists in the window", async () => {
     const team = await buildTeam();
-    await buildDocument({ teamId: team.id });
+    const document = await buildDocument({ teamId: team.id });
 
+    // Scope the partition to just this document so the global rollup count
+    // isn't affected by activity from other tests sharing the database.
     const upserted = await DocumentInsight.rollupPeriod({
       periodStart: dayStr(subDays(new Date(), 1)),
       intervalDays: 1,
       period: DocumentInsightPeriod.Day,
-      startUuid: FULL_UUID_RANGE[0],
-      endUuid: FULL_UUID_RANGE[1],
+      startUuid: document.id,
+      endUuid: document.id,
     });
 
     expect(upserted).toBe(0);


### PR DESCRIPTION
`DocumentInsight.rollupPeriod` aggregates every document in the given UUID range across the whole database, so the "writes nothing when no source activity exists" test flaked: it passed the full UUID range and asserted the global return value was 0, letting activity from other tests sharing the database leak into the window. This was especially likely near the UTC midnight boundary, where recently-created rows shifted into the "yesterday" window. This scopes the partition to the test's own document id so the count is deterministic while preserving the test's intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)