### PR TITLE
fix(editor): re-measure code block toolbar when block resizes

### DIFF
--- a/app/editor/components/StickyBlockToolbar.tsx
+++ b/app/editor/components/StickyBlockToolbar.tsx
@@ -88,11 +88,23 @@ const StickyBlockToolbar = React.forwardRef(function StickyBlockToolbar_(
   const { view } = useEditor();
   const trackRef = ref || React.createRef<HTMLDivElement>();
   const [rect, setRect] = React.useState<TrackRect | null>(null);
+  const [, forceUpdate] = React.useReducer((x: number) => x + 1, 0);
 
   // Re-measure when the window resizes; scroll is handled by `position: sticky`.
   useWindowSize();
 
   const element = getBlockElement(view);
+
+  // Re-measure when the block's size changes (e.g. after an auto-expand that
+  // settles after the initial mount, or a font load that shifts layout).
+  React.useEffect(() => {
+    if (!element) {
+      return;
+    }
+    const observer = new ResizeObserver(forceUpdate);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [element, forceUpdate]);
 
   // Measure the block relative to the portal's offset parent. Runs after every
   // render by design, the rect comparison prevents a loop.


### PR DESCRIPTION
## Problem

The code block toolbar (Copy, Wrap, Language selector) drifts to the vertical center of the code block instead of the top-right corner after navigating between documents. Refreshing the page restores the correct position.

**Root cause:** `StickyBlockToolbar` stores the block's bounding rect and uses it to position the toolbar overlay. The measurement only re-ran when React triggered a re-render — on window resize or ProseMirror's `forceUpdate()`. When the block's DOM height changed after initial mount without a React re-render (e.g. a collapsed block auto-expanding asynchronously, or a custom font finishing loading and shifting line metrics), the stale rect became permanent until a full page reload.

## Fix

Add a `ResizeObserver` on the block element. Any dimension change fires `forceUpdate` (a `useReducer` dispatch with a stable identity), triggering a re-render and a fresh measurement via the existing `useLayoutEffect`. The observer is cleaned up when the element changes or the component unmounts.

```tsx
const [, forceUpdate] = React.useReducer((x: number) => x + 1, 0);

React.useEffect(() => {
  if (!element) return;
  const observer = new ResizeObserver(forceUpdate);
  observer.observe(element);
  return () => observer.disconnect();
}, [element, forceUpdate]);
```

Fixes #13282