### PR TITLE
fix: Don't report failed image/video dimension loading to Sentry

### DIFF
--- a/shared/editor/lib/FileHelper.ts
+++ b/shared/editor/lib/FileHelper.ts
@@ -67,12 +67,12 @@ export default class FileHelper {
    * Loads the dimensions of a video file.
    *
    * @param file The file to load the dimensions for
-   * @returns The dimensions of the video
+   * @returns The dimensions of the video, if known.
    */
   static getVideoDimensions(
     file: File
-  ): Promise<{ width: number; height: number }> {
-    return new Promise((resolve, reject) => {
+  ): Promise<{ width: number; height: number } | undefined> {
+    return new Promise((resolve) => {
       const video = document.createElement("video");
       video.preload = "metadata";
       video.crossOrigin = "anonymous";
@@ -82,7 +82,9 @@ export default class FileHelper {
       };
       video.onerror = () => {
         window.URL.revokeObjectURL(video.src);
-        reject(new Error("Failed to load video for dimensions"));
+        // oxlint-disable-next-line no-console
+        console.warn("Failed to load video for dimensions");
+        resolve(undefined);
       };
       video.src = URL.createObjectURL(file);
     });
@@ -150,7 +152,7 @@ export default class FileHelper {
       }
     }
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       const img = new Image();
       img.onload = function () {
         window.URL.revokeObjectURL(img.src);
@@ -159,7 +161,9 @@ export default class FileHelper {
 
       img.onerror = () => {
         window.URL.revokeObjectURL(img.src);
-        reject(new Error("Failed to load image for dimensions"));
+        // oxlint-disable-next-line no-console
+        console.warn("Failed to load image for dimensions");
+        resolve(undefined);
       };
       img.src = URL.createObjectURL(file);
     });


### PR DESCRIPTION
`FileHelper.getImageDimensions` and `getVideoDimensions` rejected when the browser failed to decode a file, and those rejections bubbled up as errors in Sentry despite being benign.

Both now log a console warning and resolve `undefined` instead. All call sites already handled missing dimensions, so the node is simply inserted without explicit width/height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)