### PR TITLE
fix: Shared content should not resolve for a suspended workspace

### DIFF
--- a/server/commands/shareLoader.test.ts
+++ b/server/commands/shareLoader.test.ts
@@ -340,6 +340,17 @@ describe("shareLoader", () => {
       await expect(loadPublicShare({ id: share.id })).rejects.toThrow();
     });
 
+    it("should throw error when team is suspended", async () => {
+      const team = await buildTeam({
+        suspendedAt: new Date(),
+      });
+      const share = await buildShare({
+        teamId: team.id,
+      });
+
+      await expect(loadPublicShare({ id: share.id })).rejects.toThrow();
+    });
+
     it("should throw error when collection has disabled sharing", async () => {
       const collection = await buildCollection({
         sharing: false,

--- a/server/middlewares/shareDomains.test.ts
+++ b/server/middlewares/shareDomains.test.ts
@@ -1,0 +1,65 @@
+import type { Context } from "koa";
+import { randomString } from "@shared/random";
+import env from "@server/env";
+import { buildShare, buildTeam } from "@server/test/factories";
+import shareDomains from "./shareDomains";
+
+describe("shareDomains middleware", () => {
+  const buildContext = (hostname: string) =>
+    ({
+      host: hostname,
+      hostname,
+      state: {},
+    }) as Context;
+
+  beforeEach(() => {
+    vi.spyOn(env, "isCloudHosted", "get").mockReturnValue(true);
+    vi.spyOn(env, "isDevelopment", "get").mockReturnValue(false);
+  });
+
+  it("should resolve the share for a custom domain", async () => {
+    const domain = `${randomString(10).toLowerCase()}.example.com`;
+    const team = await buildTeam();
+    const share = await buildShare({
+      teamId: team.id,
+      published: true,
+      domain,
+    });
+    const ctx = buildContext(domain);
+
+    await shareDomains()(ctx, vi.fn());
+
+    expect(ctx.state.rootShare?.id).toEqual(share.id);
+  });
+
+  it("should not resolve the share when the team is deleted", async () => {
+    const domain = `${randomString(10).toLowerCase()}.example.com`;
+    const team = await buildTeam();
+    await buildShare({
+      teamId: team.id,
+      published: true,
+      domain,
+    });
+    await team.destroy();
+    const ctx = buildContext(domain);
+
+    await shareDomains()(ctx, vi.fn());
+
+    expect(ctx.state.rootShare).toEqual(null);
+  });
+
+  it("should not resolve the share when the team is suspended", async () => {
+    const domain = `${randomString(10).toLowerCase()}.example.com`;
+    const team = await buildTeam({ suspendedAt: new Date() });
+    await buildShare({
+      teamId: team.id,
+      published: true,
+      domain,
+    });
+    const ctx = buildContext(domain);
+
+    await shareDomains()(ctx, vi.fn());
+
+    expect(ctx.state.rootShare).toEqual(null);
+  });
+});

--- a/server/middlewares/shareDomains.ts
+++ b/server/middlewares/shareDomains.ts
@@ -17,6 +17,17 @@ export default function shareDomains() {
             [Op.is]: null,
           },
         },
+        include: [
+          {
+            association: "team",
+            required: true,
+            where: {
+              suspendedAt: {
+                [Op.is]: null,
+              },
+            },
+          },
+        ],
       });
       ctx.state.rootShare = share;
     }


### PR DESCRIPTION
This only applies to cloud-hosted, but included in the source here.