### PR TITLE
fix: Log failures when scheduling collection duplication task

### DIFF
--- a/server/commands/collectionDuplicator.ts
+++ b/server/commands/collectionDuplicator.ts
@@ -1,3 +1,5 @@
+import { toError } from "@shared/utils/error";
+import Logger from "@server/logging/Logger";
 import { Collection } from "@server/models";
 import DuplicateCollectionDocumentsTask from "@server/queues/tasks/DuplicateCollectionDocumentsTask";
 import type { APIContext } from "@server/types";
@@ -55,7 +57,19 @@ export default async function collectionDuplicator(
     });
 
   if (transaction) {
-    transaction.afterCommit(() => void scheduleTask());
+    transaction.afterCommit(async () => {
+      try {
+        await scheduleTask();
+      } catch (err) {
+        Logger.error(
+          "Failed to schedule duplicate collection documents task",
+          toError(err),
+          {
+            collectionId: duplicated.id,
+          }
+        );
+      }
+    });
   } else {
     await scheduleTask();
   }


### PR DESCRIPTION
Fixes #13244

- `collectionDuplicator` discarded the promise returned by `scheduleTask()` inside `afterCommit` with `void`, so a failure to enqueue the background task (e.g. Redis briefly unreachable) was silently swallowed — the duplicated collection was left empty with nothing logged.
- The callback now awaits the schedule and logs any error with the new collection id.