### PR TITLE
Show search highlight chip on shared documents

### DIFF
--- a/app/scenes/Document/components/SharedHeader.tsx
+++ b/app/scenes/Document/components/SharedHeader.tsx
@@ -35,6 +35,7 @@ import TableOfContentsMenu from "~/menus/TableOfContentsMenu";
 import type Document from "~/models/Document";
 import { documentEditPath } from "~/utils/routeHelpers";
 import PublicBreadcrumb from "./PublicBreadcrumb";
+import { SearchHighlightChip } from "./SearchHighlightChip";
 
 type Props = {
   document: Document;
@@ -180,6 +181,7 @@ function SharedDocumentHeader({ document }: Props) {
       }
       actions={
         <>
+          <SearchHighlightChip />
           {hasHeadings && !isMobile && !tocInLeft && <Action>{toc}</Action>}
           {allowSubscriptions !== false && !user && env.EMAIL_ENABLED && (
             <SubscribeAction shareId={shareId} documentId={document.id} />


### PR DESCRIPTION
Shared documents already highlight the search term when arriving from search results, but the header chip to clear it was missing.

- Render `SearchHighlightChip` in the shared document header, matching its position in the authenticated header