### PR TITLE
Inline small images into exported HTML

### DIFF
--- a/server/models/helpers/HTMLHelper.test.ts
+++ b/server/models/helpers/HTMLHelper.test.ts
@@ -26,4 +26,67 @@ describe("HTMLHelper", () => {
       expect(first).toBe(second);
     });
   });
+
+  describe("inlineImage", () => {
+    const redirectUrl = "/api/attachments.redirect?id=123";
+    const buffer = Buffer.from("small image");
+
+    it("should inline a small single-referenced image as a data URI", () => {
+      const html = `<p><img src="${redirectUrl}"></p>`;
+      const result = HTMLHelper.inlineImage(
+        html,
+        redirectUrl,
+        "image/png",
+        buffer
+      );
+      expect(result).toBe(
+        `<p><img src="data:image/png;base64,${buffer.toString("base64")}"></p>`
+      );
+    });
+
+    it("should not inline non-image attachments", () => {
+      const html = `<a href="${redirectUrl}">file</a>`;
+      const result = HTMLHelper.inlineImage(
+        html,
+        redirectUrl,
+        "application/pdf",
+        buffer
+      );
+      expect(result).toBeNull();
+    });
+
+    it("should not inline images larger than the maximum size", () => {
+      const html = `<p><img src="${redirectUrl}"></p>`;
+      const large = Buffer.alloc(HTMLHelper.maxInlineImageSize + 1);
+      const result = HTMLHelper.inlineImage(
+        html,
+        redirectUrl,
+        "image/png",
+        large
+      );
+      expect(result).toBeNull();
+    });
+
+    it("should not inline images referenced more than once", () => {
+      const html = `<p><img src="${redirectUrl}"><img src="${redirectUrl}"></p>`;
+      const result = HTMLHelper.inlineImage(
+        html,
+        redirectUrl,
+        "image/png",
+        buffer
+      );
+      expect(result).toBeNull();
+    });
+
+    it("should not inline an empty buffer", () => {
+      const html = `<p><img src="${redirectUrl}"></p>`;
+      const result = HTMLHelper.inlineImage(
+        html,
+        redirectUrl,
+        "image/png",
+        Buffer.from("")
+      );
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/server/models/helpers/HTMLHelper.ts
+++ b/server/models/helpers/HTMLHelper.ts
@@ -1,10 +1,53 @@
 import { initWasm, inline } from "@css-inline/css-inline-wasm";
+import { escapeRegExp } from "es-toolkit/compat";
 import fs from "fs-extra";
 import env from "@server/env";
 
 let initialized = false;
 
 export default class HTMLHelper {
+  /**
+   * The maximum size, in bytes, of an image that will be inlined into exported
+   * HTML as a base64 data URI. Larger images are kept as external files.
+   */
+  public static readonly maxInlineImageSize = 100 * 1024;
+
+  /**
+   * Inline a small image into exported HTML as a base64 data URI in place of
+   * its redirect URL. Images are only inlined when they are small and
+   * referenced exactly once — images used multiple times are kept as an
+   * external file to avoid duplicating the encoded data throughout the export.
+   *
+   * @param html The HTML content referencing the image.
+   * @param redirectUrl The redirect URL of the image within the HTML.
+   * @param contentType The content type of the image, e.g. "image/png".
+   * @param buffer The contents of the image.
+   * @returns The updated HTML if the image was inlined, otherwise null.
+   */
+  public static inlineImage(
+    html: string,
+    redirectUrl: string,
+    contentType: string | null | undefined,
+    buffer: Buffer
+  ): string | null {
+    if (!contentType?.startsWith("image/")) {
+      return null;
+    }
+    if (buffer.length === 0 || buffer.length > HTMLHelper.maxInlineImageSize) {
+      return null;
+    }
+
+    const pattern = new RegExp(escapeRegExp(redirectUrl), "g");
+    if ((html.match(pattern)?.length ?? 0) !== 1) {
+      return null;
+    }
+
+    return html.replace(
+      pattern,
+      `data:${contentType};base64,${buffer.toString("base64")}`
+    );
+  }
+
   /**
    * Move CSS styles from <style> tags to inline styles with default settings.
    *

--- a/server/queues/tasks/ExportDocumentTreeTask.ts
+++ b/server/queues/tasks/ExportDocumentTreeTask.ts
@@ -9,6 +9,7 @@ import type { Collection } from "@server/models";
 import Attachment from "@server/models/Attachment";
 import Document from "@server/models/Document";
 import { DocumentHelper } from "@server/models/helpers/DocumentHelper";
+import HTMLHelper from "@server/models/helpers/HTMLHelper";
 import { ProsemirrorHelper } from "@server/models/helpers/ProsemirrorHelper";
 import ZipHelper from "@server/utils/ZipHelper";
 import { serializeFilename } from "@server/utils/fs";
@@ -94,6 +95,25 @@ export default abstract class ExportDocumentTreeTask extends ExportTask {
         });
         buffer = Buffer.from("");
       }
+
+      // Inline small images referenced a single time as base64 data URIs
+      // rather than writing an external file. PDF export renders from HTML too.
+      if (
+        format === FileOperationFormat.HTMLZip ||
+        format === FileOperationFormat.PDF
+      ) {
+        const inlined = HTMLHelper.inlineImage(
+          text,
+          attachment.redirectUrl,
+          attachment.contentType,
+          buffer
+        );
+        if (inlined !== null) {
+          text = inlined;
+          continue;
+        }
+      }
+
       zip.addBuffer(buffer, path.join(dir, attachment.key), {
         mtime: attachment.updatedAt,
       });

--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -66,6 +66,7 @@ import {
 import { SearchQuerySource } from "@server/models/SearchQuery";
 import AttachmentHelper from "@server/models/helpers/AttachmentHelper";
 import { DocumentHelper } from "@server/models/helpers/DocumentHelper";
+import HTMLHelper from "@server/models/helpers/HTMLHelper";
 import { ProsemirrorHelper } from "@server/models/helpers/ProsemirrorHelper";
 import SearchProviderManager from "@server/utils/SearchProviderManager";
 import { TextHelper } from "@server/models/helpers/TextHelper";
@@ -909,7 +910,43 @@ router.post(
         })
       : [];
 
-    if (attachments.length === 0) {
+    // Read attachments and, when exporting HTML, inline small images that are
+    // referenced a single time as base64 data URIs. Any remaining attachments
+    // are bundled alongside the document in a zip.
+    const externalAttachments: { attachment: Attachment; buffer: Buffer }[] =
+      [];
+    for (const attachment of attachments) {
+      let buffer: Buffer;
+      try {
+        buffer = await attachment.buffer;
+      } catch (err) {
+        Logger.warn(`Failed to read attachment from storage`, {
+          attachmentId: attachment.id,
+          teamId: attachment.teamId,
+          error: errToString(err),
+        });
+        buffer = Buffer.from("");
+      }
+
+      if (contentType === "text/html") {
+        const inlined = HTMLHelper.inlineImage(
+          content,
+          attachment.redirectUrl,
+          attachment.contentType,
+          buffer
+        );
+        if (inlined !== null) {
+          content = inlined;
+          continue;
+        }
+      }
+
+      externalAttachments.push({ attachment, buffer });
+    }
+
+    // When there are no external attachments the document is self-contained and
+    // can be served directly rather than bundled in a zip.
+    if (externalAttachments.length === 0) {
       ctx.set("Content-Type", contentType);
       ctx.set(
         "Content-Disposition",
@@ -922,22 +959,11 @@ router.post(
     }
 
     await streamZipResponse(ctx, `${fileName}.zip`, async (zip) => {
-      for (const attachment of attachments) {
+      for (const { attachment, buffer } of externalAttachments) {
         const location = path.join(
           "attachments",
           `${attachment.id}.${mime.extension(attachment.contentType)}`
         );
-        let buffer: Buffer;
-        try {
-          buffer = await attachment.buffer;
-        } catch (err) {
-          Logger.warn(`Failed to read attachment from storage`, {
-            attachmentId: attachment.id,
-            teamId: attachment.teamId,
-            error: errToString(err),
-          });
-          buffer = Buffer.from("");
-        }
         zip.addBuffer(buffer, location, { mtime: attachment.updatedAt });
 
         content = content.replace(


### PR DESCRIPTION
It's nice to avoid a zip when possible, this also improves reliability of PDF export as there are less external resources to fetch over the network.