### PR TITLE
perf: O(1) title lookup in markdown import merge

### DIFF
--- a/server/queues/tasks/MarkdownAPIImportTask.ts
+++ b/server/queues/tasks/MarkdownAPIImportTask.ts
@@ -665,6 +665,16 @@ export default class MarkdownAPIImportTask extends APIImportTask<Markdown> {
     manifest: MarkdownAttachmentManifestItem[];
     markdownByNode: Map<ZipTreeNode, string>;
   }): void {
+    // Index existing docs by title so the folder/file merge lookup below is O(1)
+    // instead of an `out.find` scan per child (O(n²) over the number of siblings
+    // in a single directory). First occurrence wins, mirroring `find`.
+    const byTitle = new Map<string, DiscoveredDocument>();
+    for (const doc of out) {
+      if (!byTitle.has(doc.title)) {
+        byTitle.set(doc.title, doc);
+      }
+    }
+
     for (const child of children) {
       if (child.children.length > 0 && this.isAttachmentFolder(child)) {
         this.collectAttachments(child, manifest);
@@ -691,7 +701,7 @@ export default class MarkdownAPIImportTask extends APIImportTask<Markdown> {
       // Folder-and-file with the same title (a "name.md" alongside a "name/"
       // directory) is merged onto a single document: the folder body picks up
       // the file's markdown text, and the folder's contents become children.
-      const sibling = out.find((d) => d.title === child.title);
+      const sibling = byTitle.get(child.title);
 
       if (sibling) {
         if (sibling.markdownText === "" && markdownText) {
@@ -720,6 +730,7 @@ export default class MarkdownAPIImportTask extends APIImportTask<Markdown> {
         children: [],
       };
       out.push(node);
+      byTitle.set(node.title, node);
 
       if (isFolder) {
         this.collectDocumentsAndAttachments({


### PR DESCRIPTION
### What

Replaces the `out.find(d => d.title === child.title)` sibling lookup in the markdown import task with an O(1) `Map` lookup.

### Why

When importing a zip/folder, `collectDocumentsAndAttachments` merges a folder and a file that share a title (e.g. `name.md` alongside a `name/` directory) onto one document. It locates the existing sibling by scanning the output array once per child:

```ts
const sibling = out.find((d) => d.title === child.title);
```

That scan is O(n) and runs for every child at a directory level, so a directory with many entries is O(n²) in the number of siblings. A flat import with lots of files hits this on a background import path.

### How

Index the current siblings by title in a `Map` and look up in O(1), keeping the map in sync as new docs are pushed:

```ts
const byTitle = new Map<string, DiscoveredDocument>();
for (const doc of out) {
  if (!byTitle.has(doc.title)) byTitle.set(doc.title, doc);
}
// ...
const sibling = byTitle.get(child.title);
// ...
out.push(node);
byTitle.set(node.title, node);
```

Behaviour is unchanged: `find` returns the first match, and the map is seeded first-occurrence-wins to preserve that. The merge still mutates the same object reference, and the only mutation of `out` at this level is the single `out.push`, so the map stays consistent. Recursive calls operate on separate arrays.

I couldn't run the full suite locally, but the change is local and type-preserving.
