### PR TITLE
fix: cap persistence retries to prevent infinite loop for permanent errors

### DIFF
--- a/server/collaboration/PersistenceExtension.ts
+++ b/server/collaboration/PersistenceExtension.ts
@@ -21,6 +21,12 @@ export default class PersistenceExtension implements Extension {
   /** The names of documents that have changed since they were last persisted. */
   private unsavedDocumentNames = new Set<string>();
 
+  /** Tracks how many consecutive persist failures have occurred per document. */
+  private persistFailures = new Map<string, number>();
+
+  /** Maximum number of consecutive failures before giving up on retry. */
+  private static MAX_PERSIST_RETRIES = 5;
+
   async onLoadDocument({
     documentName,
     ...data
@@ -166,13 +172,30 @@ export default class PersistenceExtension implements Extension {
         isLastConnection: clientsCount === 0,
         clientVersion,
       });
+      // Reset failure count on success.
+      this.persistFailures.delete(documentName);
     } catch (err) {
-      // Restore the flag so that a subsequent store will retry the write.
+      // Restore the flag so that a subsequent store will retry the write,
+      // but only up to MAX_PERSIST_RETRIES consecutive failures to prevent
+      // an infinite retry loop for permanent errors.
+      const failures = (this.persistFailures.get(documentName) ?? 0) + 1;
+      this.persistFailures.set(documentName, failures);
+
+      if (failures > PersistenceExtension.MAX_PERSIST_RETRIES) {
+        Logger.error(
+          "Unable to persist document after max retries",
+          toError(err),
+          { documentId, userId: context.user?.id, failures }
+        );
+        return;
+      }
+
       this.unsavedDocumentNames.add(documentName);
 
       Logger.error("Unable to persist document", toError(err), {
         documentId,
         userId: context.user?.id,
+        failures,
       });
     }
   }


### PR DESCRIPTION
Closes #13243

## Problem

When `documentCollaborativeUpdater` fails with a permanent error (e.g. content that cannot round-trip through the ProseMirror schema), the catch block unconditionally restores the dirty flag via `unsavedDocumentNames.add(documentName)`, causing an infinite retry loop. Every subsequent `onStoreDocument` call finds the flag and retries — forever, as long as clients remain connected. No backoff, no error counting, no circuit breaker exists.

## Fix

Add a per-document failure counter (`MAX_PERSIST_RETRIES = 5`) that:
- Increments on each consecutive persist failure
- Resets to zero on successful persist
- Stops retrying after the limit, logging a final error instead

## Introduced by

- commit `6190684d5` (collaborator persistence fix, 2026-07-26)

Co-Authored-By: Claude <noreply@anthropic.com>