### PR TITLE
fix: useWindowScrollbarWidth measured horizontal overflow, not scrollbar width

### DIFF
--- a/app/hooks/useWindowScrollbarWidth.ts
+++ b/app/hooks/useWindowScrollbarWidth.ts
@@ -14,10 +14,6 @@ export default function useWindowScrollbarWidth(): number | null {
     const htmlElement = document.documentElement;
 
     const measure = () => {
-      // window.innerWidth includes the vertical scrollbar while the html
-      // element's clientWidth excludes it, so the difference is the scrollbar
-      // width. scrollWidth - clientWidth would instead measure horizontal
-      // overflow, which is 0 even when a vertical scrollbar is visible.
       const scrollbarWidth = window.innerWidth - htmlElement.clientWidth;
       setWidth(scrollbarWidth);
     };

--- a/app/hooks/useWindowScrollbarWidth.ts
+++ b/app/hooks/useWindowScrollbarWidth.ts
@@ -14,7 +14,11 @@ export default function useWindowScrollbarWidth(): number | null {
     const htmlElement = document.documentElement;
 
     const measure = () => {
-      const scrollbarWidth = htmlElement.scrollWidth - htmlElement.clientWidth;
+      // window.innerWidth includes the vertical scrollbar while the html
+      // element's clientWidth excludes it, so the difference is the scrollbar
+      // width. scrollWidth - clientWidth would instead measure horizontal
+      // overflow, which is 0 even when a vertical scrollbar is visible.
+      const scrollbarWidth = window.innerWidth - htmlElement.clientWidth;
       setWidth(scrollbarWidth);
     };
 


### PR DESCRIPTION
## Problem

`useWindowScrollbarWidth` is documented to return the width of the window's vertical scrollbar, but it computed `documentElement.scrollWidth - documentElement.clientWidth`. Both of those values exclude the vertical scrollbar, so the expression actually measures **horizontal content overflow** — which is `0` in the normal case even when a vertical scrollbar is visible.

As a result the hook always reported `0` on platforms with classic (non-overlay) scrollbars, and the right sidebar's `position: fixed` content in `Aside` was never narrowed to account for the scrollbar, misaligning/clipping it by ~15px on Windows and Linux. The bug is invisible on macOS and mobile, where overlay scrollbars have zero width and `0` happens to be correct.

## Fix

Measure `window.innerWidth - documentElement.clientWidth` instead: `innerWidth` spans the layout viewport including the scrollbar, `clientWidth` excludes it, so the difference is the scrollbar width. The existing `ResizeObserver` re-measure logic is unchanged and still fires when the scrollbar appears or disappears, since that changes the html element's box width.

## Verification

Checked in headless Chromium with a page tall enough to force a vertical scrollbar (800px viewport):

| Expression | Result |
|---|---|
| `scrollWidth - clientWidth` (old) | `0` |
| `innerWidth - clientWidth` (new) | `15` (true scrollbar width) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DjhYP8svLL8dU98tmQJ7RK

---
_Generated by [Claude Code](https://claude.ai/code/session_01DjhYP8svLL8dU98tmQJ7RK)_