### PR TITLE
fix: Restoring a document to a missing revision returns 404

### DIFF
--- a/server/commands/documentRestorer.ts
+++ b/server/commands/documentRestorer.ts
@@ -24,6 +24,7 @@ type Props = {
  * @param props - the document and restore options.
  * @returns the restored document.
  * @throws ValidationError if the destination collection is not active.
+ * @throws NotFoundError if the given revision does not exist.
  */
 async function documentRestorer(
   ctx: APIContext,
@@ -81,7 +82,10 @@ async function documentRestorer(
   } else if (revisionId) {
     // restore a document to a specific revision
     authorize(user, "update", document);
-    const revision = await Revision.findByPk(revisionId, { transaction });
+    const revision = await Revision.findByPk(revisionId, {
+      transaction,
+      rejectOnEmpty: true,
+    });
     authorize(document, "restore", revision);
 
     await document.restoreFromRevision(revision);

--- a/server/routes/api/documents/documents.test.ts
+++ b/server/routes/api/documents/documents.test.ts
@@ -2935,6 +2935,23 @@ describe("#documents.restore", () => {
     expect(res.status).toEqual(403);
   });
 
+  it("should fail with not found for a revision that does not exist", async () => {
+    const user = await buildUser();
+    const document = await buildDocument({
+      userId: user.id,
+      teamId: user.teamId,
+    });
+
+    const res = await server.post("/api/documents.restore", user, {
+      body: {
+        id: document.id,
+        revisionId: faker.string.uuid(),
+      },
+    });
+
+    expect(res.status).toEqual(404);
+  });
+
   it("should require id", async () => {
     const user = await buildUser();
     const document = await buildDocument({


### PR DESCRIPTION
Fixes #13247

When restoring a document to a revision that doesn't exist, `findByPk` returned null and the null was passed to `authorize`, surfacing a misleading "Authorization error" rather than a not found.

- Use `rejectOnEmpty` on the revision lookup, matching the pattern used across the revisions API, so a missing revision returns a 404
- Also narrows the type, so a null revision can no longer reach `authorize` or `restoreFromRevision`
- Adds a regression test