### PR TITLE
fix: Prevent long dialog titles from overflowing the modal

### DIFF
--- a/app/components/DialogTitle.tsx
+++ b/app/components/DialogTitle.tsx
@@ -86,4 +86,9 @@ const Subject = styled(Text)`
   > :first-child {
     flex-shrink: 0;
   }
+
+  // Allows the truncated text to shrink rather than widen its ancestors
+  > :last-child {
+    min-width: 0;
+  }
 `;

--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -225,6 +225,17 @@ const Header = styled(Flex)`
   font-weight: 600;
   padding: 24px 24px 12px;
   flex-shrink: 0;
+  gap: 8px;
+
+  // Allows a long title to wrap or truncate instead of pushing out the close
+  // button
+  > :first-child {
+    min-width: 0;
+  }
+
+  > :last-child {
+    flex-shrink: 0;
+  }
 `;
 
 const Wrapper = styled.div<{


### PR DESCRIPTION
Long confirmation dialog titles ran past the close button instead of wrapping.

- The truncated subject line in `DialogTitle` has `white-space: nowrap`, so its min-content width is the entire document title, and that intrinsic width propagated up the flex chain — it now gets `min-width: 0` so it can actually shrink and ellipsize.
- The modal header title can shrink, the close button no longer squeezes, and a gap keeps a wrapped title clear of it.