### PR TITLE
perf: Convert Notice node to component view

### DIFF
--- a/app/editor/components/ComponentView.tsx
+++ b/app/editor/components/ComponentView.tsx
@@ -42,6 +42,8 @@ export default class ComponentView {
   isSelected = false;
   /** The DOM element that the node is rendered into. */
   dom: HTMLElement | null;
+  /** The DOM element that the node's editable content is rendered into, if the node has content. */
+  contentDOM: HTMLElement | null = null;
   /** The base class name for the node's DOM element. */
   className?: string;
 
@@ -67,6 +69,12 @@ export default class ComponentView {
     this.dom = node.type.spec.inline
       ? document.createElement("span")
       : document.createElement("div");
+
+    if (!node.isLeaf) {
+      this.contentDOM = document.createElement(
+        node.type.spec.inline ? "span" : "div"
+      );
+    }
 
     this.className = `component-${node.type.name}`;
     this.dom.classList.add(this.className);
@@ -147,7 +155,29 @@ export default class ComponentView {
     }
   }
 
+  /**
+   * Ref callback for the component to mark the element that the node's
+   * editable content should be mounted within. The content itself is managed
+   * by ProseMirror rather than React.
+   */
+  handleContentRef = (element: HTMLElement | null) => {
+    if (
+      element &&
+      this.contentDOM &&
+      element !== this.contentDOM.parentElement
+    ) {
+      element.appendChild(this.contentDOM);
+    }
+  };
+
   stopEvent(event: Event) {
+    if (
+      this.contentDOM &&
+      event.target instanceof globalThis.Node &&
+      this.contentDOM.contains(event.target)
+    ) {
+      return false;
+    }
     return (
       event.type !== "mousedown" &&
       !event.type.startsWith("drag") &&
@@ -158,9 +188,13 @@ export default class ComponentView {
   destroy() {
     this.editor.nodeRenderers.delete(this.renderer);
     this.dom = null;
+    this.contentDOM = null;
   }
 
-  ignoreMutation() {
+  ignoreMutation(mutation: MutationRecord) {
+    if (this.contentDOM) {
+      return !this.contentDOM.contains(mutation.target);
+    }
     return true;
   }
 
@@ -172,6 +206,7 @@ export default class ComponentView {
       isEditable: this.view.editable,
       getPos: this.getPos,
       decorations: this.decorations,
+      contentRef: this.handleContentRef,
     } as ComponentProps;
   }
 }

--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -1236,7 +1236,7 @@ ${
 `
 }
 
-.notice-block {
+.${EditorStyleHelper.notice} {
   display: flex;
   align-items: center;
   position: relative;
@@ -1261,13 +1261,13 @@ ${
   }
 }
 
-.notice-block .content {
+.${EditorStyleHelper.notice} .${EditorStyleHelper.noticeContent} {
   flex-grow: 1;
   min-width: 0;
 }
 
-.notice-block {
-  .icon {
+.${EditorStyleHelper.notice} {
+  .${EditorStyleHelper.noticeIcon} {
     width: 24px;
     height: 24px;
     align-self: flex-start;
@@ -1275,18 +1275,18 @@ ${
     color: ${props.theme.noticeInfoBackground};
   }
 
-  &:dir(rtl) .icon {
+  &:dir(rtl) .${EditorStyleHelper.noticeIcon} {
     margin-right: 0;
     margin-left: 4px;
   }
 }
 
-.notice-block.tip {
+.${EditorStyleHelper.notice}.tip {
   background: ${transparentize(0.9, props.theme.noticeTipBackground)};
   border-left: 4px solid ${props.theme.noticeTipBackground};
   color: ${props.theme.noticeTipText};
 
-  .icon {
+  .${EditorStyleHelper.noticeIcon} {
     color: ${props.theme.noticeTipBackground};
   }
 
@@ -1295,12 +1295,12 @@ ${
   }
 }
 
-.notice-block.warning {
+.${EditorStyleHelper.notice}.warning {
   background: ${transparentize(0.9, props.theme.noticeWarningBackground)};
   border-left: 4px solid ${props.theme.noticeWarningBackground};
   color: ${props.theme.noticeWarningText};
 
-  .icon {
+  .${EditorStyleHelper.noticeIcon} {
     color: ${props.theme.noticeWarningBackground};
   }
 
@@ -1309,12 +1309,12 @@ ${
   }
 }
 
-.notice-block.success {
+.${EditorStyleHelper.notice}.success {
   background: ${transparentize(0.9, props.theme.noticeSuccessBackground)};
   border-left: 4px solid ${props.theme.noticeSuccessBackground};
   color: ${props.theme.noticeSuccessText};
 
-  .icon {
+  .${EditorStyleHelper.noticeIcon} {
     color: ${props.theme.noticeSuccessBackground};
   }
 

--- a/shared/editor/nodes/Notice.tsx
+++ b/shared/editor/nodes/Notice.tsx
@@ -7,12 +7,12 @@ import type {
   NodeType,
 } from "prosemirror-model";
 import type { Command, EditorState, Transaction } from "prosemirror-state";
-import * as React from "react";
-import ReactDOM from "react-dom";
 import type { Primitive } from "utility-types";
 import toggleWrap from "../commands/toggleWrap";
 import type { MarkdownSerializerState } from "../lib/markdown/serializer";
 import noticesRule from "../rules/notices";
+import { EditorStyleHelper } from "../styles/EditorStyleHelper";
+import type { ComponentProps } from "../types";
 import Node from "./Node";
 
 export enum NoticeTypes {
@@ -45,10 +45,11 @@ export default class Notice extends Node {
       draggable: true,
       parseDOM: [
         {
-          tag: "div.notice-block",
+          tag: `div.${EditorStyleHelper.notice}`,
           preserveWhitespace: "full",
           contentElement: (node: HTMLDivElement) =>
-            node.querySelector("div.content") || node,
+            node.querySelector(`div.${EditorStyleHelper.noticeContent}`) ||
+            node,
           getAttrs: (dom: HTMLDivElement) => ({
             style: dom.className.includes(NoticeTypes.Tip)
               ? NoticeTypes.Tip
@@ -94,33 +95,11 @@ export default class Notice extends Node {
           }),
         },
       ],
-      toDOM: (node) => {
-        let icon;
-        if (typeof document !== "undefined") {
-          let component;
-
-          if (node.attrs.style === NoticeTypes.Tip) {
-            component = <StarredIcon />;
-          } else if (node.attrs.style === NoticeTypes.Warning) {
-            component = <WarningIcon />;
-          } else if (node.attrs.style === NoticeTypes.Success) {
-            component = <DoneIcon />;
-          } else {
-            component = <InfoIcon />;
-          }
-
-          icon = document.createElement("div");
-          icon.className = "icon";
-          ReactDOM.render(component, icon);
-        }
-
-        return [
-          "div",
-          { class: `notice-block ${node.attrs.style}` },
-          ...(icon ? [icon] : []),
-          ["div", { class: "content" }, 0],
-        ];
-      },
+      toDOM: (node) => [
+        "div",
+        { class: `${EditorStyleHelper.notice} ${node.attrs.style}` },
+        ["div", { class: EditorStyleHelper.noticeContent }, 0],
+      ],
     };
   }
 
@@ -159,6 +138,33 @@ export default class Notice extends Node {
       return true;
     }
     return false;
+  };
+
+  component = (props: ComponentProps) => {
+    const { node } = props;
+
+    let icon;
+    if (node.attrs.style === NoticeTypes.Tip) {
+      icon = <StarredIcon />;
+    } else if (node.attrs.style === NoticeTypes.Warning) {
+      icon = <WarningIcon />;
+    } else if (node.attrs.style === NoticeTypes.Success) {
+      icon = <DoneIcon />;
+    } else {
+      icon = <InfoIcon />;
+    }
+
+    return (
+      <div className={`${EditorStyleHelper.notice} ${node.attrs.style}`}>
+        <div className={EditorStyleHelper.noticeIcon} contentEditable={false}>
+          {icon}
+        </div>
+        <div
+          className={EditorStyleHelper.noticeContent}
+          ref={props.contentRef}
+        />
+      </div>
+    );
   };
 
   inputRules({ type }: { type: NodeType }) {

--- a/shared/editor/styles/EditorStyleHelper.ts
+++ b/shared/editor/styles/EditorStyleHelper.ts
@@ -78,6 +78,17 @@ export class EditorStyleHelper {
   /** Toggle block folded state */
   static readonly toggleBlockFolded = "folded";
 
+  // Notices
+
+  /** Notice block wrapper */
+  static readonly notice = "notice-block";
+
+  /** Notice block icon */
+  static readonly noticeIcon = "icon";
+
+  /** Notice block content area */
+  static readonly noticeContent = "content";
+
   // Checkbox Lists
 
   /** Checkbox list wrapper */

--- a/shared/editor/types/index.ts
+++ b/shared/editor/types/index.ts
@@ -68,13 +68,22 @@ export type MenuItem = {
 };
 
 export type ComponentProps = {
+  /** The current editor theme. */
   theme: DefaultTheme;
+  /** The editor view instance. */
   view: EditorView;
+  /** The node the component is rendering. */
   node: ProsemirrorNode;
+  /** Whether the node is currently selected. */
   isSelected: boolean;
+  /** Whether the editor is editable. */
   isEditable: boolean;
+  /** A function that returns the current position of the node in the document. */
   getPos: () => number;
+  /** The decorations applied to the node. */
   decorations: Decoration[];
+  /** Ref callback marking the element that ProseMirror-managed content is mounted within. */
+  contentRef?: (element: HTMLElement | null) => void;
 };
 
 export type NodeAttrMarkName =


### PR DESCRIPTION
- Removes `ReactDOM` from toDOM server rendering
- This is the standard architecture for rich nodes now

closes #13106