### PR TITLE
fix: Serialize GitHub issue/PR/project mentions as links in Markdown

### DIFF
--- a/shared/editor/nodes/Mention.test.ts
+++ b/shared/editor/nodes/Mention.test.ts
@@ -1,0 +1,119 @@
+import { extensionManager, schema } from "../../test/editor";
+
+const serializer = extensionManager.serializer();
+
+function serializeMention(attrs: Record<string, unknown>) {
+  const doc = schema.nodeFromJSON({
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [{ type: "mention", attrs }],
+      },
+    ],
+  });
+  return serializer.serialize(doc, { commonMark: true }).trim();
+}
+
+describe("Mention serialization", () => {
+  const id = "0c440212-8b40-49fa-8a64-2548d6b60d59";
+  const modelId = "c85a0d80-3a89-4b25-a0cd-e7fc83f0d226";
+
+  describe("external integration mentions", () => {
+    it("serializes an issue mention with an href to a plain link", () => {
+      expect(
+        serializeMention({
+          type: "issue",
+          label: "Epic 1: Control plane Helm chart",
+          modelId,
+          id,
+          href: "https://github.com/acme/infra/issues/2",
+        })
+      ).toBe(
+        "[Epic 1: Control plane Helm chart](https://github.com/acme/infra/issues/2)"
+      );
+    });
+
+    it("serializes a pull request mention with an href to a plain link", () => {
+      expect(
+        serializeMention({
+          type: "pull_request",
+          label: "Add Helm chart",
+          modelId,
+          id,
+          href: "https://github.com/acme/infra/pull/42",
+        })
+      ).toBe("[Add Helm chart](https://github.com/acme/infra/pull/42)");
+    });
+
+    it("serializes a project mention with an href to a plain link", () => {
+      expect(
+        serializeMention({
+          type: "project",
+          label: "Q3 Roadmap",
+          modelId,
+          id,
+          href: "https://github.com/orgs/acme/projects/7",
+        })
+      ).toBe("[Q3 Roadmap](https://github.com/orgs/acme/projects/7)");
+    });
+
+    it("falls back to mention:// when an issue mention has no href", () => {
+      expect(
+        serializeMention({
+          type: "issue",
+          label: "Epic 1",
+          modelId,
+          id,
+        })
+      ).toBe(`@[Epic 1](mention://${id}/issue/${modelId})`);
+    });
+  });
+
+  describe("other mention types are unchanged", () => {
+    it("keeps the mention:// format for user mentions", () => {
+      expect(
+        serializeMention({
+          type: "user",
+          label: "John Doe",
+          modelId,
+          id,
+        })
+      ).toBe(`@[John Doe](mention://${id}/user/${modelId})`);
+    });
+
+    it("keeps the mention:// format for group mentions", () => {
+      expect(
+        serializeMention({
+          type: "group",
+          label: "Engineering",
+          modelId,
+          id,
+        })
+      ).toBe(`@[Engineering](mention://${id}/group/${modelId})`);
+    });
+
+    it("keeps the mention:// format for date mentions", () => {
+      expect(
+        serializeMention({
+          type: "date",
+          label: "February 3rd, 2024",
+          modelId: "2024-02-03",
+          id,
+        })
+      ).toBe(`@[February 3rd, 2024](mention://${id}/date/2024-02-03)`);
+    });
+
+    it("keeps the mention:// format for url mentions even with an href", () => {
+      expect(
+        serializeMention({
+          type: "url",
+          label: "Example",
+          modelId,
+          id,
+          href: "https://example.com",
+        })
+      ).toBe(`@[Example](mention://${id}/url/${modelId})`);
+    });
+  });
+});

--- a/shared/editor/nodes/Mention.tsx
+++ b/shared/editor/nodes/Mention.tsx
@@ -34,6 +34,23 @@ import mentionRule from "../rules/mention";
 import type { ComponentProps } from "../types";
 import Node from "./Node";
 
+/**
+ * Whether a mention type is backed by an external integration URL held in
+ * `attrs.href` (issue, pull request, project), rather than an internal Outline
+ * reference addressed via `mention://`. Used to keep the DOM and Markdown
+ * serializers in agreement about which mentions render as real links.
+ *
+ * @param type the mention type to check.
+ * @returns true if the mention links to an external URL.
+ */
+function isExternalUrlMention(type: MentionType): boolean {
+  return (
+    type === MentionType.Issue ||
+    type === MentionType.PullRequest ||
+    type === MentionType.Project
+  );
+}
+
 export default class Mention extends Node {
   get name() {
     return "mention";
@@ -128,12 +145,9 @@ export default class Mention extends Node {
           "data-id": node.attrs.modelId,
           "data-actorid": node.attrs.actorId,
           "data-anchor-id": node.attrs.anchorId,
-          "data-url":
-            node.attrs.type === MentionType.PullRequest ||
-            node.attrs.type === MentionType.Issue ||
-            node.attrs.type === MentionType.Project
-              ? sanitizeUrl(node.attrs.href)
-              : `mention://${node.attrs.id}/${node.attrs.type}/${node.attrs.modelId}`,
+          "data-url": isExternalUrlMention(node.attrs.type)
+            ? sanitizeUrl(node.attrs.href)
+            : `mention://${node.attrs.id}/${node.attrs.type}/${node.attrs.modelId}`,
           "data-unfurl": JSON.stringify(node.attrs.unfurl),
         },
         toPlainText(node),
@@ -246,11 +260,7 @@ export default class Mention extends Node {
 
           let link: string;
 
-          if (
-            mentionType === MentionType.Issue ||
-            mentionType === MentionType.PullRequest ||
-            mentionType === MentionType.Project
-          ) {
+          if (isExternalUrlMention(mentionType)) {
             link = selection.node.attrs.href;
           } else {
             const { modelId } = selection.node.attrs;
@@ -353,8 +363,15 @@ export default class Mention extends Node {
       );
     } else if (mType === MentionType.Collection) {
       state.write(`[${label}](/collection/${mId})`);
+    } else if (isExternalUrlMention(mType) && node.attrs.href) {
+      // Issue, pull request and project mentions come from external
+      // integrations and already carry the real URL in `href`. Emit a portable
+      // link instead of the internal mention:// URI so the reference resolves
+      // outside Outline, matching what toDOM already renders for these types.
+      state.write(`[${label}](${sanitizeUrl(node.attrs.href)})`);
     } else {
-      // Keep the existing mention:// format for other types (user, group, issue, pull_request, url)
+      // Keep the existing mention:// format for other types (user, group,
+      // date, url) and for any legacy node that has no href to link to.
       state.write(`@[${label}](mention://${id}/${mType}/${mId})`);
     }
   }


### PR DESCRIPTION
Closes #13053

### What

GitHub issue, pull request and project mentions serialize to an internal `mention://` URI in Markdown:

```
@[Epic 1: Control plane Helm chart](mention://0c440212-.../issue/c85a0d80-...)
```

That URI only carries Outline-internal UUIDs, so the reference can't be resolved outside Outline. It affects the three paths that share this serializer: Markdown export (single doc and collection zip), the documents API Markdown output, and the built-in MCP server document reads.

These three types already store the real URL in `attrs.href` — `toDOM` uses it for the anchor `href`/`data-url`, and the `Enter` handler navigates to it. Only `toMarkdown` dropped it and fell through to the `mention://` branch.

This changes `toMarkdown` in `shared/editor/nodes/Mention.tsx` to emit a plain link from `href` for Issue/PullRequest/Project:

```
[Epic 1: Control plane Helm chart](https://github.com/acme/infra/issues/2)
```

The branch is guarded on `href` being present, so anything without one — and user/group/date/url mentions — keeps the existing `mention://` output. The link goes through `sanitizeUrl`, matching `toDOM`. The parser is untouched, so existing `mention://` documents still parse.

Same class of problem as #5293 (Markdown export emitting non-portable internal references while HTML used full URLs).

### Points worth flagging

- **Round-trip changes for these types.** Exported Markdown becomes a plain link, so re-importing produces a regular link rather than a live mention until it is re-unfurled. #8610 suggests the mention round-trip is valued for document mentions, so I'm happy to gate this behind an export option / setting if you'd prefer `mention://` to stay the default.
- **`url` mentions left as-is.** They also carry `href` and could serialize to a plain link the same way, but they're a more general unfurl surface so I left them out of this change. Happy to include them if you want.

### Tests

- New `shared/editor/nodes/Mention.test.ts` covering the serializer:
  - Issue / PullRequest / Project with an `href` → plain `[label](href)` link
  - Issue without an `href` → `mention://` fallback
  - User / Group unchanged, and `url` (with `href`) still `mention://`
- Existing mention parser tests (`shared/editor/rules/mention.test.ts`, `shared/utils/parseMentionUrl.test.ts`) still pass unchanged.

`yarn lint`, `yarn tsc` and the affected test files are green.

### Follow-ups

- The external-URL type check is factored into a small `isExternalUrlMention` helper now shared by `toDOM` (data-url), the `Enter` handler and `toMarkdown`, so they can't drift on which mention types are real links.
- The write-direction counterpart — turning inbound `github.com` links back into live mentions on API/MCP document writes — is tracked separately in #13055.
