### PR TITLE
fix: Contributors list empty on documents

### DIFF
--- a/app/components/Collaborators.tsx
+++ b/app/components/Collaborators.tsx
@@ -61,7 +61,7 @@ function Collaborators(props: Props) {
   // ensure currently present via websocket are always ordered first
   // Memoize collaboratorIds as a Set for efficient lookup
   const collaboratorIdsSet = useMemo(
-    () => new Set(document.collaboratorIds),
+    () => new Set(document.collaboratorIds ?? []),
     [document.collaboratorIds]
   );
   const collaborators = useMemo(

--- a/app/models/Document.ts
+++ b/app/models/Document.ts
@@ -181,8 +181,11 @@ export default class Document extends ArchivableModel implements Searchable {
   @Relation(() => Document, { onArchive: "cascade", onDelete: "cascade" })
   parentDocument?: Document;
 
+  /**
+   * The ids of users that have edited this document.
+   */
   @observable
-  collaboratorIds: string[] = [];
+  collaboratorIds: string[] | undefined;
 
   @Relation(() => User)
   createdBy: User | undefined;
@@ -309,7 +312,7 @@ export default class Document extends ArchivableModel implements Searchable {
 
   @computed
   get collaborators(): User[] {
-    return this.collaboratorIds
+    return (this.collaboratorIds ?? [])
       .map((id) => this.store.rootStore.users.get(id))
       .filter(Boolean) as User[];
   }


### PR DESCRIPTION
The Contributors list in document Insights was always empty, most noticeably on freshly imported documents.

- `collaboratorIds` on the client Document model had a class field initializer, which runs *after* the base Model constructor applies the API response and reset it to an empty array on every newly constructed model
- Removed the initializer and typed the field as possibly undefined, guarding the two consumers