### PR TITLE
feat: Show when a history event happened via API or MCP

### DIFF
--- a/app/models/Event.ts
+++ b/app/models/Event.ts
@@ -1,3 +1,4 @@
+import type { AuthenticationType } from "@shared/types";
 import Collection from "./Collection";
 import Document from "./Document";
 import User from "./User";
@@ -32,6 +33,8 @@ class Event<T extends Model> extends Model {
   actor: User;
 
   actorId: string;
+
+  authType: AuthenticationType | null;
 
   data: Partial<T> | null;
 

--- a/app/scenes/Document/components/History/EventListItem.tsx
+++ b/app/scenes/Document/components/History/EventListItem.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from "react-i18next";
 import styled, { css } from "styled-components";
 import { s } from "@shared/styles";
 import Text from "@shared/components/Text";
+import { AuthenticationType } from "@shared/types";
 import type Document from "~/models/Document";
 import type Event from "~/models/Event";
 import Time from "~/components/Time";
@@ -21,6 +22,13 @@ import Logger from "~/utils/Logger";
 type Props = {
   document: Document;
   item: Event<Document>;
+};
+
+/** Authentication types that are surfaced in history, mapped to a display name. */
+const authTypeNames: Partial<Record<AuthenticationType, string>> = {
+  [AuthenticationType.API]: "API",
+  [AuthenticationType.OAUTH]: "API",
+  [AuthenticationType.MCP]: "MCP",
 };
 
 const EventListItem = ({ item }: Props) => {
@@ -88,14 +96,19 @@ const EventListItem = ({ item }: Props) => {
     return null;
   }
 
+  const authTypeName = item.authType ? authTypeNames[item.authType] : undefined;
+
   return (
     <EventItem>
       <IconWrapper size="xsmall" type="secondary">
         {icon}
       </IconWrapper>
       <Text size="xsmall" type="secondary">
-        {meta} &middot;{" "}
-        <Time dateTime={item.createdAt} relative shorten addSuffix />
+        {meta}
+        {authTypeName
+          ? ` ${t("via {{ authType }}", { authType: authTypeName })}`
+          : ""}{" "}
+        &middot; <Time dateTime={item.createdAt} relative shorten addSuffix />
       </Text>
     </EventItem>
   );

--- a/server/presenters/event.ts
+++ b/server/presenters/event.ts
@@ -8,6 +8,7 @@ export default function presentEvent(event: Event, isAdmin = false) {
     modelId: event.modelId,
     userId: event.userId,
     actorId: event.actorId,
+    authType: event.authType,
     actorIpAddress: event.ip || undefined,
     collectionId: event.collectionId,
     documentId: event.documentId,

--- a/server/types.ts
+++ b/server/types.ts
@@ -3,6 +3,7 @@ import type { IRouterParamContext } from "koa-router";
 import type { InferAttributes, Model, Transaction } from "sequelize";
 import type { z } from "zod";
 import type {
+  AuthenticationType,
   CollectionSort,
   NavigationNode,
   Client,
@@ -43,12 +44,7 @@ import type {
   OAuthClient,
 } from "./models";
 
-export enum AuthenticationType {
-  API = "api",
-  APP = "app",
-  MCP = "mcp",
-  OAUTH = "oauth",
-}
+export { AuthenticationType } from "@shared/types";
 
 export type AuthenticationResult = AccountProvisionerResult & {
   client: Client;

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -890,6 +890,7 @@
   "{{userName}} published": "{{userName}} published",
   "{{userName}} unpublished": "{{userName}} unpublished",
   "{{userName}} moved": "{{userName}} moved",
+  "via {{ authType }}": "via {{ authType }}",
   "Previous version": "Previous version",
   "Highlight changes": "Highlight changes",
   "Compare to": "Compare to",

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -13,6 +13,14 @@ export enum Scope {
   Create = "create",
 }
 
+/** The method used to authenticate a request. */
+export enum AuthenticationType {
+  API = "api",
+  APP = "app",
+  MCP = "mcp",
+  OAUTH = "oauth",
+}
+
 export type DateFilter = "day" | "week" | "month" | "year";
 
 export enum StatusFilter {


### PR DESCRIPTION
Document history now indicates when an event was performed outside the app, e.g. "Tom published via MCP".

- Moves `AuthenticationType` to shared types so the client can read it
- Exposes `authType` on the event presenter and client model
- Appends "via API" / "via MCP" to history event labels — OAuth displays as API, in-app events are unchanged

Note: "edited" rows come from revisions, which have no auth type, so they are unaffected.