### PR TITLE
fix: Introduce `useActiveSidebarContext`

### DIFF
--- a/app/components/Sidebar/components/CollectionLinkChildren.tsx
+++ b/app/components/Sidebar/components/CollectionLinkChildren.tsx
@@ -44,7 +44,7 @@ function CollectionLinkChildren({
   children,
 }: Props) {
   const pageSize = DEFAULT_PAGE_SIZE;
-  const { documents } = useStores();
+  const { documents, ui } = useStores();
   const { t } = useTranslation();
   const activeDocument = documents.active;
   const childDocuments = useCollectionDocuments(collection, activeDocument);
@@ -64,7 +64,7 @@ function CollectionLinkChildren({
 
   const expansion = useSidebarExpansionState(
     childDocuments,
-    activeDocument?.id
+    ui.activeDocumentId
   );
 
   // Handle collection-level alt-click cascade from DraggableCollectionLink

--- a/app/components/Sidebar/components/DocumentLink.tsx
+++ b/app/components/Sidebar/components/DocumentLink.tsx
@@ -14,10 +14,10 @@ import type Document from "~/models/Document";
 import type GroupMembership from "~/models/GroupMembership";
 import type UserMembership from "~/models/UserMembership";
 import type { RefHandle } from "~/components/EditableTitle";
+import { useActiveSidebarContext } from "~/hooks/useActiveSidebarContext";
 import useBoolean from "~/hooks/useBoolean";
 import useCurrentUser from "~/hooks/useCurrentUser";
 import { useDocumentMenuAction } from "~/hooks/useDocumentMenuAction";
-import { useLocationSidebarContext } from "~/hooks/useLocationSidebarContext";
 import useOnScreen from "~/hooks/useOnScreen";
 import usePolicy from "~/hooks/usePolicy";
 import useStores from "~/hooks/useStores";
@@ -66,7 +66,7 @@ const DocumentLink = observer(function DocumentLink(props: Props) {
   const hasChildDocuments =
     !!node.children.length || activeDocument?.parentDocumentId === node.id;
   const sidebarContext = useSidebarContext();
-  const locationSidebarContext = useLocationSidebarContext();
+  const activeSidebarContext = useActiveSidebarContext();
   const { fetchChildDocuments } = documents;
 
   // Keep expansion/data effects on the outer so they run regardless of whether
@@ -144,8 +144,8 @@ const DocumentLink = observer(function DocumentLink(props: Props) {
   React.useLayoutEffect(() => {
     if (
       isActiveDocument &&
-      (locationSidebarContext === sidebarContext ||
-        (!locationSidebarContext && sidebarContext === "collections")) &&
+      (activeSidebarContext === sidebarContext ||
+        (!activeSidebarContext && sidebarContext === "collections")) &&
       placeholderRef.current
     ) {
       scrollIntoView(placeholderRef.current, {
@@ -154,7 +154,7 @@ const DocumentLink = observer(function DocumentLink(props: Props) {
         boundary: (parent) => parent.id !== "sidebar",
       });
     }
-  }, [isActiveDocument, sidebarContext, locationSidebarContext]);
+  }, [isActiveDocument, sidebarContext, activeSidebarContext]);
 
   return (
     <>

--- a/app/components/Sidebar/components/DraggableCollectionLink.tsx
+++ b/app/components/Sidebar/components/DraggableCollectionLink.tsx
@@ -8,7 +8,7 @@ import styled from "styled-components";
 import type Collection from "~/models/Collection";
 import type Document from "~/models/Document";
 import CollectionIcon from "~/components/Icons/CollectionIcon";
-import { useLocationSidebarContext } from "~/hooks/useLocationSidebarContext";
+import { useActiveSidebarContext } from "~/hooks/useActiveSidebarContext";
 import useStores from "~/hooks/useStores";
 import type { DragObject } from "../hooks/useDragAndDrop";
 import CollectionLink from "./CollectionLink";
@@ -30,12 +30,12 @@ function DraggableCollectionLink({
   activeDocument,
   belowCollection,
 }: Props) {
-  const locationSidebarContext = useLocationSidebarContext();
+  const activeSidebarContext = useActiveSidebarContext();
   const sidebarContext = useSidebarContext();
   const { ui, policies, collections } = useStores();
   const [expanded, setExpanded] = useState(
     collection.id === ui.activeCollectionId &&
-      sidebarContext === locationSidebarContext
+      sidebarContext === activeSidebarContext
   );
   const belowCollectionIndex = belowCollection ? belowCollection.index : null;
 
@@ -87,7 +87,7 @@ function DraggableCollectionLink({
   useEffect(() => {
     if (
       collection.id === ui.activeCollectionId &&
-      sidebarContext === locationSidebarContext
+      sidebarContext === activeSidebarContext
     ) {
       setExpanded(true);
     }
@@ -95,7 +95,7 @@ function DraggableCollectionLink({
     collection.id,
     ui.activeCollectionId,
     sidebarContext,
-    locationSidebarContext,
+    activeSidebarContext,
   ]);
 
   const handleDisclosureClick = useCallback(

--- a/app/components/Sidebar/components/GroupLink.tsx
+++ b/app/components/Sidebar/components/GroupLink.tsx
@@ -2,7 +2,7 @@ import { observer } from "mobx-react";
 import { GroupIcon } from "outline-icons";
 import * as React from "react";
 import type Group from "~/models/Group";
-import { useLocationSidebarContext } from "~/hooks/useLocationSidebarContext";
+import { useActiveSidebarContext } from "~/hooks/useActiveSidebarContext";
 import Folder from "./Folder";
 import Relative from "./Relative";
 import SharedWithMeLink from "./SharedWithMeLink";
@@ -18,10 +18,10 @@ type Props = {
 };
 
 const GroupLink: React.FC<Props> = ({ group }) => {
-  const locationSidebarContext = useLocationSidebarContext();
+  const activeSidebarContext = useActiveSidebarContext();
   const sidebarContext = groupSidebarContext(group.id);
   const [expanded, setExpanded] = React.useState(
-    locationSidebarContext === sidebarContext
+    activeSidebarContext === sidebarContext
   );
 
   const { event: disclosureEvent, onDisclosureClick } =
@@ -40,10 +40,10 @@ const GroupLink: React.FC<Props> = ({ group }) => {
   );
 
   React.useEffect(() => {
-    if (locationSidebarContext === sidebarContext) {
+    if (activeSidebarContext === sidebarContext) {
       setExpanded(true);
     }
-  }, [sidebarContext, locationSidebarContext, setExpanded]);
+  }, [sidebarContext, activeSidebarContext, setExpanded]);
 
   return (
     <Relative>

--- a/app/components/Sidebar/components/SharedWithMeLink.tsx
+++ b/app/components/Sidebar/components/SharedWithMeLink.tsx
@@ -6,8 +6,8 @@ import { IconType, NotificationEventType } from "@shared/types";
 import { determineIconType } from "@shared/utils/icon";
 import type GroupMembership from "~/models/GroupMembership";
 import UserMembership from "~/models/UserMembership";
+import { useActiveSidebarContext } from "~/hooks/useActiveSidebarContext";
 import useBoolean from "~/hooks/useBoolean";
-import { useLocationSidebarContext } from "~/hooks/useLocationSidebarContext";
 import useStores from "~/hooks/useStores";
 import DocumentMenu from "~/menus/DocumentMenu";
 import {
@@ -40,7 +40,7 @@ function SharedWithMeLink({ membership, depth = 0 }: Props) {
   const [menuOpen, handleMenuOpen, handleMenuClose] = useBoolean();
   const { documentId } = membership;
   const isActiveDocument = documentId === ui.activeDocumentId;
-  const locationSidebarContext = useLocationSidebarContext();
+  const activeSidebarContext = useActiveSidebarContext();
   const sidebarContext = useSidebarContext();
   const document = documentId ? documents.get(documentId) : undefined;
 
@@ -54,7 +54,7 @@ function SharedWithMeLink({ membership, depth = 0 }: Props) {
     : false;
 
   const [expanded, setExpanded, setCollapsed] = useBoolean(
-    isActiveDocumentInPath && locationSidebarContext === sidebarContext
+    isActiveDocumentInPath && activeSidebarContext === sidebarContext
   );
 
   const { event: disclosureEvent, onDisclosureClick } =
@@ -63,13 +63,13 @@ function SharedWithMeLink({ membership, depth = 0 }: Props) {
   useSidebarDisclosure(setExpanded, setCollapsed);
 
   React.useEffect(() => {
-    if (isActiveDocumentInPath && locationSidebarContext === sidebarContext) {
+    if (isActiveDocumentInPath && activeSidebarContext === sidebarContext) {
       setExpanded();
     }
   }, [
     isActiveDocumentInPath,
     sidebarContext,
-    locationSidebarContext,
+    activeSidebarContext,
     setExpanded,
   ]);
 

--- a/app/components/Sidebar/components/StarredLink.tsx
+++ b/app/components/Sidebar/components/StarredLink.tsx
@@ -11,11 +11,11 @@ import type Collection from "~/models/Collection";
 import type Document from "~/models/Document";
 import type Star from "~/models/Star";
 import type { RefHandle } from "~/components/EditableTitle";
+import { useActiveSidebarContext } from "~/hooks/useActiveSidebarContext";
 import useBoolean from "~/hooks/useBoolean";
 import { useCollectionMenuAction } from "~/hooks/useCollectionMenuAction";
 import useCurrentUser from "~/hooks/useCurrentUser";
 import { useDocumentMenuAction } from "~/hooks/useDocumentMenuAction";
-import { useLocationSidebarContext } from "~/hooks/useLocationSidebarContext";
 import usePolicy from "~/hooks/usePolicy";
 import useStores from "~/hooks/useStores";
 import CollectionMenu from "~/menus/CollectionMenu";
@@ -368,7 +368,7 @@ function StarredLink({ star }: Props) {
   const { documentId, collectionId } = star;
   const collection = collectionId ? collections.get(collectionId) : undefined;
   const document = documentId ? documents.get(documentId) : undefined;
-  const locationSidebarContext = useLocationSidebarContext();
+  const activeSidebarContext = useActiveSidebarContext();
   const sidebarContext = starredSidebarContext(
     star.documentId ?? star.collectionId ?? ""
   );
@@ -376,7 +376,7 @@ function StarredLink({ star }: Props) {
     (star.documentId
       ? star.documentId === ui.activeDocumentId
       : star.collectionId === ui.activeCollectionId) &&
-      sidebarContext === locationSidebarContext
+      sidebarContext === activeSidebarContext
   );
 
   const { event: disclosureEvent, onDisclosureClick } =
@@ -385,12 +385,12 @@ function StarredLink({ star }: Props) {
   React.useEffect(() => {
     if (
       star.documentId === ui.activeDocumentId &&
-      sidebarContext === locationSidebarContext
+      sidebarContext === activeSidebarContext
     ) {
       setExpanded(true);
     } else if (
       star.collectionId === ui.activeCollectionId &&
-      sidebarContext === locationSidebarContext
+      sidebarContext === activeSidebarContext
     ) {
       setExpanded(true);
     }
@@ -400,7 +400,7 @@ function StarredLink({ star }: Props) {
     ui.activeDocumentId,
     ui.activeCollectionId,
     sidebarContext,
-    locationSidebarContext,
+    activeSidebarContext,
   ]);
 
   useEffect(() => {

--- a/app/hooks/useActiveSidebarContext.ts
+++ b/app/hooks/useActiveSidebarContext.ts
@@ -1,0 +1,25 @@
+import type { SidebarContextType } from "~/components/Sidebar/components/SidebarContext";
+import { useFocusedSplitLocation } from "./useFocusedSplitLocation";
+import { useLocationSidebarContext } from "./useLocationSidebarContext";
+
+/**
+ * Hook to retrieve the sidebar context that the sidebar should treat as
+ * active. When a secondary split view pane has focus, this resolves to that
+ * pane's context so that sidebar auto-expansion and active state follow the
+ * focused pane rather than the primary browser location.
+ *
+ * The focused pane is observable, so the calling component must be wrapped in
+ * `observer` to update when focus changes.
+ *
+ * @returns the active sidebar context.
+ */
+export function useActiveSidebarContext(): SidebarContextType {
+  const locationSidebarContext = useLocationSidebarContext();
+  const splitLocation = useFocusedSplitLocation();
+
+  if (splitLocation) {
+    return splitLocation.state?.sidebarContext;
+  }
+
+  return locationSidebarContext;
+}

--- a/app/hooks/useFocusedSplitLocation.ts
+++ b/app/hooks/useFocusedSplitLocation.ts
@@ -18,7 +18,9 @@ import { getFocusedSplitPane, getSplitPath } from "~/utils/splitView";
  * has focus, no split view is open, or the component is rendered inside a
  * pane and the router context already provides the pane's location.
  */
-export function useFocusedSplitLocation(): Location | undefined {
+export function useFocusedSplitLocation():
+  | Location<{ sidebarContext?: SidebarContextType }>
+  | undefined {
   const location = useLocation<{ sidebarContext?: SidebarContextType }>();
   const focusedPane = getFocusedSplitPane();
   const { isSplitView } = useSplitView();


### PR DESCRIPTION
When a secondary split view pane has focus, this resolves to that pane's context so that sidebar auto-expansion and active state follow the focused pane