### PR TITLE
perf: Preload route chunks on sidebar hover intent

### DIFF
--- a/app/components/Sidebar/App.tsx
+++ b/app/components/Sidebar/App.tsx
@@ -16,6 +16,7 @@ import useCurrentUser from "~/hooks/useCurrentUser";
 import usePolicy from "~/hooks/usePolicy";
 import useStores from "~/hooks/useStores";
 import TeamMenu from "~/menus/TeamMenu";
+import * as Scenes from "~/routes/scenes";
 import { homePath, searchPath } from "~/utils/routeHelpers";
 import TeamLogo from "../TeamLogo";
 import Tooltip from "../Tooltip";
@@ -110,6 +111,7 @@ function AppSidebar() {
               icon={<HomeIcon />}
               exact={false}
               label={t("Home")}
+              onClickIntent={Scenes.Home.preload}
             />
             <SidebarLink
               to={searchPath()}
@@ -117,6 +119,7 @@ function AppSidebar() {
               label={t("Search")}
               exact={false}
               onClick={handleSearchClick}
+              onClickIntent={Scenes.Search.preload}
             />
             {can.createDocument && <DraftsLink />}
           </Section>

--- a/app/components/Sidebar/components/ArchiveLink.tsx
+++ b/app/components/Sidebar/components/ArchiveLink.tsx
@@ -8,6 +8,7 @@ import type Collection from "~/models/Collection";
 import PaginatedList from "~/components/PaginatedList";
 import useRequest from "~/hooks/useRequest";
 import useStores from "~/hooks/useStores";
+import * as Scenes from "~/routes/scenes";
 import { archivePath } from "~/utils/routeHelpers";
 import { useDropToArchive } from "../hooks/useDragAndDrop";
 import { ArchivedCollectionLink } from "./ArchivedCollectionLink";
@@ -61,6 +62,7 @@ function ArchiveLink() {
         <div ref={dropToArchiveRef}>
           <SidebarLink
             to={archivePath()}
+            onClickIntent={Scenes.Archive.preload}
             icon={<ArchiveIcon open={isOverArchiveSection && isDragging} />}
             exact={false}
             label={t("Archive")}

--- a/app/components/Sidebar/components/CollectionLink.tsx
+++ b/app/components/Sidebar/components/CollectionLink.tsx
@@ -11,6 +11,7 @@ import { useCollectionMenuAction } from "~/hooks/useCollectionMenuAction";
 import usePolicy from "~/hooks/usePolicy";
 import useStores from "~/hooks/useStores";
 import CollectionMenu from "~/menus/CollectionMenu";
+import * as Scenes from "~/routes/scenes";
 import useBoolean from "~/hooks/useBoolean";
 import { documentEditPath } from "~/utils/routeHelpers";
 import { useDropToChangeCollection } from "../hooks/useDragAndDrop";
@@ -65,6 +66,7 @@ const CollectionLink: React.FC<Props> = ({
   );
 
   const handlePrefetch = React.useCallback(() => {
+    void Scenes.Collection.preload();
     void collection.fetchDocuments();
   }, [collection]);
 

--- a/app/components/Sidebar/components/DocumentLink.tsx
+++ b/app/components/Sidebar/components/DocumentLink.tsx
@@ -23,6 +23,7 @@ import useOnScreen from "~/hooks/useOnScreen";
 import usePolicy from "~/hooks/usePolicy";
 import useStores from "~/hooks/useStores";
 import DocumentMenu from "~/menus/DocumentMenu";
+import * as Scenes from "~/routes/scenes";
 import { documentEditPath } from "~/utils/routeHelpers";
 import {
   useDragDocument,
@@ -240,6 +241,7 @@ const DocumentLinkInner = observer(function DocumentLinkInner({
   }, [expansion, node.id]);
 
   const handlePrefetch = React.useCallback(() => {
+    void Scenes.Document.preload();
     void prefetchDocument?.(node.id);
   }, [prefetchDocument, node]);
 

--- a/app/components/Sidebar/components/DraftsLink.tsx
+++ b/app/components/Sidebar/components/DraftsLink.tsx
@@ -5,6 +5,7 @@ import styled from "styled-components";
 import Flex from "~/components/Flex";
 import Text from "~/components/Text";
 import useStores from "~/hooks/useStores";
+import * as Scenes from "~/routes/scenes";
 import { draftsPath } from "~/utils/routeHelpers";
 import { useDropToUnpublish } from "../hooks/useDragAndDrop";
 import SidebarLink from "./SidebarLink";
@@ -18,6 +19,7 @@ export const DraftsLink = observer(() => {
     <div ref={dropRef}>
       <SidebarLink
         to={draftsPath()}
+        onClickIntent={Scenes.Drafts.preload}
         icon={<DraftsIcon />}
         label={
           <Flex align="center" justify="space-between">

--- a/app/components/Sidebar/components/SharedWithMeLink.tsx
+++ b/app/components/Sidebar/components/SharedWithMeLink.tsx
@@ -10,6 +10,7 @@ import { useActiveSidebarContext } from "~/hooks/useActiveSidebarContext";
 import useBoolean from "~/hooks/useBoolean";
 import useStores from "~/hooks/useStores";
 import DocumentMenu from "~/menus/DocumentMenu";
+import * as Scenes from "~/routes/scenes";
 import {
   useDragMembership,
   useDropToReorderUserMembership,
@@ -181,6 +182,7 @@ function SharedWithMeLink({ membership, depth = 0 }: Props) {
       documentId={documentId ?? ""}
       document={document}
       to={{ pathname: document.path, state: { sidebarContext } }}
+      onClickIntent={Scenes.Document.preload}
       depth={depth}
       icon={icon}
       canEdit={false}

--- a/app/components/Sidebar/components/StarredLink.tsx
+++ b/app/components/Sidebar/components/StarredLink.tsx
@@ -20,6 +20,7 @@ import usePolicy from "~/hooks/usePolicy";
 import useStores from "~/hooks/useStores";
 import CollectionMenu from "~/menus/CollectionMenu";
 import DocumentMenu from "~/menus/DocumentMenu";
+import * as Scenes from "~/routes/scenes";
 import { documentEditPath } from "~/utils/routeHelpers";
 import {
   useDragStar,
@@ -290,6 +291,7 @@ const StarredCollectionLink = observer(function StarredCollectionLink({
   }, []);
 
   const handlePrefetch = React.useCallback(() => {
+    void Scenes.Collection.preload();
     void collection.fetchDocuments();
   }, [collection]);
 
@@ -432,6 +434,7 @@ function StarredLink({ star }: Props) {
 
   const handlePrefetch = React.useCallback(() => {
     if (documentId) {
+      void Scenes.Document.preload();
       void documents.prefetchDocument(documentId);
       const document = documents.get(documentId);
       const documentCollection = document?.collectionId

--- a/app/components/Sidebar/components/TrashLink.tsx
+++ b/app/components/Sidebar/components/TrashLink.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import DocumentDelete from "~/scenes/DocumentDelete";
 import { DialogTitle } from "~/components/DialogTitle";
 import useStores from "~/hooks/useStores";
+import * as Scenes from "~/routes/scenes";
 import { trashPath } from "~/utils/routeHelpers";
 import type { DragObject } from "../hooks/useDragAndDrop";
 import SidebarLink from "./SidebarLink";
@@ -48,6 +49,7 @@ function TrashLink() {
     <div ref={dropToTrashRef}>
       <SidebarLink
         to={trashPath()}
+        onClickIntent={Scenes.Trash.preload}
         icon={<TrashIcon open={isDocumentDropping} />}
         exact={false}
         label={t("Trash")}

--- a/app/routes/authenticated.tsx
+++ b/app/routes/authenticated.tsx
@@ -14,6 +14,7 @@ import useCurrentTeam from "~/hooks/useCurrentTeam";
 import usePolicy from "~/hooks/usePolicy";
 import useQueryNotices from "~/hooks/useQueryNotices";
 import lazy from "~/utils/lazyWithRetry";
+import * as Scenes from "./scenes";
 import {
   archivePath,
   draftsPath,
@@ -28,13 +29,6 @@ import {
 import env from "~/env";
 
 const SettingsRoutes = lazy(() => import("./settings"));
-const Archive = lazy(() => import("~/scenes/Archive"));
-const Collection = lazy(() => import("~/scenes/Collection"));
-const Document = lazy(() => import("~/scenes/Document"));
-const Drafts = lazy(() => import("~/scenes/Drafts"));
-const Home = lazy(() => import("~/scenes/Home"));
-const Search = lazy(() => import("~/scenes/Search"));
-const Trash = lazy(() => import("~/scenes/Trash"));
 const Debug = lazy(() => import("~/scenes/Developer/Debug"));
 const Changesets = lazy(() => import("~/scenes/Developer/Changesets"));
 
@@ -72,15 +66,30 @@ function AuthenticatedRoutes() {
           <SplitView>
             <Switch>
               {can.createDocument && (
-                <Route exact path={draftsPath()} component={Drafts} />
+                <Route
+                  exact
+                  path={draftsPath()}
+                  component={Scenes.Drafts.Component}
+                />
               )}
               {can.createDocument && (
-                <Route exact path={archivePath()} component={Archive} />
+                <Route
+                  exact
+                  path={archivePath()}
+                  component={Scenes.Archive.Component}
+                />
               )}
               {can.createDocument && (
-                <Route exact path={trashPath()} component={Trash} />
+                <Route
+                  exact
+                  path={trashPath()}
+                  component={Scenes.Trash.Component}
+                />
               )}
-              <Route path={`${homePath()}/:tab?`} component={Home} />
+              <Route
+                path={`${homePath()}/:tab?`}
+                component={Scenes.Home.Component}
+              />
               <Redirect from="/dashboard" to={homePath()} />
               <Redirect exact from="/starred" to={homePath()} />
               <Redirect
@@ -97,12 +106,12 @@ function AuthenticatedRoutes() {
               <Route
                 exact
                 path={`/collection/${collectionSlug}/overview/edit`}
-                component={Collection}
+                component={Scenes.Collection.Component}
               />
               <Route
                 exact
                 path={`/collection/${collectionSlug}/:tab?`}
-                component={Collection}
+                component={Scenes.Collection.Component}
               />
               <Route exact path="/doc/new" component={DocumentNew} />
               <Route
@@ -113,19 +122,22 @@ function AuthenticatedRoutes() {
               <Route
                 exact
                 path={`/doc/${documentSlug}/history/:revisionId?`}
-                component={Document}
+                component={Scenes.Document.Component}
               />
 
               <Route
                 exact
                 path={`/doc/${documentSlug}/edit`}
-                component={Document}
+                component={Scenes.Document.Component}
               />
-              <Route path={`/doc/${documentSlug}`} component={Document} />
+              <Route
+                path={`/doc/${documentSlug}`}
+                component={Scenes.Document.Component}
+              />
               <Route
                 exact
                 path={`${searchPath()}/:query?`}
-                component={Search}
+                component={Scenes.Search.Component}
               />
               {env.isDevelopment && (
                 <Route exact path={debugPath()} component={Debug} />

--- a/app/routes/scenes.ts
+++ b/app/routes/scenes.ts
@@ -1,0 +1,14 @@
+import { createLazyComponent as lazy } from "~/components/LazyLoad";
+
+/**
+ * Lazy-loaded scenes for the authenticated routes. Defined separately from the
+ * route definitions so that components such as the sidebar can preload a
+ * scene's chunk without importing the routes themselves.
+ */
+export const Archive = lazy(() => import("~/scenes/Archive"));
+export const Collection = lazy(() => import("~/scenes/Collection"));
+export const Document = lazy(() => import("~/scenes/Document"));
+export const Drafts = lazy(() => import("~/scenes/Drafts"));
+export const Home = lazy(() => import("~/scenes/Home"));
+export const Search = lazy(() => import("~/scenes/Search"));
+export const Trash = lazy(() => import("~/scenes/Trash"));


### PR DESCRIPTION
Sidebar links now warm the target route's JS chunk once hover intent is detected, so navigation doesn't start with a cold fetch.

- Moves the authenticated scenes into a leaf module built on `createLazyComponent`, giving each a `preload()` alongside its component without creating an import cycle between the routes and the sidebar
- Wires preloading into Home, Search, Drafts, Archive and Trash
- Document, Collection, Starred and Shared with me links preload on the hover intent handler that already prefetches their data
- Retry and stale-chunk reload behaviour is unchanged, and the chunks remain separately split