### PR TITLE
feat: Resize embeds like images and videos

### DIFF
--- a/app/editor/components/MediaDimension.tsx
+++ b/app/editor/components/MediaDimension.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import Flex from "@shared/components/Flex";
 import Text from "@shared/components/Text";
+import { EmbedDefaultHeight } from "@shared/editor/components/Embed";
 import { EditorStyleHelper } from "@shared/editor/styles/EditorStyleHelper";
 import { extraArea } from "@shared/styles";
 import Input, { NativeInput, Outline } from "~/components/Input";
@@ -48,14 +49,24 @@ export function MediaDimension() {
       getComputedStyle(ref.current).getPropertyValue("--document-width")
     );
     const maxWidth = docWidth - EditorStyleHelper.padding * 2;
-    const constrainedWidth = Math.min(width, maxWidth); // Ensure media width does not exceed the max width of the editor.
-    const aspectRatio = height / constrainedWidth;
 
-    const maxHeight = Math.round(maxWidth * aspectRatio);
-    boundsRef.current = {
-      width: { min: 50, max: maxWidth },
-      height: { min: 50, max: maxHeight },
-    };
+    if (nodeType === "embed") {
+      // Embeds have no natural aspect ratio – width and height can be set
+      // independently, so the height is not bounded by the width.
+      boundsRef.current = {
+        width: { min: 50, max: maxWidth },
+        height: { min: 50, max: Infinity },
+      };
+    } else {
+      const constrainedWidth = Math.min(width, maxWidth); // Ensure media width does not exceed the max width of the editor.
+      const aspectRatio = height / constrainedWidth;
+
+      const maxHeight = Math.round(maxWidth * aspectRatio);
+      boundsRef.current = {
+        width: { min: 50, max: maxWidth },
+        height: { min: 50, max: maxHeight },
+      };
+    }
   }
 
   const reset = useCallback(() => {
@@ -119,6 +130,33 @@ export function MediaDimension() {
       localHeightAsNumber = localDimension.height
         ? parseInt(localDimension.height, 10)
         : undefined;
+
+    // Embeds are not constrained to an aspect ratio – both dimensions are
+    // applied exactly as entered. An empty width keeps the embed responsive
+    // at the full width of the editor.
+    if (nodeType === "embed") {
+      const isEmbedUnchanged =
+        (localWidthAsNumber ?? null) === (width ?? null) &&
+        (localHeightAsNumber ?? null) === (height ?? null);
+      const isEmbedError =
+        error.width ||
+        error.height ||
+        (localWidthAsNumber !== undefined &&
+          isOutsideBounds("width", localWidthAsNumber)) ||
+        (localHeightAsNumber !== undefined &&
+          isOutsideBounds("height", localHeightAsNumber));
+
+      if (isEmbedUnchanged || isEmbedError) {
+        reset();
+        return;
+      }
+
+      commands["resizeEmbed"]({
+        width: localWidthAsNumber,
+        height: localHeightAsNumber ?? EmbedDefaultHeight,
+      });
+      return;
+    }
 
     const isUnchanged =
       !localWidthAsNumber ||

--- a/app/editor/components/SelectionToolbar.tsx
+++ b/app/editor/components/SelectionToolbar.tsx
@@ -97,7 +97,9 @@ export function SelectionToolbar(props: Props) {
     }
 
     if (isEmbedSelection && !readOnly) {
-      setActiveToolbar(Toolbar.Media);
+      // Embed selections show the toolbar menu by default – the media link
+      // editor is available through the "Edit link" menu item.
+      setActiveToolbar(Toolbar.Menu);
     } else if (
       linkMark &&
       (activeToolbar === null || activeToolbar === Toolbar.Link) &&
@@ -228,6 +230,10 @@ export function SelectionToolbar(props: Props) {
     if (item.name === "dimensions") {
       return item.visible ?? false;
     }
+    // Handled by the toolbar itself rather than an editor command, see below.
+    if (item.name === "editEmbedUrl") {
+      return item.visible ?? true;
+    }
     if (item.name && !commands[item.name]) {
       return false;
     }
@@ -254,6 +260,12 @@ export function SelectionToolbar(props: Props) {
       item.onClick = () => {
         setAutoFocusLinkInput(true);
         setActiveToolbar(Toolbar.Link);
+      };
+    }
+
+    if (item.name === "editEmbedUrl") {
+      item.onClick = () => {
+        setActiveToolbar(Toolbar.Media);
       };
     }
     return item;

--- a/app/editor/extensions/SelectionToolbar.tsx
+++ b/app/editor/extensions/SelectionToolbar.tsx
@@ -14,6 +14,7 @@ import {
 import { SelectionToolbar } from "../components/SelectionToolbar";
 import getAttachmentMenuItems from "../menus/attachment";
 import getCodeMenuItems from "../menus/code";
+import getEmbedMenuItems from "../menus/embed";
 
 import getFormattingMenuItems from "../menus/formatting";
 import getImageMenuItems from "../menus/image";
@@ -91,6 +92,11 @@ export default class SelectionToolbarExtension extends Extension {
         priority: 50,
         matches: (ctx) => ctx.selectedNodeType === "attachment",
         getItems: (ctx) => getAttachmentMenuItems(ctx),
+      },
+      {
+        priority: 50,
+        matches: (ctx) => ctx.selectedNodeType === "embed",
+        getItems: (ctx) => getEmbedMenuItems(ctx),
       },
       {
         priority: 30,

--- a/app/editor/menus/embed.tsx
+++ b/app/editor/menus/embed.tsx
@@ -1,0 +1,37 @@
+import { TrashIcon, EditIcon } from "outline-icons";
+import type { MenuItem, SelectionContext } from "@shared/editor/types";
+import { t } from "i18next";
+
+/**
+ * Returns menu items for the embed selection toolbar.
+ *
+ * @param ctx - the current selection context.
+ * @returns an array of menu items.
+ */
+export default function embedMenuItems(ctx: SelectionContext): MenuItem[] {
+  if (ctx.readOnly) {
+    return [];
+  }
+
+  return [
+    {
+      name: "dimensions",
+      tooltip: `${t("Width")} × ${t("Height")}`,
+      visible: true,
+      skipIcon: true,
+    },
+    {
+      name: "separator",
+    },
+    {
+      name: "editEmbedUrl",
+      tooltip: t("Edit link"),
+      icon: <EditIcon />,
+    },
+    {
+      name: "deleteEmbed",
+      tooltip: t("Delete embed"),
+      icon: <TrashIcon />,
+    },
+  ];
+}

--- a/shared/editor/components/Embed.tsx
+++ b/shared/editor/components/Embed.tsx
@@ -5,7 +5,14 @@ import { getMatchingEmbed } from "../lib/embeds";
 import type { ComponentProps } from "../types";
 import DisabledEmbed from "./DisabledEmbed";
 import Frame from "./Frame";
-import { ResizeBottom, ResizeLeft, ResizeRight } from "./ResizeHandle";
+import {
+  ResizeLeft,
+  ResizeRight,
+  ResizeTopLeft,
+  ResizeTopRight,
+  ResizeBottomLeft,
+  ResizeBottomRight,
+} from "./ResizeHandle";
 import useDragResize from "./hooks/useDragResize";
 
 type Props = ComponentProps & {
@@ -15,11 +22,14 @@ type Props = ComponentProps & {
   onChangeSize?: (props: { width: number; height?: number }) => void;
 };
 
+/** The height an embed is rendered at when no height attribute is set. */
+export const EmbedDefaultHeight = 400;
+
 const Embed = (props: Props) => {
   const ref = React.useRef<HTMLDivElement>(null);
   const { node, isEditable, embedsDisabled, onChangeSize } = props;
   const naturalWidth = 0;
-  const naturalHeight = 400;
+  const naturalHeight = EmbedDefaultHeight;
   const isResizable = !!onChangeSize && !embedsDisabled;
 
   const { width, height, setSize, handlePointerDown, dragging } = useDragResize(
@@ -34,28 +44,54 @@ const Embed = (props: Props) => {
   );
 
   React.useEffect(() => {
-    if (node.attrs.height && node.attrs.height !== height) {
+    const nextWidth = node.attrs.width ?? naturalWidth;
+    const nextHeight = node.attrs.height ?? naturalHeight;
+    if (nextWidth !== width || nextHeight !== height) {
       setSize({
-        width: node.attrs.width,
-        height: node.attrs.height,
+        width: nextWidth,
+        height: nextHeight,
       });
     }
-  }, [node.attrs.height]);
+  }, [node.attrs.width, node.attrs.height]);
 
   const style: React.CSSProperties = {
     width: width || "100%",
-    height: height || 400,
+    height: height || EmbedDefaultHeight,
     maxWidth: "100%",
     pointerEvents: dragging ? "none" : "all",
   };
 
   return (
-    <FrameWrapper ref={ref} $dragging={!!dragging}>
+    <FrameWrapper
+      ref={ref}
+      $dragging={!!dragging}
+      style={{ width: style.width }}
+    >
       <InnerEmbed style={style} {...props} />
       {isEditable && isResizable && (
         <>
-          <ResizeBottom
-            onPointerDown={handlePointerDown("bottom")}
+          <ResizeLeft
+            onPointerDown={handlePointerDown("left")}
+            $dragging={!!dragging}
+          />
+          <ResizeRight
+            onPointerDown={handlePointerDown("right")}
+            $dragging={!!dragging}
+          />
+          <ResizeTopLeft
+            onPointerDown={handlePointerDown("topLeft")}
+            $dragging={!!dragging}
+          />
+          <ResizeTopRight
+            onPointerDown={handlePointerDown("topRight")}
+            $dragging={!!dragging}
+          />
+          <ResizeBottomLeft
+            onPointerDown={handlePointerDown("bottomLeft")}
+            $dragging={!!dragging}
+          />
+          <ResizeBottomRight
+            onPointerDown={handlePointerDown("bottomRight")}
             $dragging={!!dragging}
           />
         </>
@@ -142,7 +178,8 @@ const FrameWrapper = styled.div<{ $dragging: boolean }>`
   transition-timing-function: ease-in-out;
 
   &:hover {
-    ${ResizeLeft}, ${ResizeRight} {
+    ${ResizeLeft}, ${ResizeRight},
+    ${ResizeTopLeft}, ${ResizeTopRight}, ${ResizeBottomLeft}, ${ResizeBottomRight} {
       opacity: 1;
     }
   }

--- a/shared/editor/components/hooks/useDragResize.ts
+++ b/shared/editor/components/hooks/useDragResize.ts
@@ -105,7 +105,11 @@ export default function useDragResize(props: Params): ReturnValue {
 
   const constrainWidth = React.useCallback(
     (width: number, max: number) => {
-      const minWidth = Math.min(naturalWidth, minWidthRatio * max);
+      // Elements without a natural width (e.g. embeds) fall back to the ratio
+      // based minimum rather than allowing a zero width.
+      const minWidth = naturalWidth
+        ? Math.min(naturalWidth, minWidthRatio * max)
+        : minWidthRatio * max;
       return Math.round(Math.min(max, Math.max(width, minWidth)));
     },
     [naturalWidth]
@@ -144,8 +148,18 @@ export default function useDragResize(props: Params): ReturnValue {
         "bottomRight",
       ].includes(dragging || "");
 
-      if (isCorner && naturalHeight && naturalWidth) {
-        const aspectRatio = naturalHeight / naturalWidth;
+      // Corner drags are locked to an aspect ratio – the natural ratio of the
+      // element when known, otherwise the ratio at the start of the drag so
+      // that elements without a natural size (e.g. embeds) keep their existing
+      // proportions.
+      const aspectRatio =
+        naturalWidth && naturalHeight
+          ? naturalHeight / naturalWidth
+          : sizeAtDragStart.width && sizeAtDragStart.height
+            ? sizeAtDragStart.height / sizeAtDragStart.width
+            : undefined;
+
+      if (isCorner && aspectRatio) {
         const hFactor = isCentered ? 0.5 : 1;
         const factor = isCentered ? 2 : 1;
         const dW =
@@ -158,7 +172,6 @@ export default function useDragResize(props: Params): ReturnValue {
         const factor = isCentered ? 2 : 1;
         const newWidth = sizeAtDragStart.width + diffX * factor;
         const constrainedWidth = constrainWidth(newWidth, maxWidth);
-        const aspectRatio = naturalHeight / naturalWidth;
 
         // When dragged to or beyond the editor edge, store the natural width as a
         // sentinel for "full width" so the element stays responsive. Only do this
@@ -170,7 +183,7 @@ export default function useDragResize(props: Params): ReturnValue {
             ? naturalWidth
             : constrainedWidth;
         const nextHeight = isCorner
-          ? naturalWidth
+          ? aspectRatio
             ? Math.round(constrainedWidth * aspectRatio)
             : undefined
           : sizeAtDragStart.height;

--- a/shared/editor/nodes/Embed.tsx
+++ b/shared/editor/nodes/Embed.tsx
@@ -21,6 +21,11 @@ import { isInList } from "../queries/isInList";
 import { findParentNodeClosestToPos } from "../queries/findParentNode";
 import { isList } from "../queries/isList";
 
+const parseDimension = (value: string | null): number | null => {
+  const parsed = parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
 export default class Embed extends Node {
   get name() {
     return "embed";
@@ -53,6 +58,8 @@ export default class Embed extends Node {
             if (response) {
               return {
                 href,
+                width: parseDimension(dom.getAttribute("width")),
+                height: parseDimension(dom.getAttribute("height")),
               };
             }
 
@@ -63,6 +70,8 @@ export default class Embed extends Node {
           tag: "a.embed",
           getAttrs: (dom: HTMLAnchorElement) => ({
             href: dom.getAttribute("href"),
+            width: parseDimension(dom.getAttribute("data-width")),
+            height: parseDimension(dom.getAttribute("data-height")),
           }),
         },
       ],
@@ -80,6 +89,8 @@ export default class Embed extends Node {
               src: sanitizeUrl(src),
               contentEditable: "false",
               allowfullscreen: "true",
+              width: node.attrs.width,
+              height: node.attrs.height,
               "data-canonical-url": sanitizeUrl(node.attrs.href),
             },
           ];
@@ -90,6 +101,8 @@ export default class Embed extends Node {
               class: "embed",
               href: sanitizeUrl(node.attrs.href),
               contentEditable: "false",
+              "data-width": node.attrs.width,
+              "data-height": node.attrs.height,
               "data-canonical-url": sanitizeUrl(node.attrs.href),
             },
             response?.embed.title ?? node.attrs.href,
@@ -133,6 +146,35 @@ export default class Embed extends Node {
 
   commands({ type }: { type: NodeType }) {
     return {
+      resizeEmbed:
+        ({ width, height }: { width?: number; height: number }): Command =>
+        (state, dispatch) => {
+          if (!(state.selection instanceof NodeSelection)) {
+            return false;
+          }
+
+          const { selection } = state;
+          const transformedAttrs = {
+            ...selection.node.attrs,
+            width: width ?? null,
+            height,
+          };
+
+          const tr = state.tr
+            .setNodeMarkup(selection.from, undefined, transformedAttrs)
+            .setMeta("addToHistory", true);
+
+          const $pos = tr.doc.resolve(selection.from);
+          dispatch?.(tr.setSelection(new NodeSelection($pos)));
+          return true;
+        },
+      deleteEmbed: (): Command => (state, dispatch) => {
+        if (!(state.selection instanceof NodeSelection)) {
+          return false;
+        }
+        dispatch?.(state.tr.deleteSelection().scrollIntoView());
+        return true;
+      },
       embed:
         (attrs: Record<string, Primitive>): Command =>
         (state, dispatch) => {


### PR DESCRIPTION
- Embed nodes now render the same side and corner resize handles as
  images; corner drags maintain the embed's existing aspect ratio while
  side drags adjust the width only.
- useDragResize falls back to the size at drag start for the corner
  aspect ratio when an element has no natural dimensions, and no longer
  allows resizing such elements to zero width.
- Selecting an embed now shows the selection toolbar menu with the
  media dimensions inputs, allowing a custom size (and aspect ratio) to
  be set; the URL editor remains available via the Edit link item.
- Adds resizeEmbed and deleteEmbed commands, and persists embed
  width/height through toDOM/parseDOM.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JjhkgiTMm3CqCtoufjEjXX