### PR TITLE
fix: Allow deleting failed and expired exports

### DIFF
--- a/app/scenes/Settings/components/FileOperationListItem.tsx
+++ b/app/scenes/Settings/components/FileOperationListItem.tsx
@@ -25,6 +25,12 @@ type Props = {
   fileOperation: FileOperation;
 };
 
+const TerminalStates = [
+  FileOperationState.Complete,
+  FileOperationState.Error,
+  FileOperationState.Expired,
+];
+
 const FileOperationListItem = ({ fileOperation }: Props) => {
   const { t } = useTranslation();
   const user = useCurrentUser();
@@ -96,7 +102,7 @@ const FileOperationListItem = ({ fileOperation }: Props) => {
 
   const showMenu =
     (fileOperation.type === FileOperationType.Export &&
-      fileOperation.state === FileOperationState.Complete) ||
+      TerminalStates.includes(fileOperation.state)) ||
     fileOperation.type === FileOperationType.Import;
 
   const selfHostedHelp = isCloudHosted

--- a/server/policies/fileOperation.ts
+++ b/server/policies/fileOperation.ts
@@ -3,6 +3,12 @@ import { User, Team, FileOperation } from "@server/models";
 import { allow } from "./cancan";
 import { and, isTeamAdmin, isTeamModel, isTeamMutable, or } from "./utils";
 
+const TerminalStates = [
+  FileOperationState.Complete,
+  FileOperationState.Error,
+  FileOperationState.Expired,
+];
+
 allow(
   User,
   ["createFileOperation", "createExport"],
@@ -24,7 +30,7 @@ allow(User, "delete", FileOperation, (actor, fileOperation) =>
     isTeamMutable(actor),
     or(
       fileOperation?.type !== FileOperationType.Export,
-      fileOperation?.state === FileOperationState.Complete
+      !!fileOperation && TerminalStates.includes(fileOperation.state)
     )
   )
 );

--- a/server/routes/api/fileOperations/fileOperations.test.ts
+++ b/server/routes/api/fileOperations/fileOperations.test.ts
@@ -360,7 +360,11 @@ describe("#fileOperations.redirect", () => {
 });
 
 describe("#fileOperations.delete", () => {
-  it("should delete file operation", async () => {
+  it.each([
+    FileOperationState.Complete,
+    FileOperationState.Error,
+    FileOperationState.Expired,
+  ])("should delete %s export file operation", async (state) => {
     const team = await buildTeam();
     const admin = await buildAdmin({
       teamId: team.id,
@@ -369,7 +373,7 @@ describe("#fileOperations.delete", () => {
       type: FileOperationType.Export,
       teamId: team.id,
       userId: admin.id,
-      state: FileOperationState.Complete,
+      state,
     });
     const deleteResponse = await server.post(
       "/api/fileOperations.delete",
@@ -396,6 +400,23 @@ describe("#fileOperations.delete", () => {
         },
       })
     ).toBe(0);
+  });
+
+  it("should not delete an export file operation in a non-terminal state", async () => {
+    const team = await buildTeam();
+    const admin = await buildAdmin({ teamId: team.id });
+    const exportData = await buildFileOperation({
+      type: FileOperationType.Export,
+      teamId: team.id,
+      userId: admin.id,
+      state: FileOperationState.Creating,
+    });
+    const res = await server.post("/api/fileOperations.delete", admin, {
+      body: {
+        id: exportData.id,
+      },
+    });
+    expect(res.status).toEqual(403);
   });
 
   it("should require authorization", async () => {


### PR DESCRIPTION
This fixes deleting failed and expired export operations from the admin settings.

## Expected behavior

Administrators should be able to delete export operations in the `Complete`, `Error`, or `Expired` state.

Failed exports may not have created a storage file, but their operation records should still be removable.

## Actual behavior

The admin UI only showed the delete menu for `Complete` exports, and `fileOperations.delete` only authorized exports in the `Complete` state.

As a result, deleting `Error` or `Expired` exports returned `authorization_error`, leaving failed 0-byte export records in the history.

## Changes

- `app/scenes/Settings/components/FileOperationListItem.tsx`
  - Show the action menu for exports in the `Complete`, `Error`, or `Expired` state.

- `server/policies/fileOperation.ts`
  - Allow team administrators to delete terminal-state export operations.
  - Continue rejecting deletion for non-terminal exports.

- `server/routes/api/fileOperations/fileOperations.test.ts`
  - Cover successful deletion for `Complete`, `Error`, and `Expired` exports.
  - Cover rejection for a non-terminal export.