### PR TITLE
fix: Mermaid links intercepted by lightbox in read-only mode

### DIFF
--- a/shared/editor/extensions/Mermaid.ts
+++ b/shared/editor/extensions/Mermaid.ts
@@ -532,6 +532,12 @@ export default function Mermaid({
             return false;
           }
 
+          // Let clicks on a link within the diagram through, they are handled
+          // on mouseup and should not select the node or open the lightbox.
+          if (target?.closest("a") instanceof SVGAElement) {
+            return false;
+          }
+
           const codeBlock = diagram.previousElementSibling;
           if (!codeBlock) {
             return false;


### PR DESCRIPTION
Clicking a Mermaid node with a `click ... href` directive opened the diagram lightbox instead of following the link when the document was read-only, and links were dead once the lightbox was open.

- Mousedown on the diagram now ignores events originating inside an SVG anchor, so the link handler runs instead of selecting the node or opening the lightbox
- The lightbox renders diagrams as inline SVG rather than an image, keeping their links interactive; following one closes the lightbox
- Clicking elsewhere on the diagram still selects the node / opens the lightbox, and click-to-zoom is unchanged

closes #13275