### PR TITLE
fix: Revision diff not shown when previous revision loads late

### DIFF
--- a/app/scenes/Document/components/RevisionViewer.tsx
+++ b/app/scenes/Document/components/RevisionViewer.tsx
@@ -93,6 +93,17 @@ function RevisionViewer(props: Props, ref: React.Ref<TEditor>) {
     ];
   }, [revision.data, comparisonData, showChanges]);
 
+  // The editor builds its extensions once, on mount, so it has to be remounted
+  // whenever the diff configuration changes. Revisions are listed without their
+  // content, so the revision being compared against — and with it the Diff
+  // extension — usually only arrives on a later render; without this neither
+  // the highlights nor the change count would ever appear.
+  const editorKey = [
+    showChanges ? "changes" : "no-changes",
+    compareToRevisionId ?? revision.before?.id ?? "none",
+    comparisonData ? "loaded" : "pending",
+  ].join("-");
+
   return (
     <Flex auto column>
       <DocumentTitle
@@ -109,7 +120,7 @@ function RevisionViewer(props: Props, ref: React.Ref<TEditor>) {
         $rtl={revision.rtl}
       />
       <Editor
-        key={compareToRevisionId}
+        key={editorKey}
         ref={ref}
         defaultValue={revision.data}
         extensions={extensions}


### PR DESCRIPTION
Closes #12964

### What

Viewing a revision with `?changes` often shows no diff highlights at all, and the "N changes" counter disappears from the header — intermittently, with nothing logged to the console.

### Why

`RevisionViewer` builds the `Diff` extension from `comparisonData`, but the editor reads `props.extensions` only in `init()`, which runs on mount (and on a read-only → editable transition that never happens here). Changing the extensions afterwards has no effect, which is why the component remounts the editor via `key` when the comparison target changes.

Since #12822, `revisions.list` no longer returns revision content, and `RevisionViewer` fetches the previous revision's data in an effect:

https://github.com/outline/outline/blob/main/app/scenes/Document/components/RevisionViewer.tsx#L68-L78

That fetch resolves *after* the first render, so the sequence is:

1. mount — `revision.before.data` is `undefined`, so `getChangeset` returns `null` and the editor is built with **no** Diff extension
2. the fetch resolves — `comparisonData` is populated, the `useMemo` produces a new extension list containing `Diff`
3. `key` is `compareToRevisionId`, which is `undefined` in the normal (non-`compareTo`) flow and unchanged — so the editor is never rebuilt and the new extension list is discarded

Both symptoms follow: no decorations, and `ChangesNavigation` reads the count off the mounted editor's extensions, finds no `Diff`, and renders nothing. It looks intermittent because it works whenever the previous revision's content is already in the store — e.g. it was viewed a moment ago, or it is the `compareTo` target loaded by the DataLoader — which is also why stepping back through history behaves differently from jumping to an old revision.

### The fix

Derive the editor key from the inputs the extensions are built from, so the editor is rebuilt when the comparison content arrives. This also covers two adjacent cases that were broken the same way: the compared-against revision changing as more revisions load into the sidebar, and toggling changes on/off via the query param.

```diff
-        key={compareToRevisionId}
+        key={editorKey}
```

### Tests

No automated test — the repo has no component-rendering harness (the 16 `app/` test files are all pure logic), and the behaviour is a mount-time React concern. Verified by reading the path end to end and confirming the premise directly: `revisions.list` presents every revision with `includeContent: false`, so `revision.before.data` is always `undefined` until the follow-up `revisions.fetch` resolves.

To check by hand: open a document with several revisions, hard-reload on `/doc/…/history`, and select a revision you have not already viewed with changes enabled — highlights and the counter appear on first paint instead of never.

`yarn lint` and `tsc --noEmit` are clean; the `app` test project passes (16 files, 149 tests).
