### PR TITLE
fix: Suppress click event before guard clauses in Templatize action

### DIFF
--- a/app/actions/definitions/documents.tsx
+++ b/app/actions/definitions/documents.tsx
@@ -1219,6 +1219,8 @@ export const createTemplateFromDocument = createAction({
     );
   },
   perform: ({ activeDocumentId, stores, t, event }) => {
+    event?.preventDefault();
+    event?.stopPropagation();
     if (!activeDocumentId) {
       return;
     }
@@ -1226,8 +1228,6 @@ export const createTemplateFromDocument = createAction({
     if (!document) {
       return;
     }
-    event?.preventDefault();
-    event?.stopPropagation();
     stores.dialogs.openModal({
       title: <DialogTitle title={t("Create template")} model={document} />,
       content: <DocumentTemplatizeDialog documentId={activeDocumentId} />,


### PR DESCRIPTION
The Templatize action ran its `activeDocumentId` and document-lookup guards before calling `preventDefault()`/`stopPropagation()`.

- If the document is evicted from the store between the `visible()` check and the click, the handler returns early and the click propagates to parent menus
- Moves event suppression to the top of `perform`, ahead of both guards

Fixes #13239