### PR TITLE
fix: Split view browser title

### DIFF
--- a/app/components/PageTitle.tsx
+++ b/app/components/PageTitle.tsx
@@ -2,6 +2,7 @@ import { observer } from "mobx-react";
 import { Helmet } from "react-helmet-async";
 import env from "~/env";
 import useStores from "~/hooks/useStores";
+import { useSplitView } from "./SplitView/context";
 import { useTeamContext } from "./TeamContext";
 
 type Props = {
@@ -16,6 +17,13 @@ const originalShortcutHref = document
 const PageTitle = ({ title, favicon }: Props) => {
   const { auth } = useStores();
   const team = useTeamContext() ?? auth.team;
+  const { isFocused } = useSplitView();
+
+  // Only the focused pane of a split view titles the tab, otherwise the panes
+  // compete and the title depends on which rendered last.
+  if (!isFocused) {
+    return null;
+  }
 
   return (
     <Helmet>


### PR DESCRIPTION
Should respect which split view is focused, not the last to mount