### PR TITLE
fix(mcp): clarify create_document HTML media handling in tool schema

### DIFF
--- a/server/routes/mcp/index.ts
+++ b/server/routes/mcp/index.ts
@@ -67,6 +67,8 @@ Document and collection markdown support @mentions using the syntax: @[Display N
 
 Read images and attachments with the "fetch" tool by setting resource to "attachment" and passing either the attachment ID or an /api/attachments.redirect?id=... URL; the tool will return a signed URL for download.
 
+Base64-encoded images are supported in document content for all formats. When creating a document from HTML that includes images or videos, pass the markup with format "html" — remote URLs and base64 media are imported as attachments automatically. Do not convert such HTML to markdown, and do not upload the HTML file itself as an attachment.
+
 When asked to create a document that follows a template, use the "list_templates" tool to find a matching template; each result already includes the template body as markdown. To use it unchanged, pass its ID as templateId to "create_document" and the new document is pre-filled from it. To adapt it first, modify the returned body and pass the result as the text parameter to "create_document". Either way no separate fetch is needed.`;
 
 /**

--- a/server/tools/documents.ts
+++ b/server/tools/documents.ts
@@ -330,7 +330,7 @@ export function documentTools(server: McpServer, scopes: string[]) {
       {
         title: "Create document",
         description:
-          "Creates a new document from markdown or HTML content. Requires a collectionId to place it in a collection, or parentDocumentId to nest it under an existing document. Pass a templateId (from list_templates) to pre-fill from a template; the template's content is used unless text is also provided.",
+          "Creates a new document from markdown or HTML content. Requires a collectionId to place the document in a collection, or parentDocumentId to nest it under an existing document. Pass a templateId (from list_templates) to pre-fill the document from a template; the template's content is used unless text is also provided.",
         annotations: {
           idempotentHint: false,
           readOnlyHint: false,
@@ -343,7 +343,7 @@ export function documentTools(server: McpServer, scopes: string[]) {
             .string()
             .optional()
             .describe(
-              'The content of the document. Interpreted as markdown unless format is "html". For HTML that includes images or videos, pass the markup with format "html" — remote and base64 media are imported as attachments automatically. Do not convert such HTML to markdown, and do not upload the HTML file itself as an attachment.'
+              'The content of the document. Interpreted as markdown unless format is set to "html".'
             ),
           format: z
             .enum(["markdown", "html"])

--- a/server/tools/documents.ts
+++ b/server/tools/documents.ts
@@ -330,7 +330,7 @@ export function documentTools(server: McpServer, scopes: string[]) {
       {
         title: "Create document",
         description:
-          "Creates a new document from markdown or HTML content. Requires a collectionId to place the document in a collection, or parentDocumentId to nest it under an existing document. Pass a templateId (from list_templates) to pre-fill the document from a template; the template's content is used unless text is also provided.",
+          "Creates a new document from markdown or HTML content. Requires a collectionId to place it in a collection, or parentDocumentId to nest it under an existing document. Pass a templateId (from list_templates) to pre-fill from a template; the template's content is used unless text is also provided.",
         annotations: {
           idempotentHint: false,
           readOnlyHint: false,
@@ -343,7 +343,7 @@ export function documentTools(server: McpServer, scopes: string[]) {
             .string()
             .optional()
             .describe(
-              'The content of the document. Interpreted as markdown unless format is set to "html".'
+              'The content of the document. Interpreted as markdown unless format is "html". For HTML that includes images or videos, pass the markup with format "html" — remote and base64 media are imported as attachments automatically. Do not convert such HTML to markdown, and do not upload the HTML file itself as an attachment.'
             ),
           format: z
             .enum(["markdown", "html"])


### PR DESCRIPTION
## Summary
- Clarifies the `create_document` `text` parameter description for HTML input that includes images/videos.
- Documents that remote and base64 media are imported as attachments automatically when `format` is `"html"`.
- Explicitly steers agents away from two failure modes seen in practice: converting media-rich HTML to markdown, or uploading the HTML file itself as an attachment instead of creating a document.
## Context
After adding HTML support to `create_document` (#12943), agents sometimes still:
1. Flatten HTML with `<img>` / `<video>` into markdown (dropping media), or
2. Upload the whole HTML file via `create_attachment` instead of creating a document
The server already handles remote URL and base64 media via `documentImporter` → `ProsemirrorHelper.replaceImagesWithAttachments`. This change only updates the MCP tool schema so models know to pass the HTML through unchanged.
