### PR TITLE
fix: Show roles as a selection list in the user role menu

### DIFF
--- a/app/actions/definitions/users.tsx
+++ b/app/actions/definitions/users.tsx
@@ -31,30 +31,45 @@ export const inviteUser = dialogActionFactory({
     stores.policies.abilities(stores.auth.team?.id || "").inviteUser,
 });
 
+/**
+ * Creates an action that sets the given user's role, marked as selected when
+ * it is the role they already have.
+ *
+ * @param user - the user to update.
+ * @param role - the role to assign.
+ * @returns an action for use in menus.
+ */
 export const updateUserRoleActionFactory = (user: User, role: UserRole) =>
-  dialogActionFactory({
+  createAction({
+    name: ({ t }) => UserRoleHelper.displayName(role, t),
     analyticsName: "Update user role",
     section: UserSection,
-    name: (t) =>
-      UserRoleHelper.isRoleHigher(role, user.role)
-        ? `${t("Promote to {{ role }}", {
-            role: UserRoleHelper.displayName(role, t),
-          })}…`
-        : `${t("Demote to {{ role }}", {
-            role: UserRoleHelper.displayName(role, t),
-          })}…`,
-    title: (t) => t("Update role"),
-    content: (onSubmit) => (
-      <UserChangeRoleDialog user={user} role={role} onSubmit={onSubmit} />
-    ),
+    selected: () => user.role === role,
     visible: () => {
-      const can = stores.policies.abilities(user.id);
+      if (user.role === role) {
+        return true;
+      }
 
+      const can = stores.policies.abilities(user.id);
       return UserRoleHelper.isRoleHigher(role, user.role)
         ? can.promote
-        : UserRoleHelper.isRoleLower(role, user.role)
-          ? can.demote
-          : false;
+        : can.demote;
+    },
+    perform: ({ t }) => {
+      if (user.role === role) {
+        return;
+      }
+
+      stores.dialogs.openModal({
+        title: t("Update role"),
+        content: (
+          <UserChangeRoleDialog
+            user={user}
+            role={role}
+            onSubmit={stores.dialogs.closeAllModals}
+          />
+        ),
+      });
     },
   });
 

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -219,8 +219,6 @@
   "Print template": "Print template",
   "Invite people": "Invite people",
   "Invite to workspace": "Invite to workspace",
-  "Promote to {{ role }}": "Promote to {{ role }}",
-  "Demote to {{ role }}": "Demote to {{ role }}",
   "Update role": "Update role",
   "Change profile picture": "Change profile picture",
   "Change name": "Change name",


### PR DESCRIPTION
The user role submenu labelled each item "Promote to…" or "Demote to…"
depending on the target user's current role, and hid the role they
already had. Show the plain role names with a checkmark against the
current one, matching the group member role menu.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LfzcABi86HH7n6j9QrY4po