### PR TITLE
fix: Handle link copy error

### DIFF
--- a/shared/editor/nodes/Heading.ts
+++ b/shared/editor/nodes/Heading.ts
@@ -129,9 +129,14 @@ export default class Heading extends Node<HeadingOptions> {
     const normalizedUrl = window.location.href
       .split("#")[0]
       .replace("/edit", "");
-    copy(normalizedUrl + hash);
-
-    toast.message(t("Link copied to clipboard"));
+    try {
+      copy(normalizedUrl + hash);
+      toast.message(t("Link copied to clipboard"));
+    } catch (_err) {
+      // Some browser contexts disable the prompt() fallback used by
+      // copy-to-clipboard, causing it to throw – surface it rather than crash.
+      toast.error(t("Sorry, the link could not be copied"));
+    }
   };
 
   keys({ type, schema }: { type: NodeType; schema: Schema }) {

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -1822,6 +1822,7 @@
   "Show {{ count }} completed_many": "Show {{ count }} completed",
   "Show {{ count }} completed_other": "Show {{ count }} completed",
   "Hide completed": "Hide completed",
+  "Sorry, the link could not be copied": "Sorry, the link could not be copied",
   "Write a caption": "Write a caption",
   "Add title": "Add title",
   "Add content": "Add content",


### PR DESCRIPTION
Some browser contexts disable the `prompt()` causing an error when copying headings