### PR TITLE
feat(MCP): Return public share urls

### DIFF
--- a/server/models/Share.ts
+++ b/server/models/Share.ts
@@ -1,5 +1,5 @@
 import type { InferAttributes, InferCreationAttributes } from "sequelize";
-import { type SaveOptions } from "sequelize";
+import { Op, type SaveOptions } from "sequelize";
 import {
   ForeignKey,
   BelongsTo,
@@ -198,6 +198,36 @@ class Share extends IdModel<
     return model;
   }
 
+  // static methods
+
+  /**
+   * Finds published, non-revoked shares for the given document(s) within a team.
+   *
+   * @param teamId - the team the documents belong to.
+   * @param documentIds - a single document ID or an array of document IDs.
+   * @returns the matching public shares.
+   */
+  static getPublicSharesForDocumentIds(
+    teamId: string,
+    documentIds: string | string[]
+  ): Promise<Share[]> {
+    return this.findPublicShares(teamId, "documentId", documentIds);
+  }
+
+  /**
+   * Finds published, non-revoked shares for the given collection(s) within a team.
+   *
+   * @param teamId - the team the collections belong to.
+   * @param collectionIds - a single collection ID or an array of collection IDs.
+   * @returns the matching public shares.
+   */
+  static getPublicSharesForCollectionIds(
+    teamId: string,
+    collectionIds: string | string[]
+  ): Promise<Share[]> {
+    return this.findPublicShares(teamId, "collectionId", collectionIds);
+  }
+
   // getters
 
   get isRevoked() {
@@ -257,6 +287,26 @@ class Share extends IdModel<
     this.revokedAt = new Date();
     this.revokedById = user.id;
     return this.saveWithCtx(ctx, undefined, { name: "revoke" });
+  }
+
+  private static findPublicShares(
+    teamId: string,
+    column: "documentId" | "collectionId",
+    ids: string | string[]
+  ): Promise<Share[]> {
+    const values = Array.isArray(ids) ? ids : [ids];
+    if (values.length === 0) {
+      return Promise.resolve([]);
+    }
+
+    return this.unscoped().findAll({
+      where: {
+        teamId,
+        published: true,
+        revokedAt: { [Op.is]: null },
+        [column]: values,
+      },
+    });
   }
 }
 

--- a/server/models/Share.ts
+++ b/server/models/Share.ts
@@ -306,6 +306,9 @@ class Share extends IdModel<
         revokedAt: { [Op.is]: null },
         [column]: values,
       },
+      // Deterministic order so the same share consistently wins when a
+      // resource has more than one active share.
+      order: [["createdAt", "ASC"]],
     });
   }
 }

--- a/server/tools/collections.ts
+++ b/server/tools/collections.ts
@@ -12,6 +12,8 @@ import {
   error,
   getActorFromContext,
   buildAPIContext,
+  getPublicShareUrlForCollection,
+  getPublicShareUrlsForCollections,
   optionalString,
   pathToUrl,
   withTracing,
@@ -108,27 +110,35 @@ export function collectionTools(server: McpServer, scopes: string[]) {
               }
             }
 
-            const presented = await Promise.all(
-              collections
-                .filter((c) => c.id !== exactMatch?.id)
-                .map(async (collection) =>
-                  pathToUrl(
+            const matchedCollections = [
+              ...(exactMatch ? [exactMatch] : []),
+              ...collections.filter((c) => c.id !== exactMatch?.id),
+            ];
+            const [shareUrls, presented] = await Promise.all([
+              getPublicShareUrlsForCollections(
+                user.team,
+                matchedCollections.map((c) => c.id)
+              ),
+              Promise.all(
+                matchedCollections.map(async (collection) => ({
+                  collection,
+                  presented: pathToUrl(
                     user.team,
                     await presentCollection(undefined, collection)
-                  )
-                )
-            );
+                  ),
+                }))
+              ),
+            ]);
 
-            if (exactMatch) {
-              presented.unshift(
-                pathToUrl(
-                  user.team,
-                  await presentCollection(undefined, exactMatch)
-                )
-              );
-            }
+            const results = presented.map(({ collection, presented }) => {
+              const shareUrl = shareUrls.get(collection.id);
+              return {
+                ...presented,
+                ...(shareUrl !== undefined && { shareUrl }),
+              };
+            });
 
-            return success(presented);
+            return success(results);
           } catch (message) {
             return error(message);
           }
@@ -272,10 +282,17 @@ export function collectionTools(server: McpServer, scopes: string[]) {
 
           await collection.saveWithCtx(ctx);
 
-          const presented = pathToUrl(
+          const shareUrl = await getPublicShareUrlForCollection(
             user.team,
-            await presentCollection(undefined, collection)
+            collection.id
           );
+          const presented = {
+            ...pathToUrl(
+              user.team,
+              await presentCollection(undefined, collection)
+            ),
+            ...(shareUrl !== undefined && { shareUrl }),
+          };
           return success(presented);
         } catch (message) {
           return error(message);

--- a/server/tools/documents.ts
+++ b/server/tools/documents.ts
@@ -27,6 +27,8 @@ import {
   getActorFromContext,
   getBreadcrumbsForDocuments,
   getDocumentBreadcrumb,
+  getPublicShareUrlForDocument,
+  getPublicShareUrlsForDocuments,
   optionalString,
   pathToUrl,
   withTracing,
@@ -168,13 +170,17 @@ export function documentTools(server: McpServer, scopes: string[]) {
               const filteredResults = results.filter(
                 (result) => result.document.id !== exactMatch?.id
               );
-              const breadcrumbs = await getBreadcrumbsForDocuments(
-                [
-                  ...(exactMatch ? [exactMatch] : []),
-                  ...filteredResults.map((r) => r.document),
-                ],
-                user
-              );
+              const matchedDocuments = [
+                ...(exactMatch ? [exactMatch] : []),
+                ...filteredResults.map((r) => r.document),
+              ];
+              const [breadcrumbs, shareUrls] = await Promise.all([
+                getBreadcrumbsForDocuments(matchedDocuments, user),
+                getPublicShareUrlsForDocuments(
+                  user.team,
+                  matchedDocuments.map((doc) => doc.id)
+                ),
+              ]);
 
               const presented = await Promise.all(
                 filteredResults.map(async (result) => {
@@ -186,10 +192,12 @@ export function documentTools(server: McpServer, scopes: string[]) {
                     })
                   );
                   const breadcrumb = breadcrumbs.get(result.document.id);
+                  const shareUrl = shareUrls.get(result.document.id);
                   const siblingIndex = indexMap?.get(result.document.id);
                   return {
                     document: doc,
                     ...(breadcrumb !== undefined && { breadcrumb }),
+                    ...(shareUrl !== undefined && { shareUrl }),
                     context: result.context,
                     ...(siblingIndex !== undefined && {
                       index: siblingIndex,
@@ -207,10 +215,12 @@ export function documentTools(server: McpServer, scopes: string[]) {
                   })
                 );
                 const breadcrumb = breadcrumbs.get(exactMatch.id);
+                const shareUrl = shareUrls.get(exactMatch.id);
                 const siblingIndex = indexMap?.get(exactMatch.id);
                 presented.unshift({
                   document: doc,
                   ...(breadcrumb !== undefined && { breadcrumb }),
+                  ...(shareUrl !== undefined && { shareUrl }),
                   context: undefined,
                   ...(siblingIndex !== undefined && { index: siblingIndex }),
                 });
@@ -231,10 +241,13 @@ export function documentTools(server: McpServer, scopes: string[]) {
 
             const documents = results.map((result) => result.document);
 
-            const breadcrumbs = await getBreadcrumbsForDocuments(
-              documents,
-              user
-            );
+            const [breadcrumbs, shareUrls] = await Promise.all([
+              getBreadcrumbsForDocuments(documents, user),
+              getPublicShareUrlsForDocuments(
+                user.team,
+                documents.map((document) => document.id)
+              ),
+            ]);
 
             const presented = await Promise.all(
               documents.map(async (document) => {
@@ -246,10 +259,12 @@ export function documentTools(server: McpServer, scopes: string[]) {
                   })
                 );
                 const breadcrumb = breadcrumbs.get(document.id);
+                const shareUrl = shareUrls.get(document.id);
                 const siblingIndex = indexMap?.get(document.id);
                 return {
                   document: doc,
                   ...(breadcrumb !== undefined && { breadcrumb }),
+                  ...(shareUrl !== undefined && { shareUrl }),
                   ...(siblingIndex !== undefined && { index: siblingIndex }),
                 };
               })
@@ -536,10 +551,13 @@ export function documentTools(server: McpServer, scopes: string[]) {
               }
             }
 
-            const breadcrumbs = await getBreadcrumbsForDocuments(
-              documents,
-              user
-            );
+            const [breadcrumbs, shareUrls] = await Promise.all([
+              getBreadcrumbsForDocuments(documents, user),
+              getPublicShareUrlsForDocuments(
+                user.team,
+                documents.map((document) => document.id)
+              ),
+            ]);
 
             const presented = await Promise.all(
               documents.map(async (document) => {
@@ -551,10 +569,12 @@ export function documentTools(server: McpServer, scopes: string[]) {
                   })
                 );
                 const breadcrumb = breadcrumbs.get(document.id);
+                const shareUrl = shareUrls.get(document.id);
                 const siblingIndex = indexMap.get(document.id);
                 return {
                   document: doc,
                   ...(breadcrumb !== undefined && { breadcrumb }),
+                  ...(shareUrl !== undefined && { shareUrl }),
                   ...(siblingIndex !== undefined && { index: siblingIndex }),
                 };
               })
@@ -675,14 +695,16 @@ export function documentTools(server: McpServer, scopes: string[]) {
             }
           }
 
-          const [{ text, ...attributes }, breadcrumb] = await Promise.all([
-            presentDocument(updated, {
-              includeData: false,
-              includeText: true,
-              includeUpdatedAt: true,
-            }),
-            getDocumentBreadcrumb(updated, user),
-          ]);
+          const [{ text, ...attributes }, breadcrumb, shareUrl] =
+            await Promise.all([
+              presentDocument(updated, {
+                includeData: false,
+                includeText: true,
+                includeUpdatedAt: true,
+              }),
+              getDocumentBreadcrumb(updated, user),
+              getPublicShareUrlForDocument(user.team, updated.id),
+            ]);
           return {
             content: [
               {
@@ -690,6 +712,7 @@ export function documentTools(server: McpServer, scopes: string[]) {
                 text: JSON.stringify({
                   document: pathToUrl(user.team, attributes),
                   ...(breadcrumb !== undefined && { breadcrumb }),
+                  ...(shareUrl !== undefined && { shareUrl }),
                 }),
               },
               {
@@ -802,14 +825,16 @@ export function documentTools(server: McpServer, scopes: string[]) {
 
             await documentRestorer(ctx, { document, collectionId });
 
-            const [{ text, ...attributes }, breadcrumb] = await Promise.all([
-              presentDocument(document, {
-                includeData: false,
-                includeText: true,
-                includeUpdatedAt: true,
-              }),
-              getDocumentBreadcrumb(document, user),
-            ]);
+            const [{ text, ...attributes }, breadcrumb, shareUrl] =
+              await Promise.all([
+                presentDocument(document, {
+                  includeData: false,
+                  includeText: true,
+                  includeUpdatedAt: true,
+                }),
+                getDocumentBreadcrumb(document, user),
+                getPublicShareUrlForDocument(user.team, document.id),
+              ]);
             return {
               content: [
                 {
@@ -817,6 +842,7 @@ export function documentTools(server: McpServer, scopes: string[]) {
                   text: JSON.stringify({
                     document: pathToUrl(user.team, attributes),
                     ...(breadcrumb !== undefined && { breadcrumb }),
+                    ...(shareUrl !== undefined && { shareUrl }),
                   }),
                 },
                 {

--- a/server/tools/fetch.test.ts
+++ b/server/tools/fetch.test.ts
@@ -3,6 +3,7 @@ import {
   buildComment,
   buildDocument,
   buildResolvedComment,
+  buildShare,
   buildTemplate,
 } from "@server/test/factories";
 import { getTestServer } from "@server/test/support";
@@ -60,6 +61,85 @@ describe("fetch", () => {
 
     // Second content is markdown text
     expect(res!.result!.content![1].text).toContain("Hello");
+  });
+
+  it("returns the public share url for a shared document", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const document = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+    });
+    const share = await buildShare({
+      teamId: user.teamId,
+      userId: user.id,
+      documentId: document.id,
+      published: true,
+    });
+
+    const res = await callMcpTool(server, accessToken, "fetch", {
+      resource: "document",
+      id: document.id,
+    });
+
+    const metadata = JSON.parse(res!.result!.content![0].text ?? "{}");
+    expect(metadata.shareUrl).toMatch(/^https?:\/\//);
+    expect(metadata.shareUrl).toContain(`/s/${share.id}`);
+  });
+
+  it("omits shareUrl when the share is revoked", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const document = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+    });
+    await buildShare({
+      teamId: user.teamId,
+      userId: user.id,
+      documentId: document.id,
+      published: true,
+      revokedAt: new Date(),
+    });
+
+    const res = await callMcpTool(server, accessToken, "fetch", {
+      resource: "document",
+      id: document.id,
+    });
+
+    const metadata = JSON.parse(res!.result!.content![0].text ?? "{}");
+    expect(metadata.shareUrl).toBeUndefined();
+  });
+
+  it("returns the public share url for a shared collection", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const share = await buildShare({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+      published: true,
+    });
+
+    const res = await callMcpTool(server, accessToken, "fetch", {
+      resource: "collection",
+      id: collection.id,
+    });
+
+    const data = JSON.parse(res!.result!.content![0].text ?? "{}");
+    expect(data.shareUrl).toMatch(/^https?:\/\//);
+    expect(data.shareUrl).toContain(`/s/${share.id}`);
   });
 
   it("returns unresolved commentCount on documents", async () => {

--- a/server/tools/fetch.ts
+++ b/server/tools/fetch.ts
@@ -23,6 +23,8 @@ import {
   success,
   getActorFromContext,
   getDocumentBreadcrumb,
+  getPublicShareUrlForCollection,
+  getPublicShareUrlForDocument,
   pathToUrl,
   withTracing,
 } from "./util";
@@ -131,15 +133,17 @@ export function fetchTool(server: McpServer, scopes: string[]) {
 
             authorize(actor, "read", document);
 
-            const [{ text, ...attributes }, breadcrumb] = await Promise.all([
-              presentDocument(document, {
-                includeData: false,
-                includeText: true,
-                includeUpdatedAt: true,
-                includeCommentCount: true,
-              }),
-              getDocumentBreadcrumb(document, actor),
-            ]);
+            const [{ text, ...attributes }, breadcrumb, shareUrl] =
+              await Promise.all([
+                presentDocument(document, {
+                  includeData: false,
+                  includeText: true,
+                  includeUpdatedAt: true,
+                  includeCommentCount: true,
+                }),
+                getDocumentBreadcrumb(document, actor),
+                getPublicShareUrlForDocument(actor.team, document.id),
+              ]);
             return {
               content: [
                 {
@@ -147,6 +151,7 @@ export function fetchTool(server: McpServer, scopes: string[]) {
                   text: JSON.stringify({
                     document: pathToUrl(actor.team, attributes),
                     ...(breadcrumb !== undefined && { breadcrumb }),
+                    ...(shareUrl !== undefined && { shareUrl }),
                   }),
                 },
                 {
@@ -166,9 +171,15 @@ export function fetchTool(server: McpServer, scopes: string[]) {
 
             authorize(actor, "read", collection);
 
-            const presented = await presentCollection(undefined, collection);
+            const [presented, shareUrl] = await Promise.all([
+              presentCollection(undefined, collection),
+              getPublicShareUrlForCollection(actor.team, collection.id),
+            ]);
             return success([
-              pathToUrl(actor.team, presented),
+              {
+                ...pathToUrl(actor.team, presented),
+                ...(shareUrl !== undefined && { shareUrl }),
+              },
               (collection.documentStructure ?? []).map((node) =>
                 presentNavigationNode(actor.team, node)
               ),

--- a/server/tools/util.ts
+++ b/server/tools/util.ts
@@ -2,7 +2,7 @@ import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { errToString } from "@shared/utils/error";
-import { Collection, type Team, type User } from "@server/models";
+import { Collection, Share, type Team, type User } from "@server/models";
 import { addTags } from "@server/logging/tracer";
 import { traceFunction } from "@server/logging/tracing";
 import { can } from "@server/policies";
@@ -287,6 +287,96 @@ export async function getBreadcrumbsForDocuments(
   }
 
   return breadcrumbs;
+}
+
+/**
+ * Resolves public share URLs for a batch of documents. Only published,
+ * non-revoked shares are considered, so the returned URLs are always publicly
+ * accessible links.
+ *
+ * @param team - the team the documents belong to, used to build absolute URLs.
+ * @param documentIds - a single document ID or an array of document IDs.
+ * @returns a map from document ID to its public share URL.
+ */
+export async function getPublicShareUrlsForDocuments(
+  team: Team,
+  documentIds: string | string[]
+): Promise<Map<string, string>> {
+  const shares = await Share.getPublicSharesForDocumentIds(
+    team.id,
+    documentIds
+  );
+  return toShareUrlMap(team, shares);
+}
+
+/**
+ * Resolves public share URLs for a batch of collections. Only published,
+ * non-revoked shares are considered, so the returned URLs are always publicly
+ * accessible links.
+ *
+ * @param team - the team the collections belong to, used to build absolute URLs.
+ * @param collectionIds - a single collection ID or an array of collection IDs.
+ * @returns a map from collection ID to its public share URL.
+ */
+export async function getPublicShareUrlsForCollections(
+  team: Team,
+  collectionIds: string | string[]
+): Promise<Map<string, string>> {
+  const shares = await Share.getPublicSharesForCollectionIds(
+    team.id,
+    collectionIds
+  );
+  return toShareUrlMap(team, shares);
+}
+
+/**
+ * Resolves the public share URL for a single document.
+ *
+ * @param team - the team the document belongs to, used to build the absolute URL.
+ * @param documentId - the document ID to look up.
+ * @returns the public share URL, or undefined when the document is not publicly shared.
+ */
+export async function getPublicShareUrlForDocument(
+  team: Team,
+  documentId: string
+): Promise<string | undefined> {
+  const map = await getPublicShareUrlsForDocuments(team, documentId);
+  return map.get(documentId);
+}
+
+/**
+ * Resolves the public share URL for a single collection.
+ *
+ * @param team - the team the collection belongs to, used to build the absolute URL.
+ * @param collectionId - the collection ID to look up.
+ * @returns the public share URL, or undefined when the collection is not publicly shared.
+ */
+export async function getPublicShareUrlForCollection(
+  team: Team,
+  collectionId: string
+): Promise<string | undefined> {
+  const map = await getPublicShareUrlsForCollections(team, collectionId);
+  return map.get(collectionId);
+}
+
+/**
+ * Maps public shares to a lookup of resource ID to canonical share URL, keyed
+ * by the share's document or collection ID. The first share wins when more than
+ * one points at the same resource.
+ */
+function toShareUrlMap(team: Team, shares: Share[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const share of shares) {
+    const key = share.documentId ?? share.collectionId;
+    if (!key || map.has(key)) {
+      continue;
+    }
+    // canonicalUrl reads the team association, which the unscoped query does
+    // not load — supply the already-loaded team.
+    share.team = team;
+    map.set(key, share.canonicalUrl);
+  }
+  return map;
 }
 
 /**


### PR DESCRIPTION
Returns the publicly shared url for entities in MCP responses