### PR TITLE
fix: Whitelist fields in URL unfurl presenter

### DIFF
--- a/server/presenters/unfurl.ts
+++ b/server/presenters/unfurl.ts
@@ -33,8 +33,19 @@ async function presentUnfurl(
   }
 }
 
-const presentURL = (data: UnfurlData): UnfurlResponse[UnfurlResourceType.URL] =>
-  data as UnfurlResponse[UnfurlResourceType.URL]; // this would have been transformed by the unfurl plugin.
+// The data will have been transformed by the unfurl plugin, fields are picked
+// individually so that additional metadata is never exposed in the response.
+const presentURL = (
+  data: UnfurlData
+): UnfurlResponse[UnfurlResourceType.URL] => ({
+  type: UnfurlResourceType.URL,
+  url: data.url,
+  title: data.title,
+  description: data.description,
+  color: data.color,
+  thumbnailUrl: data.thumbnailUrl,
+  faviconUrl: data.faviconUrl,
+});
 
 const presentMention = async (
   data: UnfurlData,


### PR DESCRIPTION
presentURL was casting the entire UnfurlData blob into the response, so any extra metadata attached by an unfurl plugin or internal caller was serialized to API consumers.

- Restore field-level picking of type, url, title, description, color, thumbnailUrl and faviconUrl
- Coerce type to the URL literal, since presentURL is only reached from the fallback branch where the incoming type is absent or unrecognized

Both current URL producers (iframely and figma plugins) already return exactly these fields, so no output is lost.

Closes #13237