### PR TITLE
fix: allow read-scoped API tokens to list collection memberships

### DIFF
--- a/shared/helpers/AuthenticationHelper.test.ts
+++ b/shared/helpers/AuthenticationHelper.test.ts
@@ -80,6 +80,19 @@ describe("AuthenticationHelper", () => {
         expect(canAccess("/api/users.create", scopes)).toBe(false);
       });
 
+      it("collections read scope grants access to membership listing", async () => {
+        const scopes = ["collections:read"];
+
+        expect(canAccess("/api/collections.list", scopes)).toBe(true);
+        expect(canAccess("/api/collections.memberships", scopes)).toBe(true);
+        expect(canAccess("/api/collections.group_memberships", scopes)).toBe(
+          true
+        );
+        expect(canAccess("/api/collections.add_user", scopes)).toBe(false);
+        expect(canAccess("/api/collections.remove_user", scopes)).toBe(false);
+        expect(canAccess("/api/documents.memberships", scopes)).toBe(false);
+      });
+
       it("write", async () => {
         const scopes = ["documents:write"];
 
@@ -115,6 +128,10 @@ describe("AuthenticationHelper", () => {
         expect(canAccess("/api/users.info", scopes)).toBe(true);
         expect(canAccess("/api/groups.info", scopes)).toBe(true);
         expect(canAccess("/api/collections.list", scopes)).toBe(true);
+        expect(canAccess("/api/collections.memberships", scopes)).toBe(true);
+        expect(canAccess("/api/collections.group_memberships", scopes)).toBe(
+          true
+        );
         expect(canAccess("/api/documents.create", scopes)).toBe(false);
         expect(canAccess("/api/documents.update", scopes)).toBe(false);
         expect(canAccess("/api/users.create", scopes)).toBe(false);

--- a/shared/helpers/AuthenticationHelper.ts
+++ b/shared/helpers/AuthenticationHelper.ts
@@ -8,6 +8,8 @@ export default class AuthenticationHelper {
    * - `documents.create` -> `Scope.Create`
    * - `documents.list` -> `Scope.Read`
    * - `documents.info` -> `Scope.Read`
+   * - `collections.memberships` -> `Scope.Read`
+   * - `collections.group_memberships` -> `Scope.Read`
    */
   private static methodToScope = {
     create: Scope.Create,
@@ -19,6 +21,8 @@ export default class AuthenticationHelper {
     drafts: Scope.Read,
     viewed: Scope.Read,
     export: Scope.Read,
+    memberships: Scope.Read,
+    group_memberships: Scope.Read,
   };
 
   /**


### PR DESCRIPTION
Fixes #13056

`collections.memberships` and `collections.group_memberships` both use `authorize(user, "read", collection)` — they are read-only listing endpoints. But `methodToScope` in `AuthenticationHelper` had no entries for `memberships` or `group_memberships`, so they defaulted to `Scope.Write`. This meant read-scoped OAuth tokens and API keys got 403 errors when trying to list collection members.

Fix: add both methods to the `methodToScope` map with `Scope.Read`.

The underlying policy checks (`authorize`) still run for every request, so this doesn't affect the write-requiring `documents.memberships`/`documents.group_memberships` endpoints — the scope map gates initial access but doesn't replace the authorization layer.