### PR TITLE
feat(mcp): Add available icon names as resource

### DIFF
--- a/server/routes/mcp/index.test.ts
+++ b/server/routes/mcp/index.test.ts
@@ -1,4 +1,5 @@
 import { Scope, TeamPreference } from "@shared/types";
+import { iconNames } from "@shared/utils/IconNames";
 import { UserFlag } from "@server/models/User";
 import {
   buildUser,
@@ -139,6 +140,70 @@ describe("POST /mcp/", () => {
 
       await user.reload();
       expect(user.getFlag(UserFlag.MCP)).toEqual(1);
+    });
+  });
+
+  describe("resources", () => {
+    it("initialize advertises the resources capability", async () => {
+      const { accessToken } = await buildOAuthUser();
+      const { body } = mcpRequest("initialize", {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: { name: "test-client", version: "1.0.0" },
+      });
+
+      const res = await server.post("/mcp/", {
+        headers: mcpHeaders(accessToken),
+        body,
+      });
+      expect(res.status).toEqual(200);
+
+      const parsed = await parseMcpResponse(res);
+      const result = parsed?.result as {
+        capabilities?: { resources?: unknown };
+      };
+      expect(result?.capabilities?.resources).toBeDefined();
+    });
+
+    it("resources/list includes the icons resource", async () => {
+      const { accessToken } = await buildOAuthUser();
+      const { body } = mcpRequest("resources/list");
+
+      const res = await server.post("/mcp/", {
+        headers: mcpHeaders(accessToken),
+        body,
+      });
+      expect(res.status).toEqual(200);
+
+      const parsed = await parseMcpResponse(res);
+      const result = parsed?.result as {
+        resources?: { uri: string; mimeType?: string }[];
+      };
+      const icons = result?.resources?.find((r) => r.uri === "outline://icons");
+      expect(icons).toBeDefined();
+      expect(icons?.mimeType).toEqual("application/json");
+    });
+
+    it("resources/read returns the icon names as JSON", async () => {
+      const { accessToken } = await buildOAuthUser();
+      const { body } = mcpRequest("resources/read", {
+        uri: "outline://icons",
+      });
+
+      const res = await server.post("/mcp/", {
+        headers: mcpHeaders(accessToken),
+        body,
+      });
+      expect(res.status).toEqual(200);
+
+      const parsed = await parseMcpResponse(res);
+      const result = parsed?.result as {
+        contents?: { uri: string; mimeType?: string; text: string }[];
+      };
+      const content = result?.contents?.[0];
+      expect(content?.uri).toEqual("outline://icons");
+      expect(content?.mimeType).toEqual("application/json");
+      expect(JSON.parse(content?.text ?? "null")).toEqual(iconNames);
     });
   });
 

--- a/server/routes/mcp/index.ts
+++ b/server/routes/mcp/index.ts
@@ -7,6 +7,7 @@ import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import { ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { toError } from "@shared/utils/error";
 import { TeamPreference } from "@shared/types";
+import { iconNames } from "@shared/utils/IconNames";
 import { NotFoundError } from "@server/errors";
 import env from "@server/env";
 import Logger from "@server/logging/Logger";
@@ -23,6 +24,7 @@ import { documentTools } from "@server/tools/documents";
 import { fetchTool } from "@server/tools/fetch";
 import { templateTools } from "@server/tools/templates";
 import { userTools } from "@server/tools/users";
+import { iconNamesResourceUri } from "@server/tools/util";
 import { version } from "../../../package.json";
 
 const app = new Koa();
@@ -88,9 +90,32 @@ function createMcpServer(scopes: string[], guidance?: string): McpServer {
     {
       capabilities: {
         tools: {},
+        resources: {},
       },
       instructions,
     }
+  );
+
+  // Exposed as a resource rather than inlined into every icon field's schema,
+  // so the full list is fetched on demand instead of shipped with tools/list.
+  server.registerResource(
+    "icons",
+    iconNamesResourceUri,
+    {
+      title: "Icon names",
+      description:
+        "The names of the icons available for document and collection icons.",
+      mimeType: "application/json",
+    },
+    (uri) => ({
+      contents: [
+        {
+          uri: uri.href,
+          mimeType: "application/json",
+          text: JSON.stringify(iconNames),
+        },
+      ],
+    })
   );
 
   attachmentTools(server, scopes);

--- a/server/tools/collections.ts
+++ b/server/tools/collections.ts
@@ -165,7 +165,7 @@ export function collectionTools(server: McpServer, scopes: string[]) {
             .optional()
             .describe("A markdown description for the collection."),
           icon: optionalString().describe(
-            "An icon for the collection, e.g. an emoji."
+            "An icon for the collection. May be an emoji or a named icon; read the outline://icons resource for the list of available icon names."
           ),
           color: optionalString().describe(
             "The hex color for the collection icon, e.g. #FF0000."
@@ -235,7 +235,7 @@ export function collectionTools(server: McpServer, scopes: string[]) {
             .nullable()
             .optional()
             .describe(
-              "An icon for the collection, e.g. an emoji. Set to null to remove."
+              "An icon for the collection. Set to null to remove. May be an emoji or a named icon; read the outline://icons resource for the list of available icon names."
             ),
           color: z
             .string()

--- a/server/tools/documents.ts
+++ b/server/tools/documents.ts
@@ -361,7 +361,7 @@ export function documentTools(server: McpServer, scopes: string[]) {
             "The ID of a template to pre-fill the new document from. The template's title, content, icon, and color are used unless overridden by the corresponding parameters."
           ),
           icon: optionalString().describe(
-            "An icon for the document, e.g. an emoji."
+            "An icon for the document. May be an emoji or a named icon; read the outline://icons resource for the list of available icon names."
           ),
           color: optionalString().describe(
             "The hex color for the document icon, e.g. #FF0000."
@@ -627,7 +627,7 @@ export function documentTools(server: McpServer, scopes: string[]) {
             .nullable()
             .optional()
             .describe(
-              "An icon for the document, e.g. an emoji. Set to null to remove."
+              "An icon for the document. Set to null to remove. May be an emoji or a named icon; read the outline://icons resource for the list of available icon names."
             ),
           color: z
             .string()

--- a/server/tools/util.ts
+++ b/server/tools/util.ts
@@ -65,6 +65,9 @@ export function optionalString() {
     .transform((v) => (v === "" ? undefined : v));
 }
 
+/** The URI of the MCP resource that lists the available named icons. */
+export const iconNamesResourceUri = "outline://icons";
+
 /**
  * Helper function to format successful MCP tool responses.
  *


### PR DESCRIPTION
Not ever MCP client can read resources, but as this is complementary data that's ok.

ref https://github.com/outline/outline/discussions/12951