### PR TITLE
perf: Unnecessary loading of `state` column

### DIFF
--- a/server/models/Document.ts
+++ b/server/models/Document.ts
@@ -137,6 +137,7 @@ interface QueryGeneratorWithWhere {
     template: false,
   },
   attributes: {
+    exclude: ["state"],
     include: [stateIfContentEmpty],
   },
 }))
@@ -144,6 +145,7 @@ interface QueryGeneratorWithWhere {
 @Scopes(() => ({
   withoutState: {
     attributes: {
+      exclude: ["state"],
       include: [stateIfContentEmpty],
     },
   },


### PR DESCRIPTION
Sequelize’s `attributes.include` only adds columns, so the queries included the state binary (edit history, often 10–100× the document content) has been transferred from Postgres for every row of every default-scoped document query