### PR TITLE
fix: Ensure JSDOM’s window is torn down

### DIFF
--- a/server/models/helpers/DocumentHelper.tsx
+++ b/server/models/helpers/DocumentHelper.tsx
@@ -432,13 +432,14 @@ export class DocumentHelper {
    * @param before The before document
    * @param after The after document
    * @param options Options passed to HTML generation
-   * @returns The diff as a HTML string
+   * @returns The diff as an HTML string, an empty string when there is no
+   * before document, or undefined when the documents contain no changes.
    */
   static async toEmailDiff(
     before: Document | Revision | null,
     after: Revision,
     options?: HTMLOptions
-  ) {
+  ): Promise<string | undefined> {
     if (!before) {
       return "";
     }

--- a/server/models/helpers/DocumentHelper.tsx
+++ b/server/models/helpers/DocumentHelper.tsx
@@ -451,7 +451,11 @@ export class DocumentHelper {
     try {
       return DocumentHelper.clipEmailDiff(dom.window.document);
     } finally {
-      dom.window.close();
+      try {
+        dom.window.close();
+      } catch (_err) {
+        // Best effort, closing the window releases its timers and resources.
+      }
     }
   }
 

--- a/server/models/helpers/DocumentHelper.tsx
+++ b/server/models/helpers/DocumentHelper.tsx
@@ -1,3 +1,4 @@
+import type { JSDOM } from "jsdom";
 import { Node, Fragment, type NodeType } from "prosemirror-model";
 import ukkonen from "ukkonen";
 import { updateYFragment, yDocToProsemirrorJSON } from "y-prosemirror";
@@ -446,8 +447,22 @@ export class DocumentHelper {
     // Loaded lazily to keep jsdom off the startup path — only HTML export needs it.
     const { JSDOM } = await import("jsdom");
     const dom = new JSDOM(html);
-    const doc = dom.window.document;
+    try {
+      return DocumentHelper.clipEmailDiff(dom.window.document);
+    } finally {
+      dom.window.close();
+    }
+  }
 
+  /**
+   * Clips a rendered diff document down to only the changed nodes and their
+   * surrounding context, returning the resulting HTML or undefined when the
+   * document contains no diff elements.
+   *
+   * @param doc The rendered diff document to clip.
+   * @returns The clipped HTML, or undefined when there is nothing to show.
+   */
+  private static clipEmailDiff(doc: JSDOM["window"]["document"]) {
     const containsDiffElement = (node: Element | null) => {
       if (!node) {
         return false;

--- a/server/models/helpers/ProsemirrorHelper.tsx
+++ b/server/models/helpers/ProsemirrorHelper.tsx
@@ -509,6 +509,7 @@ export class ProsemirrorHelper extends SharedProsemirrorHelper {
   public static async toHTML(node: Node, options?: HTMLOptions) {
     let view;
     let cleanupEnv;
+    let dom;
 
     // Loaded lazily to keep jsdom off the startup path — only HTML export needs it.
     const { JSDOM } = await import("jsdom");
@@ -575,7 +576,7 @@ export class ProsemirrorHelper extends SharedProsemirrorHelper {
 
       // Render the Prosemirror document using virtual DOM and serialize the
       // result to a string
-      const dom = new JSDOM(
+      dom = new JSDOM(
         `<!DOCTYPE html><meta charset="utf-8">${
           options?.includeStyles === false ? "" : styleTags
         }${html}`
@@ -717,6 +718,11 @@ export class ProsemirrorHelper extends SharedProsemirrorHelper {
         view?.destroy();
       } catch (err) {
         Logger.error("Error destroying ProseMirror view", toError(err));
+      }
+      try {
+        dom?.window.close();
+      } catch (err) {
+        Logger.error("Error closing JSDOM window", toError(err));
       }
       cleanupEnv?.();
     }

--- a/server/models/helpers/ProsemirrorHelper.tsx
+++ b/server/models/helpers/ProsemirrorHelper.tsx
@@ -509,7 +509,7 @@ export class ProsemirrorHelper extends SharedProsemirrorHelper {
   public static async toHTML(node: Node, options?: HTMLOptions) {
     let view;
     let cleanupEnv;
-    let dom;
+    let dom: JSDOM | undefined;
 
     // Loaded lazily to keep jsdom off the startup path — only HTML export needs it.
     const { JSDOM } = await import("jsdom");
@@ -721,8 +721,8 @@ export class ProsemirrorHelper extends SharedProsemirrorHelper {
       }
       try {
         dom?.window.close();
-      } catch (err) {
-        Logger.error("Error closing JSDOM window", toError(err));
+      } catch (_err) {
+        // Best effort, closing the window releases its timers and resources.
       }
       cleanupEnv?.();
     }

--- a/server/utils/DocumentConverter.ts
+++ b/server/utils/DocumentConverter.ts
@@ -119,7 +119,11 @@ export class DocumentConverter {
       return domParser.parse(document.body);
     } finally {
       cleanup();
-      dom.window.close();
+      try {
+        dom.window.close();
+      } catch (_err) {
+        // Best effort, closing the window releases its timers and resources.
+      }
     }
   }
 

--- a/server/utils/DocumentConverter.ts
+++ b/server/utils/DocumentConverter.ts
@@ -119,6 +119,7 @@ export class DocumentConverter {
       return domParser.parse(document.body);
     } finally {
       cleanup();
+      dom.window.close();
     }
   }
 


### PR DESCRIPTION
Addresses a possible source of memory retention