### PR TITLE
perf: Reduce connections required for `findByPk`

### DIFF
--- a/server/models/Document.ts
+++ b/server/models/Document.ts
@@ -200,7 +200,6 @@ interface QueryGeneratorWithWhere {
             userId,
           },
           required: false,
-          separate: true,
         },
       ],
     };
@@ -228,7 +227,6 @@ interface QueryGeneratorWithWhere {
             userId,
           },
           required: false,
-          separate: true,
         },
         {
           association: "groupMemberships",

--- a/server/routes/api/subscriptions/subscriptions.ts
+++ b/server/routes/api/subscriptions/subscriptions.ts
@@ -177,28 +177,28 @@ router.get(
       return;
     }
 
-    const [documentSubscription, document, user] = await Promise.all([
-      Subscription.findOne({
-        where: {
-          userId,
-          documentId,
-        },
-        lock: Transaction.LOCK.UPDATE,
-        transaction,
-      }),
-      Document.unscoped().findOne({
-        attributes: ["collectionId"],
-        where: {
-          id: documentId,
-        },
-        paranoid: false,
-        transaction,
-      }),
-      User.scope("withTeam").findByPk(userId, {
-        rejectOnEmpty: true,
-        transaction,
-      }),
-    ]);
+    // Queries within a transaction share a single connection, so they are run
+    // sequentially rather than with Promise.all.
+    const documentSubscription = await Subscription.findOne({
+      where: {
+        userId,
+        documentId,
+      },
+      lock: Transaction.LOCK.UPDATE,
+      transaction,
+    });
+    const document = await Document.unscoped().findOne({
+      attributes: ["collectionId"],
+      where: {
+        id: documentId,
+      },
+      paranoid: false,
+      transaction,
+    });
+    const user = await User.scope("withTeam").findByPk(userId, {
+      rejectOnEmpty: true,
+      transaction,
+    });
 
     const context = createContext({
       user,


### PR DESCRIPTION
One `documents.list` was holding up to 4 connections simultaneously; now 2.
Much better for concurrent requests of which we see many at scale