### PR TITLE
fix: Improve handling of files not found in remote bucket

### DIFF
--- a/server/storage/files/S3Storage.test.ts
+++ b/server/storage/files/S3Storage.test.ts
@@ -1,7 +1,50 @@
+import { vi } from "vitest";
 import { Week, Day } from "@shared/utils/time";
+import Logger from "@server/logging/Logger";
 import BaseStorage from "./BaseStorage";
+import S3Storage from "./S3Storage";
 
 describe("S3Storage", () => {
+  describe("getFileStream", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("returns null and does not report an error when the object is missing (masked 403)", async () => {
+      // S3 returns AccessDenied for s3:ListBucket instead of 404 when the IAM
+      // identity lacks ListBucket permission and the key does not exist.
+      const error = Object.assign(new Error("AccessDenied"), {
+        name: "AccessDenied",
+        $metadata: { httpStatusCode: 403 },
+      });
+      const storage = new S3Storage();
+      vi.spyOn(Reflect.get(storage, "client"), "send").mockRejectedValue(error);
+      const errorSpy = vi.spyOn(Logger, "error");
+      const debugSpy = vi.spyOn(Logger, "debug");
+
+      const stream = await storage.getFileStream("missing/key");
+
+      expect(stream).toBeNull();
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(debugSpy).toHaveBeenCalled();
+    });
+
+    it("reports a real error for unexpected failures", async () => {
+      const error = Object.assign(new Error("boom"), {
+        name: "InternalError",
+        $metadata: { httpStatusCode: 500 },
+      });
+      const storage = new S3Storage();
+      vi.spyOn(Reflect.get(storage, "client"), "send").mockRejectedValue(error);
+      const errorSpy = vi.spyOn(Logger, "error");
+
+      const stream = await storage.getFileStream("some/key");
+
+      expect(stream).toBeNull();
+      expect(errorSpy).toHaveBeenCalled();
+    });
+  });
+
   describe("getSignedUrl expiration limits", () => {
     it("should define maximum expiration as 7 days for AWS S3 Signature V4", () => {
       // AWS S3 Signature V4 presigned URLs have a maximum expiration of 7 days

--- a/server/storage/files/S3Storage.test.ts
+++ b/server/storage/files/S3Storage.test.ts
@@ -13,20 +13,25 @@ describe("S3Storage", () => {
     it("returns null and does not report an error when the object is missing (masked 403)", async () => {
       // S3 returns AccessDenied for s3:ListBucket instead of 404 when the IAM
       // identity lacks ListBucket permission and the key does not exist.
-      const error = Object.assign(new Error("AccessDenied"), {
-        name: "AccessDenied",
-        $metadata: { httpStatusCode: 403 },
-      });
+      const error = Object.assign(
+        new Error(
+          "User: arn:aws:iam::123:user/attachments is not authorized to perform: s3:ListBucket on resource"
+        ),
+        {
+          name: "AccessDenied",
+          $metadata: { httpStatusCode: 403 },
+        }
+      );
       const storage = new S3Storage();
       vi.spyOn(Reflect.get(storage, "client"), "send").mockRejectedValue(error);
       const errorSpy = vi.spyOn(Logger, "error");
-      const debugSpy = vi.spyOn(Logger, "debug");
+      const infoSpy = vi.spyOn(Logger, "info");
 
       const stream = await storage.getFileStream("missing/key");
 
       expect(stream).toBeNull();
       expect(errorSpy).not.toHaveBeenCalled();
-      expect(debugSpy).toHaveBeenCalled();
+      expect(infoSpy).toHaveBeenCalled();
     });
 
     it("reports a real error for unexpected failures", async () => {

--- a/server/storage/files/S3Storage.ts
+++ b/server/storage/files/S3Storage.ts
@@ -320,7 +320,7 @@ export default class S3Storage extends BaseStorage {
         // lacks the ListBucket permission — S3 masks not-found as forbidden.
         // Neither is a real error, so log quietly and return null.
         if (this.isNotFoundError(err)) {
-          Logger.debug("utils", "File not found in S3", { key });
+          Logger.info("utils", "File not found in S3", { key });
         } else {
           Logger.error("Error getting file stream from S3 ", toError(err), {
             key,
@@ -335,15 +335,18 @@ export default class S3Storage extends BaseStorage {
     if (!(err instanceof Error)) {
       return false;
     }
+    // A genuinely missing object is reported as NoSuchKey / NotFound (404).
     if (
       err.name === "NoSuchKey" ||
       err.name === "NotFound" ||
-      err.name === "AccessDenied"
+      this.getHttpStatusCode(err) === 404
     ) {
       return true;
     }
-    const statusCode = this.getHttpStatusCode(err);
-    return statusCode === 404 || statusCode === 403;
+    // When the IAM identity lacks s3:ListBucket, S3 masks a missing object as a
+    // 403 AccessDenied referencing s3:ListBucket. A 403 that does not mention
+    // ListBucket is a genuine permission error and should still be surfaced.
+    return err.message.includes("s3:ListBucket");
   }
 
   private getHttpStatusCode(err: Error): number | undefined {

--- a/server/storage/files/S3Storage.ts
+++ b/server/storage/files/S3Storage.ts
@@ -315,12 +315,50 @@ export default class S3Storage extends BaseStorage {
       )
       .then((item) => item.Body as NodeJS.ReadableStream)
       .catch((err) => {
-        Logger.error("Error getting file stream from S3 ", err, {
-          key,
-        });
+        // A missing object is reported as NoSuchKey (404), or as an
+        // AccessDenied (403) referencing s3:ListBucket when the IAM identity
+        // lacks the ListBucket permission — S3 masks not-found as forbidden.
+        // Neither is a real error, so log quietly and return null.
+        if (this.isNotFoundError(err)) {
+          Logger.debug("utils", "File not found in S3", { key });
+        } else {
+          Logger.error("Error getting file stream from S3 ", toError(err), {
+            key,
+          });
+        }
 
         return null;
       });
+  }
+
+  private isNotFoundError(err: unknown): boolean {
+    if (!(err instanceof Error)) {
+      return false;
+    }
+    if (
+      err.name === "NoSuchKey" ||
+      err.name === "NotFound" ||
+      err.name === "AccessDenied"
+    ) {
+      return true;
+    }
+    const statusCode = this.getHttpStatusCode(err);
+    return statusCode === 404 || statusCode === 403;
+  }
+
+  private getHttpStatusCode(err: Error): number | undefined {
+    if ("$metadata" in err) {
+      const metadata = err.$metadata;
+      if (
+        metadata &&
+        typeof metadata === "object" &&
+        "httpStatusCode" in metadata
+      ) {
+        const statusCode = metadata.httpStatusCode;
+        return typeof statusCode === "number" ? statusCode : undefined;
+      }
+    }
+    return undefined;
   }
 
   private client: S3Client;


### PR DESCRIPTION
Instead of reporting to error handling, log for debugging in these cases.