### PR TITLE
fix: Remove cache mutation in unfurl

### DIFF
--- a/plugins/figma/server/figma.ts
+++ b/plugins/figma/server/figma.ts
@@ -168,7 +168,6 @@ export class Figma {
             description: `Created by ${data.file.creator.handle}`,
             thumbnailUrl: data.file.thumbnail_url,
             faviconUrl: cdnPath("/images/figma.png"),
-            transformedUnfurl: true,
           };
         }
       } catch (err) {

--- a/plugins/iframely/server/iframely.ts
+++ b/plugins/iframely/server/iframely.ts
@@ -71,7 +71,6 @@ class Iframely {
         parsedData.meta.site === "Figma"
           ? cdnPath("/images/figma.png")
           : ((parsedData.links.icon ?? [])[0]?.href ?? ""),
-      transformedUnfurl: true,
     };
   };
 }

--- a/server/presenters/unfurl.ts
+++ b/server/presenters/unfurl.ts
@@ -33,24 +33,8 @@ async function presentUnfurl(
   }
 }
 
-const presentURL = (
-  data: UnfurlData
-): UnfurlResponse[UnfurlResourceType.URL] => {
-  // TODO: For backwards compatibility, remove once cache has expired in next release.
-  if (data.transformedUnfurl) {
-    delete data.transformedUnfurl;
-    return data as UnfurlResponse[UnfurlResourceType.URL]; // this would have been transformed by the unfurl plugin.
-  }
-
-  return {
-    type: UnfurlResourceType.URL,
-    url: data.url,
-    title: data.meta.title,
-    description: data.meta.description,
-    thumbnailUrl: (data.links.thumbnail ?? [])[0]?.href ?? "",
-    faviconUrl: (data.links.icon ?? [])[0]?.href ?? "",
-  };
-};
+const presentURL = (data: UnfurlData): UnfurlResponse[UnfurlResourceType.URL] =>
+  data as UnfurlResponse[UnfurlResourceType.URL]; // this would have been transformed by the unfurl plugin.
 
 const presentMention = async (
   data: UnfurlData,

--- a/server/types.ts
+++ b/server/types.ts
@@ -596,9 +596,7 @@ export type UnfurlIssueOrPR =
 
 export type UnfurlProject = UnfurlResponse[UnfurlResourceType.Project];
 
-export type UnfurlURL = UnfurlResponse[UnfurlResourceType.URL] & {
-  transformedUnfurl: true;
-};
+export type UnfurlURL = UnfurlResponse[UnfurlResourceType.URL];
 
 export type Unfurl =
   | UnfurlIssueOrPR


### PR DESCRIPTION
This line was causing an occasional `Cannot read properties of undefined (reading 'title')`, but is no longer needed anyway.