### PR TITLE
fix: Inline images are not correctly output in HTML export

### DIFF
--- a/shared/editor/components/Image.tsx
+++ b/shared/editor/components/Image.tsx
@@ -36,6 +36,53 @@ type Props = ComponentProps & {
 /** Images rendered smaller than this width are displayed as inline icons. */
 export const InlineIconMaxWidth = 48;
 
+type ImageClassNameOptions = {
+  /** Layout modifier, e.g. "full-width", "left-50". */
+  layoutClass?: string | null;
+  /** Rendered width of the image in pixels. */
+  width?: number | null;
+  /** Whether the image failed to load. */
+  error?: boolean;
+};
+
+/**
+ * Whether an image should render as an inline icon rather than a block. Small
+ * images are displayed inline with the surrounding text.
+ *
+ * @param options The image's layout, width, and error state.
+ * @returns True if the image should be rendered as an inline icon.
+ */
+export function isInlineImageIcon({
+  layoutClass,
+  width,
+  error,
+}: ImageClassNameOptions): boolean {
+  return (
+    layoutClass !== "full-width" &&
+    !!width &&
+    width < InlineIconMaxWidth &&
+    !error
+  );
+}
+
+/**
+ * Builds the className for an image node's container, including the layout and
+ * inline-icon modifiers. Shared by the live NodeView and the static HTML
+ * serializer so that exported documents render small images inline too.
+ *
+ * @param options The image's layout, width, and error state.
+ * @returns The space-separated className string.
+ */
+export function imageClassName(options: ImageClassNameOptions): string {
+  return [
+    "image",
+    options.layoutClass ? `image-${options.layoutClass}` : "",
+    isInlineImageIcon(options) ? "image-icon" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
 const Image = (props: Props) => {
   const { isSelected, node, isEditable, onChangeSize, onClick } = props;
   const { src, layoutClass } = node.attrs;
@@ -64,18 +111,11 @@ const Image = (props: Props) => {
   });
 
   const isFullWidth = layoutClass === "full-width";
-  const isInlineIcon =
-    !isFullWidth && !!width && width < InlineIconMaxWidth && !error;
+  const isInlineIcon = isInlineImageIcon({ layoutClass, width, error });
   const isResizable = !!props.onChangeSize && !error && !isInlineIcon;
   const isDownloadable = !!props.onDownload && !error;
 
-  const className = [
-    "image",
-    layoutClass ? `image-${layoutClass}` : "",
-    isInlineIcon ? "image-icon" : "",
-  ]
-    .filter(Boolean)
-    .join(" ");
+  const className = imageClassName({ layoutClass, width, error });
 
   React.useEffect(() => {
     if (node.attrs.width && node.attrs.width !== width) {

--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -435,7 +435,7 @@ const emailStyle = (props: Props) => css`
     border-radius: 8px;
     padding: 6px 8px;
   }
-  .image > img {
+  .image:not(.image-icon) > img {
     width: auto;
     height: auto;
   }

--- a/shared/editor/nodes/Image.tsx
+++ b/shared/editor/nodes/Image.tsx
@@ -11,7 +11,10 @@ import { NodeSelection, Plugin, TextSelection } from "prosemirror-state";
 import * as React from "react";
 import { sanitizeImageSrc, sanitizeUrl } from "../../utils/urls";
 import Caption from "../components/Caption";
-import ImageComponent from "../components/Image";
+import ImageComponent, {
+  imageClassName,
+  isInlineImageIcon,
+} from "../components/Image";
 import type { MarkdownSerializerState } from "../lib/markdown/serializer";
 import { EditorStyleHelper } from "../styles/EditorStyleHelper";
 import type { ComponentProps, NodeAttrMark } from "../types";
@@ -136,8 +139,9 @@ export default class Image extends SimpleImage {
       atom: true,
       parseDOM: [
         {
-          tag: "div[class~=image]",
-          getAttrs: (dom: HTMLDivElement) => {
+          // `span` covers inline icons, which use a phrasing-content wrapper.
+          tag: "div[class~=image], span[class~=image]",
+          getAttrs: (dom: HTMLElement) => {
             const img = dom.getElementsByTagName("img")[0] as
               | HTMLImageElement
               | undefined;
@@ -206,9 +210,16 @@ export default class Image extends SimpleImage {
         },
       ],
       toDOM: (node) => {
-        const className = node.attrs.layoutClass
-          ? `image image-${node.attrs.layoutClass}`
-          : "image";
+        // Shared with the live NodeView so exported/static HTML renders small
+        // images as inline icons too.
+        const isInlineIcon = isInlineImageIcon({
+          layoutClass: node.attrs.layoutClass,
+          width: node.attrs.width,
+        });
+        const className = imageClassName({
+          layoutClass: node.attrs.layoutClass,
+          width: node.attrs.width,
+        });
 
         // `marks` is held separately below and is not a valid DOM attribute.
         const { marks, ...attrs } = node.attrs;
@@ -231,6 +242,13 @@ export default class Image extends SimpleImage {
         const href = typeof linkHref === "string" ? linkHref : undefined;
 
         const children = [href ? ["a", { href: sanitizeUrl(href) }, img] : img];
+
+        // Inline icons must use a span wrapper so the browser keeps them inside
+        // them inside the containing paragraph; a block `div` (or `p` caption)
+        // would be forced onto its own line when the HTML is parsed.
+        if (isInlineIcon) {
+          return ["span", { class: className }, ...children];
+        }
 
         if (node.attrs.alt) {
           children.push([


### PR DESCRIPTION
Previously the block style was kept, making the export look considerably different to the in-app representation