### PR TITLE
fix: Option to invite existing user not in doc

### DIFF
--- a/app/components/Sharing/components/Suggestions.tsx
+++ b/app/components/Sharing/components/Suggestions.tsx
@@ -104,7 +104,7 @@ export const Suggestions = observer(
             : users.activeOrInvited
       ).filter((u) => !u.isSuspended);
 
-      if (isEmail(query)) {
+      if (isEmail(query) && !users.getByEmail(query)) {
         filtered.push(getSuggestionForEmail(query));
       }
 

--- a/app/stores/UsersStore.ts
+++ b/app/stores/UsersStore.ts
@@ -117,13 +117,13 @@ export default class UsersStore extends Store<User> {
   /**
    * Returns the loaded user with the given email address, if any.
    *
-   * @param email The email address to look up.
-   * @returns The matching user, or undefined if none exists.
+   * @param email the email address to look up.
+   * @returns the matching user, or undefined if none exists.
    */
   getByEmail = (email: string): User | undefined => {
-    const normalizedEmail = email.trim().toLocaleLowerCase();
+    const normalizedEmail = email.trim().toLowerCase();
     return this.all.find(
-      (user) => user.email?.toLocaleLowerCase() === normalizedEmail
+      (user) => user.email?.trim().toLowerCase() === normalizedEmail
     );
   };
 

--- a/app/stores/UsersStore.ts
+++ b/app/stores/UsersStore.ts
@@ -115,6 +115,19 @@ export default class UsersStore extends Store<User> {
     });
 
   /**
+   * Returns the loaded user with the given email address, if any.
+   *
+   * @param email The email address to look up.
+   * @returns The matching user, or undefined if none exists.
+   */
+  getByEmail = (email: string): User | undefined => {
+    const normalizedEmail = email.trim().toLocaleLowerCase();
+    return this.all.find(
+      (user) => user.email?.toLocaleLowerCase() === normalizedEmail
+    );
+  };
+
+  /**
    * Returns users that are not in the given document, optionally filtered by a query.
    *
    * @param documentId


### PR DESCRIPTION
If the user is already in the workspace but not in the doc, the option to invite them should not be shown