### PR TITLE
feat: MCP `responseFormat` — return content as Markdown by default

### DIFF
--- a/server/tools/collections.test.ts
+++ b/server/tools/collections.test.ts
@@ -62,6 +62,52 @@ describe("collection tools", () => {
     expect(data.id).toBeDefined();
     expect(data.url).toMatch(/^https?:\/\//);
     expect(data.permission).toEqual(null);
+    expect(data.description).toEqual("A test description");
+    expect(data.data).toBeUndefined();
+  });
+
+  it("returns the description as markdown, not ProseMirror JSON", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+      description: "Hello, `world`!",
+    });
+
+    const res = await callMcpTool(server, accessToken, "list_collections");
+    const data = parseMcpListContent<{
+      id: string;
+      description?: string;
+      data?: unknown;
+    }>(res?.result?.content);
+
+    const match = data.find((c) => c.id === collection.id);
+    expect(match).toBeDefined();
+    expect(match!.description).toEqual("Hello, `world`!");
+    expect(match!.data).toBeUndefined();
+  });
+
+  it("returns ProseMirror JSON when responseFormat is json", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+      description: "Hello, `world`!",
+    });
+
+    const res = await callMcpTool(server, accessToken, "list_collections", {
+      responseFormat: "json",
+    });
+    const data = parseMcpListContent<{
+      id: string;
+      description?: string;
+      data?: { type: string };
+    }>(res?.result?.content);
+
+    const match = data.find((c) => c.id === collection.id);
+    expect(match).toBeDefined();
+    expect(match!.data?.type).toEqual("doc");
+    expect(match!.description).toBeUndefined();
   });
 
   it("update_collection updates fields on existing collection", async () => {

--- a/server/tools/collections.test.ts
+++ b/server/tools/collections.test.ts
@@ -87,6 +87,26 @@ describe("collection tools", () => {
     expect(match!.data).toBeUndefined();
   });
 
+  it("treats an empty responseFormat as omitted", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+      description: "Hello, `world`!",
+    });
+
+    const res = await callMcpTool(server, accessToken, "list_collections", {
+      responseFormat: "",
+    });
+    const data = parseMcpListContent<{ id: string; description?: string }>(
+      res?.result?.content
+    );
+
+    const match = data.find((c) => c.id === collection.id);
+    expect(res?.result?.isError).toBeFalsy();
+    expect(match!.description).toEqual("Hello, `world`!");
+  });
+
   it("returns ProseMirror JSON when responseFormat is json", async () => {
     const { user, accessToken } = await buildOAuthUser();
     const collection = await buildCollection({

--- a/server/tools/collections.test.ts
+++ b/server/tools/collections.test.ts
@@ -127,7 +127,47 @@ describe("collection tools", () => {
     const match = data.find((c) => c.id === collection.id);
     expect(match).toBeDefined();
     expect(match!.data?.type).toEqual("doc");
-    expect(match!.description).toBeUndefined();
+    // The markdown description is kept — update_collection has no `data`
+    // input, so it is the only representation that can be written back.
+    expect(match!.description).toEqual("Hello, `world`!");
+  });
+
+  it("returns the description verbatim rather than re-escaped markdown", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+      description: "Rates: 5 * 3 and C:\\Users\\foo",
+    });
+
+    const res = await callMcpTool(server, accessToken, "list_collections");
+    const data = parseMcpListContent<{ id: string; description?: string }>(
+      res?.result?.content
+    );
+
+    // Round-tripping through the markdown serializer would return
+    // "5 \\* 3" and "C:\\\\Users", which a caller echoing the value back into
+    // update_collection would persist.
+    const match = data.find((c) => c.id === collection.id);
+    expect(match!.description).toEqual("Rates: 5 * 3 and C:\\Users\\foo");
+  });
+
+  it("keeps description present when it is empty, so a cleared value is distinguishable", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+      description: null,
+    });
+
+    const res = await callMcpTool(server, accessToken, "list_collections");
+    const data = parseMcpListContent<{ id: string; description?: string }>(
+      res?.result?.content
+    );
+
+    const match = data.find((c) => c.id === collection.id);
+    expect(match).toHaveProperty("description");
+    expect(match!.description).toEqual("");
   });
 
   it("update_collection updates fields on existing collection", async () => {

--- a/server/tools/collections.ts
+++ b/server/tools/collections.ts
@@ -2,13 +2,11 @@ import { z } from "zod";
 import { Sequelize, Op, type WhereOptions } from "sequelize";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Collection, Team } from "@server/models";
-import { DocumentHelper } from "@server/models/helpers/DocumentHelper";
 import { sequelize } from "@server/storage/database";
 import { authorize } from "@server/policies";
 import { presentCollection } from "@server/presenters";
 import AuthenticationHelper from "@shared/helpers/AuthenticationHelper";
 import { UrlHelper } from "@shared/utils/UrlHelper";
-import type { ProsemirrorData } from "@shared/types";
 import {
   success,
   error,
@@ -24,10 +22,19 @@ import {
 } from "./util";
 
 /**
- * Presents a collection for a tool response. The description is rendered as
+ * Presents a collection for a tool response. The description is returned as
  * markdown rather than the ProseMirror JSON the standard presenter emits,
- * which costs a small multiple of the tokens for the same content. Callers
- * that need the structure can ask for it with `format: "json"`.
+ * which costs a small multiple of the tokens for the same content.
+ *
+ * `collection.description` is used verbatim rather than re-serializing the
+ * ProseMirror content: the model keeps the two in sync on save, so the stored
+ * markdown is authoritative, and round-tripping it through the serializer
+ * would add escapes (`5 * 3` becoming `5 \* 3`) that a caller echoing the
+ * value back into `update_collection` would write into the record.
+ *
+ * `description` is always present, so a caller can tell a cleared description
+ * from an absent field. `json` adds the ProseMirror `data` on top rather than
+ * replacing the markdown, since only the markdown can be written back.
  *
  * @param collection - the collection to present.
  * @param format - the format to render the description in.
@@ -38,18 +45,14 @@ export async function presentCollectionForTool(
   format: ContentFormat = ContentFormat.Markdown
 ) {
   const presented = await presentCollection(undefined, collection);
+  const description = collection.description ?? "";
 
   if (format === ContentFormat.Json) {
-    return presented;
+    return { ...presented, description };
   }
 
-  const { data, ...rest } = presented;
-  const description = data
-    ? (await DocumentHelper.toMarkdown(data as ProsemirrorData)).trim()
-    : "";
-
-  // Omit the field entirely when empty rather than emitting an empty string.
-  return description ? { ...rest, description } : rest;
+  const { data: _data, ...rest } = presented;
+  return { ...rest, description };
 }
 
 /**

--- a/server/tools/collections.ts
+++ b/server/tools/collections.ts
@@ -2,14 +2,18 @@ import { z } from "zod";
 import { Sequelize, Op, type WhereOptions } from "sequelize";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Collection, Team } from "@server/models";
+import { DocumentHelper } from "@server/models/helpers/DocumentHelper";
 import { sequelize } from "@server/storage/database";
 import { authorize } from "@server/policies";
 import { presentCollection } from "@server/presenters";
 import AuthenticationHelper from "@shared/helpers/AuthenticationHelper";
 import { UrlHelper } from "@shared/utils/UrlHelper";
+import type { ProsemirrorData } from "@shared/types";
 import {
   success,
   error,
+  ContentFormat,
+  formatParam,
   getActorFromContext,
   buildAPIContext,
   getPublicShareUrlForCollection,
@@ -18,6 +22,35 @@ import {
   pathToUrl,
   withTracing,
 } from "./util";
+
+/**
+ * Presents a collection for a tool response. The description is rendered as
+ * markdown rather than the ProseMirror JSON the standard presenter emits,
+ * which costs a small multiple of the tokens for the same content. Callers
+ * that need the structure can ask for it with `format: "json"`.
+ *
+ * @param collection - the collection to present.
+ * @param format - the format to render the description in.
+ * @returns the presented collection object.
+ */
+export async function presentCollectionForTool(
+  collection: Collection,
+  format: ContentFormat = ContentFormat.Markdown
+) {
+  const presented = await presentCollection(undefined, collection);
+
+  if (format === ContentFormat.Json) {
+    return presented;
+  }
+
+  const { data, ...rest } = presented;
+  const description = data
+    ? (await DocumentHelper.toMarkdown(data as ProsemirrorData)).trim()
+    : "";
+
+  // Omit the field entirely when empty rather than emitting an empty string.
+  return description ? { ...rest, description } : rest;
+}
 
 /**
  * Registers collection-related MCP tools on the given server, filtered by
@@ -57,11 +90,12 @@ export function collectionTools(server: McpServer, scopes: string[]) {
             .describe(
               "The maximum number of results to return. Defaults to 25, max 100."
             ),
+          responseFormat: formatParam(),
         },
       },
       withTracing(
         "list_collections",
-        async ({ query, offset, limit }, extra) => {
+        async ({ query, offset, limit, responseFormat }, extra) => {
           try {
             const user = getActorFromContext(extra);
             const collectionIds = await user.collectionIds();
@@ -124,7 +158,7 @@ export function collectionTools(server: McpServer, scopes: string[]) {
                   collection,
                   presented: pathToUrl(
                     user.team,
-                    await presentCollection(undefined, collection)
+                    await presentCollectionForTool(collection, responseFormat)
                   ),
                 }))
               ),
@@ -170,6 +204,7 @@ export function collectionTools(server: McpServer, scopes: string[]) {
           color: optionalString().describe(
             "The hex color for the collection icon, e.g. #FF0000."
           ),
+          responseFormat: formatParam(),
         },
       },
       withTracing("create_collection", async (input, context) => {
@@ -200,7 +235,7 @@ export function collectionTools(server: McpServer, scopes: string[]) {
 
           const presented = pathToUrl(
             user.team,
-            await presentCollection(undefined, reloaded)
+            await presentCollectionForTool(reloaded, input.responseFormat)
           );
           return success(presented);
         } catch (message) {
@@ -244,6 +279,7 @@ export function collectionTools(server: McpServer, scopes: string[]) {
             .describe(
               "The hex color for the collection icon. Set to null to remove."
             ),
+          responseFormat: formatParam(),
         },
       },
       withTracing("update_collection", async (input, context) => {
@@ -289,7 +325,7 @@ export function collectionTools(server: McpServer, scopes: string[]) {
           const presented = {
             ...pathToUrl(
               user.team,
-              await presentCollection(undefined, collection)
+              await presentCollectionForTool(collection, input.responseFormat)
             ),
             ...(shareUrl !== undefined && { shareUrl }),
           };

--- a/server/tools/comments.test.ts
+++ b/server/tools/comments.test.ts
@@ -140,6 +140,52 @@ describe("create_comment", () => {
     expect(data.documentId).toEqual(document.id);
   });
 
+  it("returns markdown text and omits ProseMirror data", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const document = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+    });
+
+    const res = await callMcpTool(server, accessToken, "create_comment", {
+      documentId: document.id,
+      text: "Hello, `world`!",
+    });
+    const data = JSON.parse(res?.result?.content?.[0]?.text ?? "{}");
+
+    // Inline code survives markdown, where toPlainText() would drop the ticks.
+    expect(data.text).toEqual("Hello, `world`!");
+    expect(data.data).toBeUndefined();
+  });
+
+  it("returns ProseMirror data when responseFormat is json", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const document = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+    });
+
+    const res = await callMcpTool(server, accessToken, "create_comment", {
+      documentId: document.id,
+      text: "Hello, `world`!",
+      responseFormat: "json",
+    });
+    const data = JSON.parse(res?.result?.content?.[0]?.text ?? "{}");
+
+    expect(data.data?.type).toEqual("doc");
+    expect(data.text).toEqual("Hello, world!");
+  });
+
   it("creates a reply to an existing comment", async () => {
     const { user, accessToken } = await buildOAuthUser();
     const collection = await buildCollection({

--- a/server/tools/comments.test.ts
+++ b/server/tools/comments.test.ts
@@ -13,6 +13,21 @@ import { buildOAuthUser, callMcpTool } from "@server/test/McpHelper";
 
 const server = getTestServer();
 
+/** A comment body whose inline code is lost by plain-text rendering. */
+const inlineCodeComment = {
+  type: "doc",
+  content: [
+    {
+      type: "paragraph",
+      content: [
+        { type: "text", text: "Hello, " },
+        { type: "text", text: "world", marks: [{ type: "code_inline" }] },
+        { type: "text", text: "!" },
+      ],
+    },
+  ],
+} as ProsemirrorData;
+
 describe("list_comments", () => {
   it("returns comments on a document", async () => {
     const { user, accessToken } = await buildOAuthUser();
@@ -115,6 +130,123 @@ describe("list_comments", () => {
     expect(data.length).toBeGreaterThanOrEqual(1);
     expect(data[0].anchorText).toBeUndefined();
   });
+
+  it("returns markdown text and omits ProseMirror data by default", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const document = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+    });
+    const comment = await buildComment({
+      userId: user.id,
+      documentId: document.id,
+    });
+    await comment.update({ data: inlineCodeComment });
+
+    const res = await callMcpTool(server, accessToken, "list_comments", {
+      documentId: document.id,
+    });
+    const data = (res?.result?.content ?? []).map((c: { text: string }) =>
+      JSON.parse(c.text)
+    );
+
+    expect(data[0].text).toEqual("Hello, `world`!");
+    expect(data[0].data).toBeUndefined();
+  });
+
+  it("adds ProseMirror data alongside the markdown when responseFormat is json", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const document = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+    });
+    const comment = await buildComment({
+      userId: user.id,
+      documentId: document.id,
+    });
+    await comment.update({ data: inlineCodeComment });
+
+    const res = await callMcpTool(server, accessToken, "list_comments", {
+      documentId: document.id,
+      responseFormat: "json",
+    });
+    const data = (res?.result?.content ?? []).map((c: { text: string }) =>
+      JSON.parse(c.text)
+    );
+
+    expect(data[0].data?.type).toEqual("doc");
+    // text stays markdown so the value can be written back via update_comment.
+    expect(data[0].text).toEqual("Hello, `world`!");
+  });
+
+  it("resolves anchorText for every comment when several share a document", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const document = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+    });
+    const first = await buildComment({
+      userId: user.id,
+      documentId: document.id,
+    });
+    const second = await buildComment({
+      userId: user.id,
+      documentId: document.id,
+    });
+
+    // Both marks live in one document, so both must resolve off the single
+    // cached parse shared across the async fan-out.
+    const content = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "first anchor",
+              marks: [buildCommentMark({ id: first.id, userId: user.id })],
+            },
+            { type: "text", text: " and " },
+            {
+              type: "text",
+              text: "second anchor",
+              marks: [buildCommentMark({ id: second.id, userId: user.id })],
+            },
+          ],
+        },
+      ],
+    } as ProsemirrorData;
+    await document.update({ content });
+
+    const res = await callMcpTool(server, accessToken, "list_comments", {
+      documentId: document.id,
+    });
+    const data = (res?.result?.content ?? []).map((c: { text: string }) =>
+      JSON.parse(c.text)
+    );
+
+    const anchorById = new Map<string, string>(
+      data.map((c: { id: string; anchorText: string }) => [c.id, c.anchorText])
+    );
+    expect(anchorById.get(first.id)).toEqual("first anchor");
+    expect(anchorById.get(second.id)).toEqual("second anchor");
+  });
 });
 
 describe("create_comment", () => {
@@ -183,7 +315,8 @@ describe("create_comment", () => {
     const data = JSON.parse(res?.result?.content?.[0]?.text ?? "{}");
 
     expect(data.data?.type).toEqual("doc");
-    expect(data.text).toEqual("Hello, world!");
+    // text stays markdown so the value can be written back via update_comment.
+    expect(data.text).toEqual("Hello, `world`!");
   });
 
   it("creates a reply to an existing comment", async () => {

--- a/server/tools/comments.ts
+++ b/server/tools/comments.ts
@@ -32,6 +32,11 @@ import { ValidationError } from "@server/errors";
  * JSON. The ProseMirror `data` repeats that same content at a multiple of the
  * token cost, so it is omitted unless the caller asks for it.
  *
+ * `text` is markdown in both formats — `json` adds `data` on top rather than
+ * changing what `text` means. `update_comment` parses its `text` input as
+ * markdown, so a caller that read plain text and wrote it back would silently
+ * strip every mark in the comment.
+ *
  * @param comment - the comment model instance.
  * @param commentMarks - optional precomputed comment marks to avoid reparsing.
  * @param format - the format to render the comment content in.
@@ -46,16 +51,11 @@ async function presentCommentWithText(
     includeAnchorText: true,
     commentMarks,
   });
+  const text = (await DocumentHelper.toMarkdown(data)).trim();
 
-  // Plain text alongside the structure, matching what a JSON caller had before.
-  if (format === ContentFormat.Json) {
-    return { ...rest, data, text: comment.toPlainText() };
-  }
-
-  return {
-    ...rest,
-    text: (await DocumentHelper.toMarkdown(data)).trim(),
-  };
+  return format === ContentFormat.Json
+    ? { ...rest, data, text }
+    : { ...rest, text };
 }
 
 /**

--- a/server/tools/comments.ts
+++ b/server/tools/comments.ts
@@ -51,7 +51,7 @@ async function presentCommentWithText(
     includeAnchorText: true,
     commentMarks,
   });
-  const text = (await DocumentHelper.toMarkdown(data)).trim();
+  const text = await DocumentHelper.toMarkdown(data);
 
   return format === ContentFormat.Json
     ? { ...rest, data, text }

--- a/server/tools/comments.ts
+++ b/server/tools/comments.ts
@@ -18,6 +18,8 @@ import {
   error,
   success,
   buildAPIContext,
+  ContentFormat,
+  formatParam,
   getActorFromContext,
   optionalString,
   withTracing,
@@ -25,25 +27,34 @@ import {
 import { ValidationError } from "@server/errors";
 
 /**
- * Presents a comment with a plain-text rendering of its content so that
- * MCP consumers (typically AI agents) can read it without parsing
- * ProseMirror JSON.
+ * Presents a comment with a markdown rendering of its content so that MCP
+ * consumers (typically AI agents) can read it without parsing ProseMirror
+ * JSON. The ProseMirror `data` repeats that same content at a multiple of the
+ * token cost, so it is omitted unless the caller asks for it.
  *
  * @param comment - the comment model instance.
  * @param commentMarks - optional precomputed comment marks to avoid reparsing.
+ * @param format - the format to render the comment content in.
  * @returns the presented comment with an additional `text` field.
  */
-function presentCommentWithText(
+async function presentCommentWithText(
   comment: Comment,
-  commentMarks?: CommentMark[]
+  commentMarks?: CommentMark[],
+  format: ContentFormat = ContentFormat.Markdown
 ) {
-  const presented = presentComment(comment, {
+  const { data, ...rest } = presentComment(comment, {
     includeAnchorText: true,
     commentMarks,
   });
+
+  // Plain text alongside the structure, matching what a JSON caller had before.
+  if (format === ContentFormat.Json) {
+    return { ...rest, data, text: comment.toPlainText() };
+  }
+
   return {
-    ...presented,
-    text: comment.toPlainText(),
+    ...rest,
+    text: (await DocumentHelper.toMarkdown(data)).trim(),
   };
 }
 
@@ -97,6 +108,7 @@ export function commentTools(server: McpServer, scopes: string[]) {
             .describe(
               "The maximum number of results to return. Defaults to 25, max 100."
             ),
+          responseFormat: formatParam(),
         },
       },
       withTracing(
@@ -109,6 +121,7 @@ export function commentTools(server: McpServer, scopes: string[]) {
             statusFilter,
             offset,
             limit,
+            responseFormat,
           },
           extra
         ) => {
@@ -196,22 +209,24 @@ export function commentTools(server: McpServer, scopes: string[]) {
             // Precompute comment marks per document to avoid reparsing
             // the same document for every comment.
             const marksCache = new Map<string, CommentMark[]>();
-            const presented = comments.map((comment) => {
-              const doc = comment.document;
-              let marks: CommentMark[] | undefined;
-              if (doc) {
-                if (!marksCache.has(doc.id)) {
-                  marksCache.set(
-                    doc.id,
-                    ProsemirrorHelper.getComments(
-                      DocumentHelper.toProsemirror(doc)
-                    )
-                  );
+            const presented = await Promise.all(
+              comments.map((comment) => {
+                const doc = comment.document;
+                let marks: CommentMark[] | undefined;
+                if (doc) {
+                  if (!marksCache.has(doc.id)) {
+                    marksCache.set(
+                      doc.id,
+                      ProsemirrorHelper.getComments(
+                        DocumentHelper.toProsemirror(doc)
+                      )
+                    );
+                  }
+                  marks = marksCache.get(doc.id);
                 }
-                marks = marksCache.get(doc.id);
-              }
-              return presentCommentWithText(comment, marks);
-            });
+                return presentCommentWithText(comment, marks, responseFormat);
+              })
+            );
             return success(presented);
           } catch (err) {
             return error(err);
@@ -249,6 +264,7 @@ export function commentTools(server: McpServer, scopes: string[]) {
           anchorSuffix: optionalString().describe(
             "Only provide this if anchorText appears more than once in the document and you need to target a specific occurrence. Plain text that immediately follows anchorText."
           ),
+          responseFormat: formatParam(),
         },
       },
       withTracing(
@@ -261,6 +277,7 @@ export function commentTools(server: McpServer, scopes: string[]) {
             anchorText,
             anchorPrefix,
             anchorSuffix,
+            responseFormat,
           },
           context
         ) => {
@@ -333,7 +350,11 @@ export function commentTools(server: McpServer, scopes: string[]) {
               return created;
             });
 
-            const presented = presentCommentWithText(comment);
+            const presented = await presentCommentWithText(
+              comment,
+              undefined,
+              responseFormat
+            );
             return {
               content: [
                 { type: "text" as const, text: JSON.stringify(presented) },
@@ -372,9 +393,11 @@ export function commentTools(server: McpServer, scopes: string[]) {
             .describe(
               "Set to 'resolved' to resolve or 'unresolved' to unresolve a top-level comment thread."
             ),
+          responseFormat: formatParam(),
         },
       },
-      withTracing("update_comment", async ({ id, text, status }, context) => {
+      withTracing("update_comment", async (input, context) => {
+        const { id, text, status, responseFormat } = input;
         try {
           const ctx = buildAPIContext(context);
           const { user } = ctx.state.auth;
@@ -420,7 +443,11 @@ export function commentTools(server: McpServer, scopes: string[]) {
           await comment.saveWithCtx(ctx, status ? { silent: true } : undefined);
 
           comment.document = document!;
-          const presented = presentCommentWithText(comment);
+          const presented = await presentCommentWithText(
+            comment,
+            undefined,
+            responseFormat
+          );
           return {
             content: [
               { type: "text" as const, text: JSON.stringify(presented) },

--- a/server/tools/documents.test.ts
+++ b/server/tools/documents.test.ts
@@ -295,6 +295,98 @@ describe("list_documents", () => {
   });
 });
 
+describe("responseFormat on document write tools", () => {
+  /** create_document, update_document and restore_document all build their
+   * result through the same documentResult/bodyOptionsFor pair, so each is
+   * pinned in both formats here. */
+  const setup = async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    return { user, accessToken, collection };
+  };
+
+  it.each(["omitted", "markdown"])(
+    "create_document returns markdown when responseFormat is %s",
+    async (responseFormat) => {
+      const { accessToken, collection } = await setup();
+
+      const res = await callMcpTool(server, accessToken, "create_document", {
+        title: "Doc",
+        text: "Hello, `world`!",
+        collectionId: collection.id,
+        ...(responseFormat === "omitted" ? {} : { responseFormat }),
+      });
+
+      expect(res?.result?.content?.length).toEqual(2);
+      const data = JSON.parse(res?.result?.content?.[0]?.text ?? "{}");
+      expect(data.document.data).toBeUndefined();
+      expect(res?.result?.content?.[1]?.text).toEqual("Hello, `world`!");
+    }
+  );
+
+  it("create_document returns data alongside the markdown for json", async () => {
+    const { accessToken, collection } = await setup();
+
+    const res = await callMcpTool(server, accessToken, "create_document", {
+      title: "Doc",
+      text: "Hello, `world`!",
+      collectionId: collection.id,
+      responseFormat: "json",
+    });
+
+    const data = JSON.parse(res?.result?.content?.[0]?.text ?? "{}");
+    expect(data.document.data?.type).toEqual("doc");
+    // The markdown body is still present — update_document's patch mode
+    // requires findText to be copied verbatim from it.
+    expect(res?.result?.content?.length).toEqual(2);
+    expect(res?.result?.content?.[1]?.text).toEqual("Hello, `world`!");
+  });
+
+  it("update_document returns data alongside the markdown for json", async () => {
+    const { user, accessToken, collection } = await setup();
+    const document = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+    });
+
+    const res = await callMcpTool(server, accessToken, "update_document", {
+      id: document.id,
+      text: "Updated `body`",
+      responseFormat: "json",
+    });
+
+    const data = JSON.parse(res?.result?.content?.[0]?.text ?? "{}");
+    expect(data.document.data?.type).toEqual("doc");
+    expect(res?.result?.content?.length).toEqual(2);
+    expect(res?.result?.content?.[1]?.text).toContain("Updated `body`");
+  });
+
+  it("restore_document returns data alongside the markdown for json", async () => {
+    const { user, accessToken, collection } = await setup();
+    const document = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+      text: "Hello, `world`!",
+    });
+    await document.destroy();
+
+    const res = await callMcpTool(server, accessToken, "restore_document", {
+      id: document.id,
+      responseFormat: "json",
+    });
+
+    const data = JSON.parse(res?.result?.content?.[0]?.text ?? "{}");
+    expect(data.document.data?.type).toEqual("doc");
+    expect(res?.result?.content?.length).toEqual(2);
+    expect(res?.result?.content?.[1]?.text).toContain("Hello, `world`!");
+  });
+});
+
 describe("create_document", () => {
   it("creates in a collection", async () => {
     const { user, accessToken } = await buildOAuthUser();

--- a/server/tools/documents.test.ts
+++ b/server/tools/documents.test.ts
@@ -327,6 +327,20 @@ describe("responseFormat on document write tools", () => {
     }
   );
 
+  it("omits the body block for a title-only document", async () => {
+    const { accessToken, collection } = await setup();
+
+    const res = await callMcpTool(server, accessToken, "create_document", {
+      title: "Title only",
+      collectionId: collection.id,
+    });
+
+    // No body text, so only the metadata block — never a stray empty block.
+    expect(res?.result?.content?.length).toEqual(1);
+    const data = JSON.parse(res?.result?.content?.[0]?.text ?? "{}");
+    expect(data.document.title).toEqual("Title only");
+  });
+
   it("create_document returns data alongside the markdown for json", async () => {
     const { accessToken, collection } = await setup();
 

--- a/server/tools/documents.ts
+++ b/server/tools/documents.ts
@@ -81,12 +81,17 @@ export function bodyOptionsFor(format: ContentFormat | undefined) {
 }
 
 /**
- * Builds a tool result carrying document metadata as JSON plus, for markdown
- * callers, the document body as its own content block. Keeping the body out of
- * the JSON avoids escaping every newline and quote in it.
+ * Builds a tool result carrying document metadata as JSON plus the document
+ * body as its own content block. Keeping the body out of the JSON avoids
+ * escaping every newline and quote in it.
+ *
+ * The body block is emitted in both formats — `bodyOptionsFor` always requests
+ * the markdown, since `json` adds the ProseMirror structure to the metadata
+ * rather than replacing the markdown. It is omitted when the body is empty (a
+ * title-only document), so callers never receive a stray empty text block.
  *
  * @param metadata - the document metadata to serialize.
- * @param text - the markdown body, or undefined when JSON was requested.
+ * @param text - the markdown body.
  * @returns the tool result.
  */
 export function documentResult(
@@ -96,7 +101,9 @@ export function documentResult(
   return {
     content: [
       { type: "text" as const, text: JSON.stringify(metadata) },
-      ...(typeof text === "string" ? [{ type: "text" as const, text }] : []),
+      ...(typeof text === "string" && text.length > 0
+        ? [{ type: "text" as const, text }]
+        : []),
     ],
   } satisfies CallToolResult;
 }

--- a/server/tools/documents.ts
+++ b/server/tools/documents.ts
@@ -24,6 +24,8 @@ import {
   success,
   buildAPIContext,
   buildSiblingIndexMap,
+  ContentFormat,
+  formatParam,
   getActorFromContext,
   getBreadcrumbsForDocuments,
   getDocumentBreadcrumb,
@@ -54,6 +56,41 @@ export function presentDocument(
   } = {}
 ) {
   return presentDocumentBase(undefined, document, options);
+}
+
+/**
+ * Builds the presenter options that render a document body in the requested
+ * format. Markdown is returned as a separate content block by
+ * `documentResult`; ProseMirror JSON is carried inline in the metadata as
+ * `data`, since it is already JSON.
+ *
+ * @param format - the format to render the document body in.
+ * @returns presenter options for `presentDocument`.
+ */
+export function bodyOptionsFor(format: ContentFormat | undefined) {
+  const asJson = format === ContentFormat.Json;
+  return { includeData: asJson, includeText: !asJson };
+}
+
+/**
+ * Builds a tool result carrying document metadata as JSON plus, for markdown
+ * callers, the document body as its own content block. Keeping the body out of
+ * the JSON avoids escaping every newline and quote in it.
+ *
+ * @param metadata - the document metadata to serialize.
+ * @param text - the markdown body, or undefined when JSON was requested.
+ * @returns the tool result.
+ */
+export function documentResult(
+  metadata: Record<string, unknown>,
+  text: unknown
+): CallToolResult {
+  return {
+    content: [
+      { type: "text" as const, text: JSON.stringify(metadata) },
+      ...(typeof text === "string" ? [{ type: "text" as const, text }] : []),
+    ],
+  } satisfies CallToolResult;
 }
 
 /**
@@ -378,6 +415,7 @@ export function documentTools(server: McpServer, scopes: string[]) {
             .describe(
               "Whether the document should occupy full width of the screen. Defaults to false. Do not set this to true for HTML input unless the user explicitly asks for a full-width document layout."
             ),
+          responseFormat: formatParam(),
         },
       },
       withTracing("create_document", async (input, context) => {
@@ -425,27 +463,18 @@ export function documentTools(server: McpServer, scopes: string[]) {
 
           const [{ text, ...attributes }, breadcrumb] = await Promise.all([
             presentDocument(document, {
-              includeData: false,
-              includeText: true,
+              ...bodyOptionsFor(input.responseFormat),
               includeUpdatedAt: true,
             }),
             getDocumentBreadcrumb(document, user),
           ]);
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: JSON.stringify({
-                  document: pathToUrl(user.team, attributes),
-                  ...(breadcrumb !== undefined && { breadcrumb }),
-                }),
-              },
-              {
-                type: "text" as const,
-                text: typeof text === "string" ? text : "",
-              },
-            ],
-          } satisfies CallToolResult;
+          return documentResult(
+            {
+              document: pathToUrl(user.team, attributes),
+              ...(breadcrumb !== undefined && { breadcrumb }),
+            },
+            text
+          );
         } catch (message) {
           return error(message);
         }
@@ -648,6 +677,7 @@ export function documentTools(server: McpServer, scopes: string[]) {
             .describe(
               "Whether the document should occupy full width of the screen."
             ),
+          responseFormat: formatParam(),
         },
       },
       withTracing("update_document", async (input, context) => {
@@ -698,29 +728,20 @@ export function documentTools(server: McpServer, scopes: string[]) {
           const [{ text, ...attributes }, breadcrumb, shareUrl] =
             await Promise.all([
               presentDocument(updated, {
-                includeData: false,
-                includeText: true,
+                ...bodyOptionsFor(input.responseFormat),
                 includeUpdatedAt: true,
               }),
               getDocumentBreadcrumb(updated, user),
               getPublicShareUrlForDocument(user.team, updated.id),
             ]);
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: JSON.stringify({
-                  document: pathToUrl(user.team, attributes),
-                  ...(breadcrumb !== undefined && { breadcrumb }),
-                  ...(shareUrl !== undefined && { shareUrl }),
-                }),
-              },
-              {
-                type: "text" as const,
-                text: typeof text === "string" ? text : "",
-              },
-            ],
-          } satisfies CallToolResult;
+          return documentResult(
+            {
+              document: pathToUrl(user.team, attributes),
+              ...(breadcrumb !== undefined && { breadcrumb }),
+              ...(shareUrl !== undefined && { shareUrl }),
+            },
+            text
+          );
         } catch (message) {
           return error(message);
         }
@@ -801,9 +822,11 @@ export function documentTools(server: McpServer, scopes: string[]) {
           collectionId: optionalString().describe(
             "The collection to restore the document into. Defaults to its original collection."
           ),
+          responseFormat: formatParam(),
         },
       },
-      withTracing("restore_document", async ({ id, collectionId }, context) => {
+      withTracing("restore_document", async (input, context) => {
+        const { id, collectionId, responseFormat } = input;
         try {
           const ctx = buildAPIContext(context);
           const { user } = ctx.state.auth;
@@ -828,29 +851,20 @@ export function documentTools(server: McpServer, scopes: string[]) {
             const [{ text, ...attributes }, breadcrumb, shareUrl] =
               await Promise.all([
                 presentDocument(document, {
-                  includeData: false,
-                  includeText: true,
+                  ...bodyOptionsFor(responseFormat),
                   includeUpdatedAt: true,
                 }),
                 getDocumentBreadcrumb(document, user),
                 getPublicShareUrlForDocument(user.team, document.id),
               ]);
-            return {
-              content: [
-                {
-                  type: "text" as const,
-                  text: JSON.stringify({
-                    document: pathToUrl(user.team, attributes),
-                    ...(breadcrumb !== undefined && { breadcrumb }),
-                    ...(shareUrl !== undefined && { shareUrl }),
-                  }),
-                },
-                {
-                  type: "text" as const,
-                  text: typeof text === "string" ? text : "",
-                },
-              ],
-            } satisfies CallToolResult;
+            return documentResult(
+              {
+                document: pathToUrl(user.team, attributes),
+                ...(breadcrumb !== undefined && { breadcrumb }),
+                ...(shareUrl !== undefined && { shareUrl }),
+              },
+              text
+            );
           });
         } catch (message) {
           return error(message);

--- a/server/tools/documents.ts
+++ b/server/tools/documents.ts
@@ -64,12 +64,20 @@ export function presentDocument(
  * `documentResult`; ProseMirror JSON is carried inline in the metadata as
  * `data`, since it is already JSON.
  *
+ * `json` adds the structure on top of the markdown rather than replacing it.
+ * `update_document` documents `patch` as the safe edit mode and requires
+ * `findText` to be copied verbatim from the document's markdown, so a response
+ * carrying only ProseMirror would leave the caller unable to edit without
+ * falling back to a whole-document `replace`.
+ *
  * @param format - the format to render the document body in.
  * @returns presenter options for `presentDocument`.
  */
 export function bodyOptionsFor(format: ContentFormat | undefined) {
-  const asJson = format === ContentFormat.Json;
-  return { includeData: asJson, includeText: !asJson };
+  return {
+    includeData: format === ContentFormat.Json,
+    includeText: true,
+  };
 }
 
 /**

--- a/server/tools/fetch.test.ts
+++ b/server/tools/fetch.test.ts
@@ -63,6 +63,52 @@ describe("fetch", () => {
     expect(res!.result!.content![1].text).toContain("Hello");
   });
 
+  it("returns ProseMirror data inline when responseFormat is json", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const document = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+      text: "# Hello\n\nWorld",
+    });
+
+    const res = await callMcpTool(server, accessToken, "fetch", {
+      resource: "document",
+      id: document.id,
+      responseFormat: "json",
+    });
+
+    // The body is already JSON, so it rides along in the metadata block
+    // instead of being appended as a second markdown block.
+    expect(res!.result!.content!.length).toEqual(1);
+
+    const metadata = JSON.parse(res!.result!.content![0].text ?? "{}");
+    expect(metadata.document.data?.type).toEqual("doc");
+    expect(metadata.document.text).toBeUndefined();
+  });
+
+  it("returns a collection description as markdown, not ProseMirror JSON", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+      description: "Hello, `world`!",
+    });
+
+    const res = await callMcpTool(server, accessToken, "fetch", {
+      resource: "collection",
+      id: collection.id,
+    });
+
+    const data = JSON.parse(res!.result!.content![0].text ?? "{}");
+    expect(data.description).toEqual("Hello, `world`!");
+    expect(data.data).toBeUndefined();
+  });
+
   it("returns the public share url for a shared document", async () => {
     const { user, accessToken } = await buildOAuthUser();
     const collection = await buildCollection({

--- a/server/tools/fetch.test.ts
+++ b/server/tools/fetch.test.ts
@@ -82,13 +82,39 @@ describe("fetch", () => {
       responseFormat: "json",
     });
 
-    // The body is already JSON, so it rides along in the metadata block
-    // instead of being appended as a second markdown block.
-    expect(res!.result!.content!.length).toEqual(1);
+    // json adds the structure to the metadata block but keeps the markdown
+    // body, which update_document's patch mode needs for findText.
+    expect(res!.result!.content!.length).toEqual(2);
 
     const metadata = JSON.parse(res!.result!.content![0].text ?? "{}");
     expect(metadata.document.data?.type).toEqual("doc");
-    expect(metadata.document.text).toBeUndefined();
+    expect(res!.result!.content![1].text).toContain("Hello");
+  });
+
+  it("honors responseFormat for templates", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const template = await buildTemplate({
+      teamId: user.teamId,
+      userId: user.id,
+      text: "Hello, `world`!",
+    });
+
+    const markdown = await callMcpTool(server, accessToken, "fetch", {
+      resource: "template",
+      id: template.id,
+    });
+    const markdownMeta = JSON.parse(markdown!.result!.content![0].text ?? "{}");
+    expect(markdownMeta.data).toBeUndefined();
+    expect(markdown!.result!.content![1].text).toContain("Hello, `world`!");
+
+    const json = await callMcpTool(server, accessToken, "fetch", {
+      resource: "template",
+      id: template.id,
+      responseFormat: "json",
+    });
+    const jsonMeta = JSON.parse(json!.result!.content![0].text ?? "{}");
+    expect(jsonMeta.data?.type).toEqual("doc");
+    expect(json!.result!.content![1].text).toContain("Hello, `world`!");
   });
 
   it("returns a collection description as markdown, not ProseMirror JSON", async () => {

--- a/server/tools/fetch.ts
+++ b/server/tools/fetch.ts
@@ -10,17 +10,15 @@ import {
 } from "@server/models";
 import { authorize, can } from "@server/policies";
 import { AuthorizationError } from "@server/errors";
-import {
-  presentCollection,
-  presentNavigationNode,
-  presentUser,
-} from "@server/presenters";
+import { presentNavigationNode, presentUser } from "@server/presenters";
 import AuthenticationHelper from "@shared/helpers/AuthenticationHelper";
-import { presentDocument } from "./documents";
+import { presentCollectionForTool } from "./collections";
+import { bodyOptionsFor, documentResult, presentDocument } from "./documents";
 import { presentTemplate } from "./templates";
 import {
   error,
   success,
+  formatParam,
   getActorFromContext,
   getDocumentBreadcrumb,
   getPublicShareUrlForCollection,
@@ -117,9 +115,11 @@ export function fetchTool(server: McpServer, scopes: string[]) {
           .describe(
             'The unique identifier or URL. For users, "current_user" returns the authenticated user.'
           ),
+        responseFormat: formatParam(),
       },
     },
-    withTracing("fetch", async ({ resource, id: rawId }, extra) => {
+    withTracing("fetch", async (input, extra) => {
+      const { resource, id: rawId, responseFormat } = input;
       try {
         const actor = getActorFromContext(extra);
         const id = extractId(rawId);
@@ -136,30 +136,21 @@ export function fetchTool(server: McpServer, scopes: string[]) {
             const [{ text, ...attributes }, breadcrumb, shareUrl] =
               await Promise.all([
                 presentDocument(document, {
-                  includeData: false,
-                  includeText: true,
+                  ...bodyOptionsFor(responseFormat),
                   includeUpdatedAt: true,
                   includeCommentCount: true,
                 }),
                 getDocumentBreadcrumb(document, actor),
                 getPublicShareUrlForDocument(actor.team, document.id),
               ]);
-            return {
-              content: [
-                {
-                  type: "text" as const,
-                  text: JSON.stringify({
-                    document: pathToUrl(actor.team, attributes),
-                    ...(breadcrumb !== undefined && { breadcrumb }),
-                    ...(shareUrl !== undefined && { shareUrl }),
-                  }),
-                },
-                {
-                  type: "text" as const,
-                  text: typeof text === "string" ? text : "",
-                },
-              ],
-            } satisfies CallToolResult;
+            return documentResult(
+              {
+                document: pathToUrl(actor.team, attributes),
+                ...(breadcrumb !== undefined && { breadcrumb }),
+                ...(shareUrl !== undefined && { shareUrl }),
+              },
+              text
+            );
           }
 
           case "collection": {
@@ -172,7 +163,7 @@ export function fetchTool(server: McpServer, scopes: string[]) {
             authorize(actor, "read", collection);
 
             const [presented, shareUrl] = await Promise.all([
-              presentCollection(undefined, collection),
+              presentCollectionForTool(collection, responseFormat),
               getPublicShareUrlForCollection(actor.team, collection.id),
             ]);
             return success([

--- a/server/tools/fetch.ts
+++ b/server/tools/fetch.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { type CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import {
   Attachment,
   Collection,
@@ -221,19 +220,11 @@ export function fetchTool(server: McpServer, scopes: string[]) {
 
             authorize(actor, "read", template);
 
-            const { text, ...attributes } = await presentTemplate(template);
-            return {
-              content: [
-                {
-                  type: "text" as const,
-                  text: JSON.stringify(pathToUrl(actor.team, attributes)),
-                },
-                {
-                  type: "text" as const,
-                  text,
-                },
-              ],
-            } satisfies CallToolResult;
+            const { text, ...attributes } = await presentTemplate(
+              template,
+              responseFormat
+            );
+            return documentResult(pathToUrl(actor.team, attributes), text);
           }
 
           default:

--- a/server/tools/templates.ts
+++ b/server/tools/templates.ts
@@ -9,6 +9,8 @@ import AuthenticationHelper from "@shared/helpers/AuthenticationHelper";
 import {
   error,
   success,
+  ContentFormat,
+  formatParam,
   getActorFromContext,
   optionalString,
   pathToUrl,
@@ -23,13 +25,21 @@ import {
  * @param template - the template to present.
  * @returns the presented template with its body as markdown.
  */
-export async function presentTemplate(template: Template) {
+export async function presentTemplate(
+  template: Template,
+  format: ContentFormat = ContentFormat.Markdown
+) {
   return {
     id: template.id,
     url: template.path,
     title: template.title,
     collectionId: template.collectionId ?? null,
     updatedAt: template.updatedAt,
+    // `json` adds the structure alongside the markdown; the markdown is what
+    // `create_document` accepts, so it is never dropped.
+    ...(format === ContentFormat.Json && template.content
+      ? { data: template.content }
+      : {}),
     text: template.content
       ? await DocumentHelper.toMarkdown(template.content, {
           includeTitle: false,
@@ -76,11 +86,12 @@ export function templateTools(server: McpServer, scopes: string[]) {
             .describe(
               "The maximum number of results to return. Defaults to 25, max 100."
             ),
+          responseFormat: formatParam(),
         },
       },
       withTracing(
         "list_templates",
-        async ({ collectionId, offset, limit }, extra) => {
+        async ({ collectionId, offset, limit, responseFormat }, extra) => {
           try {
             const user = getActorFromContext(extra);
             const effectiveOffset = offset ?? 0;
@@ -120,7 +131,10 @@ export function templateTools(server: McpServer, scopes: string[]) {
 
             const presented = await Promise.all(
               templates.map(async (template) =>
-                pathToUrl(user.team, await presentTemplate(template))
+                pathToUrl(
+                  user.team,
+                  await presentTemplate(template, responseFormat)
+                )
               )
             );
             return success(presented);

--- a/server/tools/util.test.ts
+++ b/server/tools/util.test.ts
@@ -1,3 +1,4 @@
+import { toJSONSchema, z } from "zod";
 import { CollectionPermission, type NavigationNode } from "@shared/types";
 import {
   buildCollection,
@@ -7,6 +8,8 @@ import {
 } from "@server/test/factories";
 import {
   buildBreadcrumb,
+  ContentFormat,
+  formatParam,
   getBreadcrumbsForDocuments,
   optionalString,
   success,
@@ -107,6 +110,49 @@ describe("optionalString", () => {
 
   it("preserves whitespace-only strings", () => {
     expect(schema.parse(" ")).toBe(" ");
+  });
+});
+
+describe("formatParam", () => {
+  const schema = formatParam();
+
+  it("returns undefined when input is omitted", () => {
+    expect(schema.parse(undefined)).toBeUndefined();
+  });
+
+  it.each([
+    ["an empty string", ""],
+    ["null", null],
+  ])("coerces %s to undefined", (_label, input) => {
+    expect(schema.parse(input)).toBeUndefined();
+  });
+
+  it.each([ContentFormat.Markdown, ContentFormat.Json])(
+    "passes through %s",
+    (format) => {
+      expect(schema.parse(format)).toBe(format);
+    }
+  );
+
+  it("rejects an unrecognized format", () => {
+    expect(() => schema.parse("yaml")).toThrow();
+  });
+
+  it("advertises every accepted input in its published JSON Schema", () => {
+    // The published schema is derived from the input side. A z.preprocess step
+    // is erased during that conversion, which would leave the schema stricter
+    // than the server.
+    const jsonSchema = toJSONSchema(z.object({ responseFormat: schema }), {
+      io: "input",
+    }) as unknown as {
+      properties: { responseFormat: { anyOf: unknown[] } };
+    };
+
+    expect(jsonSchema.properties.responseFormat.anyOf).toEqual([
+      { type: "string", enum: ["markdown", "json"] },
+      { type: "string", const: "" },
+      { type: "null" },
+    ]);
   });
 });
 

--- a/server/tools/util.ts
+++ b/server/tools/util.ts
@@ -83,8 +83,12 @@ export enum ContentFormat {
  */
 export function formatParam() {
   return z
-    .enum(ContentFormat)
-    .optional()
+    .preprocess(
+      // Clients sometimes send "" for a field they meant to omit; fall back to
+      // the default rather than failing the call. See `optionalString`.
+      (value) => (value === "" ? undefined : value),
+      z.enum(ContentFormat).optional()
+    )
     .describe(
       'The format to return content in. "markdown" (default) is compact but lossy — formatting with no markdown equivalent, such as comment anchors, highlight colors, table column widths, and embeds, is not represented. "json" returns the ProseMirror document, which is many times larger but preserves everything; use it only when the structure itself is needed.'
     );

--- a/server/tools/util.ts
+++ b/server/tools/util.ts
@@ -65,6 +65,31 @@ export function optionalString() {
     .transform((v) => (v === "" ? undefined : v));
 }
 
+/** The format used to represent rich text content in tool responses. */
+export enum ContentFormat {
+  /** Markdown. Compact and readable, but lossy. */
+  Markdown = "markdown",
+  /** ProseMirror JSON. Verbose, but preserves every mark and node. */
+  Json = "json",
+}
+
+/**
+ * Builds a zod schema for the `format` input shared by every tool that returns
+ * document, collection, or comment content. Markdown is the default because it
+ * costs a fraction of the tokens; ProseMirror JSON remains available for
+ * callers that need to inspect or preserve structure.
+ *
+ * @returns a zod schema accepting `ContentFormat | undefined`.
+ */
+export function formatParam() {
+  return z
+    .enum(ContentFormat)
+    .optional()
+    .describe(
+      'The format to return content in. "markdown" (default) is compact but lossy — formatting with no markdown equivalent, such as comment anchors, highlight colors, table column widths, and embeds, is not represented. "json" returns the ProseMirror document, which is many times larger but preserves everything; use it only when the structure itself is needed.'
+    );
+}
+
 /** The URI of the MCP resource that lists the available named icons. */
 export const iconNamesResourceUri = "outline://icons";
 

--- a/server/tools/util.ts
+++ b/server/tools/util.ts
@@ -74,23 +74,27 @@ export enum ContentFormat {
 }
 
 /**
- * Builds a zod schema for the `format` input shared by every tool that returns
- * document, collection, or comment content. Markdown is the default because it
- * costs a fraction of the tokens; ProseMirror JSON remains available for
- * callers that need to inspect or preserve structure.
+ * Builds a zod schema for the `responseFormat` input shared by every tool that
+ * returns document, collection, or comment content. Markdown is the default
+ * because it costs a fraction of the tokens; ProseMirror JSON is returned
+ * alongside it for callers that need to inspect or preserve structure.
+ *
+ * `""` and `null` are accepted as "omitted" — clients and LLM-generated tool
+ * arguments routinely serialize an unset optional field as one of the two. The
+ * union spells this out rather than using `z.preprocess`, because the published
+ * JSON Schema is derived from the *input* side and a preprocess step is erased
+ * during that conversion; a host that validates arguments against the schema
+ * before dispatch would reject values the server accepts. See `optionalString`.
  *
  * @returns a zod schema accepting `ContentFormat | undefined`.
  */
 export function formatParam() {
   return z
-    .preprocess(
-      // Clients sometimes send "" for a field they meant to omit; fall back to
-      // the default rather than failing the call. See `optionalString`.
-      (value) => (value === "" ? undefined : value),
-      z.enum(ContentFormat).optional()
-    )
+    .union([z.enum(ContentFormat), z.literal(""), z.null()])
+    .optional()
+    .transform((value) => value || undefined)
     .describe(
-      'The format to return content in. "markdown" (default) is compact but lossy — formatting with no markdown equivalent, such as comment anchors, highlight colors, table column widths, and embeds, is not represented. "json" returns the ProseMirror document, which is many times larger but preserves everything; use it only when the structure itself is needed.'
+      'The format to return content in. "markdown" (default) is compact but lossy — formatting with no markdown equivalent, such as comment anchors, highlight colors, table column widths, and embeds, is not represented. "json" additionally returns the ProseMirror document, which is many times larger but preserves everything; use it only when the structure itself is needed.'
     );
 }
 


### PR DESCRIPTION
### What

Adds a `responseFormat` input, `"markdown"` (default) or `"json"`, to the MCP tools that return rich text content.

### Why

MCP tools returned content as raw ProseMirror JSON. A collection description of ``Hello, `world`!`` was serialized as:

```json
{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Hello, "},{"type":"text","marks":[{"type":"code_inline"}],"text":"world"},{"type":"text","text":"!"}]}]}
```

183 characters against 17 for the markdown — **~11x the tokens for the same content**, paid on every read.

Two places leaked it:

- **Collections.** `server/tools/collections.ts` called `presentCollection(undefined, collection)`. With no ctx the presenter takes its `asData = true` branch (`server/presenters/collection.ts:21`), so *every* collection result - `list_collections`, `create_collection`, `update_collection`, `fetch` - shipped its description as a node tree.
- **Comments.** `presentCommentWithText` returned ProseMirror `data` *and* a plain-text `text`: the same content twice, with the expensive copy adding nothing for a reader.

### What changed

`"markdown"` (default) renders collection descriptions and comment bodies as markdown and omits `data`. Comment `text` is now markdown rather than `toPlainText()` in *both* formats, so inline code, links and emphasis survive. Previously, `` `world` `` came back as `world`.

`"json"` adds the ProseMirror document *alongside* the markdown, for documents, collections, comments and templates. It is additive rather than a replacement because every write tool takes markdown — `update_document`, `update_collection` and `update_comment` have no ProseMirror input — so a response carrying only the structure leaves the caller unable to write their edit back.

Documents already defaulted to markdown in a separate content block, so `"markdown"` is a no-op there. `"json"` is the new opt-in: it adds `data` inline in the metadata block and keeps the markdown block. Dropping the markdown would break the documented edit path — `update_document` presents `patch` as the safe mode and requires `findText` to be copied verbatim from the document's markdown, so a structure-only response would push callers into a whole-document `replace`, destroying the formatting they chose `"json"` to preserve.

`fetch` previously advertised the parameter for templates and ignored it; templates now honour it too. `""` and `null` are accepted as "omitted", since clients and LLM-generated arguments routinely serialize an unset optional field as one of the two, and the published JSON Schema advertises all three accepted inputs.

Collection descriptions come from the stored `description` column rather than being re-serialized from the ProseMirror content. The model keeps the two in sync on save, and the round trip was adding escapes — `5 * 3` came back as `5 \* 3` — which a caller echoing the value into `update_collection` would have written into the record. `description` is always present, so a cleared description is distinguishable from an absent field.

The parameter is named `responseFormat` rather than `format` because `create_document` already has a `format` input describing the format of the text being *sent*.

### Compatibility

Documents are unchanged by default. **Collections and comments change shape in the default markdown mode**: `data` is replaced by `description` / markdown `text`. Under `responseFormat: "json"` both are returned, so nothing is lost. That is the point of the change, but the default is breaking for anything parsing those fields, hence the escape hatch.

### On markdown being lossy

Markdown is the right default for *reading* and the wrong format for lossless round-trips, so this is deliberately opt-out rather than the only option:

- Constructs with no markdown equivalent degrade or vanish: comment anchors, highlight colours, table column widths, embeds, attachment metadata, per-node IDs. Diagram sources are being fixed for exactly this reason (#13082); GitHub mentions serialise to opaque `mention://` URIs (#13053).
- Round-tripping mutates text - quotes and brackets get rewritten (#12773).

So an agent that reads markdown and writes it back with `editMode: "replace"` can destroy formatting it never saw. `update_document`'s description already pushes `patch` mode for this reason, and that guidance matters more now that markdown is the default. `responseFormat: "json"` remains authoritative for structural work.
