### PR TITLE
fix: Never downgrade Node.js in update workflow

### DIFF
--- a/.github/workflows/update-node.yml
+++ b/.github/workflows/update-node.yml
@@ -38,9 +38,15 @@ jobs:
           echo "latest=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
           echo "Latest Node.js LTS version: $LATEST_VERSION"
 
+          # Only update when the latest LTS is strictly newer, never downgrade
+          NEWEST=$(printf '%s\n%s\n' "$CURRENT_VERSION" "$LATEST_VERSION" | sort -V | tail -n1)
+
           if [ "$CURRENT_VERSION" = "$LATEST_VERSION" ]; then
             echo "updated=false" >> "$GITHUB_OUTPUT"
             echo "Already up to date."
+          elif [ "$NEWEST" = "$CURRENT_VERSION" ]; then
+            echo "updated=false" >> "$GITHUB_OUTPUT"
+            echo "Current version $CURRENT_VERSION is newer than the latest LTS $LATEST_VERSION, skipping."
           else
             echo "updated=true" >> "$GITHUB_OUTPUT"
             echo "Update available: $CURRENT_VERSION -> $LATEST_VERSION"


### PR DESCRIPTION
The scheduled Node.js update workflow only compared the current version against the latest LTS for inequality, so when the Dockerfile sits on a Current-line release ahead of any LTS it opened a downgrade PR (e.g. #13151, 26.3.0 → 24.18.0).

This adds a `sort -V` comparison so the job only proceeds when the latest LTS is strictly newer, and otherwise logs why it skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)