### PR TITLE
fix: `documents.add_user` event missing `teamId`

### DIFF
--- a/server/models/UserMembership.test.ts
+++ b/server/models/UserMembership.test.ts
@@ -1,7 +1,32 @@
-import { buildCollection, buildUser } from "@server/test/factories";
+import {
+  buildCollection,
+  buildDocument,
+  buildUser,
+} from "@server/test/factories";
+import Event from "./Event";
 import UserMembership from "./UserMembership";
 
 describe("UserMembership", () => {
+  describe("events", () => {
+    it("should derive the event teamId from the document when the context has no authenticated user", async () => {
+      const document = await buildDocument();
+      const user = await buildUser({ teamId: document.teamId });
+
+      await UserMembership.create({
+        createdById: user.id,
+        userId: user.id,
+        documentId: document.id,
+      });
+
+      const event = await Event.findOne({
+        where: { name: "documents.add_user", documentId: document.id },
+      });
+
+      expect(event).not.toBeNull();
+      expect(event?.teamId).toEqual(document.teamId);
+    });
+  });
+
   describe("withCollection scope", () => {
     it("should return the collection", async () => {
       const collection = await buildCollection();

--- a/server/models/base/Model.ts
+++ b/server/models/base/Model.ts
@@ -283,33 +283,58 @@ class Model<
       );
     }
 
+    const collectionId =
+      "collectionId" in model
+        ? model.collectionId
+        : model instanceof models.collection
+          ? model.id
+          : undefined;
+
+    const documentId =
+      "documentId" in model
+        ? model.documentId
+        : model instanceof models.document
+          ? model.id
+          : undefined;
+
+    let teamId =
+      "teamId" in model
+        ? model.teamId
+        : model instanceof models.team
+          ? model.id
+          : context.auth?.user?.teamId;
+
+    // Membership-style models (e.g. UserMembership, GroupMembership) carry no
+    // teamId of their own, so derive it from the associated document or
+    // collection when the mutating context has no authenticated team. This
+    // guarantees events are never persisted without a team.
+    if (!teamId && (documentId || collectionId)) {
+      const parent = documentId
+        ? await models.document.unscoped().findByPk(documentId, {
+            attributes: ["teamId"],
+            paranoid: false,
+            transaction: context.transaction,
+          })
+        : await models.collection.unscoped().findByPk(collectionId, {
+            attributes: ["teamId"],
+            paranoid: false,
+            transaction: context.transaction,
+          });
+      teamId = parent?.getDataValue("teamId") ?? teamId;
+    }
+
     const attrs = {
       name: `${namespace}.${context.event.name ?? name}`,
       modelId: "modelId" in model ? model.modelId : model.id,
-      collectionId:
-        "collectionId" in model
-          ? model.collectionId
-          : model instanceof models.collection
-            ? model.id
-            : undefined,
-      documentId:
-        "documentId" in model
-          ? model.documentId
-          : model instanceof models.document
-            ? model.id
-            : undefined,
+      collectionId,
+      documentId,
       userId:
         "userId" in model
           ? model.userId
           : model instanceof models.user
             ? model.id
             : undefined,
-      teamId:
-        "teamId" in model
-          ? model.teamId
-          : model instanceof models.team
-            ? model.id
-            : context.auth?.user.teamId,
+      teamId,
       actorId:
         context.auth?.user?.id ??
         (model instanceof models.user && name === "create"


### PR DESCRIPTION
The audit log for these events was missing team id due to the source model not having that column and getting created from a background context.