### PR TITLE
feat: Persist policies to IndexedDB so abilities survive reload

### DIFF
--- a/app/models/base/Model.ts
+++ b/app/models/base/Model.ts
@@ -2,13 +2,29 @@ import { isEqual, pick } from "es-toolkit/compat";
 import { observable, action, toJS } from "mobx";
 import type { JSONObject } from "@shared/types";
 import type Store from "~/stores/base/Store";
+import type { PartialExcept } from "~/types";
 import Logger from "~/utils/Logger";
-import { getFieldsForModel } from "../decorators/Field";
+import { getFieldsForModel, getFieldsForModelClass } from "../decorators/Field";
 import { LifecycleManager } from "../decorators/Lifecycle";
 import { getRelationsForModelClass } from "../decorators/Relation";
 
 export default abstract class Model {
   static modelName: string;
+
+  /**
+   * Restores data written by toPersisted to the shape the model expects,
+   * discarding any properties that are not declared fields. Records written by
+   * a different version of the app may not match the current model.
+   *
+   * @param record the persisted representation of a model.
+   * @returns the data to construct or update a model with.
+   */
+  static fromPersisted<T extends Model>(
+    record: Record<string, unknown>
+  ): PartialExcept<T, "id"> {
+    const fields = getFieldsForModelClass(this);
+    return JSON.parse(JSON.stringify(pick(record, ["id", ...fields])));
+  }
 
   @observable
   id: string;
@@ -200,6 +216,16 @@ export default abstract class Model {
     const fields = getFieldsForModel(this);
     return pick(this, fields);
   };
+
+  /**
+   * Returns a plain object representation of the model, containing its
+   * identifier and declared fields only, safe to store outside of memory.
+   * Internal state and observables are not included.
+   *
+   * @returns A plain object representation of the model
+   */
+  toPersisted = (): PartialExcept<Model, "id"> =>
+    JSON.parse(JSON.stringify({ ...this.toAPI(), id: this.id }));
 
   /**
    * Returns a plain object representation of all the properties on the model

--- a/app/models/decorators/Field.ts
+++ b/app/models/decorators/Field.ts
@@ -2,15 +2,31 @@ import type Model from "../base/Model";
 
 const fields = new Map<string, (string | number | symbol)[]>();
 
+/**
+ * Returns the keys recorded as serializable fields on a model.
+ *
+ * @param target the model to inspect.
+ * @returns the keys decorated with @Field.
+ */
 export const getFieldsForModel = <T extends Model>(target: T) =>
-  fields.get(target.constructor.name) ?? [];
+  getFieldsForModelClass(target.constructor);
+
+/**
+ * Returns the keys recorded as serializable fields on a model class.
+ *
+ * @param model the model class to inspect.
+ * @returns the keys decorated with @Field.
+ */
+export function getFieldsForModelClass(model: { name: string }) {
+  return fields.get(model.name) ?? [];
+}
 
 /**
  * A decorator that records this key as a serializable field on the model.
  * Properties decorated with @Field will be included in API requests by default.
  *
- * @param target
- * @param propertyKey
+ * @param target the model the property is defined on.
+ * @param propertyKey the key to record as a field.
  */
 const Field = (target: Model, propertyKey: string | symbol) => {
   const className = target.constructor.name;

--- a/app/stores/AuthStore.ts
+++ b/app/stores/AuthStore.ts
@@ -223,6 +223,10 @@ export default class AuthStore extends Store<Team> {
         this.availableTeams = res.data.availableTeams;
         this.collaborationToken = res.data.collaborationToken;
 
+        // Covers the first session after login, where no team was available
+        // in localStorage when the root store was constructed.
+        this.rootStore.enablePersistence();
+
         if (env.SENTRY_DSN) {
           const scope = Sentry.getCurrentScope();
           scope.setUser({ id: this.currentUserId! });

--- a/app/stores/PoliciesStore.ts
+++ b/app/stores/PoliciesStore.ts
@@ -36,6 +36,10 @@ export default class PoliciesStore extends Store<Policy> {
             policy.abilities[key] = can;
           }
 
+          // The abilities are mutated in place rather than through add(), so
+          // the persisted copy must be refreshed explicitly.
+          this.persistence?.persist(policy.id);
+
           Logger.debug("policies", "Removed membership from policy", {
             policy: policy.id,
             ability: key,

--- a/app/stores/PoliciesStore.ts
+++ b/app/stores/PoliciesStore.ts
@@ -7,6 +7,8 @@ import Store from "./base/Store";
 export default class PoliciesStore extends Store<Policy> {
   actions = [];
 
+  persistable = true;
+
   constructor(rootStore: RootStore) {
     super(rootStore, Policy);
   }

--- a/app/stores/RootStore.ts
+++ b/app/stores/RootStore.ts
@@ -35,8 +35,7 @@ import UserMembershipsStore from "./UserMembershipsStore";
 import UsersStore from "./UsersStore";
 import ViewsStore from "./ViewsStore";
 import WebhookSubscriptionsStore from "./WebhookSubscriptionStore";
-import type Store from "./base/Store";
-import StorePersistence from "./base/StorePersistence";
+import Store from "./base/Store";
 
 export default class RootStore {
   apiKeys: ApiKeysStore;
@@ -121,9 +120,9 @@ export default class RootStore {
   }
 
   /**
-   * Enable IndexedDB persistence for eligible stores, scoped to the current
-   * team. A no-op when there is no authenticated team or persistence is
-   * already enabled.
+   * Enable IndexedDB persistence for all stores marked as persistable, scoped
+   * to the current team. A no-op when there is no authenticated team or
+   * persistence is already enabled.
    */
   public enablePersistence() {
     const teamId = this.auth.currentTeamId;
@@ -131,9 +130,11 @@ export default class RootStore {
       return;
     }
 
-    void this.policies.enablePersistence(
-      StorePersistence.databaseName("policies", teamId)
-    );
+    Object.values(this).forEach((store) => {
+      if (store instanceof Store && store.persistable) {
+        void store.enablePersistence(teamId);
+      }
+    });
   }
 
   /**

--- a/app/stores/RootStore.ts
+++ b/app/stores/RootStore.ts
@@ -131,7 +131,7 @@ export default class RootStore {
     }
 
     Object.values(this).forEach((store) => {
-      if (store instanceof Store && store.persistable) {
+      if (store instanceof Store) {
         void store.enablePersistence(teamId);
       }
     });

--- a/app/stores/RootStore.ts
+++ b/app/stores/RootStore.ts
@@ -36,6 +36,7 @@ import UsersStore from "./UsersStore";
 import ViewsStore from "./ViewsStore";
 import WebhookSubscriptionsStore from "./WebhookSubscriptionStore";
 import type Store from "./base/Store";
+import StorePersistence from "./base/StorePersistence";
 
 export default class RootStore {
   apiKeys: ApiKeysStore;
@@ -113,6 +114,26 @@ export default class RootStore {
 
     // AuthStore must be initialized last as it makes use of the other stores.
     this.registerStore(AuthStore, "auth");
+
+    // AuthStore will have synchronously rehydrated the current team from
+    // localStorage at this point, if a session exists.
+    this.enablePersistence();
+  }
+
+  /**
+   * Enable IndexedDB persistence for eligible stores, scoped to the current
+   * team. A no-op when there is no authenticated team or persistence is
+   * already enabled.
+   */
+  public enablePersistence() {
+    const teamId = this.auth.currentTeamId;
+    if (!teamId) {
+      return;
+    }
+
+    void this.policies.enablePersistence(
+      StorePersistence.databaseName("policies", teamId)
+    );
   }
 
   /**

--- a/app/stores/base/Store.ts
+++ b/app/stores/base/Store.ts
@@ -76,6 +76,12 @@ export default abstract class Store<T extends Model> {
 
   apiEndpoint: string;
 
+  /**
+   * Whether the store's data should be persisted to IndexedDB, and restored
+   * at boot, once persistence is enabled for the authenticated team.
+   */
+  persistable = false;
+
   rootStore: RootStore;
 
   protected persistence?: StorePersistence<T>;
@@ -105,19 +111,22 @@ export default abstract class Store<T extends Model> {
   }
 
   /**
-   * Enables persistence of this store's data to IndexedDB and hydrates any
-   * previously persisted records into the store. Safe to call multiple times,
-   * subsequent calls are a no-op.
+   * Enables persistence of this store's data to IndexedDB, scoped to the
+   * given team, and hydrates any previously persisted records into the store.
+   * Safe to call multiple times, subsequent calls are a no-op.
    *
-   * @param databaseName the name of the IndexedDB database to persist to.
+   * @param teamId the ID of the team the persisted data belongs to.
    * @returns a promise that resolves when hydration is complete.
    */
-  async enablePersistence(databaseName: string): Promise<void> {
+  async enablePersistence(teamId: string): Promise<void> {
     if (this.persistence || !StorePersistence.isSupported) {
       return;
     }
 
-    this.persistence = new StorePersistence<T>(this, databaseName);
+    this.persistence = new StorePersistence<T>(
+      this,
+      StorePersistence.databaseName(this.apiEndpoint, teamId)
+    );
     await this.persistence.hydrate();
   }
 

--- a/app/stores/base/Store.ts
+++ b/app/stores/base/Store.ts
@@ -23,6 +23,7 @@ import type { PaginationParams, PartialExcept, Properties } from "~/types";
 import { client } from "~/utils/ApiClient";
 import { AuthorizationError, NotFoundError } from "~/utils/errors";
 import ParanoidModel from "~/models/base/ParanoidModel";
+import StorePersistence from "./StorePersistence";
 
 type ListPredicate<T> =
   | ((value: T, index: number, collection: ArrayLike<T>) => boolean)
@@ -77,6 +78,8 @@ export default abstract class Store<T extends Model> {
 
   rootStore: RootStore;
 
+  protected persistence?: StorePersistence<T>;
+
   actions = [
     RPCAction.Info,
     RPCAction.List,
@@ -98,6 +101,24 @@ export default abstract class Store<T extends Model> {
   @action
   clear() {
     this.data.clear();
+    this.persistence?.clear();
+  }
+
+  /**
+   * Enables persistence of this store's data to IndexedDB and hydrates any
+   * previously persisted records into the store. Safe to call multiple times,
+   * subsequent calls are a no-op.
+   *
+   * @param databaseName the name of the IndexedDB database to persist to.
+   * @returns a promise that resolves when hydration is complete.
+   */
+  async enablePersistence(databaseName: string): Promise<void> {
+    if (this.persistence || !StorePersistence.isSupported) {
+      return;
+    }
+
+    this.persistence = new StorePersistence<T>(this, databaseName);
+    await this.persistence.hydrate();
   }
 
   addPolicies = (policies: Policy[]) => {
@@ -158,16 +179,19 @@ export default abstract class Store<T extends Model> {
 
       if (existingModel) {
         existingModel.updateData(item);
+        this.persistence?.persist(existingModel.id);
         return existingModel;
       }
 
       // @ts-expect-error TS thinks that we're instantiating an abstract class here
       const newModel = new ModelClass(item, this);
       this.data.set(newModel.id, newModel);
+      this.persistence?.persist(newModel.id);
       return newModel;
     }
 
     this.data.set(item.id, item);
+    this.persistence?.persist(item.id);
     return item;
   };
 
@@ -218,6 +242,10 @@ export default abstract class Store<T extends Model> {
     }
 
     LifecycleManager.executeHooks(model.constructor, "afterRemove", model);
+
+    // Persists the soft-deleted model, or removes the persisted record if the
+    // model was hard-deleted from the store.
+    this.persistence?.persist(id);
   }
 
   @action

--- a/app/stores/base/Store.ts
+++ b/app/stores/base/Store.ts
@@ -107,26 +107,28 @@ export default abstract class Store<T extends Model> {
   @action
   clear() {
     this.data.clear();
-    this.persistence?.clear();
+    void this.persistence?.clear();
   }
 
   /**
    * Enables persistence of this store's data to IndexedDB, scoped to the
    * given team, and hydrates any previously persisted records into the store.
-   * Safe to call multiple times, subsequent calls are a no-op.
+   * A no-op if the store is not persistable, persistence is unsupported, or it
+   * is already enabled, so it is safe to call on every store and more than once.
    *
    * @param teamId the ID of the team the persisted data belongs to.
    * @returns a promise that resolves when hydration is complete.
    */
   async enablePersistence(teamId: string): Promise<void> {
-    if (this.persistence || !StorePersistence.isSupported) {
+    if (
+      !this.persistable ||
+      this.persistence ||
+      !StorePersistence.isSupported
+    ) {
       return;
     }
 
-    this.persistence = new StorePersistence<T>(
-      this,
-      StorePersistence.databaseName(this.apiEndpoint, teamId)
-    );
+    this.persistence = new StorePersistence<T>(this, teamId);
     await this.persistence.hydrate();
   }
 

--- a/app/stores/base/Store.ts
+++ b/app/stores/base/Store.ts
@@ -23,6 +23,7 @@ import type { PaginationParams, PartialExcept, Properties } from "~/types";
 import { client } from "~/utils/ApiClient";
 import { AuthorizationError, NotFoundError } from "~/utils/errors";
 import ParanoidModel from "~/models/base/ParanoidModel";
+import StorePersistence from "./StorePersistence";
 
 type ListPredicate<T> =
   | ((value: T, index: number, collection: ArrayLike<T>) => boolean)
@@ -77,6 +78,8 @@ export default abstract class Store<T extends Model> {
 
   rootStore: RootStore;
 
+  protected persistence?: StorePersistence<T>;
+
   actions = [
     RPCAction.Info,
     RPCAction.List,
@@ -98,6 +101,24 @@ export default abstract class Store<T extends Model> {
   @action
   clear() {
     this.data.clear();
+    this.persistence?.clear();
+  }
+
+  /**
+   * Enables persistence of this store's data to IndexedDB and hydrates any
+   * previously persisted records into the store. Safe to call multiple times,
+   * subsequent calls are a no-op.
+   *
+   * @param databaseName the name of the IndexedDB database to persist to.
+   * @returns a promise that resolves when hydration is complete.
+   */
+  async enablePersistence(databaseName: string): Promise<void> {
+    if (this.persistence || !StorePersistence.isSupported) {
+      return;
+    }
+
+    this.persistence = new StorePersistence<T>(this, databaseName);
+    await this.persistence.hydrate();
   }
 
   addPolicies = (policies: Policy[]) => {
@@ -176,16 +197,19 @@ export default abstract class Store<T extends Model> {
 
       if (existingModel) {
         existingModel.updateData(item);
+        this.persistence?.persist(existingModel.id);
         return existingModel;
       }
 
       // @ts-expect-error TS thinks that we're instantiating an abstract class here
       const newModel = new ModelClass(item, this);
       this.data.set(newModel.id, newModel);
+      this.persistence?.persist(newModel.id);
       return newModel;
     }
 
     this.data.set(item.id, item);
+    this.persistence?.persist(item.id);
     return item;
   };
 
@@ -244,6 +268,10 @@ export default abstract class Store<T extends Model> {
     }
 
     LifecycleManager.executeHooks(model.constructor, "afterRemove", model);
+
+    // Persists the soft-deleted model, or removes the persisted record if the
+    // model was hard-deleted from the store.
+    this.persistence?.persist(id);
   }
 
   @action

--- a/app/stores/base/StorePersistence.test.ts
+++ b/app/stores/base/StorePersistence.test.ts
@@ -1,0 +1,95 @@
+/* oxlint-disable */
+import "fake-indexeddb/auto";
+// The stores singleton must be imported before RootStore so that the module
+// cycle through AuthStore -> developer.ts -> ~/stores resolves in the same
+// order as the application entry point.
+import "~/stores";
+import { toJS } from "mobx";
+import RootStore from "~/stores/RootStore";
+import StorePersistence from "./StorePersistence";
+
+describe("StorePersistence", () => {
+  test("round-trips models through IndexedDB into a fresh store", async () => {
+    const name = StorePersistence.databaseName("policies", "team-1");
+    const source = new RootStore();
+    const persistence = new StorePersistence(source.policies, name);
+
+    source.policies.add({
+      id: "doc-1",
+      abilities: { read: true, update: ["membership-1"] },
+    });
+    persistence.persist("doc-1");
+    await persistence.flush();
+
+    const target = new RootStore();
+    const targetPersistence = new StorePersistence(target.policies, name);
+    await targetPersistence.hydrate();
+
+    expect(toJS(target.policies.get("doc-1")?.abilities)).toEqual({
+      read: true,
+      update: ["membership-1"],
+    });
+    expect(target.policies.abilities("doc-1").read).toBe(true);
+    expect(target.policies.abilities("doc-1").update).toBeTruthy();
+  });
+
+  test("does not overwrite models already in the store when hydrating", async () => {
+    const name = StorePersistence.databaseName("policies", "team-2");
+    const source = new RootStore();
+    const persistence = new StorePersistence(source.policies, name);
+
+    source.policies.add({ id: "doc-1", abilities: { read: false } });
+    persistence.persist("doc-1");
+    await persistence.flush();
+
+    const target = new RootStore();
+    target.policies.add({ id: "doc-1", abilities: { read: true } });
+    const targetPersistence = new StorePersistence(target.policies, name);
+    await targetPersistence.hydrate();
+
+    expect(target.policies.get("doc-1")?.abilities).toEqual({ read: true });
+  });
+
+  test("deletes the persisted record when the model has been removed", async () => {
+    const name = StorePersistence.databaseName("policies", "team-3");
+    const source = new RootStore();
+    const persistence = new StorePersistence(source.policies, name);
+
+    source.policies.add({ id: "doc-1", abilities: { read: true } });
+    persistence.persist("doc-1");
+    await persistence.flush();
+
+    source.policies.remove("doc-1");
+    persistence.persist("doc-1");
+    await persistence.flush();
+
+    const target = new RootStore();
+    const targetPersistence = new StorePersistence(target.policies, name);
+    await targetPersistence.hydrate();
+
+    expect(target.policies.get("doc-1")).toBeUndefined();
+  });
+
+  test("clear removes all persisted records", async () => {
+    const name = StorePersistence.databaseName("policies", "team-4");
+    const source = new RootStore();
+    const persistence = new StorePersistence(source.policies, name);
+
+    source.policies.add({ id: "doc-1", abilities: { read: true } });
+    source.policies.add({ id: "doc-2", abilities: { read: true } });
+    persistence.persist("doc-1");
+    persistence.persist("doc-2");
+    await persistence.flush();
+
+    persistence.clear();
+
+    // clear() runs asynchronously in the background, wait for it to finish.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const target = new RootStore();
+    const targetPersistence = new StorePersistence(target.policies, name);
+    await targetPersistence.hydrate();
+
+    expect(target.policies.orderedData).toHaveLength(0);
+  });
+});

--- a/app/stores/base/StorePersistence.test.ts
+++ b/app/stores/base/StorePersistence.test.ts
@@ -10,9 +10,9 @@ import StorePersistence from "./StorePersistence";
 
 describe("StorePersistence", () => {
   test("round-trips models through IndexedDB into a fresh store", async () => {
-    const name = StorePersistence.databaseName("policies", "team-1");
+    const teamId = "team-1";
     const source = new RootStore();
-    const persistence = new StorePersistence(source.policies, name);
+    const persistence = new StorePersistence(source.policies, teamId);
 
     source.policies.add({
       id: "doc-1",
@@ -22,7 +22,7 @@ describe("StorePersistence", () => {
     await persistence.flush();
 
     const target = new RootStore();
-    const targetPersistence = new StorePersistence(target.policies, name);
+    const targetPersistence = new StorePersistence(target.policies, teamId);
     await targetPersistence.hydrate();
 
     expect(toJS(target.policies.get("doc-1")?.abilities)).toEqual({
@@ -34,9 +34,9 @@ describe("StorePersistence", () => {
   });
 
   test("does not overwrite models already in the store when hydrating", async () => {
-    const name = StorePersistence.databaseName("policies", "team-2");
+    const teamId = "team-2";
     const source = new RootStore();
-    const persistence = new StorePersistence(source.policies, name);
+    const persistence = new StorePersistence(source.policies, teamId);
 
     source.policies.add({ id: "doc-1", abilities: { read: false } });
     persistence.persist("doc-1");
@@ -44,16 +44,16 @@ describe("StorePersistence", () => {
 
     const target = new RootStore();
     target.policies.add({ id: "doc-1", abilities: { read: true } });
-    const targetPersistence = new StorePersistence(target.policies, name);
+    const targetPersistence = new StorePersistence(target.policies, teamId);
     await targetPersistence.hydrate();
 
     expect(target.policies.get("doc-1")?.abilities).toEqual({ read: true });
   });
 
   test("deletes the persisted record when the model has been removed", async () => {
-    const name = StorePersistence.databaseName("policies", "team-3");
+    const teamId = "team-3";
     const source = new RootStore();
-    const persistence = new StorePersistence(source.policies, name);
+    const persistence = new StorePersistence(source.policies, teamId);
 
     source.policies.add({ id: "doc-1", abilities: { read: true } });
     persistence.persist("doc-1");
@@ -64,16 +64,16 @@ describe("StorePersistence", () => {
     await persistence.flush();
 
     const target = new RootStore();
-    const targetPersistence = new StorePersistence(target.policies, name);
+    const targetPersistence = new StorePersistence(target.policies, teamId);
     await targetPersistence.hydrate();
 
     expect(target.policies.get("doc-1")).toBeUndefined();
   });
 
   test("clear removes all persisted records", async () => {
-    const name = StorePersistence.databaseName("policies", "team-4");
+    const teamId = "team-4";
     const source = new RootStore();
-    const persistence = new StorePersistence(source.policies, name);
+    const persistence = new StorePersistence(source.policies, teamId);
 
     source.policies.add({ id: "doc-1", abilities: { read: true } });
     source.policies.add({ id: "doc-2", abilities: { read: true } });
@@ -81,13 +81,10 @@ describe("StorePersistence", () => {
     persistence.persist("doc-2");
     await persistence.flush();
 
-    persistence.clear();
-
-    // clear() runs asynchronously in the background, wait for it to finish.
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await persistence.clear();
 
     const target = new RootStore();
-    const targetPersistence = new StorePersistence(target.policies, name);
+    const targetPersistence = new StorePersistence(target.policies, teamId);
     await targetPersistence.hydrate();
 
     expect(target.policies.orderedData).toHaveLength(0);

--- a/app/stores/base/StorePersistence.test.ts
+++ b/app/stores/base/StorePersistence.test.ts
@@ -9,7 +9,7 @@ import RootStore from "~/stores/RootStore";
 import StorePersistence from "./StorePersistence";
 
 describe("StorePersistence", () => {
-  test("round-trips models through IndexedDB into a fresh store", async () => {
+  it("round-trips models through IndexedDB into a fresh store", async () => {
     const teamId = "team-1";
     const source = new RootStore();
     const persistence = new StorePersistence(source.policies, teamId);
@@ -33,7 +33,7 @@ describe("StorePersistence", () => {
     expect(target.policies.abilities("doc-1").update).toBeTruthy();
   });
 
-  test("does not overwrite models already in the store when hydrating", async () => {
+  it("does not overwrite models already in the store when hydrating", async () => {
     const teamId = "team-2";
     const source = new RootStore();
     const persistence = new StorePersistence(source.policies, teamId);
@@ -50,7 +50,7 @@ describe("StorePersistence", () => {
     expect(target.policies.get("doc-1")?.abilities).toEqual({ read: true });
   });
 
-  test("deletes the persisted record when the model has been removed", async () => {
+  it("deletes the persisted record when the model has been removed", async () => {
     const teamId = "team-3";
     const source = new RootStore();
     const persistence = new StorePersistence(source.policies, teamId);
@@ -70,7 +70,31 @@ describe("StorePersistence", () => {
     expect(target.policies.get("doc-1")).toBeUndefined();
   });
 
-  test("clear removes all persisted records", async () => {
+  it("does not write back records that were just hydrated", async () => {
+    const teamId = "team-5";
+    const source = new RootStore();
+    const persistence = new StorePersistence(source.policies, teamId);
+
+    source.policies.add({ id: "doc-1", abilities: { read: true } });
+    persistence.persist("doc-1");
+    await persistence.flush();
+
+    const target = new RootStore();
+    await target.policies.enablePersistence(teamId);
+
+    // Drop the model without notifying persistence, so that any flush scheduled
+    // during hydration would delete the persisted record when it fires.
+    target.policies.data.delete("doc-1");
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+
+    const other = new RootStore();
+    const otherPersistence = new StorePersistence(other.policies, teamId);
+    await otherPersistence.hydrate();
+
+    expect(other.policies.get("doc-1")).toBeTruthy();
+  });
+
+  it("clear removes all persisted records", async () => {
     const teamId = "team-4";
     const source = new RootStore();
     const persistence = new StorePersistence(source.policies, teamId);

--- a/app/stores/base/StorePersistence.test.ts
+++ b/app/stores/base/StorePersistence.test.ts
@@ -33,6 +33,53 @@ describe("StorePersistence", () => {
     expect(target.policies.abilities("doc-1").update).toBeTruthy();
   });
 
+  it("stores the model flat, without internal state or a duplicated id", async () => {
+    const teamId = "team-6";
+    const source = new RootStore();
+    const persistence = new StorePersistence(source.policies, teamId);
+
+    source.policies.add({ id: "doc-1", abilities: { read: true } });
+    persistence.persist("doc-1");
+    await persistence.flush();
+
+    const records = await readAll(
+      StorePersistence.databaseName(source.policies.apiEndpoint, teamId)
+    );
+
+    expect(records).toEqual([{ id: "doc-1", abilities: { read: true } }]);
+  });
+
+  it("ignores unknown properties on records written by another version", async () => {
+    const teamId = "team-7";
+    const source = new RootStore();
+    const persistence = new StorePersistence(source.policies, teamId);
+    const databaseName = StorePersistence.databaseName(
+      source.policies.apiEndpoint,
+      teamId
+    );
+
+    // A record in the shape an earlier version of this code wrote.
+    await writeAll(databaseName, [
+      {
+        id: "doc-1",
+        data: { id: "doc-1", initialized: true, abilities: { read: true } },
+      },
+    ]);
+    await persistence.hydrate();
+
+    expect(source.policies.get("doc-1")).toBeTruthy();
+    expect("data" in source.policies.get("doc-1")!).toBe(false);
+
+    // The stale shape must not be written back out on the next flush.
+    source.policies.add({ id: "doc-1", abilities: { read: false } });
+    persistence.persist("doc-1");
+    await persistence.flush();
+
+    expect(await readAll(databaseName)).toEqual([
+      { id: "doc-1", abilities: { read: false } },
+    ]);
+  });
+
   it("does not overwrite models already in the store when hydrating", async () => {
     const teamId = "team-2";
     const source = new RootStore();
@@ -114,3 +161,39 @@ describe("StorePersistence", () => {
     expect(target.policies.orderedData).toHaveLength(0);
   });
 });
+
+/** Writes raw records into a database, bypassing the store. */
+function writeAll(databaseName: string, records: unknown[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(databaseName, 1);
+    request.onerror = () => reject(request.error);
+    request.onupgradeneeded = () =>
+      request.result.createObjectStore("items", { keyPath: "id" });
+    request.onsuccess = () => {
+      const transaction = request.result.transaction("items", "readwrite");
+      const objectStore = transaction.objectStore("items");
+      records.forEach((record) => objectStore.put(record));
+      transaction.oncomplete = () => {
+        request.result.close();
+        resolve();
+      };
+      transaction.onerror = () => reject(transaction.error);
+    };
+  });
+}
+
+/** Reads the raw persisted records from a database, bypassing the store. */
+function readAll(databaseName: string): Promise<unknown[]> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(databaseName);
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => {
+      const getAll = request.result
+        .transaction("items", "readonly")
+        .objectStore("items")
+        .getAll();
+      getAll.onerror = () => reject(getAll.error);
+      getAll.onsuccess = () => resolve(getAll.result);
+    };
+  });
+}

--- a/app/stores/base/StorePersistence.ts
+++ b/app/stores/base/StorePersistence.ts
@@ -1,0 +1,226 @@
+import { debounce } from "es-toolkit/compat";
+import type Model from "~/models/base/Model";
+import type { PartialExcept } from "~/types";
+import Logger from "~/utils/Logger";
+import type Store from "./Store";
+
+/** Bump to discard previously persisted data when the format changes. */
+const SCHEMA_VERSION = 1;
+
+/** Name of the single object store used within each database. */
+const OBJECT_STORE_NAME = "items";
+
+/** How long to wait after the last change before writing to IndexedDB. */
+const FLUSH_DELAY_MS = 1000;
+
+interface PersistedRecord<T extends Model> {
+  id: string;
+  data: PartialExcept<T, "id">;
+}
+
+/**
+ * Persists a store's models to IndexedDB so that previously loaded data
+ * survives a reload and is available offline. Persisted data is strictly a
+ * cache – it is hydrated into the store at boot as stale data and revalidated
+ * by normal API traffic, which always wins over the cached copy.
+ */
+export default class StorePersistence<T extends Model> {
+  /** Whether IndexedDB persistence is supported in the current environment. */
+  public static get isSupported(): boolean {
+    return typeof window !== "undefined" && !!window.indexedDB;
+  }
+
+  /**
+   * Builds the name of the database backing a store, scoped to a team so that
+   * cached data is never shared between accounts on the same origin.
+   *
+   * @param storeName the name of the store, eg "policies".
+   * @param teamId the ID of the team the data belongs to.
+   * @returns the database name.
+   */
+  public static databaseName(storeName: string, teamId: string): string {
+    return `outline.${storeName}.${teamId}`;
+  }
+
+  constructor(store: Store<T>, databaseName: string) {
+    this.store = store;
+    this.name = databaseName;
+  }
+
+  /**
+   * Loads all persisted records into the store. Records for models already in
+   * the store are skipped, as in-memory data is always fresher than the cache.
+   *
+   * @returns a promise that resolves when hydration is complete.
+   */
+  public hydrate = async (): Promise<void> => {
+    try {
+      const database = await this.open();
+      const records = await promisifyRequest<PersistedRecord<T>[]>(
+        database
+          .transaction(OBJECT_STORE_NAME, "readonly")
+          .objectStore(OBJECT_STORE_NAME)
+          .getAll()
+      );
+
+      for (const record of records) {
+        if (!this.store.get(record.id)) {
+          this.store.add(record.data);
+        }
+      }
+    } catch (err) {
+      this.disabled = true;
+      Logger.warn("Failed to hydrate store from IndexedDB", {
+        database: this.name,
+        error: err,
+      });
+    }
+  };
+
+  /**
+   * Schedules the model with the given ID to be written to IndexedDB. If the
+   * model is no longer in the store when the write occurs, the persisted
+   * record is deleted instead.
+   *
+   * @param id the ID of the model to persist.
+   */
+  public persist = (id: string) => {
+    if (this.disabled) {
+      return;
+    }
+    this.dirty.add(id);
+    this.scheduleFlush();
+  };
+
+  /**
+   * Writes all pending changes to IndexedDB immediately.
+   *
+   * @returns a promise that resolves when the write is complete.
+   */
+  public flush = async (): Promise<void> => {
+    if (this.disabled || this.dirty.size === 0) {
+      return;
+    }
+
+    const ids = Array.from(this.dirty);
+    this.dirty.clear();
+
+    try {
+      const database = await this.open();
+      const transaction = database.transaction(OBJECT_STORE_NAME, "readwrite");
+      const objectStore = transaction.objectStore(OBJECT_STORE_NAME);
+
+      for (const id of ids) {
+        const model = this.store.get(id);
+        if (model) {
+          objectStore.put({ id, data: serialize(model) });
+        } else {
+          objectStore.delete(id);
+        }
+      }
+
+      await promisifyTransaction(transaction);
+    } catch (err) {
+      Logger.warn("Failed to write store to IndexedDB", {
+        database: this.name,
+        error: err,
+      });
+    }
+  };
+
+  /**
+   * Removes all persisted records, used when the store is cleared on logout.
+   */
+  public clear = () => {
+    this.dirty.clear();
+
+    if (this.disabled) {
+      return;
+    }
+
+    void this.open()
+      .then((database) =>
+        promisifyRequest(
+          database
+            .transaction(OBJECT_STORE_NAME, "readwrite")
+            .objectStore(OBJECT_STORE_NAME)
+            .clear()
+        )
+      )
+      .catch((err) => {
+        Logger.warn("Failed to clear persisted store in IndexedDB", {
+          database: this.name,
+          error: err,
+        });
+      });
+  };
+
+  private open = (): Promise<IDBDatabase> => {
+    if (!this.database) {
+      this.database = new Promise((resolve, reject) => {
+        const request = window.indexedDB.open(this.name, SCHEMA_VERSION);
+
+        request.onupgradeneeded = () => {
+          const database = request.result;
+          if (database.objectStoreNames.contains(OBJECT_STORE_NAME)) {
+            database.deleteObjectStore(OBJECT_STORE_NAME);
+          }
+          database.createObjectStore(OBJECT_STORE_NAME, { keyPath: "id" });
+        };
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+      });
+    }
+    return this.database;
+  };
+
+  private scheduleFlush = debounce(() => void this.flush(), FLUSH_DELAY_MS);
+
+  private store: Store<T>;
+
+  private name: string;
+
+  private database?: Promise<IDBDatabase>;
+
+  private dirty = new Set<string>();
+
+  private disabled = false;
+}
+
+/**
+ * Serializes a model to a plain object safe for structured cloning, dropping
+ * functions and other non-serializable properties.
+ *
+ * @param model the model to serialize.
+ * @returns a plain object representation of the model.
+ */
+function serialize<T extends Model>(model: T): PartialExcept<T, "id"> {
+  return JSON.parse(JSON.stringify(model));
+}
+
+/**
+ * Converts an IndexedDB request into a promise.
+ *
+ * @param request the request to convert.
+ * @returns a promise that resolves with the request result.
+ */
+function promisifyRequest<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+/**
+ * Converts an IndexedDB transaction into a promise.
+ *
+ * @param transaction the transaction to convert.
+ * @returns a promise that resolves when the transaction completes.
+ */
+function promisifyTransaction(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error);
+    transaction.onabort = () => reject(transaction.error);
+  });
+}

--- a/app/stores/base/StorePersistence.ts
+++ b/app/stores/base/StorePersistence.ts
@@ -42,9 +42,9 @@ export default class StorePersistence<T extends Model> {
     return `outline.${storeName}.${teamId}`;
   }
 
-  constructor(store: Store<T>, databaseName: string) {
+  constructor(store: Store<T>, teamId: string) {
     this.store = store;
-    this.name = databaseName;
+    this.name = StorePersistence.databaseName(store.apiEndpoint, teamId);
   }
 
   /**
@@ -130,29 +130,30 @@ export default class StorePersistence<T extends Model> {
 
   /**
    * Removes all persisted records, used when the store is cleared on logout.
+   *
+   * @returns a promise that resolves when the records have been removed.
    */
-  public clear = () => {
+  public clear = async (): Promise<void> => {
     this.dirty.clear();
 
     if (this.disabled) {
       return;
     }
 
-    void this.open()
-      .then((database) =>
-        promisifyRequest(
-          database
-            .transaction(OBJECT_STORE_NAME, "readwrite")
-            .objectStore(OBJECT_STORE_NAME)
-            .clear()
-        )
-      )
-      .catch((err) => {
-        Logger.warn("Failed to clear persisted store in IndexedDB", {
-          database: this.name,
-          error: err,
-        });
+    try {
+      const database = await this.open();
+      await promisifyRequest(
+        database
+          .transaction(OBJECT_STORE_NAME, "readwrite")
+          .objectStore(OBJECT_STORE_NAME)
+          .clear()
+      );
+    } catch (err) {
+      Logger.warn("Failed to clear persisted store in IndexedDB", {
+        database: this.name,
+        error: err,
       });
+    }
   };
 
   private open = (): Promise<IDBDatabase> => {

--- a/app/stores/base/StorePersistence.ts
+++ b/app/stores/base/StorePersistence.ts
@@ -1,6 +1,5 @@
 import { debounce } from "es-toolkit/compat";
 import type Model from "~/models/base/Model";
-import type { PartialExcept } from "~/types";
 import Logger from "~/utils/Logger";
 import type Store from "./Store";
 
@@ -12,11 +11,6 @@ const OBJECT_STORE_NAME = "items";
 
 /** How long to wait after the last change before writing to IndexedDB. */
 const FLUSH_DELAY_MS = 1000;
-
-interface PersistedRecord<T extends Model> {
-  id: string;
-  data: PartialExcept<T, "id">;
-}
 
 /**
  * Persists a store's models to IndexedDB so that previously loaded data
@@ -56,7 +50,7 @@ export default class StorePersistence<T extends Model> {
   public hydrate = async (): Promise<void> => {
     try {
       const database = await this.open();
-      const records = await promisifyRequest<PersistedRecord<T>[]>(
+      const records = await promisifyRequest<Record<string, unknown>[]>(
         database
           .transaction(OBJECT_STORE_NAME, "readonly")
           .objectStore(OBJECT_STORE_NAME)
@@ -65,9 +59,11 @@ export default class StorePersistence<T extends Model> {
 
       this.hydrating = true;
       for (const record of records) {
-        if (!this.store.get(record.id)) {
-          this.store.add(record.data);
+        const id = record?.id;
+        if (typeof id !== "string" || this.store.get(id)) {
+          continue;
         }
+        this.store.add(this.store.model.fromPersisted<T>(record));
       }
     } catch (err) {
       this.disabled = true;
@@ -117,7 +113,7 @@ export default class StorePersistence<T extends Model> {
       for (const id of ids) {
         const model = this.store.get(id);
         if (model) {
-          objectStore.put({ id, data: serialize(model) });
+          objectStore.put(model.toPersisted());
         } else {
           objectStore.delete(id);
         }
@@ -189,17 +185,6 @@ export default class StorePersistence<T extends Model> {
   private disabled = false;
 
   private hydrating = false;
-}
-
-/**
- * Serializes a model to a plain object safe for structured cloning, dropping
- * functions and other non-serializable properties.
- *
- * @param model the model to serialize.
- * @returns a plain object representation of the model.
- */
-function serialize<T extends Model>(model: T): PartialExcept<T, "id"> {
-  return JSON.parse(JSON.stringify(model));
 }
 
 /**

--- a/app/stores/base/StorePersistence.ts
+++ b/app/stores/base/StorePersistence.ts
@@ -63,6 +63,7 @@ export default class StorePersistence<T extends Model> {
           .getAll()
       );
 
+      this.hydrating = true;
       for (const record of records) {
         if (!this.store.get(record.id)) {
           this.store.add(record.data);
@@ -74,18 +75,21 @@ export default class StorePersistence<T extends Model> {
         database: this.name,
         error: err,
       });
+    } finally {
+      this.hydrating = false;
     }
   };
 
   /**
    * Schedules the model with the given ID to be written to IndexedDB. If the
    * model is no longer in the store when the write occurs, the persisted
-   * record is deleted instead.
+   * record is deleted instead. A no-op while hydrating, as those records have
+   * just been read from the cache.
    *
    * @param id the ID of the model to persist.
    */
   public persist = (id: string) => {
-    if (this.disabled) {
+    if (this.disabled || this.hydrating) {
       return;
     }
     this.dirty.add(id);
@@ -142,12 +146,9 @@ export default class StorePersistence<T extends Model> {
 
     try {
       const database = await this.open();
-      await promisifyRequest(
-        database
-          .transaction(OBJECT_STORE_NAME, "readwrite")
-          .objectStore(OBJECT_STORE_NAME)
-          .clear()
-      );
+      const transaction = database.transaction(OBJECT_STORE_NAME, "readwrite");
+      transaction.objectStore(OBJECT_STORE_NAME).clear();
+      await promisifyTransaction(transaction);
     } catch (err) {
       Logger.warn("Failed to clear persisted store in IndexedDB", {
         database: this.name,
@@ -186,6 +187,8 @@ export default class StorePersistence<T extends Model> {
   private dirty = new Set<string>();
 
   private disabled = false;
+
+  private hydrating = false;
 }
 
 /**

--- a/app/utils/developer.ts
+++ b/app/utils/developer.ts
@@ -1,5 +1,6 @@
 import { flatten } from "es-toolkit/compat";
 import stores from "~/stores";
+import StorePersistence from "~/stores/base/StorePersistence";
 import { flattenTree } from "@shared/utils/tree";
 
 /**
@@ -10,6 +11,12 @@ import { flattenTree } from "@shared/utils/tree";
 export async function deleteAllDatabases() {
   if (!window.indexedDB) {
     return;
+  }
+
+  if (stores.auth.currentTeamId) {
+    window.indexedDB.deleteDatabase(
+      StorePersistence.databaseName("policies", stores.auth.currentTeamId)
+    );
   }
 
   if ("databases" in window.indexedDB) {

--- a/app/utils/developer.ts
+++ b/app/utils/developer.ts
@@ -1,5 +1,6 @@
 import { flatten } from "es-toolkit/compat";
 import stores from "~/stores";
+import Store from "~/stores/base/Store";
 import StorePersistence from "~/stores/base/StorePersistence";
 import { flattenTree } from "@shared/utils/tree";
 
@@ -13,10 +14,15 @@ export async function deleteAllDatabases() {
     return;
   }
 
-  if (stores.auth.currentTeamId) {
-    window.indexedDB.deleteDatabase(
-      StorePersistence.databaseName("policies", stores.auth.currentTeamId)
-    );
+  const teamId = stores.auth.currentTeamId;
+  if (teamId) {
+    Object.values(stores).forEach((store) => {
+      if (store instanceof Store && store.persistable) {
+        window.indexedDB.deleteDatabase(
+          StorePersistence.databaseName(store.apiEndpoint, teamId)
+        );
+      }
+    });
   }
 
   if ("databases" in window.indexedDB) {

--- a/package.json
+++ b/package.json
@@ -354,6 +354,7 @@
     "browserslist-to-esbuild": "^1.2.0",
     "concurrently": "^8.2.2",
     "discord-api-types": "^0.38.48",
+    "fake-indexeddb": "^6.2.5",
     "husky": "^8.0.3",
     "i18next-parser": "^9.4.0",
     "ioredis-mock": "^8.13.1",

--- a/package.json
+++ b/package.json
@@ -350,6 +350,7 @@
     "browserslist-to-esbuild": "^1.2.0",
     "concurrently": "^8.2.2",
     "discord-api-types": "^0.38.48",
+    "fake-indexeddb": "^6.2.5",
     "husky": "^8.0.3",
     "i18next-parser": "^9.4.0",
     "ioredis-mock": "^8.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11186,6 +11186,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fake-indexeddb@npm:^6.2.5":
+  version: 6.2.5
+  resolution: "fake-indexeddb@npm:6.2.5"
+  checksum: 10c0/6c5e2fe84a61daa06d7ad63699d1041fe61847f15f92db12415634b3db94f363a64be9e08a3c3c4434af9c3c0132086b85c4d5dc5e8e06edae1e7daf70ce1f3c
+  languageName: node
+  linkType: hard
+
 "fast-content-type-parse@npm:^3.0.0":
   version: 3.0.0
   resolution: "fast-content-type-parse@npm:3.0.0"
@@ -15605,6 +15612,7 @@ __metadata:
     emoji-regex: "npm:^10.6.0"
     es-toolkit: "npm:^1.47.1"
     es6-error: "npm:^4.1.1"
+    fake-indexeddb: "npm:^6.2.5"
     fast-deep-equal: "npm:^3.1.3"
     fetch-retry: "npm:^5.0.6"
     form-data: "npm:^4.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15023,11 +15023,11 @@ __metadata:
   linkType: hard
 
 "nanoid@npm:^3.3.16":
-  version: 3.3.17
-  resolution: "nanoid@npm:3.3.17"
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/06f7949c7cce5c92c6aea66022f29a1eae7f56e05acbfddf1e049e819b4bf234c44a765cc44da7163482b111677948514012e27acdfa56f95309295768bdae32
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11109,6 +11109,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fake-indexeddb@npm:^6.2.5":
+  version: 6.2.5
+  resolution: "fake-indexeddb@npm:6.2.5"
+  checksum: 10c0/6c5e2fe84a61daa06d7ad63699d1041fe61847f15f92db12415634b3db94f363a64be9e08a3c3c4434af9c3c0132086b85c4d5dc5e8e06edae1e7daf70ce1f3c
+  languageName: node
+  linkType: hard
+
 "fast-content-type-parse@npm:^3.0.0":
   version: 3.0.0
   resolution: "fast-content-type-parse@npm:3.0.0"
@@ -15546,6 +15553,7 @@ __metadata:
     emoji-regex: "npm:^10.6.0"
     es-toolkit: "npm:^1.47.1"
     es6-error: "npm:^4.1.1"
+    fake-indexeddb: "npm:^6.2.5"
     fast-deep-equal: "npm:^3.1.3"
     fetch-retry: "npm:^5.0.6"
     form-data: "npm:^4.0.6"


### PR DESCRIPTION
Adds a StorePersistence layer that caches a store's models in IndexedDB and hydrates them back at boot as stale data, revalidated by normal API traffic. Enabled for the policies store, scoped per team, so cached abilities are available immediately after a reload instead of every policy needing a forced refetch.

- Persistence hooks in the base Store add/remove/clear methods, since
  add() updates existing models in place and map observation would miss
  those changes
- Enabled from RootStore construction (team read from localStorage) and
  again after auth.info succeeds to cover the first session after login
- `Store.clear()` wipes the persisted records, covering both logout paths
- `deleteAllDatabases()` fallback removes the policies database on
  browsers without indexedDB.databases()

Baby steps towards full offline