### PR TITLE
fix: Respect move policy in sidebar drag and drop

### DIFF
--- a/app/components/Sidebar/components/Collections.tsx
+++ b/app/components/Sidebar/components/Collections.tsx
@@ -23,7 +23,7 @@ import Text from "@shared/components/Text";
 import usePolicy from "~/hooks/usePolicy";
 
 function Collections() {
-  const { documents, auth, collections } = useStores();
+  const { documents, auth, collections, policies } = useStores();
   const { t } = useTranslation();
   const can = usePolicy(auth.team?.id);
   const orderedCollections = collections.allActive;
@@ -46,10 +46,12 @@ function Collections() {
         fractionalIndex(null, orderedCollections[0].index)
       );
     },
-    canDrop: (item) => item.id !== orderedCollections[0].id,
+    canDrop: (item) =>
+      item.id !== orderedCollections[0]?.id &&
+      !!policies.abilities(item.id).move,
     collect: (monitor) => ({
       isCollectionDropping: monitor.isOver(),
-      isDraggingAnyCollection: monitor.getItemType() === "collection",
+      isDraggingAnyCollection: monitor.canDrop(),
     }),
   });
 

--- a/app/components/Sidebar/components/DraggableCollectionLink.tsx
+++ b/app/components/Sidebar/components/DraggableCollectionLink.tsx
@@ -58,7 +58,7 @@ function DraggableCollectionLink({
     canDrop: (item) =>
       collection.id !== item.id &&
       (!belowCollection || item.id !== belowCollection.id) &&
-      policies.abilities(item.id)?.move,
+      !!policies.abilities(item.id).move,
     collect: (monitor: DropTargetMonitor<Collection, Collection>) => ({
       isCollectionDropping: monitor.isOver(),
       isDraggingAnyCollection: monitor.canDrop(),

--- a/app/components/Sidebar/hooks/useDragAndDrop.tsx
+++ b/app/components/Sidebar/hooks/useDragAndDrop.tsx
@@ -226,7 +226,7 @@ export function useDropToChangeCollection(
   parentRef: React.RefObject<HTMLDivElement>
 ) {
   const { t } = useTranslation();
-  const { documents, collections, dialogs } = useStores();
+  const { documents, collections, dialogs, policies } = useStores();
   const can = usePolicy(collection);
   const startHover = useHover(parentRef, expandNode);
 
@@ -281,7 +281,7 @@ export function useDropToChangeCollection(
         }
       }
     },
-    canDrop: () => can.createDocument,
+    canDrop: (item) => can.createDocument && !!policies.abilities(item.id).move,
     hover: (_, monitor) => {
       if (
         collection.hasDocuments &&
@@ -311,7 +311,7 @@ export function useDropToReparentDocument(
   parentRef: React.RefObject<HTMLDivElement>
 ) {
   const { t } = useTranslation();
-  const { documents, collections, dialogs } = useStores();
+  const { documents, collections, dialogs, policies } = useStores();
   const hasChildDocuments = !!node?.children.length;
   const document = node ? documents.get(node.id) : undefined;
   const pathToNode = React.useMemo(
@@ -373,7 +373,7 @@ export function useDropToReparentDocument(
       }
     },
     canDrop: (item) => {
-      if (!node || item.id === node.id) {
+      if (!node || item.id === node.id || !policies.abilities(item.id).move) {
         return false;
       }
 
@@ -425,7 +425,7 @@ export function useDropToReorderDocument(
       }
 ) {
   const { t } = useTranslation();
-  const { documents, collections, dialogs } = useStores();
+  const { documents, collections, dialogs, policies } = useStores();
 
   const document = documents.get(node.id);
 
@@ -435,7 +435,7 @@ export function useDropToReorderDocument(
       if (item.id === node.id || (document && !document.isActive)) {
         return false;
       }
-      return true;
+      return !!policies.abilities(item.id).move;
     },
     drop: async (item) => {
       if (!collection?.isManualSort && item.collectionId === collection?.id) {


### PR DESCRIPTION
Sidebar drop targets that move an item — reordering a collection, reordering a document, reparenting a document, and dragging a document into another collection — did not check the dragged item's `move` ability, so users without permission could drag an item onto an inviting drop cursor only to get an authorization error toast back from the server.

Each of those targets now requires `move` on the dragged item, which means no drop cursor or row highlight appears where the move would be rejected. The top-of-list collection cursor in `Collections.tsx` was additionally missing the check its sibling in `DraggableCollectionLink` already had, and now hides entirely rather than rendering an insertion line that does nothing.

Drag start itself is intentionally left ungated: the same drag sources feed the Archive, Trash and Starred drop targets, and the server allows `archive`/`delete` in cases where `move` is false, so blocking the drag would have broken those flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)