### PR TITLE
feat: Add custom emojis to JSON export/import

### DIFF
--- a/server/models/helpers/ProsemirrorHelper.tsx
+++ b/server/models/helpers/ProsemirrorHelper.tsx
@@ -16,6 +16,7 @@ import {
   yDocToProsemirrorJSON,
 } from "y-prosemirror";
 import * as Y from "yjs";
+import { isUUID } from "validator";
 import { toError, errToString } from "@shared/utils/error";
 import Diff from "@shared/editor/extensions/Diff";
 import { EditorStyleHelper } from "@shared/editor/styles/EditorStyleHelper";
@@ -494,6 +495,26 @@ export class ProsemirrorHelper extends SharedProsemirrorHelper {
         }
       }
     }
+
+    return [...ids];
+  }
+
+  /**
+   * Returns an array of custom emoji IDs referenced inline in the node. Unicode
+   * emojis are stored by shortcode rather than id and are skipped.
+   *
+   * @param doc The node to parse custom emojis from
+   * @returns An array of emoji IDs
+   */
+  static parseEmojiIds(doc: Node) {
+    const ids = new Set<string>();
+
+    doc.descendants((node) => {
+      const name = node.type.name === "emoji" && node.attrs["data-name"];
+      if (typeof name === "string" && isUUID(name)) {
+        ids.add(name);
+      }
+    });
 
     return [...ids];
   }

--- a/server/queues/tasks/ExportJSONTask.test.ts
+++ b/server/queues/tasks/ExportJSONTask.test.ts
@@ -1,0 +1,145 @@
+import fs from "fs-extra";
+import { Attachment } from "@server/models";
+import type { CollectionJSONExport } from "@server/types";
+import ZipHelper from "@server/utils/ZipHelper";
+import {
+  buildCollection,
+  buildDocument,
+  buildEmoji,
+  buildFileOperation,
+  buildTeam,
+  buildUser,
+} from "@server/test/factories";
+import ExportJSONTask from "./ExportJSONTask";
+
+describe("ExportJSONTask", () => {
+  it("should include custom emojis referenced by content and icons", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const [inlineEmoji, iconEmoji, unusedEmoji] = await Promise.all([
+      buildEmoji({ teamId: team.id, createdById: user.id, name: "inline" }),
+      buildEmoji({ teamId: team.id, createdById: user.id, name: "icon" }),
+      buildEmoji({ teamId: team.id, createdById: user.id, name: "unused" }),
+    ]);
+    const collection = await buildCollection({
+      teamId: team.id,
+      createdById: user.id,
+      name: "Emojis",
+    });
+    const documents = await Promise.all([
+      buildDocument({
+        teamId: team.id,
+        userId: user.id,
+        collectionId: collection.id,
+        title: "Inline",
+        text: `Hello :${inlineEmoji.id}: :smile:`,
+      }),
+      buildDocument({
+        teamId: team.id,
+        userId: user.id,
+        collectionId: collection.id,
+        title: "Icon",
+        icon: iconEmoji.id,
+      }),
+    ]);
+    for (const document of documents) {
+      await collection.addDocumentToStructure(document);
+    }
+    const fileOperation = await buildFileOperation({
+      teamId: team.id,
+      userId: user.id,
+    });
+
+    const task = new ExportJSONTask();
+    const filePath = await task.exportCollections([collection], fileOperation);
+
+    try {
+      const files = new Map<string, Buffer>();
+      await ZipHelper.walk(filePath, async (entry) => {
+        if (!entry.isDirectory) {
+          files.set(entry.fileName, await entry.readBuffer(1024 * 1024));
+        }
+      });
+
+      const output = JSON.parse(
+        files.get("Emojis.json")!.toString("utf8")
+      ) as CollectionJSONExport;
+
+      expect(Object.keys(output.emojis ?? {}).sort()).toEqual(
+        [inlineEmoji.id, iconEmoji.id].sort()
+      );
+      expect(output.emojis![inlineEmoji.id]).toEqual({
+        id: inlineEmoji.id,
+        name: "inline",
+        attachmentId: inlineEmoji.attachmentId,
+      });
+
+      // The emoji image travels with the export so the importing workspace can
+      // recreate it.
+      const attachment = await Attachment.findByPk(inlineEmoji.attachmentId, {
+        rejectOnEmpty: true,
+      });
+      expect(output.attachments[inlineEmoji.attachmentId]).toBeDefined();
+      expect(files.has(attachment.key)).toBe(true);
+
+      // Emojis the collection doesn't reference are not exported.
+      expect(output.emojis![unusedEmoji.id]).toBeUndefined();
+    } finally {
+      await fs.remove(filePath);
+    }
+  });
+
+  it("should write a shared emoji image to the archive once", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const emoji = await buildEmoji({
+      teamId: team.id,
+      createdById: user.id,
+      name: "shared",
+    });
+    const collections = await Promise.all([
+      buildCollection({ teamId: team.id, createdById: user.id, name: "One" }),
+      buildCollection({ teamId: team.id, createdById: user.id, name: "Two" }),
+    ]);
+    for (const collection of collections) {
+      const document = await buildDocument({
+        teamId: team.id,
+        userId: user.id,
+        collectionId: collection.id,
+        text: `:${emoji.id}:`,
+      });
+      await collection.addDocumentToStructure(document);
+    }
+    const fileOperation = await buildFileOperation({
+      teamId: team.id,
+      userId: user.id,
+    });
+
+    const task = new ExportJSONTask();
+    const filePath = await task.exportCollections(collections, fileOperation);
+
+    try {
+      const attachment = await Attachment.findByPk(emoji.attachmentId, {
+        rejectOnEmpty: true,
+      });
+      const fileNames: string[] = [];
+      await ZipHelper.walk(filePath, (entry) => {
+        if (!entry.isDirectory) {
+          fileNames.push(entry.fileName);
+        }
+      });
+
+      expect(fileNames.filter((name) => name === attachment.key).length).toBe(
+        1
+      );
+
+      // Both collection files still describe the emoji so either can be
+      // imported on its own.
+      for (const name of ["One.json", "Two.json"]) {
+        expect(fileNames).toContain(name);
+      }
+    } finally {
+      await fs.remove(filePath);
+    }
+  });
+});

--- a/server/queues/tasks/ExportJSONTask.ts
+++ b/server/queues/tasks/ExportJSONTask.ts
@@ -1,11 +1,13 @@
 import { ZipFile } from "yazl";
 import { omit } from "es-toolkit/compat";
 import { errToString } from "@shared/utils/error";
+import { determineIconType } from "@shared/utils/icon";
 import type { NavigationNode } from "@shared/types";
+import { IconType } from "@shared/types";
 import env from "@server/env";
 import Logger from "@server/logging/Logger";
 import type { Collection, FileOperation } from "@server/models";
-import { Attachment, Document } from "@server/models";
+import { Attachment, Document, Emoji } from "@server/models";
 import { DocumentHelper } from "@server/models/helpers/DocumentHelper";
 import { ProsemirrorHelper } from "@server/models/helpers/ProsemirrorHelper";
 import { presentAttachment, presentCollection } from "@server/presenters";
@@ -22,6 +24,11 @@ export default class ExportJSONTask extends ExportTask {
   ) {
     const zip = new ZipFile();
     const usedFilenames = new Set<string>();
+    // Custom emojis are workspace-wide, so the same image can be referenced
+    // from several collections. Keys already in the archive are not written
+    // again, though each collection's JSON still describes every attachment it
+    // references so it remains importable on its own.
+    const archivedKeys = new Set<string>();
 
     // serial to avoid overloading, slow and steady wins the race
     for (const collection of collections) {
@@ -36,7 +43,8 @@ export default class ExportJSONTask extends ExportTask {
         zip,
         collection,
         fileOperation.options?.includeAttachments ?? true,
-        filename
+        filename,
+        archivedKeys
       );
     }
 
@@ -73,8 +81,11 @@ export default class ExportJSONTask extends ExportTask {
     zip: ZipFile,
     collection: Collection,
     includeAttachments: boolean,
-    filename: string
+    filename: string,
+    archivedKeys: Set<string>
   ) {
+    const emojis: NonNullable<CollectionJSONExport["emojis"]> = {};
+
     const output: CollectionJSONExport = {
       collection: {
         ...(omit(await presentCollection(undefined, collection), [
@@ -85,24 +96,39 @@ export default class ExportJSONTask extends ExportTask {
       },
       documents: {},
       attachments: {},
+      emojis,
     };
+
+    // Custom emoji ids referenced by the collection or its documents, either
+    // inline in content or as an icon. Resolved once the tree has been walked.
+    const emojiIds = new Set<string>();
+
+    function addEmojiIcon(icon?: string | null) {
+      if (icon && determineIconType(icon) === IconType.Custom) {
+        emojiIds.add(icon);
+      }
+    }
 
     async function addAttachments(attachments: Attachment[]) {
       for (const attachment of attachments) {
-        let buffer: Buffer;
-        try {
-          buffer = await attachment.buffer;
-        } catch (err) {
-          Logger.warn(`Failed to read attachment from storage`, {
-            attachmentId: attachment.id,
-            teamId: attachment.teamId,
-            error: errToString(err),
+        if (!archivedKeys.has(attachment.key)) {
+          archivedKeys.add(attachment.key);
+
+          let buffer: Buffer;
+          try {
+            buffer = await attachment.buffer;
+          } catch (err) {
+            Logger.warn(`Failed to read attachment from storage`, {
+              attachmentId: attachment.id,
+              teamId: attachment.teamId,
+              error: errToString(err),
+            });
+            buffer = Buffer.from("");
+          }
+          zip.addBuffer(buffer, attachment.key, {
+            mtime: attachment.updatedAt,
           });
-          buffer = Buffer.from("");
         }
-        zip.addBuffer(buffer, attachment.key, {
-          mtime: attachment.updatedAt,
-        });
 
         output.attachments[attachment.id] = {
           ...omit(presentAttachment(attachment), "url"),
@@ -120,6 +146,11 @@ export default class ExportJSONTask extends ExportTask {
         if (!document) {
           continue;
         }
+
+        addEmojiIcon(document.icon);
+        ProsemirrorHelper.parseEmojiIds(
+          DocumentHelper.toProsemirror(document)
+        ).forEach((id) => emojiIds.add(id));
 
         const documentAttachments = includeAttachments
           ? await Attachment.findAll({
@@ -172,8 +203,39 @@ export default class ExportJSONTask extends ExportTask {
 
     await addAttachments(collectionAttachments);
 
+    addEmojiIcon(collection.icon);
+    ProsemirrorHelper.parseEmojiIds(
+      DocumentHelper.toProsemirror(collection)
+    ).forEach((id) => emojiIds.add(id));
+
     if (collection.documentStructure) {
       await addDocumentTree(collection.documentStructure);
+    }
+
+    // Custom emoji images live outside the document content, so they're only
+    // resolvable once every referencing document has been visited.
+    if (includeAttachments && emojiIds.size) {
+      const referenced = await Emoji.findAll({
+        where: {
+          teamId: collection.teamId,
+          id: [...emojiIds],
+        },
+        include: [{ model: Attachment, as: "attachment", paranoid: false }],
+      });
+
+      await addAttachments(
+        referenced.map((emoji) => emoji.attachment).filter(Boolean)
+      );
+
+      for (const emoji of referenced) {
+        if (emoji.attachment) {
+          emojis[emoji.id] = {
+            id: emoji.id,
+            name: emoji.name,
+            attachmentId: emoji.attachmentId,
+          };
+        }
+      }
     }
 
     zip.addBuffer(

--- a/server/queues/tasks/JSONAPIImportTask.test.ts
+++ b/server/queues/tasks/JSONAPIImportTask.test.ts
@@ -7,6 +7,7 @@ import {
   Attachment,
   Collection,
   Document,
+  Emoji,
   ImportTask,
   User,
 } from "@server/models";
@@ -20,6 +21,7 @@ import {
 import {
   buildAdmin,
   buildDocument,
+  buildEmoji,
   buildImport,
   buildTeam,
   buildUser,
@@ -27,6 +29,7 @@ import {
 import JSONImportsProcessor from "../processors/JSONImportsProcessor";
 import JSONAPIImportTask, {
   rewriteAttachmentReferences,
+  rewriteEmojiReferences,
 } from "./JSONAPIImportTask";
 
 // Fixed external IDs and email used across the user-mapping tests — these
@@ -34,10 +37,15 @@ import JSONAPIImportTask, {
 const FIXTURE_USER_ID = "ccec260a-e060-4925-ade8-17cfabaf2cac";
 const FIXTURE_USER_EMAIL = "hmac.devo@gmail.com";
 
+// Name of the custom emoji written into every zip, referenced both inline in
+// Document 1 and as Document 2's icon.
+const FIXTURE_EMOJI_NAME = "party_parrot";
+
 interface BuiltZip {
   filePath: string;
   documentOneUrlId: string;
   documentTwoUrlId: string;
+  emojiExternalId: string;
   cleanup: () => Promise<void>;
 }
 
@@ -47,7 +55,7 @@ interface BuiltZip {
  * collide on `urlId` uniqueness. The structure matches what ExportJSONTask
  * produces: a single collection JSON + metadata.json at the zip root,
  * documents carrying source user attribution, plus one referenced
- * attachment.
+ * attachment and one custom emoji.
  */
 async function buildJSONExportZip(): Promise<BuiltZip> {
   const collectionExternalId = randomUUID();
@@ -58,6 +66,9 @@ async function buildJSONExportZip(): Promise<BuiltZip> {
   const documentTwoUrlId = randomUrlId();
   const attachmentExternalId = randomUUID();
   const attachmentKey = `uploads/${FIXTURE_USER_ID}/${attachmentExternalId}/pikachu.jpg`;
+  const emojiExternalId = randomUUID();
+  const emojiAttachmentExternalId = randomUUID();
+  const emojiAttachmentKey = `uploads/${FIXTURE_USER_ID}/${emojiAttachmentExternalId}/${FIXTURE_EMOJI_NAME}.png`;
 
   const collectionExport = {
     collection: {
@@ -138,6 +149,13 @@ async function buildJSONExportZip(): Promise<BuiltZip> {
                 },
               ],
             },
+            {
+              type: "paragraph",
+              content: [
+                { type: "emoji", attrs: { "data-name": emojiExternalId } },
+                { type: "emoji", attrs: { "data-name": "smile" } },
+              ],
+            },
           ],
         },
         createdById: FIXTURE_USER_ID,
@@ -153,7 +171,7 @@ async function buildJSONExportZip(): Promise<BuiltZip> {
         id: documentTwoId,
         urlId: documentTwoUrlId,
         title: "Document 2",
-        icon: null,
+        icon: emojiExternalId,
         color: null,
         data: {
           type: "doc",
@@ -183,6 +201,21 @@ async function buildJSONExportZip(): Promise<BuiltZip> {
         size: 6,
         key: attachmentKey,
       },
+      [emojiAttachmentExternalId]: {
+        id: emojiAttachmentExternalId,
+        documentId: null,
+        contentType: "image/png",
+        name: `${FIXTURE_EMOJI_NAME}.png`,
+        size: 6,
+        key: emojiAttachmentKey,
+      },
+    },
+    emojis: {
+      [emojiExternalId]: {
+        id: emojiExternalId,
+        name: FIXTURE_EMOJI_NAME,
+        attachmentId: emojiAttachmentExternalId,
+      },
     },
   };
 
@@ -198,6 +231,7 @@ async function buildJSONExportZip(): Promise<BuiltZip> {
   zip.file("metadata.json", JSON.stringify(metadata));
   zip.file("Test JSON.json", JSON.stringify(collectionExport));
   zip.file(attachmentKey, Buffer.from("pixels"));
+  zip.file(emojiAttachmentKey, Buffer.from("pixels"));
 
   const buffer = await zip.generateAsync({ type: "nodebuffer" });
   const filePath: string = await new Promise((resolve, reject) => {
@@ -209,6 +243,7 @@ async function buildJSONExportZip(): Promise<BuiltZip> {
     filePath,
     documentOneUrlId,
     documentTwoUrlId,
+    emojiExternalId,
     cleanup: async () => {
       await fs.rm(filePath, { force: true }).catch(() => {});
     },
@@ -390,6 +425,82 @@ describe("JSONAPIImportTask", () => {
     expect(linkMark?.attrs?.href).toBe(collection.path);
   });
 
+  describe("custom emojis", () => {
+    it("creates referenced emojis and points content at them", async () => {
+      const admin = await buildAdmin();
+      const { importId } = await runImport({
+        teamId: admin.teamId,
+        createdById: admin.id,
+        zipPath: zip.filePath,
+      });
+
+      const emojis = await Emoji.findAll({ where: { teamId: admin.teamId } });
+      expect(emojis.length).toBe(1);
+      expect(emojis[0].name).toBe(FIXTURE_EMOJI_NAME);
+      expect(emojis[0].id).not.toBe(zip.emojiExternalId);
+
+      const attachment = await Attachment.findByPk(emojis[0].attachmentId);
+      expect(attachment).not.toBeNull();
+
+      const docOne = await Document.findOne({
+        where: { apiImportId: importId, title: "Document 1" },
+        rejectOnEmpty: true,
+      });
+      const emojiParagraph = docOne.content?.content?.[4];
+      expect(emojiParagraph?.content?.[0]?.attrs?.["data-name"]).toBe(
+        emojis[0].id
+      );
+      // Unicode emojis are addressed by shortcode, not id, and are untouched.
+      expect(emojiParagraph?.content?.[1]?.attrs?.["data-name"]).toBe("smile");
+    });
+
+    it("rewrites a document icon that is a custom emoji", async () => {
+      const admin = await buildAdmin();
+      const { importId } = await runImport({
+        teamId: admin.teamId,
+        createdById: admin.id,
+        zipPath: zip.filePath,
+      });
+
+      const emoji = await Emoji.findOne({
+        where: { teamId: admin.teamId, name: FIXTURE_EMOJI_NAME },
+        rejectOnEmpty: true,
+      });
+      const docTwo = await Document.findOne({
+        where: { apiImportId: importId, title: "Document 2" },
+        rejectOnEmpty: true,
+      });
+
+      expect(docTwo.icon).toBe(emoji.id);
+      expect(docTwo.icon).not.toBe(zip.emojiExternalId);
+    });
+
+    it("reuses an existing emoji of the same name", async () => {
+      const admin = await buildAdmin();
+      const existing = await buildEmoji({
+        teamId: admin.teamId,
+        createdById: admin.id,
+        name: FIXTURE_EMOJI_NAME,
+      });
+
+      const { importId } = await runImport({
+        teamId: admin.teamId,
+        createdById: admin.id,
+        zipPath: zip.filePath,
+      });
+
+      const emojis = await Emoji.findAll({ where: { teamId: admin.teamId } });
+      expect(emojis.length).toBe(1);
+      expect(emojis[0].id).toBe(existing.id);
+
+      const docTwo = await Document.findOne({
+        where: { apiImportId: importId, title: "Document 2" },
+        rejectOnEmpty: true,
+      });
+      expect(docTwo.icon).toBe(existing.id);
+    });
+  });
+
   describe("user mapping", () => {
     it("maps createdById to an existing user by ID", async () => {
       let originalAuthor = await User.findByPk(FIXTURE_USER_ID);
@@ -530,7 +641,7 @@ describe("rewriteAttachmentReferences", () => {
     expect(attachment?.attrs?.id).toBe("new-2");
   });
 
-  it("leaves unknown references untouched", () => {
+  it("leaves unknown attachment references untouched", () => {
     const out = rewriteAttachmentReferences(
       {
         type: "doc",
@@ -554,5 +665,42 @@ describe("rewriteAttachmentReferences", () => {
     expect(image?.attrs?.src).toBe(
       "/api/attachments.redirect?id=does-not-exist"
     );
+  });
+});
+
+describe("rewriteEmojiReferences", () => {
+  const nested = (...names: string[]) => ({
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: names.map((name) => ({
+          type: "emoji",
+          attrs: { "data-name": name },
+        })),
+      },
+    ],
+  });
+
+  it("rewrites custom emoji references to new ids", () => {
+    const out = rewriteEmojiReferences(nested("external-1"), {
+      "external-1": "new-1",
+    });
+    expect(out.content?.[0].content?.[0].attrs?.["data-name"]).toBe("new-1");
+  });
+
+  it("leaves unicode emojis and unknown ids untouched", () => {
+    const out = rewriteEmojiReferences(nested("smile", "external-2"), {
+      "external-1": "new-1",
+    });
+    expect(out.content?.[0].content?.[0].attrs?.["data-name"]).toBe("smile");
+    expect(out.content?.[0].content?.[1].attrs?.["data-name"]).toBe(
+      "external-2"
+    );
+  });
+
+  it("returns content unchanged when there are no emojis to map", () => {
+    const content = nested("external-1");
+    expect(rewriteEmojiReferences(content, {})).toBe(content);
   });
 });

--- a/server/queues/tasks/JSONAPIImportTask.ts
+++ b/server/queues/tasks/JSONAPIImportTask.ts
@@ -1,11 +1,13 @@
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 import { Fragment, Node } from "prosemirror-model";
-import { UniqueConstraintError } from "sequelize";
+import { Op, UniqueConstraintError } from "sequelize";
+import { isUUID } from "validator";
 import type {
   ImportTaskInput,
   ImportTaskOutput,
   JSONAttachmentManifestItem,
+  JSONEmojiManifestItem,
   JSONPageImportTaskInputItem,
 } from "@shared/schema";
 import type {
@@ -14,13 +16,14 @@ import type {
   ProsemirrorDoc,
 } from "@shared/types";
 import { AttachmentPreset } from "@shared/types";
+import { errToString } from "@shared/utils/error";
 import attachmentCreator from "@server/commands/attachmentCreator";
 import { createContext } from "@server/context";
 import { schema } from "@server/editor";
 import env from "@server/env";
 import Logger from "@server/logging/Logger";
 import type { ImportTask } from "@server/models";
-import { Attachment } from "@server/models";
+import { Attachment, Emoji } from "@server/models";
 import AttachmentHelper from "@server/models/helpers/AttachmentHelper";
 import { ProsemirrorDataHelper } from "@shared/utils/ProsemirrorDataHelper";
 import { sequelize } from "@server/storage/database";
@@ -29,6 +32,7 @@ import type {
   AttachmentJSONExport,
   CollectionJSONExport,
   DocumentJSONExport,
+  EmojiJSONExport,
   JSONExportMetadata,
 } from "@server/types";
 import ZipHelper from "@server/utils/ZipHelper";
@@ -121,6 +125,57 @@ export function rewriteAttachmentReferences(
   return doc.copy(transformFragment(doc.content)).toJSON() as ProsemirrorData;
 }
 
+/**
+ * Rewrites inline custom emoji references in a ProseMirror document to the
+ * emoji ids the import resolved them to. Emojis are addressed by id in the
+ * `data-name` attribute; unicode emojis use a shortcode there instead and are
+ * left alone, as are ids missing from the map.
+ *
+ * Exported for tests; not part of the module's public surface.
+ *
+ * @param content ProseMirror content from a document or collection.
+ * @param emojiIdMap Map of external emoji id → new internal id.
+ * @returns ProseMirror content with rewritten emoji references.
+ */
+export function rewriteEmojiReferences(
+  content: ProsemirrorData,
+  emojiIdMap: Record<string, string>
+): ProsemirrorData {
+  if (!Object.keys(emojiIdMap).length) {
+    return content;
+  }
+
+  const transform = (node: ProsemirrorData): ProsemirrorData => {
+    const name = node.type === "emoji" ? node.attrs?.["data-name"] : undefined;
+    const rewritten = typeof name === "string" ? emojiIdMap[name] : undefined;
+
+    return {
+      ...node,
+      ...(rewritten
+        ? { attrs: { ...node.attrs, "data-name": rewritten } }
+        : undefined),
+      ...(node.content ? { content: node.content.map(transform) } : undefined),
+    };
+  };
+
+  return transform(content);
+}
+
+/**
+ * Maps a document or collection icon onto the emoji id the import resolved it
+ * to, when the icon is a custom emoji. Other icon types pass through.
+ *
+ * @param icon The icon as it appears in the export.
+ * @param emojiIdMap Map of external emoji id → new internal id.
+ * @returns The icon to store on the imported model.
+ */
+function rewriteEmojiIcon(
+  icon: string | null | undefined,
+  emojiIdMap: Record<string, string>
+): string | null | undefined {
+  return icon && isUUID(icon) ? (emojiIdMap[icon] ?? icon) : icon;
+}
+
 export default class JSONAPIImportTask extends APIImportTask<Service> {
   protected shouldUploadAttachmentsPerPage(): boolean {
     return false;
@@ -137,6 +192,8 @@ export default class JSONAPIImportTask extends APIImportTask<Service> {
     if (!scratch?.storageKey || !scratch.manifest?.length) {
       return;
     }
+
+    const { teamId, createdById } = lastImportTask.import;
 
     const handle = await FileStorage.getFileHandle(scratch.storageKey);
 
@@ -200,6 +257,12 @@ export default class JSONAPIImportTask extends APIImportTask<Service> {
             `JSON import attachment missing in zip, skipping: ${item.pathInZip}`
           );
         }
+      }
+
+      // Emojis point at the attachments created above, so they can only be
+      // created once the walk is complete.
+      if (scratch.emojis?.length) {
+        await this.createEmojis(scratch.emojis, teamId, createdById);
       }
     } finally {
       await handle.cleanup().catch(() => {});
@@ -290,6 +353,20 @@ export default class JSONAPIImportTask extends APIImportTask<Service> {
         }
       }
 
+      // Custom emojis are resolved against the destination team before any
+      // content is rewritten, so documents can reference them by their final
+      // id even though the Emoji rows are only created once their attachments
+      // have landed in the completion phase.
+      const emojiManifest: JSONEmojiManifestItem[] = [];
+      const emojiIdMap: Record<string, string> = {};
+      await this.registerEmojis(
+        collectionExports.map((c) => c.data),
+        importTask.import.teamId,
+        attachmentIdMap,
+        emojiManifest,
+        emojiIdMap
+      );
+
       // Discover documents per collection, building the parent/child tree
       // shape expected by the per-page cascade.
       const collections = collectionExports.map((c) =>
@@ -308,7 +385,11 @@ export default class JSONAPIImportTask extends APIImportTask<Service> {
           permission: placeholder.permission,
         })),
       ];
-      associatedImport.scratch = { storageKey, manifest };
+      associatedImport.scratch = {
+        storageKey,
+        manifest,
+        emojis: emojiManifest,
+      };
       await associatedImport.save();
 
       // Collection placeholder items so ImportsProcessor iterates them
@@ -325,6 +406,7 @@ export default class JSONAPIImportTask extends APIImportTask<Service> {
           color: c.export.color,
           data: c.export.data ?? ProsemirrorDataHelper.getEmpty(),
           attachmentIdMap,
+          emojiIdMap,
         })),
       ];
 
@@ -332,11 +414,14 @@ export default class JSONAPIImportTask extends APIImportTask<Service> {
         externalId: c.externalId,
         title: c.export.name,
         urlId: c.export.urlId,
-        icon: c.export.icon,
+        icon: rewriteEmojiIcon(c.export.icon, emojiIdMap),
         color: c.export.color,
-        content: rewriteAttachmentReferences(
-          c.export.data ?? ProsemirrorDataHelper.getEmpty(),
-          attachmentIdMap
+        content: rewriteEmojiReferences(
+          rewriteAttachmentReferences(
+            c.export.data ?? ProsemirrorDataHelper.getEmpty(),
+            attachmentIdMap
+          ),
+          emojiIdMap
         ) as ProsemirrorDoc,
       }));
 
@@ -346,7 +431,10 @@ export default class JSONAPIImportTask extends APIImportTask<Service> {
       // depth-ordered cascade of ImportTask rows so parent FKs are always
       // satisfied at child-doc creation time.
       const childTasksInput: ImportTaskInput<Service> = collections.flatMap(
-        (c) => c.children.map((d) => this.toPageInput(d, attachmentIdMap))
+        (c) =>
+          c.children.map((d) =>
+            this.toPageInput(d, attachmentIdMap, emojiIdMap)
+          )
       );
 
       return { taskOutput: collectionOutputs, childTasksInput };
@@ -363,16 +451,17 @@ export default class JSONAPIImportTask extends APIImportTask<Service> {
 
     const items = importTask.input as JSONPageImportTaskInputItem[];
     for (const item of items) {
-      const transformed = rewriteAttachmentReferences(
-        item.data,
-        item.attachmentIdMap
+      const emojiIdMap = item.emojiIdMap ?? {};
+      const transformed = rewriteEmojiReferences(
+        rewriteAttachmentReferences(item.data, item.attachmentIdMap),
+        emojiIdMap
       ) as ProsemirrorDoc;
 
       taskOutput.push({
         externalId: item.externalId,
         title: item.title,
         urlId: item.urlId,
-        icon: item.icon,
+        icon: rewriteEmojiIcon(item.icon, emojiIdMap),
         color: item.color,
         author: item.createdByName,
         createdById: item.createdById,
@@ -513,11 +602,13 @@ export default class JSONAPIImportTask extends APIImportTask<Service> {
    *
    * @param doc The discovered document, including its descendants.
    * @param attachmentIdMap External attachment id → new internal id map.
+   * @param emojiIdMap External custom emoji id → new internal id map.
    * @returns A self-contained per-page task input.
    */
   private toPageInput(
     doc: DiscoveredDocument,
-    attachmentIdMap: Record<string, string>
+    attachmentIdMap: Record<string, string>,
+    emojiIdMap: Record<string, string>
   ): JSONPageImportTaskInputItem {
     const exported = doc.export;
     return {
@@ -536,9 +627,119 @@ export default class JSONAPIImportTask extends APIImportTask<Service> {
       updatedAt: exported.updatedAt,
       publishedAt: exported.publishedAt,
       attachmentIdMap,
+      emojiIdMap,
       children: doc.children.length
-        ? doc.children.map((c) => this.toPageInput(c, attachmentIdMap))
+        ? doc.children.map((c) =>
+            this.toPageInput(c, attachmentIdMap, emojiIdMap)
+          )
         : undefined,
     };
+  }
+
+  /**
+   * Resolves the custom emojis referenced by an export against the destination
+   * team. An emoji whose name already exists in the team is reused, otherwise
+   * an id is pre-assigned so content can be rewritten now and the Emoji row
+   * created once its attachment exists. Emojis whose image is missing from the
+   * export are skipped, leaving their references untouched.
+   *
+   * @param collections Parsed collection exports to read emojis from.
+   * @param teamId Team the import is landing in.
+   * @param attachmentIdMap External attachment id → new internal id map.
+   * @param manifest Manifest array to push to-be-created emojis into.
+   * @param emojiIdMap External emoji id → resolved id map to populate.
+   */
+  private async registerEmojis(
+    collections: CollectionJSONExport[],
+    teamId: string,
+    attachmentIdMap: Record<string, string>,
+    manifest: JSONEmojiManifestItem[],
+    emojiIdMap: Record<string, string>
+  ): Promise<void> {
+    const exported = new Map<string, EmojiJSONExport>();
+    for (const collection of collections) {
+      for (const emoji of Object.values(collection.emojis ?? {})) {
+        exported.set(emoji.id, emoji);
+      }
+    }
+
+    if (!exported.size) {
+      return;
+    }
+
+    const existing = await Emoji.findAll({
+      where: {
+        teamId,
+        name: [...exported.values()].map((emoji) => emoji.name),
+      },
+    });
+    const existingByName = new Map(existing.map((e) => [e.name, e.id]));
+
+    for (const emoji of exported.values()) {
+      const existingId = existingByName.get(emoji.name);
+      if (existingId) {
+        emojiIdMap[emoji.id] = existingId;
+        continue;
+      }
+
+      const attachmentId = attachmentIdMap[emoji.attachmentId];
+      if (!attachmentId) {
+        Logger.warn(
+          `JSON import emoji image missing in export, skipping: ${emoji.name}`
+        );
+        continue;
+      }
+
+      const id = randomUUID();
+      emojiIdMap[emoji.id] = id;
+      manifest.push({ id, name: emoji.name, attachmentId });
+    }
+  }
+
+  /**
+   * Creates the Emoji rows pre-assigned during bootstrap. Called once every
+   * attachment has landed, since an emoji is a pointer to its image. Failures
+   * are logged rather than thrown — a single unusable emoji shouldn't fail an
+   * otherwise complete import.
+   *
+   * @param emojis Emoji manifest recorded on the import's scratch state.
+   * @param teamId Team the import is landing in.
+   * @param createdById User that initiated the import.
+   */
+  private async createEmojis(
+    emojis: JSONEmojiManifestItem[],
+    teamId: string,
+    createdById: string
+  ): Promise<void> {
+    for (const emoji of emojis) {
+      try {
+        // A retried completion hook re-encounters emojis it already created,
+        // and a name may have been taken since bootstrap resolved it.
+        const existing = await Emoji.findOne({
+          where: {
+            teamId,
+            [Op.or]: [{ id: emoji.id }, { name: emoji.name }],
+          },
+        });
+        if (existing) {
+          continue;
+        }
+
+        await Emoji.create({
+          id: emoji.id,
+          name: emoji.name,
+          attachmentId: emoji.attachmentId,
+          teamId,
+          createdById,
+        });
+      } catch (err) {
+        if (err instanceof UniqueConstraintError) {
+          continue;
+        }
+        Logger.warn(`JSON import could not create emoji: ${emoji.name}`, {
+          error: errToString(err),
+        });
+      }
+    }
   }
 }

--- a/server/types.ts
+++ b/server/types.ts
@@ -569,6 +569,13 @@ export type AttachmentJSONExport = {
   key: string;
 };
 
+export type EmojiJSONExport = {
+  id: string;
+  name: string;
+  /** Id of the attachment holding the emoji image, present in `attachments`. */
+  attachmentId: string;
+};
+
 export type CollectionJSONExport = {
   collection: {
     id: string;
@@ -587,6 +594,14 @@ export type CollectionJSONExport = {
   };
   attachments: {
     [id: string]: AttachmentJSONExport;
+  };
+  /**
+   * Custom emojis referenced by the collection or its documents, either inline
+   * in content or as an icon. Absent in exports created before custom emoji
+   * support was added.
+   */
+  emojis?: {
+    [id: string]: EmojiJSONExport;
   };
 };
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -115,14 +115,31 @@ export type JSONAttachmentManifestItem = z.infer<
 >;
 
 /**
+ * Manifest entry describing a single custom emoji discovered during the JSON
+ * zip bootstrap phase. `id` is either a pre-assigned UUID for an emoji that
+ * still needs creating, or the id of an existing team emoji with the same name
+ * that the import reuses — either way it's the id that content references are
+ * rewritten to. `attachmentId` points at the emoji image's new Attachment row.
+ */
+export const JSONEmojiManifestItemSchema = z.object({
+  id: z.uuid(),
+  name: z.string(),
+  attachmentId: z.uuid(),
+});
+
+export type JSONEmojiManifestItem = z.infer<typeof JSONEmojiManifestItemSchema>;
+
+/**
  * JSON importer scratch state. `storageKey` is set at import creation (it's
  * the only durable handle on the uploaded zip). `manifest` is added by the
  * bootstrap phase so the completion phase can re-download the zip and create
- * Attachment rows without re-parsing the JSON files.
+ * Attachment rows without re-parsing the JSON files, and `emojis` so it can
+ * create the Emoji rows those attachments belong to.
  */
 export interface JSONImportScratch {
   storageKey: string;
   manifest?: JSONAttachmentManifestItem[];
+  emojis?: JSONEmojiManifestItem[];
 }
 
 /**
@@ -198,6 +215,8 @@ export interface JSONPageImportTaskInputItem {
   publishedAt?: string | null;
   /** Map of external attachment id → manifest entry id, scoped to this doc. */
   attachmentIdMap: Record<string, string>;
+  /** Map of external custom emoji id → the emoji id used after import. */
+  emojiIdMap?: Record<string, string>;
   children?: JSONPageImportTaskInputItem[];
 }
 


### PR DESCRIPTION
Closes #12175

### What

Custom emojis now round-trip through the JSON export/import.

Each collection JSON gains an `emojis` map describing the custom emojis that collection references — inline in document content or as a document/collection icon — and the emoji images travel with the export as regular attachments. A workspace-wide emoji shared by several collections is written to the archive only once, though every collection JSON still describes it so a single collection file stays importable on its own.

On import the emojis are resolved against the destination workspace before any content is rewritten:

- an emoji whose **name already exists** in the workspace is reused, so re-importing a backup into a live workspace doesn't create duplicates
- otherwise an id is pre-assigned and the `Emoji` row is created in the completion phase, once its image has been uploaded (an emoji is a pointer to its attachment, so it can't be created earlier)
- inline `emoji` nodes and icons are rewritten to the resolved ids; unicode emojis are addressed by shortcode rather than id and are left alone, as are ids the export didn't ship an image for

### Why

`ExportJSONTask` never emitted custom emojis, so a workspace restored from its own backup lost every custom emoji — inline references and icons became dangling ids pointing at emojis that didn't exist in the new workspace. As noted on the issue, teams use custom emojis for things like partner logos, so this is content loss rather than cosmetic drift.

### Notes

- `emojis` is optional on `CollectionJSONExport`; exports created before this change import exactly as they did before, so `exportVersion` stays at `1`.
- An emoji that fails to create is logged and skipped rather than failing an otherwise complete import.
- Emojis are skipped when an export is created with `includeAttachments: false`, matching how images are handled.

### Tests

- `ExportJSONTask.test.ts` (new): referenced emojis (inline + icon) are exported with their image; unreferenced emojis are not; a shared image is archived once.
- `JSONAPIImportTask.test.ts`: end-to-end import creates the emoji and rewrites content references and a document icon to it; an existing emoji of the same name is reused; unit coverage for `rewriteEmojiReferences`.

Run locally against Postgres: `server/queues` and `server/models/helpers` pass, except four pre-existing `MarkdownAPIImportTask` path-separator failures that also fail on `main` on Windows.
