### PR TITLE
fix: Silence false positive sequelize class fields warning

### DIFF
--- a/server/models/base/Model.ts
+++ b/server/models/base/Model.ts
@@ -51,6 +51,13 @@ class Model<
   TCreationAttributes extends object = TModelAttributes,
 > extends SequelizeModel<TModelAttributes, TCreationAttributes> {
   /**
+   * Disables Sequelize's public class field detection, which reports a false positive for the
+   * per-instance accessors that sequelize-strict-attributes installs on attributes omitted from
+   * a query's selection.
+   */
+  static _overwrittenAttributesChecked = true;
+
+  /**
    * The namespace to use for events - defaults to the table name if none is provided.
    */
   static eventNamespace: string | undefined;


### PR DESCRIPTION
Sequelize warns that models are "declaring public class fields" for their attributes, but nothing is actually shadowed — `sequelize-strict-attributes` installs per-instance accessors for every attribute omitted from a query's selection (e.g. `PersistenceExtension`'s `attributes: ["state"]` fetch), and Sequelize's constructor check can't tell those guards apart from compiled class fields.

The `Fix` decorator used to suppress this check on every model by setting `_overwrittenAttributesChecked`; removing it in #13100 let the false positive through. This sets the same flag once on the base model so all models inherit it.
