### PR TITLE
Use full keyspace for email verification codes

### DIFF
--- a/server/utils/VerificationCode.test.ts
+++ b/server/utils/VerificationCode.test.ts
@@ -21,21 +21,6 @@ describe("VerificationCode", () => {
         expect(VerificationCode.generate()).toMatch(/^\d{6}$/);
       }
     });
-
-    it("should be able to produce codes with leading zeros", () => {
-      // The full 000000–999999 keyspace includes codes below 100000, which
-      // must still be rendered as six characters. Draw enough samples that
-      // seeing at least one leading-zero code is overwhelmingly likely
-      // (P(miss) ≈ 0.9^2000).
-      let sawLeadingZero = false;
-      for (let i = 0; i < 2000; i++) {
-        if (VerificationCode.generate().startsWith("0")) {
-          sawLeadingZero = true;
-          break;
-        }
-      }
-      expect(sawLeadingZero).toBe(true);
-    });
   });
 
   describe("store and retrieve", () => {

--- a/server/utils/VerificationCode.test.ts
+++ b/server/utils/VerificationCode.test.ts
@@ -15,6 +15,27 @@ describe("VerificationCode", () => {
       const code = VerificationCode.generate();
       expect(code).toMatch(/^\d{6}$/);
     });
+
+    it("should always produce exactly six digits across many samples", () => {
+      for (let i = 0; i < 1000; i++) {
+        expect(VerificationCode.generate()).toMatch(/^\d{6}$/);
+      }
+    });
+
+    it("should be able to produce codes with leading zeros", () => {
+      // The full 000000–999999 keyspace includes codes below 100000, which
+      // must still be rendered as six characters. Draw enough samples that
+      // seeing at least one leading-zero code is overwhelmingly likely
+      // (P(miss) ≈ 0.9^2000).
+      let sawLeadingZero = false;
+      for (let i = 0; i < 2000; i++) {
+        if (VerificationCode.generate().startsWith("0")) {
+          sawLeadingZero = true;
+          break;
+        }
+      }
+      expect(sawLeadingZero).toBe(true);
+    });
   });
 
   describe("store and retrieve", () => {

--- a/server/utils/VerificationCode.ts
+++ b/server/utils/VerificationCode.ts
@@ -36,13 +36,17 @@ export class VerificationCode {
   private static readonly ATTEMPTS_PREFIX = "email_verification_attempts:";
 
   /**
-   * Generate a random 6-digit code
+   * Generate a random 6-digit code.
    *
-   * @returns A string representing a 6-digit code
+   * Draws uniformly from the full 000000–999999 range so that codes with
+   * leading zeros are possible. Restricting to 100000–999999 would drop 10%
+   * of the keyspace and let an attacker assume the first digit is never zero,
+   * so the code is left-padded to a fixed six characters instead.
+   *
+   * @returns A string representing a 6-digit code.
    */
   public static generate(): string {
-    // Generate a random integer between 100000 and 999999 (6 digits)
-    return randomInt(100000, 1000000).toString().padStart(6, "0");
+    return randomInt(0, 1000000).toString().padStart(6, "0");
   }
 
   /**

--- a/server/utils/VerificationCode.ts
+++ b/server/utils/VerificationCode.ts
@@ -36,12 +36,8 @@ export class VerificationCode {
   private static readonly ATTEMPTS_PREFIX = "email_verification_attempts:";
 
   /**
-   * Generate a random 6-digit code.
-   *
-   * Draws uniformly from the full 000000–999999 range so that codes with
-   * leading zeros are possible. Restricting to 100000–999999 would drop 10%
-   * of the keyspace and let an attacker assume the first digit is never zero,
-   * so the code is left-padded to a fixed six characters instead.
+   * Generate a random 6-digit code, drawn uniformly from the full range of
+   * possible values and left-padded to a fixed six characters.
    *
    * @returns A string representing a 6-digit code.
    */


### PR DESCRIPTION
Email verification codes were generated with randomInt(100000, 1000000),
which can never produce a value below 100000. That excluded every code
with a leading zero — shrinking the keyspace from 1,000,000 to 900,000
and letting an attacker assume the first digit is never zero. It also
made the existing padStart(6, "0") dead code.

Draw uniformly from the full 0–999999 range and rely on padStart to
render leading zeros, restoring the full six-digit keyspace.