### PR TITLE
fix: Indent group-shared document children

### DIFF
--- a/app/components/Sidebar/components/SharedWithMeLink.tsx
+++ b/app/components/Sidebar/components/SharedWithMeLink.tsx
@@ -208,7 +208,7 @@ function SharedWithMeLink({ membership, depth = 0 }: Props) {
                 membership={membership}
                 activeDocument={documents.active}
                 isDraft={childNode.isDraft}
-                depth={2}
+                depth={depth + 1}
                 index={index}
                 parentId={document.id}
               />


### PR DESCRIPTION
Fixes #13027.

## Summary

- derive direct child indentation from the current shared document depth
- preserve the nested hierarchy for documents displayed under **Shared with me**

## Testing

- `git diff --check`
- Automated lint and tests were not run because project dependencies are not installed in the local workspace.