### PR TITLE
fix: Remove user listing for guests

### DIFF
--- a/app/scenes/Search/components/UserFilter.tsx
+++ b/app/scenes/Search/components/UserFilter.tsx
@@ -5,6 +5,8 @@ import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { Avatar, AvatarSize } from "~/components/Avatar";
 import FilterOptions from "~/components/FilterOptions";
+import useCurrentTeam from "~/hooks/useCurrentTeam";
+import usePolicy from "~/hooks/usePolicy";
 import useStores from "~/hooks/useStores";
 
 type Props = {
@@ -20,6 +22,8 @@ function UserFilter(props: Props) {
   const { onSelect, userId } = props;
   const { t } = useTranslation();
   const { users } = useStores();
+  const team = useCurrentTeam();
+  const can = usePolicy(team);
 
   const options = useMemo(() => {
     const userOptions = users.all.map((user) => ({
@@ -43,7 +47,7 @@ function UserFilter(props: Props) {
       selectedKeys={[userId]}
       onSelect={onSelect}
       defaultLabel={t("Any author")}
-      fetchQuery={users.fetchPage}
+      fetchQuery={can.listUsers ? users.fetchPage : undefined}
       fetchQueryOptions={fetchQueryOptions}
       showFilter
     />

--- a/server/routes/api/users/users.test.ts
+++ b/server/routes/api/users/users.test.ts
@@ -235,16 +235,12 @@ describe("#users.list", () => {
     expect(body2.data[0].id).toEqual(user.id);
   });
 
-  it("should restrict guest from viewing other user's email", async () => {
+  it("should not allow guests to list users", async () => {
     const team = await buildTeam();
     await buildUser({ teamId: team.id });
     const guest = await buildUser({ teamId: team.id, role: UserRole.Guest });
     const res = await server.post("/api/users.list", guest);
-    const body = await res.json();
-    expect(res.status).toEqual(200);
-    expect(body.data).toHaveLength(2);
-    expect(body.data[0].email).toEqual(undefined);
-    expect(body.data[1].email).toEqual(guest.email);
+    expect(res.status).toEqual(403);
   });
 
   it("should restrict viewer from viewing other user's email", async () => {
@@ -269,24 +265,6 @@ describe("#users.list", () => {
     expect(body.data).toHaveLength(2);
     expect(body.data[0].email).toEqual(user.email);
     expect(body.data[1].email).toEqual(member.email);
-  });
-
-  it("should restrict guest from viewing other user's details", async () => {
-    const team = await buildTeam();
-    await buildUser({ teamId: team.id });
-    const guest = await buildUser({ teamId: team.id, role: UserRole.Guest });
-    const res = await server.post("/api/users.list", guest);
-    const body = await res.json();
-    expect(res.status).toEqual(200);
-    expect(body.data).toHaveLength(2);
-    expect(body.data[0].language).toEqual(undefined);
-    expect(body.data[0].preferences).toEqual(undefined);
-    expect(body.data[0].notificationSettings).toEqual(undefined);
-    expect(body.data[1].language).toEqual(guest.language);
-    expect(body.data[1].preferences).toEqual(guest.preferences);
-    expect(body.data[1].notificationSettings).toEqual(
-      guest.notificationSettings
-    );
   });
 
   it("should restrict viewer from viewing other user's details", async () => {

--- a/server/routes/api/users/users.ts
+++ b/server/routes/api/users/users.ts
@@ -40,6 +40,8 @@ router.post(
       ctx.input.body;
 
     const actor = ctx.state.auth.user;
+    authorize(actor, "listUsers", actor.team);
+
     let where: WhereOptions<User> = {
       teamId: actor.teamId,
     };


### PR DESCRIPTION
Guests could see all users in a workspace through the search author filter, this removes that capability leaving them only with the ability to filter by authors that have already been loaded into the local store.

closes #13075