### PR TITLE
Reorder search in command menu

### DIFF
--- a/app/actions/definitions/documents.tsx
+++ b/app/actions/definitions/documents.tsx
@@ -66,6 +66,7 @@ import {
 import {
   ActiveDocumentSection,
   DocumentSection,
+  SearchResultsSection,
   TrashSection,
 } from "~/actions/sections";
 import { setPersistedState } from "~/hooks/usePersistedState";
@@ -1227,7 +1228,8 @@ export const searchDocumentsForQueryActionFactory = (query: string) =>
     name: ({ t }) =>
       t(`Search documents for "{{searchQuery}}"`, { searchQuery: query }),
     analyticsName: "Search documents",
-    section: DocumentSection,
+    section: SearchResultsSection,
+    priority: -1,
     icon: <SearchIcon />,
     to: searchPath({ query }),
     visible: ({ location }) => location.pathname !== searchPath(),

--- a/app/components/CommandBar/SearchIndex.test.ts
+++ b/app/components/CommandBar/SearchIndex.test.ts
@@ -1,26 +1,26 @@
 import { SearchIndex } from "./SearchIndex";
 
 describe("SearchIndex", () => {
-  it("returns no results for an empty query", async () => {
+  it("returns no results for an empty query", () => {
     const index = new SearchIndex();
     index.update([{ id: "1", title: "Engineering Handbook", url: "/doc/1" }]);
 
-    expect(await index.search("")).toEqual([]);
-    expect(await index.search("   ")).toEqual([]);
+    expect(index.search("")).toEqual([]);
+    expect(index.search("   ")).toEqual([]);
   });
 
-  it("matches titles despite spelling mistakes", async () => {
+  it("matches titles despite spelling mistakes", () => {
     const index = new SearchIndex();
     index.update([
       { id: "1", title: "Engineering Handbook", url: "/doc/1" },
       { id: "2", title: "Marketing Plan", url: "/doc/2" },
     ]);
 
-    const results = await index.search("enginering handbok");
+    const results = index.search("enginering handbok");
     expect(results[0]?.document.id).toBe("1");
   });
 
-  it("matches document content and highlights the context", async () => {
+  it("matches document content and highlights the context", () => {
     const index = new SearchIndex();
     index.update([
       {
@@ -31,12 +31,12 @@ describe("SearchIndex", () => {
       },
     ]);
 
-    const results = await index.search("revenue");
+    const results = index.search("revenue");
     expect(results[0]?.document.id).toBe("1");
     expect(results[0]?.context).toContain("<b>revenue</b>");
   });
 
-  it("highlights only exact matches, not fuzzy character runs", async () => {
+  it("highlights only exact matches, not fuzzy character runs", () => {
     const index = new SearchIndex();
     index.update([
       {
@@ -49,14 +49,14 @@ describe("SearchIndex", () => {
 
     // The typo "numbrs" has no literal occurrence, so only whole contiguous
     // matches are marked rather than the scattered characters Fuse matched on.
-    const results = await index.search("revenu numbrs");
+    const results = index.search("revenu numbrs");
     expect(results[0]?.document.id).toBe("1");
     expect(results[0]?.context).toContain("<b>revenu</b>");
     expect(results[0]?.context).not.toContain("numbrs");
     expect(results[0]?.context?.match(/<b>/g)).toHaveLength(1);
   });
 
-  it("highlights the query where it appears inside a longer word", async () => {
+  it("highlights the query where it appears inside a longer word", () => {
     const index = new SearchIndex();
     index.update([
       {
@@ -68,12 +68,10 @@ describe("SearchIndex", () => {
     ]);
 
     // Partway through typing "revenue", the typed prefix is still marked.
-    expect((await index.search("revenu"))[0]?.context).toContain(
-      "<b>revenu</b>"
-    );
+    expect(index.search("revenu")[0]?.context).toContain("<b>revenu</b>");
   });
 
-  it("highlights each term of a multi-word query separately", async () => {
+  it("highlights each term of a multi-word query separately", () => {
     const index = new SearchIndex();
     index.update([
       {
@@ -84,11 +82,11 @@ describe("SearchIndex", () => {
       },
     ]);
 
-    const context = (await index.search("revenue numbers"))[0]?.context;
+    const context = index.search("revenue numbers")[0]?.context;
     expect(context).toContain("<b>revenue numbers</b>");
   });
 
-  it("marks a match as one contiguous run rather than letter runs", async () => {
+  it("marks a match as one contiguous run rather than letter runs", () => {
     const index = new SearchIndex();
     index.update([
       {
@@ -99,13 +97,13 @@ describe("SearchIndex", () => {
       },
     ]);
 
-    const context = (await index.search("deployment"))[0]?.context;
+    const context = index.search("deployment")[0]?.context;
     // The whole word is marked once, rather than scattered letter runs.
     expect(context).toContain("<b>deployment</b>");
     expect(context?.match(/<b>/g)).toHaveLength(1);
   });
 
-  it("preserves previously indexed content when a later update omits it", async () => {
+  it("preserves previously indexed content when a later update omits it", () => {
     const index = new SearchIndex();
     index.update([
       {
@@ -118,10 +116,10 @@ describe("SearchIndex", () => {
     // A subsequent update (e.g. a title-only tree pass) must not drop content.
     index.update([{ id: "1", title: "Report", url: "/doc/1" }]);
 
-    expect((await index.search("pineapple"))[0]?.document.id).toBe("1");
+    expect(index.search("pineapple")[0]?.document.id).toBe("1");
   });
 
-  it("clears content when an update sets text to an empty string", async () => {
+  it("clears content when an update sets text to an empty string", () => {
     const index = new SearchIndex();
     index.update([
       {
@@ -134,10 +132,10 @@ describe("SearchIndex", () => {
     // An explicit empty string (e.g. content emptied) must replace stale text.
     index.update([{ id: "1", title: "Report", url: "/doc/1", text: "" }]);
 
-    expect(await index.search("pineapple")).toEqual([]);
+    expect(index.search("pineapple")).toEqual([]);
   });
 
-  it("previews content for a title match that has no content match", async () => {
+  it("previews content for a title match that has no content match", () => {
     const index = new SearchIndex();
     index.update([
       {
@@ -148,18 +146,18 @@ describe("SearchIndex", () => {
       },
     ]);
 
-    const context = (await index.search("engineering"))[0]?.context;
+    const context = index.search("engineering")[0]?.context;
     expect(context).toBe("Everything a new hire needs to know about our team.");
   });
 
-  it("has no context for a document with no content", async () => {
+  it("has no context for a document with no content", () => {
     const index = new SearchIndex();
     index.update([{ id: "1", title: "Engineering Handbook", url: "/doc/1" }]);
 
-    expect((await index.search("engineering"))[0]?.context).toBeUndefined();
+    expect(index.search("engineering")[0]?.context).toBeUndefined();
   });
 
-  it("truncates a long preview", async () => {
+  it("truncates a long preview", () => {
     const index = new SearchIndex();
     index.update([
       {
@@ -170,12 +168,12 @@ describe("SearchIndex", () => {
       },
     ]);
 
-    const context = (await index.search("engineering"))[0]?.context ?? "";
+    const context = index.search("engineering")[0]?.context ?? "";
     expect(context.endsWith("…")).toBe(true);
     expect(context.length).toBeLessThan(220);
   });
 
-  it("orders a title prefix ahead of a shorter mid-title match", async () => {
+  it("orders a title prefix ahead of a shorter mid-title match", () => {
     const index = new SearchIndex();
     index.update([
       // Fuse scores this higher on its own, as the field is shorter and
@@ -188,10 +186,10 @@ describe("SearchIndex", () => {
       },
     ]);
 
-    expect((await index.search("design"))[0]?.document.id).toBe("prefix");
+    expect(index.search("design")[0]?.document.id).toBe("prefix");
   });
 
-  it("orders a title prefix ahead of a shorter trailing-word match", async () => {
+  it("orders a title prefix ahead of a shorter trailing-word match", () => {
     const index = new SearchIndex();
     index.update([
       { id: "mid", title: "Team Onboarding", url: "/doc/mid" },
@@ -202,10 +200,10 @@ describe("SearchIndex", () => {
       },
     ]);
 
-    expect((await index.search("onboarding"))[0]?.document.id).toBe("prefix");
+    expect(index.search("onboarding")[0]?.document.id).toBe("prefix");
   });
 
-  it("orders a title prefix ahead of an equally scored mid-title match", async () => {
+  it("orders a title prefix ahead of an equally scored mid-title match", () => {
     const index = new SearchIndex();
     index.update([
       // Both score identically in Fuse, leaving the order arbitrary.
@@ -213,10 +211,10 @@ describe("SearchIndex", () => {
       { id: "prefix", title: "Design Is A Guide", url: "/doc/prefix" },
     ]);
 
-    expect((await index.search("design"))[0]?.document.id).toBe("prefix");
+    expect(index.search("design")[0]?.document.id).toBe("prefix");
   });
 
-  it("orders a title prefix ahead of a content-only match", async () => {
+  it("orders a title prefix ahead of a content-only match", () => {
     const index = new SearchIndex();
     index.update([
       { id: "content", title: "Q3", url: "/doc/content", text: "revenue" },
@@ -227,10 +225,10 @@ describe("SearchIndex", () => {
       },
     ]);
 
-    expect((await index.search("revenue"))[0]?.document.id).toBe("prefix");
+    expect(index.search("revenue")[0]?.document.id).toBe("prefix");
   });
 
-  it("breaks ties within a tier by fuzzy score", async () => {
+  it("breaks ties within a tier by fuzzy score", () => {
     const index = new SearchIndex();
     index.update([
       { id: "long", title: "Design System Guidelines", url: "/doc/long" },
@@ -238,10 +236,10 @@ describe("SearchIndex", () => {
     ]);
 
     // Both are prefix matches, so the closer title wins.
-    expect((await index.search("design"))[0]?.document.id).toBe("short");
+    expect(index.search("design")[0]?.document.id).toBe("short");
   });
 
-  it("weights title matches above content matches", async () => {
+  it("weights title matches above content matches", () => {
     const index = new SearchIndex();
     index.update([
       { id: "1", title: "Onboarding", url: "/doc/1", text: "unrelated body" },
@@ -253,21 +251,21 @@ describe("SearchIndex", () => {
       },
     ]);
 
-    const results = await index.search("onboarding");
+    const results = index.search("onboarding");
     expect(results[0]?.document.id).toBe("1");
   });
 
-  it("reports whether an update changed the collection", async () => {
+  it("reports whether an update changed the collection", () => {
     const index = new SearchIndex();
     expect(index.update([{ id: "1", title: "A", url: "/doc/1" }])).toBe(true);
     expect(index.update([{ id: "1", title: "A", url: "/doc/1" }])).toBe(false);
   });
 
-  it("clears all indexed documents", async () => {
+  it("clears all indexed documents", () => {
     const index = new SearchIndex();
     index.update([{ id: "1", title: "Engineering", url: "/doc/1" }]);
     index.clear();
 
-    expect(await index.search("engineering")).toEqual([]);
+    expect(index.search("engineering")).toEqual([]);
   });
 });

--- a/app/components/CommandBar/SearchIndex.ts
+++ b/app/components/CommandBar/SearchIndex.ts
@@ -1,6 +1,5 @@
 import { escapeRegExp } from "es-toolkit/compat";
 import Fuse, { type IFuseOptions } from "fuse.js";
-import { FuseWorker } from "fuse.js/worker";
 
 /** A document as represented within the search index. */
 export interface SearchIndexDocument {
@@ -40,17 +39,10 @@ const options: IFuseOptions<SearchIndexDocument> = {
   ],
   includeScore: true,
   ignoreLocation: true,
+  useTokenSearch: true,
   threshold: 0.3,
   minMatchCharLength: minTermLength,
 };
-
-/**
- * Scanning document content is the expensive part of a query, so it is sharded
- * across web workers to keep it off the main thread. Indices here hold at most
- * a few hundred documents, where more shards cost more in messaging overhead
- * and worker startup than they win back in parallelism.
- */
-const workerOptions = { numWorkers: 2 };
 
 const resultLimit = 25;
 const contextLead = 40;
@@ -179,12 +171,7 @@ function buildContext(
 export class SearchIndex {
   private records = new Map<string, SearchIndexDocument>();
 
-  // Workers are unavailable when server rendering and under jsdom, where the
-  // main-thread implementation stands in with an identical API.
-  private fuse: Fuse<SearchIndexDocument> | FuseWorker<SearchIndexDocument> =
-    typeof Worker === "undefined"
-      ? new Fuse<SearchIndexDocument>([], { ...options, useTokenSearch: true })
-      : new FuseWorker<SearchIndexDocument>([], options, workerOptions);
+  private fuse = new Fuse<SearchIndexDocument>([], options);
 
   /**
    * Merges documents into the index, rebuilding the collection only when
@@ -223,7 +210,7 @@ export class SearchIndex {
     }
 
     if (changed) {
-      this.setCollection(Array.from(this.records.values()));
+      this.fuse.setCollection(Array.from(this.records.values()));
     }
 
     return changed;
@@ -234,17 +221,7 @@ export class SearchIndex {
    */
   public clear(): void {
     this.records.clear();
-    this.setCollection([]);
-  }
-
-  /**
-   * Releases the workers backing the index. The index must not be used again
-   * afterwards.
-   */
-  public dispose(): void {
-    if (this.fuse instanceof FuseWorker) {
-      this.fuse.terminate();
-    }
+    this.fuse.setCollection([]);
   }
 
   /**
@@ -255,17 +232,16 @@ export class SearchIndex {
    * @param query the search query.
    * @returns the matching documents ordered by relevance.
    */
-  public async search(query: string): Promise<SearchIndexResult[]> {
+  public search(query: string): SearchIndexResult[] {
     const trimmed = query.trim();
     if (!trimmed) {
       return [];
     }
 
-    const matches = await this.fuse.search(trimmed);
-
     // Building context scans the full text of a document, so it is deferred
     // until the results have been truncated to those actually displayed.
-    return matches
+    return this.fuse
+      .search(trimmed)
       .map((result) => ({
         document: result.item,
         score: result.score ?? 1,
@@ -278,17 +254,5 @@ export class SearchIndex {
         score,
         context: buildContext(document.text, trimmed),
       }));
-  }
-
-  /**
-   * Replaces the indexed collection. Workers apply this asynchronously, but
-   * they process messages in order, so a search issued afterwards always sees
-   * the new collection.
-   */
-  private setCollection(documents: SearchIndexDocument[]): void {
-    void Promise.resolve(this.fuse.setCollection(documents)).catch(() => {
-      // A worker that failed to accept the collection will also fail the next
-      // search, which is where the error surfaces.
-    });
   }
 }

--- a/app/components/CommandBar/useSearchIndex.ts
+++ b/app/components/CommandBar/useSearchIndex.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import type Document from "~/models/Document";
 import { ProsemirrorHelper } from "~/models/helpers/ProsemirrorHelper";
 import {
@@ -78,7 +78,7 @@ export interface UseSearchIndex {
 /**
  * Maintains a client-side fuzzy search index and searches it for the given
  * query. The index is fed incrementally via the returned `feed` function, and
- * matching runs in web workers so that typing is never blocked by it.
+ * results are computed synchronously so they never lag behind the query.
  *
  * @param query the current search query.
  * @returns the current results and functions to feed or reset the index.
@@ -90,9 +90,8 @@ export function useSearchIndex(query: string): UseSearchIndex {
   }
   const index = indexRef.current;
 
-  // Bumped whenever the index changes, to re-run the search below.
+  // Bumped whenever the index changes, to re-run the memoized search below.
   const [version, setVersion] = useState(0);
-  const [results, setResults] = useState<SearchIndexResult[]>([]);
 
   const feed = useCallback(
     (documents: SearchIndexDocument[]) => {
@@ -108,35 +107,12 @@ export function useSearchIndex(query: string): UseSearchIndex {
     setVersion((v) => v + 1);
   }, [index]);
 
-  useEffect(() => {
-    if (!query) {
-      setResults([]);
-      return;
-    }
-
-    // Searches resolve out of order, so a stale response must not overwrite the
-    // results of a query the user has since moved on from.
-    let disposed = false;
-
-    void index
-      .search(query)
-      .then((next) => {
-        if (!disposed) {
-          setResults(next);
-        }
-      })
-      .catch(() => {
-        if (!disposed) {
-          setResults([]);
-        }
-      });
-
-    return () => {
-      disposed = true;
-    };
-  }, [index, query, version]);
-
-  useEffect(() => () => index.dispose(), [index]);
+  const results = useMemo<SearchIndexResult[]>(
+    () => (query ? index.search(query) : []),
+    // The index mutates in place, so `version` is what marks the memo stale.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [index, query, version]
+  );
 
   return { results, feed, reset };
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,8 +37,7 @@
       // Vite 8 and its plugins ship types only via their exports map, which
       // resolvePackageJsonExports disables; point tsc at their declaration entries.
       "vite": ["./node_modules/vite/dist/node/index.d.ts"],
-      "@vitejs/plugin-react": ["./node_modules/@vitejs/plugin-react/dist/index.d.ts"],
-      "fuse.js/worker": ["./node_modules/fuse.js/dist/fuse-worker.d.ts"]
+      "@vitejs/plugin-react": ["./node_modules/@vitejs/plugin-react/dist/index.d.ts"]
     }
   },
   "exclude": ["node_modules", "build", "server/migrations"]


### PR DESCRIPTION
Remove Fuse workers which have a bunch of complications served from CDN / different domains that are hard to control in self-hosted.