### PR TITLE
fix: Don't show success toast when a batch operation fails entirely

### DIFF
--- a/app/actions/definitions/common.tsx
+++ b/app/actions/definitions/common.tsx
@@ -56,7 +56,8 @@ export function everyActiveModel<T extends Model>(
  * @param modelClass The class of models to operate on.
  * @param operation The operation to perform on each model.
  * @param message Given the models and how many succeeded, returns the toast to
- * show, or undefined to show none (e.g. to stay silent for a single model).
+ * show, or undefined to show none (e.g. to stay silent for a single model). No
+ * toast is shown when every operation failed.
  * @returns the number of operations that succeeded.
  */
 export async function performBatchOnActiveModels<T extends Model>(
@@ -71,7 +72,7 @@ export async function performBatchOnActiveModels<T extends Model>(
   }
 
   const succeeded = await performBatch(models, operation);
-  const text = message?.(models, succeeded, context.t);
+  const text = succeeded ? message?.(models, succeeded, context.t) : undefined;
   if (text) {
     toast.success(text);
   }

--- a/app/actions/definitions/documents.tsx
+++ b/app/actions/definitions/documents.tsx
@@ -1354,11 +1354,13 @@ export const archiveDocument = createAction({
             const succeeded = await performBatch(documents, (document) =>
               document.archive()
             );
-            toast.success(
-              documents.length === 1
-                ? t("Document archived")
-                : t("{{ count }} documents archived", { count: succeeded })
-            );
+            if (succeeded) {
+              toast.success(
+                documents.length === 1
+                  ? t("Document archived")
+                  : t("{{ count }} documents archived", { count: succeeded })
+              );
+            }
           }}
           savingText={`${t("Archiving")}…`}
         >
@@ -1506,9 +1508,11 @@ export const deleteDocument = createAction({
             const succeeded = await performBatch(documents, (document) =>
               document.delete()
             );
-            toast.success(
-              t("{{ count }} documents moved to trash", { count: succeeded })
-            );
+            if (succeeded) {
+              toast.success(
+                t("{{ count }} documents moved to trash", { count: succeeded })
+              );
+            }
           }}
         >
           {t("Deleting these documents will move them to the trash.")}


### PR DESCRIPTION
Batch actions toasted success unconditionally, so a single-document archive that failed still showed "Document archived", and fully-failed bulk actions showed "0 documents archived".

- performBatchOnActiveModels only toasts when at least one operation succeeded — covers restore, unpublish, pin, unpin, star, unstar
- Same guard on the archive and bulk delete-to-trash confirmations

Partial failures still toast with the real succeeded count, and the API error toast surfaces as before.

Fixes #13240