### PR TITLE
fix: Fade menu content at bottom edge when scrollable

### DIFF
--- a/app/components/Scrollable.tsx
+++ b/app/components/Scrollable.tsx
@@ -1,5 +1,6 @@
 import { observer } from "mobx-react";
 import * as React from "react";
+import { mergeRefs } from "react-merge-refs";
 import styled, { css } from "styled-components";
 import { hideScrollbars } from "@shared/styles";
 
@@ -12,7 +13,7 @@ type Props = React.HTMLAttributes<HTMLDivElement> & {
   bottomShadow?: boolean;
   /** Whether to hide the scrollbars */
   hiddenScrollbars?: boolean;
-  /** Color to fade to (enables fade effect) */
+  /** Color to fade to (enables fade effect), applied to both edges unless topShadow or bottomShadow narrows it to one */
   fadeTo?: string;
   /** Whether to use flexbox layout */
   flex?: boolean;
@@ -39,27 +40,34 @@ function Scrollable(
     children,
     ...rest
   }: Props,
-  ref: React.RefObject<HTMLDivElement>
+  ref: React.Ref<HTMLDivElement>
 ) {
-  const fallbackRef = React.useRef<HTMLDivElement>();
+  const localRef = React.useRef<HTMLDivElement>(null);
   const [topShadowVisible, setTopShadow] = React.useState(false);
   const [bottomShadowVisible, setBottomShadow] = React.useState(false);
+
+  // When an edge is named alongside fadeTo the fade is limited to that edge,
+  // otherwise both edges fade.
+  const singleEdge = topShadow !== undefined || bottomShadow !== undefined;
+  const fadeTop = !!fadeTo && (!singleEdge || !!topShadow);
+  const fadeBottom = !!fadeTo && (!singleEdge || !!bottomShadow);
+  const trackTop = !!(shadow || topShadow || fadeTop);
+  const trackBottom = !!(shadow || bottomShadow || fadeBottom);
+
   const updateShadows = React.useCallback(() => {
-    const c = (ref || fallbackRef).current;
+    const c = localRef.current;
     if (!c) {
       return;
     }
     const scrollTop = c.scrollTop;
-    setTopShadow(!!((shadow || topShadow || fadeTo) && scrollTop > 0));
+    setTopShadow(trackTop && scrollTop > 0);
 
     const wrapperHeight = c.scrollHeight - c.clientHeight;
-    setBottomShadow(
-      !!((shadow || bottomShadow || fadeTo) && wrapperHeight - scrollTop > 1)
-    );
-  }, [shadow, topShadow, bottomShadow, fadeTo, ref]);
+    setBottomShadow(trackBottom && wrapperHeight - scrollTop > 1);
+  }, [trackTop, trackBottom]);
 
   React.useEffect(() => {
-    const c = (ref || fallbackRef).current;
+    const c = localRef.current;
     if (!c) {
       return;
     }
@@ -74,22 +82,24 @@ function Scrollable(
     }
 
     return () => observer.disconnect();
-  }, [ref, updateShadows]);
+  }, [updateShadows]);
 
   return (
     <Wrapper
-      ref={ref || fallbackRef}
+      ref={mergeRefs([localRef, ref])}
       onScroll={updateShadows}
       $flex={flex}
       $hiddenScrollbars={hiddenScrollbars}
-      $topShadowVisible={topShadowVisible && !fadeTo}
-      $bottomShadowVisible={bottomShadowVisible && !fadeTo}
+      $topShadowVisible={topShadowVisible && !fadeTop}
+      $bottomShadowVisible={bottomShadowVisible && !fadeBottom}
       $overflow={overflow}
       {...rest}
     >
-      {fadeTo && <Fade to={fadeTo} visible={topShadowVisible} top />}
+      {fadeTo && fadeTop && <Fade to={fadeTo} visible={topShadowVisible} top />}
       {children}
-      {fadeTo && <Fade to={fadeTo} visible={bottomShadowVisible} bottom />}
+      {fadeTo && fadeBottom && (
+        <Fade to={fadeTo} visible={bottomShadowVisible} bottom />
+      )}
     </Wrapper>
   );
 }

--- a/app/components/primitives/components/Menu.tsx
+++ b/app/components/primitives/components/Menu.tsx
@@ -181,10 +181,18 @@ export const MenuShortcut = styled.span`
   flex-shrink: 0;
 `;
 
-export const MenuContent = styled(Scrollable)<{
+type MenuContentProps = {
   maxHeightVar: string;
   transformOriginVar: string;
-}>`
+};
+
+export const MenuContent = styled(Scrollable).attrs<MenuContentProps>(
+  (props) => ({
+    // Fades the last item out at the bottom edge when the menu is scrollable.
+    fadeTo: props.theme.menuBackground,
+    bottomShadow: true,
+  })
+)<MenuContentProps>`
   z-index: ${depths.menu};
   min-width: 180px;
   max-width: 320px;
@@ -195,8 +203,17 @@ export const MenuContent = styled(Scrollable)<{
   background: ${s("menuBackground")};
   box-shadow: ${s("menuShadow")};
   border-radius: 6px;
-  padding: 6px;
+  // Vertical spacing comes from spacers rather than padding so that the bottom
+  // fade, which is confined to the content box, can reach the menu's edge.
+  padding: 0 6px;
   outline: none;
+
+  &::before,
+  &::after {
+    content: "";
+    display: block;
+    height: 6px;
+  }
 
   transform-origin: ${({ transformOriginVar }) => `var(${transformOriginVar})`};
 


### PR DESCRIPTION
Context and dropdown menus that overflow now fade their last item into the menu background, signalling there's more content behind the scroll.

- Menu content passes `fadeTo` through to Scrollable, limited to the bottom edge
- Scrollable's fade support gains single-edge control, previously it always applied to both
- Fixed Scrollable dropping callback refs, which is what Radix forwards through `asChild`, so scroll tracking silently did nothing inside menus
- Menu vertical spacing moved from padding to spacers, a sticky fade is confined to the content box and otherwise stops short of the menu edge