### PR TITLE
chore: Refactor `get`+`post` combos to `register`

### DIFF
--- a/plugins/email/server/auth/email.ts
+++ b/plugins/email/server/auth/email.ts
@@ -212,17 +212,14 @@ const emailCallback = async (ctx: APIContext<T.EmailCallbackReq>) => {
     client,
   });
 };
-router.get(
+router.register(
   "email.callback",
-  rateLimiter(RateLimiterStrategy.FivePerMinute),
-  validate(T.EmailCallbackSchema),
-  emailCallback
-);
-router.post(
-  "email.callback",
-  rateLimiter(RateLimiterStrategy.FivePerMinute),
-  validate(T.EmailCallbackSchema),
-  emailCallback
+  ["get", "post"],
+  [
+    rateLimiter(RateLimiterStrategy.FivePerMinute),
+    validate(T.EmailCallbackSchema),
+    emailCallback,
+  ]
 );
 
 export default router;

--- a/plugins/oidc/server/auth/oidcRouter.ts
+++ b/plugins/oidc/server/auth/oidcRouter.ts
@@ -255,8 +255,11 @@ export function createOIDCRouter(
   );
 
   router.get(config.id, startOAuthFlow, passport.authenticate(config.id));
-  router.get(`${config.id}.callback`, passportMiddleware(config.id));
-  router.post(`${config.id}.callback`, passportMiddleware(config.id));
+  router.register(
+    `${config.id}.callback`,
+    ["get", "post"],
+    passportMiddleware(config.id)
+  );
 
   // Performs a spec-compliant RP-initiated logout against the provider's end
   // session endpoint. Passing `id_token_hint` identifies the session being

--- a/server/routes/api/attachments/attachments.ts
+++ b/server/routes/api/attachments/attachments.ts
@@ -337,17 +337,14 @@ const handleAttachmentsRedirect = async (
   }
 };
 
-router.get(
+router.register(
   "attachments.redirect",
-  auth({ optional: true }),
-  validate(T.AttachmentsRedirectSchema),
-  handleAttachmentsRedirect
-);
-router.post(
-  "attachments.redirect",
-  auth({ optional: true }),
-  validate(T.AttachmentsRedirectSchema),
-  handleAttachmentsRedirect
+  ["get", "post"],
+  [
+    auth({ optional: true }),
+    validate(T.AttachmentsRedirectSchema),
+    handleAttachmentsRedirect,
+  ]
 );
 
 export default router;

--- a/server/routes/api/cron/cron.ts
+++ b/server/routes/api/cron/cron.ts
@@ -93,11 +93,17 @@ const cronHandler = async (ctx: APIContext<T.CronSchemaReq>) => {
     success: true,
   };
 };
-router.get("cron.:period", validate(T.CronSchema), cronHandler);
-router.post("cron.:period", validate(T.CronSchema), cronHandler);
+router.register(
+  "cron.:period",
+  ["get", "post"],
+  [validate(T.CronSchema), cronHandler]
+);
 
 // For backwards compatibility
-router.get("utils.gc", validate(T.CronSchema), cronHandler);
-router.post("utils.gc", validate(T.CronSchema), cronHandler);
+router.register(
+  "utils.gc",
+  ["get", "post"],
+  [validate(T.CronSchema), cronHandler]
+);
 
 export default router;

--- a/server/routes/api/fileOperations/fileOperations.ts
+++ b/server/routes/api/fileOperations/fileOperations.ts
@@ -90,17 +90,14 @@ const handleFileOperationsRedirect = async (
   ctx.redirect(accessUrl);
 };
 
-router.get(
+router.register(
   "fileOperations.redirect",
-  auth(),
-  validate(T.FileOperationsRedirectSchema),
-  handleFileOperationsRedirect
-);
-router.post(
-  "fileOperations.redirect",
-  auth(),
-  validate(T.FileOperationsRedirectSchema),
-  handleFileOperationsRedirect
+  ["get", "post"],
+  [
+    auth(),
+    validate(T.FileOperationsRedirectSchema),
+    handleFileOperationsRedirect,
+  ]
 );
 
 router.post(

--- a/server/routes/api/index.ts
+++ b/server/routes/api/index.ts
@@ -131,11 +131,7 @@ if (env.isDevelopment) {
   router.use("/", developer.routes());
 }
 
-router.post("*", (ctx) => {
-  ctx.throw(NotFoundError("Endpoint not found"));
-});
-
-router.get("*", (ctx) => {
+router.register("*", ["get", "post"], (ctx) => {
   ctx.throw(NotFoundError("Endpoint not found"));
 });
 


### PR DESCRIPTION
DRY up these spots with `register` which is exactly capable of defining a handler for multiple verbs at once.