### PR TITLE
fix: Suppress 499 error reporting

### DIFF
--- a/app/utils/ApiClient.ts
+++ b/app/utils/ApiClient.ts
@@ -12,6 +12,7 @@ import {
   AuthorizationError,
   BadGatewayError,
   BadRequestError,
+  ClientClosedRequestError,
   NetworkError,
   NotFoundError,
   OfflineError,
@@ -309,6 +310,12 @@ class ApiClient {
       throw new RateLimitExceededError(
         `Too many requests, try again in a minute.`
       );
+    }
+
+    // The client, or an intermediate proxy, closed the connection before the
+    // response was received – there is nothing actionable to report.
+    if (response.status === 499) {
+      throw new ClientClosedRequestError(error.message);
     }
 
     const err = new RequestError(`Error ${response.status}`);

--- a/app/utils/errors.ts
+++ b/app/utils/errors.ts
@@ -30,6 +30,9 @@ export class UnprocessableEntityError extends ExtendableError {}
 /** Error thrown when the client has exceeded the allowed request rate. */
 export class RateLimitExceededError extends ExtendableError {}
 
+/** Error thrown when the client closed the connection before a response. */
+export class ClientClosedRequestError extends ExtendableError {}
+
 /** Error thrown when a request fails for a generic reason. */
 export class RequestError extends ExtendableError {}
 

--- a/app/utils/sentry.ts
+++ b/app/utils/sentry.ts
@@ -4,6 +4,7 @@ import env from "~/env";
 import {
   AuthorizationError,
   BadRequestError,
+  ClientClosedRequestError,
   NetworkError,
   NotFoundError,
   OfflineError,
@@ -22,6 +23,7 @@ export function initSentry(history: History) {
   const ignoredErrorTypes = [
     AuthorizationError,
     BadRequestError,
+    ClientClosedRequestError,
     NetworkError,
     NotFoundError,
     OfflineError,


### PR DESCRIPTION
The client, or an intermediate proxy, closed the connection before the response was received – there is nothing actionable to report to the error tracker.