### PR TITLE
fix: Allow inline comments on documents created via the API

### DIFF
--- a/server/models/helpers/DocumentHelper.tsx
+++ b/server/models/helpers/DocumentHelper.tsx
@@ -103,6 +103,24 @@ export class DocumentHelper {
   }
 
   /**
+   * Returns the collaborative state for a document. Documents that have never been opened in a
+   * collaborative session have no state, in which case one is derived from the content, falling
+   * back to Markdown.
+   *
+   * @param document The document to convert
+   * @returns The collaborative state
+   */
+  static toState(document: Document): Uint8Array {
+    if (document.state) {
+      return document.state;
+    }
+
+    return ProsemirrorHelper.toState(
+      ProsemirrorHelper.toYDoc(document.content ?? document.text ?? "")
+    );
+  }
+
+  /**
    * Returns the document as a plain JSON object. This method uses the derived content if available
    * then the collaborative state, otherwise it falls back to Markdown.
    *

--- a/server/routes/api/comments/comments.test.ts
+++ b/server/routes/api/comments/comments.test.ts
@@ -953,7 +953,42 @@ describe("#comments.create", () => {
       expect(res.status).toEqual(404);
     });
 
-    it("should error when the document has no collaborative state", async () => {
+    it("should create state when the document has no collaborative state", async () => {
+      const team = await buildTeam();
+      const user = await buildUser({ teamId: team.id });
+      const document = await buildDocument({
+        userId: user.id,
+        teamId: user.teamId,
+        content: documentContent,
+      });
+      expect(document.state).toBeFalsy();
+
+      const res = await server.post("/api/comments.create", user, {
+        body: {
+          documentId: document.id,
+          text: "comment",
+          anchorText: "brown fox",
+        },
+      });
+      const body = await res.json();
+
+      expect(res.status).toEqual(200);
+
+      const updated = await Document.findByPk(document.id, {
+        userId: user.id,
+        includeState: true,
+      });
+      expect(updated!.state).toBeTruthy();
+
+      const ydoc = new Y.Doc();
+      Y.applyUpdate(ydoc, updated!.state!);
+      const doc = Node.fromJSON(schema, yDocToProsemirrorJSON(ydoc, "default"));
+      expect(SharedProsemirrorHelper.getComments(doc)).toMatchObject([
+        { id: body.data.id, userId: user.id, text: "brown fox" },
+      ]);
+    });
+
+    it("should error when the anchor node is not in a document without state", async () => {
       const team = await buildTeam();
       const user = await buildUser({ teamId: team.id });
       const document = await buildDocument({
@@ -969,7 +1004,7 @@ describe("#comments.create", () => {
         },
       });
 
-      expect(res.status).toEqual(400);
+      expect(res.status).toEqual(404);
     });
   });
 });

--- a/server/routes/api/comments/comments.test.ts
+++ b/server/routes/api/comments/comments.test.ts
@@ -1,5 +1,5 @@
 import { Node } from "prosemirror-model";
-import { prosemirrorToYDoc, yDocToProsemirrorJSON } from "y-prosemirror";
+import { prosemirrorToYDoc } from "y-prosemirror";
 import * as Y from "yjs";
 import type { ProsemirrorData, ReactionSummary } from "@shared/types";
 import { CommentStatusFilter } from "@shared/types";
@@ -812,12 +812,8 @@ describe("#comments.create", () => {
 
       const updated = await Document.findByPk(document.id, {
         userId: user.id,
-        includeState: true,
       });
-      const ydoc = new Y.Doc();
-      Y.applyUpdate(ydoc, updated!.state!);
-      const doc = Node.fromJSON(schema, yDocToProsemirrorJSON(ydoc, "default"));
-      const image = doc.child(1).child(0);
+      const image = DocumentHelper.toProsemirror(updated!).child(1).child(0);
       expect(image.attrs.marks).toEqual([
         {
           type: "comment",

--- a/server/routes/api/comments/comments.test.ts
+++ b/server/routes/api/comments/comments.test.ts
@@ -7,6 +7,7 @@ import { ProsemirrorHelper as SharedProsemirrorHelper } from "@shared/utils/Pros
 import documentCollaborativeUpdater from "@server/commands/documentCollaborativeUpdater";
 import { schema } from "@server/editor";
 import { Comment, Document, Reaction } from "@server/models";
+import { DocumentHelper } from "@server/models/helpers/DocumentHelper";
 import {
   buildAdmin,
   buildCollection,
@@ -980,10 +981,11 @@ describe("#comments.create", () => {
       });
       expect(updated!.state).toBeTruthy();
 
-      const ydoc = new Y.Doc();
-      Y.applyUpdate(ydoc, updated!.state!);
-      const doc = Node.fromJSON(schema, yDocToProsemirrorJSON(ydoc, "default"));
-      expect(SharedProsemirrorHelper.getComments(doc)).toMatchObject([
+      expect(
+        SharedProsemirrorHelper.getComments(
+          DocumentHelper.toProsemirror(updated!)
+        )
+      ).toMatchObject([
         { id: body.data.id, userId: user.id, text: "brown fox" },
       ]);
     });

--- a/server/routes/api/comments/comments.ts
+++ b/server/routes/api/comments/comments.ts
@@ -13,6 +13,7 @@ import { transaction } from "@server/middlewares/transaction";
 import validate from "@server/middlewares/validate";
 import { ValidationError } from "@server/errors";
 import { Document, Comment, Collection, Reaction, Emoji } from "@server/models";
+import { DocumentHelper } from "@server/models/helpers/DocumentHelper";
 import { ProsemirrorHelper } from "@server/models/helpers/ProsemirrorHelper";
 import { TextHelper } from "@server/models/helpers/TextHelper";
 import { authorize } from "@server/policies";
@@ -78,13 +79,11 @@ router.post(
     const commentId = id || uuidv4();
 
     if (anchored) {
-      if (!document.state) {
-        throw ValidationError("Cannot inline comment on this document");
-      }
+      const docState = DocumentHelper.toState(document);
 
       const updated = anchorText
         ? ProsemirrorHelper.applyCommentMarkByText({
-            docState: document.state,
+            docState,
             anchorText,
             commentId,
             userId: user.id,
@@ -93,7 +92,7 @@ router.post(
           })
         : anchorNodeId
           ? ProsemirrorHelper.applyCommentMarkByNode({
-              docState: document.state,
+              docState,
               anchorNodeId,
               commentId,
               userId: user.id,

--- a/server/tools/comments.ts
+++ b/server/tools/comments.ts
@@ -295,14 +295,8 @@ export function commentTools(server: McpServer, scopes: string[]) {
               authorize(user, "comment", document);
 
               if (anchorText) {
-                if (!document.state) {
-                  throw ValidationError(
-                    "Cannot inline comment on this document"
-                  );
-                }
-
                 const updated = ProsemirrorHelper.applyCommentMarkByText({
-                  docState: document.state,
+                  docState: DocumentHelper.toState(document),
                   anchorText,
                   commentId,
                   userId: user.id,


### PR DESCRIPTION
Documents created through the API or MCP have no collaborative state until someone opens them in an editor, so anchored comments were rejected with "Cannot inline comment on this document".

- Add `DocumentHelper.toState`, which returns the document's state or derives one from its content when missing
- Use it in both the comments.create endpoint and the MCP create_comment tool
closes #13283