### PR TITLE
fix: Copy as Markdown does not include unsaved changes

### DIFF
--- a/app/actions/definitions/documents.tsx
+++ b/app/actions/definitions/documents.tsx
@@ -40,12 +40,12 @@ import { toast } from "sonner";
 import { errToString } from "@shared/utils/error";
 import Icon from "@shared/components/Icon";
 import type { NavigationNode } from "@shared/types";
-import { ExportContentType } from "@shared/types";
+import { ExportContentType, IconType } from "@shared/types";
 import { isMobile } from "@shared/utils/browser";
 import { getEventFiles } from "@shared/utils/files";
+import { determineIconType } from "@shared/utils/icon";
 import { Week } from "@shared/utils/time";
 import type UserMembership from "~/models/UserMembership";
-import { client } from "~/utils/ApiClient";
 import DocumentDelete from "~/scenes/DocumentDelete";
 import { ProsemirrorHelper } from "~/models/helpers/ProsemirrorHelper";
 import DocumentPermanentDelete from "~/scenes/DocumentPermanentDelete";
@@ -71,6 +71,7 @@ import {
   TrashSection,
 } from "~/actions/sections";
 import { setPersistedState } from "~/hooks/usePersistedState";
+import { attachmentsToSignedUrls } from "~/utils/files";
 import history from "~/utils/history";
 import {
   documentHistoryPath,
@@ -802,16 +803,26 @@ export const copyDocumentAsMarkdown = createAction({
   iconInContextMenu: false,
   visible: ({ activeDocumentId, stores }) =>
     !!activeDocumentId && stores.policies.abilities(activeDocumentId).download,
-  perform: async ({ stores, activeDocumentId, t }) => {
+  perform: async ({ stores, activeDocumentId, getEditorData, t }) => {
     const document = activeDocumentId
       ? stores.documents.get(activeDocumentId)
       : undefined;
     if (document) {
-      const res = await client.post("/documents.export", {
-        id: document.id,
-        signedUrls: Week.seconds, // 7 days (AWS S3 max for presigned URLs)
-      });
-      copy(res.data);
+      // Serialize from the editor rather than asking the server for the
+      // document, as the collaboration server persists on a delay and edits
+      // made in the last few seconds would otherwise be missing.
+      const data = getEditorData(document.id) ?? document.data;
+
+      // Attachment urls are then signed in a second pass so that they resolve
+      // for anyone the Markdown is pasted to, without a session.
+      const markdown = await attachmentsToSignedUrls(
+        ProsemirrorHelper.toMarkdown({ data }).trim(),
+        Week.seconds // 7 days (AWS S3 max for presigned URLs)
+      );
+
+      const iconType = determineIconType(document.icon);
+      const title = `${iconType === IconType.Emoji ? `${document.icon} ` : ""}${document.title}`;
+      copy(`# ${title}\n\n${markdown}`);
       toast.success(t("Markdown copied to clipboard"));
     }
   },

--- a/app/components/AuthenticatedLayout.tsx
+++ b/app/components/AuthenticatedLayout.tsx
@@ -22,7 +22,6 @@ import {
   settingsPath,
   homePath,
 } from "~/utils/routeHelpers";
-import { DocumentContextProvider } from "./DocumentContext";
 import Fade from "./Fade";
 import NotificationBadge from "./NotificationBadge";
 import { PortalContext } from "./Portal";
@@ -98,27 +97,25 @@ const AuthenticatedLayout: React.FC = ({ children }: Props) => {
   );
 
   return (
-    <DocumentContextProvider>
-      <RightSidebarProvider>
-        <PortalContext.Provider value={layoutRef.current}>
-          <DndProvider backend={EditorAwareHTML5Backend}>
-            <Layout
-              title={team.name}
-              sidebar={sidebar}
-              sidebarCanCollapse={!isSettings}
-              ref={layoutRef}
-            >
-              <RegisterKeyDown trigger="n" handler={goToNewDocument} />
-              <RegisterKeyDown trigger="t" handler={goToSearch} />
-              <RegisterKeyDown trigger="/" handler={goToSearch} />
-              {children}
-              <CommandBar />
-              <NotificationBadge />
-            </Layout>
-          </DndProvider>
-        </PortalContext.Provider>
-      </RightSidebarProvider>
-    </DocumentContextProvider>
+    <RightSidebarProvider>
+      <PortalContext.Provider value={layoutRef.current}>
+        <DndProvider backend={EditorAwareHTML5Backend}>
+          <Layout
+            title={team.name}
+            sidebar={sidebar}
+            sidebarCanCollapse={!isSettings}
+            ref={layoutRef}
+          >
+            <RegisterKeyDown trigger="n" handler={goToNewDocument} />
+            <RegisterKeyDown trigger="t" handler={goToSearch} />
+            <RegisterKeyDown trigger="/" handler={goToSearch} />
+            {children}
+            <CommandBar />
+            <NotificationBadge />
+          </Layout>
+        </DndProvider>
+      </PortalContext.Provider>
+    </RightSidebarProvider>
   );
 };
 

--- a/app/components/DocumentContext.tsx
+++ b/app/components/DocumentContext.tsx
@@ -1,6 +1,7 @@
 import { action, computed, observable } from "mobx";
 import type { PropsWithChildren } from "react";
 import { createContext, useContext, useMemo } from "react";
+import type { ProsemirrorData } from "@shared/types";
 import type { Heading } from "@shared/utils/ProsemirrorHelper";
 import type Document from "~/models/Document";
 import type { Editor } from "~/editor";
@@ -55,6 +56,19 @@ class DocumentContext {
     this.focusedCommentId = commentId;
   };
 
+  /**
+   * Returns the editor contents for the given document, including changes that
+   * have not been persisted yet, or undefined if the document is not open in
+   * this context.
+   *
+   * @param documentId The id of the document to read
+   * @returns The current editor data, if available
+   */
+  getEditorData = (documentId: string): ProsemirrorData | undefined =>
+    this.document?.id === documentId
+      ? (this.editor?.value(false) as ProsemirrorData | undefined)
+      : undefined;
+
   @action
   updateState = () => {
     this.updateHeadings();
@@ -81,6 +95,11 @@ class DocumentContext {
 }
 
 const Context = createContext<DocumentContext | null>(null);
+
+/**
+ * Returns the document context, or null when rendered outside of a provider.
+ */
+export const useOptionalDocumentContext = () => useContext(Context);
 
 export const useDocumentContext = () => {
   const ctx = useContext(Context);

--- a/app/hooks/useActionContext.tsx
+++ b/app/hooks/useActionContext.tsx
@@ -7,6 +7,7 @@ import useStores from "~/hooks/useStores";
 import type Model from "~/models/base/Model";
 import type Policy from "~/models/Policy";
 import type { ActionContext as ActionContextType } from "~/types";
+import { useOptionalDocumentContext } from "~/components/DocumentContext";
 import type { SidebarContextType } from "~/components/Sidebar/components/SidebarContext";
 
 export const ActionContext = createContext<ActionContextType | undefined>(
@@ -55,6 +56,7 @@ export const ActionContextProvider = observer(function ActionContextProvider_({
   const parentContext = useContext(ActionContext);
   const stores = useStores();
   const { t } = useTranslation();
+  const documentContext = useOptionalDocumentContext();
 
   // Use history (stable reference) and read location lazily via a getter so
   // navigation does not invalidate the context value. Action perform/visible
@@ -127,6 +129,11 @@ export const ActionContextProvider = observer(function ActionContextProvider_({
     [allActiveModels]
   );
 
+  const getEditorData = useCallback(
+    (documentId: string) => documentContext?.getEditorData(documentId),
+    [documentContext]
+  );
+
   const contextValue = useMemo<ActionContextType>(() => {
     const baseContext: ActionContextType = parentContext ?? {
       isMenu: false,
@@ -142,6 +149,7 @@ export const ActionContextProvider = observer(function ActionContextProvider_({
       getActivePolicies,
       isModelActive,
       activeModels: allActiveModels,
+      getEditorData,
 
       currentUserId,
       currentTeamId,
@@ -176,6 +184,7 @@ export const ActionContextProvider = observer(function ActionContextProvider_({
       getActivePolicies,
       isModelActive,
       activeModels: allActiveModels,
+      getEditorData,
     };
 
     // Define `location` as a getter so reads always return the current
@@ -207,6 +216,7 @@ export const ActionContextProvider = observer(function ActionContextProvider_({
     getActivePolicies,
     isModelActive,
     allActiveModels,
+    getEditorData,
   ]);
 
   return (

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -11,6 +11,7 @@ import { Router } from "react-router-dom";
 import stores from "~/stores";
 import Analytics from "~/components/Analytics";
 import Dialogs from "~/components/Dialogs";
+import { DocumentContextProvider } from "~/components/DocumentContext";
 import Presentation from "~/components/Presentation";
 import ErrorBoundary from "~/components/ErrorBoundary";
 import PageTheme from "~/components/PageTheme";
@@ -67,26 +68,30 @@ if (element) {
           <Analytics>
             <Router history={history}>
               <Theme>
-                <ActionContextProvider>
-                  <ErrorBoundary showTitle>
-                    <KBarProvider actions={[]} options={commandBarOptions}>
-                      <LazyPolyfill>
-                        <LazyMotion features={domMax}>
-                          <PageScroll>
-                            <PageTheme />
-                            <ScrollToTop>
-                              <Routes />
-                            </ScrollToTop>
-                            <Toasts />
-                            <Dialogs />
-                            <Presentation />
-                            <Desktop />
-                          </PageScroll>
-                        </LazyMotion>
-                      </LazyPolyfill>
-                    </KBarProvider>
-                  </ErrorBoundary>
-                </ActionContextProvider>
+                {/* Above the action context so that actions can read the
+                    contents of the editor that is currently in view. */}
+                <DocumentContextProvider>
+                  <ActionContextProvider>
+                    <ErrorBoundary showTitle>
+                      <KBarProvider actions={[]} options={commandBarOptions}>
+                        <LazyPolyfill>
+                          <LazyMotion features={domMax}>
+                            <PageScroll>
+                              <PageTheme />
+                              <ScrollToTop>
+                                <Routes />
+                              </ScrollToTop>
+                              <Toasts />
+                              <Dialogs />
+                              <Presentation />
+                              <Desktop />
+                            </PageScroll>
+                          </LazyMotion>
+                        </LazyPolyfill>
+                      </KBarProvider>
+                    </ErrorBoundary>
+                  </ActionContextProvider>
+                </DocumentContextProvider>
               </Theme>
             </Router>
           </Analytics>

--- a/app/types.ts
+++ b/app/types.ts
@@ -5,6 +5,7 @@ import type {
   CollectionPermission,
   DocumentPermission,
   GroupPermission,
+  ProsemirrorData,
 } from "@shared/types";
 import type RootStore from "~/stores/RootStore";
 import type { SidebarContextType } from "./components/Sidebar/components/SidebarContext";
@@ -126,6 +127,12 @@ export type ActionContext = {
   ) => Policy[];
   isModelActive: (model: Model) => boolean;
   activeModels: ReadonlySet<Model>;
+
+  /**
+   * Returns the editor contents for a document that is currently in view,
+   * including changes that have not been persisted yet, or undefined.
+   */
+  getEditorData: (documentId: string) => ProsemirrorData | undefined;
 
   currentUserId: string | undefined;
   currentTeamId: string | undefined;

--- a/app/utils/files.test.ts
+++ b/app/utils/files.test.ts
@@ -1,4 +1,8 @@
-import { extname } from "./files";
+import env from "@shared/env";
+import { client } from "./ApiClient";
+import { attachmentsToSignedUrls, extname } from "./files";
+
+vi.mock("./ApiClient");
 
 describe("#extname", () => {
   test("should extract file extension from string", () => {
@@ -8,5 +12,44 @@ describe("#extname", () => {
     expect(extname("directory/one.pdf")).toBe(".pdf");
     expect(extname("../relative/one.doc")).toBe(".doc");
     expect(extname(".hidden/directory/one.txt")).toBe(".txt");
+  });
+});
+
+describe("#attachmentsToSignedUrls", () => {
+  const id = "5f0a1d0e-9b1d-4c4e-8a4d-1a9e4c0d3b2a";
+
+  beforeEach(() => {
+    env.URL = "https://app.example.com";
+    vi.mocked(client.post).mockReset();
+  });
+
+  test("should not call the api when there are no attachments", async () => {
+    expect(await attachmentsToSignedUrls("# Title\n\nno images")).toBe(
+      "# Title\n\nno images"
+    );
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  test("should replace both relative and absolute attachment urls", async () => {
+    vi.mocked(client.post).mockResolvedValue({
+      data: { [id]: "https://s3.example.com/signed" },
+    });
+
+    const text = `![one](/api/attachments.redirect?id=${id})\n![two](${env.URL}/api/attachments.redirect?id=${id})`;
+
+    expect(await attachmentsToSignedUrls(text)).toBe(
+      "![one](https://s3.example.com/signed)\n![two](https://s3.example.com/signed)"
+    );
+    expect(client.post).toHaveBeenCalledWith("/attachments.signUrls", {
+      ids: [id],
+      expiresIn: undefined,
+    });
+  });
+
+  test("should leave urls untouched when the attachment is not returned", async () => {
+    vi.mocked(client.post).mockResolvedValue({ data: {} });
+
+    const text = `![one](/api/attachments.redirect?id=${id})`;
+    expect(await attachmentsToSignedUrls(text)).toBe(text);
   });
 });

--- a/app/utils/files.ts
+++ b/app/utils/files.ts
@@ -1,6 +1,9 @@
+import { escapeRegExp, uniq } from "es-toolkit/compat";
 import invariant from "invariant";
+import env from "@shared/env";
 import { AttachmentPreset } from "@shared/types";
 import { dataUrlToBlob } from "@shared/utils/files";
+import { attachmentRedirectRegex } from "@shared/utils/ProsemirrorHelper";
 import { client } from "./ApiClient";
 import Logger from "./Logger";
 
@@ -141,6 +144,38 @@ export const uploadFile = async (
   }
 
   return attachment;
+};
+
+/**
+ * Converts attachment urls in the given text to signed equivalents that allow
+ * direct access without a session cookie, the client-side counterpart of the
+ * server's TextHelper.attachmentsToSignedUrls.
+ *
+ * @param text The text, either markdown or HTML, which contains urls to convert
+ * @param expiresIn The time that signed urls should expire (in seconds)
+ * @returns The replaced text
+ */
+export const attachmentsToSignedUrls = async (
+  text: string,
+  expiresIn?: number
+) => {
+  // Urls may be absolute or relative depending on how the text was generated.
+  const regex = new RegExp(
+    `(?:${escapeRegExp(env.URL ?? "")})?${attachmentRedirectRegex.source}`,
+    "gi"
+  );
+  const ids = uniq(Array.from(text.matchAll(regex), ([, id]) => id));
+
+  if (!ids.length) {
+    return text;
+  }
+
+  const res = await client.post<{ data: Record<string, string> }>(
+    "/attachments.signUrls",
+    { ids, expiresIn }
+  );
+
+  return text.replace(regex, (match, id: string) => res.data[id] ?? match);
 };
 
 export { dataUrlToBlob };

--- a/server/routes/api/attachments/attachments.test.ts
+++ b/server/routes/api/attachments/attachments.test.ts
@@ -633,3 +633,52 @@ describe("#attachments.redirect", () => {
     expect(body.message).toEqual("id is required");
   });
 });
+
+describe("#attachments.signUrls", () => {
+  it("should return a signed url for each attachment", async () => {
+    const user = await buildUser();
+    const attachment = await buildAttachment({
+      teamId: user.teamId,
+      userId: user.id,
+      acl: "private",
+    });
+    const res = await server.post("/api/attachments.signUrls", user, {
+      body: {
+        ids: [attachment.id],
+      },
+    });
+    const body = await res.json();
+
+    expect(res.status).toEqual(200);
+    expect(body.data[attachment.id]).toEqual("http://s3mock");
+  });
+
+  it("should omit attachments from another team", async () => {
+    const user = await buildUser();
+    const attachment = await buildAttachment({ acl: "private" });
+    const res = await server.post("/api/attachments.signUrls", user, {
+      body: {
+        ids: [attachment.id],
+      },
+    });
+    const body = await res.json();
+
+    expect(res.status).toEqual(200);
+    expect(body.data).toEqual({});
+  });
+
+  it("should require authentication", async () => {
+    const res = await server.post("/api/attachments.signUrls");
+    expect(res.status).toEqual(401);
+  });
+
+  it("should fail in absence of ids", async () => {
+    const user = await buildUser();
+    const res = await server.post("/api/attachments.signUrls", user, {
+      body: {
+        ids: [],
+      },
+    });
+    expect(res.status).toEqual(400);
+  });
+});

--- a/server/routes/api/attachments/attachments.ts
+++ b/server/routes/api/attachments/attachments.ts
@@ -297,6 +297,41 @@ router.post(
   }
 );
 
+router.post(
+  "attachments.signUrls",
+  rateLimiter(RateLimiterStrategy.TwentyFivePerMinute),
+  auth(),
+  validate(T.AttachmentsSignUrlsSchema),
+  async (ctx: APIContext<T.AttachmentsSignUrlsReq>) => {
+    const { ids, expiresIn } = ctx.input.body;
+    const { user } = ctx.state.auth;
+
+    // Attachments are owned by the workspace rather than by individual
+    // documents, so team membership is the check applied here – the same rule
+    // as attachments.redirect.
+    const attachments = await Attachment.findAll({
+      where: {
+        id: ids,
+        teamId: user.teamId,
+      },
+    });
+
+    const data: Record<string, string> = {};
+
+    await Promise.all(
+      attachments.map(async (attachment) => {
+        data[attachment.id] = attachment.isStoredInPublicBucket
+          ? attachment.canonicalUrl
+          : await FileStorage.getSignedUrl(attachment.key, expiresIn);
+      })
+    );
+
+    ctx.body = {
+      data,
+    };
+  }
+);
+
 const handleAttachmentsRedirect = async (
   ctx: APIContext<T.AttachmentsRedirectReq>
 ) => {

--- a/server/routes/api/attachments/schema.ts
+++ b/server/routes/api/attachments/schema.ts
@@ -1,6 +1,7 @@
 import { isEmpty } from "es-toolkit/compat";
 import { z } from "zod";
 import { AttachmentPreset } from "@shared/types";
+import { Week } from "@shared/utils/time";
 import { BaseSchema } from "@server/routes/api/schema";
 
 export const AttachmentsListSchema = BaseSchema.extend({
@@ -70,6 +71,18 @@ export const AttachmentDeleteSchema = BaseSchema.extend({
 });
 
 export type AttachmentDeleteReq = z.infer<typeof AttachmentDeleteSchema>;
+
+export const AttachmentsSignUrlsSchema = BaseSchema.extend({
+  body: z.object({
+    /** Ids of the attachments to sign */
+    ids: z.array(z.uuid()).min(1).max(1000),
+
+    /** Number of seconds the signatures remain valid for */
+    expiresIn: z.number().int().positive().max(Week.seconds).optional(),
+  }),
+});
+
+export type AttachmentsSignUrlsReq = z.infer<typeof AttachmentsSignUrlsSchema>;
 
 export const AttachmentsRedirectSchema = BaseSchema.extend({
   body: z.object({


### PR DESCRIPTION
Fixes #11491

### Problem

`copyDocumentAsMarkdown` calls `documents.export`, which serializes the copy of the document held by the server. The collaboration server persists on a delay, so anything typed in the last few seconds is missing from the clipboard until the document is saved.

A previous attempt (#11773) moved the serialization to the client but dropped the signed attachment urls that #10821 added, which is the tradeoff described in the issue thread. The approach here is the one suggested there: build the Markdown locally, then sign the attachments in a second pass through a purpose-built endpoint.

### Changes

**`attachments.signUrls`** — new endpoint that takes attachment ids and returns a map of id to signed url, with an optional `expiresIn`. Public-bucket attachments return their canonical url. Scoped to the acting user's team, the same rule `attachments.redirect` applies, since attachments are owned by the workspace rather than by individual documents.

**`attachmentsToSignedUrls`** in `app/utils/files.ts` — the client-side counterpart of the server's `TextHelper.attachmentsToSignedUrls`. Finds attachment redirect urls in the text (relative or absolute), signs them in one request and substitutes them. No request is made when the document has no attachments.

**Reaching the editor from an action** — `DocumentContext` already holds the editor for the document in view, so it gains a `getEditorData(documentId)` accessor. `DocumentContextProvider` moves from `AuthenticatedLayout` up to sit above `ActionContextProvider` in `app/index.tsx`, which lets the action context expose `getEditorData` to every action, including from the command bar. The action falls back to `document.data` when the document is not open in an editor, for example when copying from a sidebar context menu.

### Notes

- The client serializer writes CommonMark, the same dialect the editor already uses when copying a selection to the clipboard. The server export path is untouched and still emits Outline-flavoured Markdown so that exports round-trip on import.
- The document title is prepended with its emoji icon exactly as `DocumentHelper.toMarkdown` does, so the copied output keeps the shape it had before.
- "Copy as text" reads `document.data` and has the same staleness; left alone here to keep the change focused.

### Tests

- `attachments.signUrls`: signs an attachment, omits attachments from another team, requires authentication, rejects an empty id list.
- `attachmentsToSignedUrls`: skips the request with no attachments, replaces relative and absolute urls, leaves urls untouched when the attachment is not returned.

I could not run the server suite locally as it needs Postgres, so those four are unverified outside CI — the app tests, typecheck and lint all pass.