### PR TITLE
fix: reorder drop always places at same level when target is expanded

### DIFF
--- a/app/components/Sidebar/components/DocumentLink.tsx
+++ b/app/components/Sidebar/components/DocumentLink.tsx
@@ -331,14 +331,6 @@ const DocumentLinkInner = observer(function DocumentLinkInner({
       if (!moveCollectionId) {
         return;
       }
-      if (expansion.isExpanded(node.id)) {
-        return {
-          documentId: item.id,
-          collectionId: moveCollectionId,
-          parentDocumentId: node.id,
-          index: 0,
-        };
-      }
       return {
         documentId: item.id,
         collectionId: moveCollectionId,


### PR DESCRIPTION
When a doc in the sidebar is expanded (children visible), dragging another doc and hovering *below* it shows the reorder cursor — but on drop, the item is silently reparented as the first child of the expanded doc instead of being placed after it at the same level.

**Root cause:** `dropToReorder`'s `getMoveParams` callback has a branch that fires when `expansion.isExpanded(node.id)`:

```ts
if (expansion.isExpanded(node.id)) {
  return {
    parentDocumentId: node.id, // ← reparents as child
    index: 0,
  };
}
```

But `dropToReparent` already owns the "make it a child" interaction — it activates when the user hovers over the doc body, and it correctly calls `handleExpand` to open the node. `dropToReorder` is only responsible for placing items *after* the target at the same level, regardless of expansion state.

**Fix:** remove the `isExpanded` branch entirely from `dropToReorder`'s callback. The same-level placement logic (`parentDocumentId: parentId, index: index + 1`) already works correctly for both collapsed and expanded states.

Fixes #10685