### PR TITLE
fix: "Shared with me" hidden when first page holds only deleted documents

### DIFF
--- a/server/routes/api/groupMemberships/groupMemberships.test.ts
+++ b/server/routes/api/groupMemberships/groupMemberships.test.ts
@@ -117,4 +117,58 @@ describe("groupMemberships.list", () => {
     expect(body.pagination.total).toEqual(3);
     expect(body.data.groupMemberships).toHaveLength(3);
   });
+
+  it("should not return memberships for deleted or archived documents", async () => {
+    const user = await buildUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      createdById: user.id,
+      permission: null,
+    });
+    const group = await buildGroup({
+      teamId: user.teamId,
+    });
+    const member = await buildUser({
+      teamId: user.teamId,
+    });
+    await GroupUser.create({
+      groupId: group.id,
+      userId: member.id,
+      createdById: user.id,
+    });
+
+    const documents = await Promise.all(
+      [0, 1, 2].map(() =>
+        buildDocument({
+          collectionId: collection.id,
+          createdById: user.id,
+          teamId: user.teamId,
+        })
+      )
+    );
+
+    for (const document of documents) {
+      await server.post("/api/documents.add_group", user, {
+        body: {
+          id: document.id,
+          groupId: group.id,
+        },
+      });
+    }
+
+    await server.post("/api/documents.delete", user, {
+      body: { id: documents[0].id },
+    });
+    await server.post("/api/documents.archive", user, {
+      body: { id: documents[1].id },
+    });
+
+    const res = await server.post("/api/groupMemberships.list", member);
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.pagination.total).toEqual(1);
+    expect(body.data.groupMemberships).toHaveLength(1);
+    expect(body.data.groupMemberships[0].documentId).toEqual(documents[2].id);
+    expect(body.data.documents).toHaveLength(1);
+  });
 });

--- a/server/routes/api/groupMemberships/groupMemberships.ts
+++ b/server/routes/api/groupMemberships/groupMemberships.ts
@@ -39,6 +39,17 @@ router.post(
       },
       include: [
         {
+          model: Document.unscoped(),
+          as: "document",
+          required: true,
+          attributes: [],
+          where: {
+            archivedAt: {
+              [Op.eq]: null,
+            },
+          },
+        },
+        {
           association: "group",
           required: true,
           where: groupId ? { id: groupId } : undefined,

--- a/server/routes/api/userMemberships/userMemberships.test.ts
+++ b/server/routes/api/userMemberships/userMemberships.test.ts
@@ -56,6 +56,52 @@ describe("#userMemberships.list", () => {
     expect(body.policies[1].abilities).not.toBeFalsy();
     expect(body.policies[1].abilities.update).toBeTruthy();
   });
+
+  it("should not return memberships for deleted or archived documents", async () => {
+    const user = await buildUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      createdById: user.id,
+      permission: null,
+    });
+    const member = await buildUser({
+      teamId: user.teamId,
+    });
+
+    const documents = await Promise.all(
+      [0, 1, 2].map(() =>
+        buildDocument({
+          collectionId: collection.id,
+          createdById: user.id,
+          teamId: user.teamId,
+        })
+      )
+    );
+
+    for (const document of documents) {
+      await server.post("/api/documents.add_user", user, {
+        body: {
+          id: document.id,
+          userId: member.id,
+        },
+      });
+    }
+
+    await server.post("/api/documents.delete", user, {
+      body: { id: documents[0].id },
+    });
+    await server.post("/api/documents.archive", user, {
+      body: { id: documents[1].id },
+    });
+
+    const res = await server.post("/api/userMemberships.list", member);
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.data.memberships).toHaveLength(1);
+    expect(body.data.memberships[0].documentId).toEqual(documents[2].id);
+    expect(body.data.documents).toHaveLength(1);
+    expect(body.data.documents[0].id).toEqual(documents[2].id);
+  });
 });
 
 describe("#userMemberships.update", () => {

--- a/server/routes/api/userMemberships/userMemberships.ts
+++ b/server/routes/api/userMemberships/userMemberships.ts
@@ -34,6 +34,19 @@ router.post(
           [Op.eq]: null,
         },
       },
+      include: [
+        {
+          model: Document.unscoped(),
+          as: "document",
+          required: true,
+          attributes: [],
+          where: {
+            archivedAt: {
+              [Op.eq]: null,
+            },
+          },
+        },
+      ],
       order: [
         Sequelize.literal('"user_permission"."index" collate "C"'),
         ["updatedAt", "DESC"],


### PR DESCRIPTION
Fixes #13238

Memberships pointing at soft-deleted or archived documents were still returned by the membership list endpoints, so they consumed slots in the single page the sidebar requests — a user whose first 10 memberships were all trashed got zero side-loaded documents and the section vanished, along with the "show more" control that would have loaded the live shares.

- Inner join the document in userMemberships.list and groupMemberships.list, excluding deleted (paranoid) and archived rows from the query
- Same join in groupMemberships.list, which feeds the group entries of the same sidebar section and had an inflated pagination total
- The join is unscoped so drafts and templates stay visible, matching what the side-loaded documents already return
- Tests covering both endpoints

No migration needed; the stale permission rows are simply no longer selected.