### PR TITLE
fix: Statement timeouts reported as 404

### DIFF
--- a/server/errors.ts
+++ b/server/errors.ts
@@ -242,6 +242,15 @@ export function UnprocessableEntityError(
   });
 }
 
+export function RequestTimeoutError(
+  message = "Request took too long to complete"
+) {
+  return httpErrors(503, message, {
+    id: "request_timeout",
+    isReportable: true,
+  });
+}
+
 export function ClientClosedRequestError(
   message = "Client closed request before response was received"
 ) {

--- a/server/onerror.test.ts
+++ b/server/onerror.test.ts
@@ -1,4 +1,5 @@
 import type Koa from "koa";
+import { DatabaseError } from "sequelize";
 import type { Mock } from "vitest";
 import { requestErrorHandler } from "@server/logging/sentry";
 import { InternalError, ValidationError, NotFoundError } from "./errors";
@@ -15,7 +16,7 @@ type MockCtx = {
   writable: boolean;
   accepts: Mock;
   set: Mock;
-  res: { end: Mock };
+  res: { end: Mock; statusCode: number };
   status: number | undefined;
   type: string | undefined;
   body: unknown;
@@ -48,6 +49,7 @@ describe("onerror", () => {
       set: vi.fn(),
       res: {
         end: vi.fn(),
+        statusCode: 404,
       },
       status: undefined,
       type: undefined,
@@ -111,6 +113,27 @@ describe("onerror", () => {
     app.context.onerror.call(ctx, error);
 
     expect(requestErrorHandler).not.toHaveBeenCalled();
+  });
+
+  it("should convert a canceled query into a service unavailable error", () => {
+    const parent = new Error("canceling statement due to statement timeout");
+    Object.assign(parent, { code: "57014", sql: "SELECT 1" });
+    const error = new DatabaseError(parent as never);
+
+    app.context.onerror.call(ctx, error);
+
+    expect(requestErrorHandler).toHaveBeenCalled();
+    expect(ctx.status).toBe(503);
+    expect(ctx.body).toContain("request_timeout");
+  });
+
+  it("should set the response status code when the response is not writable", () => {
+    ctx.writable = false;
+
+    app.context.onerror.call(ctx, InternalError("Test internal error"));
+
+    expect(ctx.res.statusCode).toBe(500);
+    expect(ctx.res.end).not.toHaveBeenCalled();
   });
 
   it("should report errors explicitly marked with isReportable: true", () => {

--- a/server/onerror.ts
+++ b/server/onerror.ts
@@ -5,8 +5,13 @@ import formidable from "formidable";
 import type Koa from "koa";
 import { escape, isNil, snakeCase } from "es-toolkit/compat";
 import env from "@server/env";
-import { ClientClosedRequestError, InternalError } from "@server/errors";
+import {
+  ClientClosedRequestError,
+  InternalError,
+  RequestTimeoutError,
+} from "@server/errors";
 import { requestErrorHandler } from "@server/logging/sentry";
+import { isQueryCanceledError } from "@server/storage/database";
 import type { AppContext } from "@server/types";
 
 let errorHtmlCache: Buffer | undefined;
@@ -32,6 +37,8 @@ export default function onerror(app: Koa) {
       err.code === "EPIPE"
     ) {
       err = ClientClosedRequestError();
+    } else if (isQueryCanceledError(err)) {
+      err = RequestTimeoutError();
     }
 
     // Push only errors explicitly marked for Sentry reporting.
@@ -44,10 +51,15 @@ export default function onerror(app: Koa) {
           !http.STATUS_CODES[err.status] ||
           err.status === 500));
 
+    // Errors raised by the application describe an expected condition, so their
+    // status and message are safe to send even when they are also reported.
+    const isKnownError =
+      typeof err.id === "string" && err.id !== "internal_error";
+
     if (shouldReport) {
       requestErrorHandler(err, this);
 
-      if (!(err instanceof InternalError)) {
+      if (!isKnownError) {
         if (env.ENVIRONMENT === "test") {
           // oxlint-disable-next-line no-console
           console.error(err);
@@ -57,12 +69,17 @@ export default function onerror(app: Koa) {
     }
 
     const headerSent = this.headerSent || !this.writable;
-    if (headerSent) {
-      err.headerSent = true;
-    }
 
     // Nothing we can do here other than delegate to the app-level handler and log.
     if (headerSent) {
+      err.headerSent = true;
+
+      // Nothing was written, so the status code is still Koa's placeholder 404 –
+      // correct it so that logging and tracing report the real outcome.
+      if (!this.headerSent && typeof err.status === "number") {
+        this.res.statusCode = err.status;
+      }
+
       return;
     }
 

--- a/server/storage/database.ts
+++ b/server/storage/database.ts
@@ -1,5 +1,6 @@
 import cluster from "node:cluster";
 import path from "node:path";
+import { DatabaseError } from "sequelize";
 import type {
   InferAttributes,
   InferCreationAttributes,
@@ -46,6 +47,12 @@ function getDatabaseConfig() {
   );
 }
 
+/** Postgres error code for `query_canceled`. */
+const QueryCanceledErrorCode = "57014";
+
+/** Headroom between the statement timeout and the HTTP request timeout. */
+const StatementTimeoutMargin = 500;
+
 const isSSLDisabled = env.PGSSLMODE === "disable";
 const poolMax = env.DATABASE_CONNECTION_POOL_MAX ?? 5;
 const poolMin = env.DATABASE_CONNECTION_POOL_MIN ?? 0;
@@ -60,12 +67,32 @@ const isApiProcess =
   !env.SERVICES.includes("worker") &&
   !env.SERVICES.includes("cron");
 
-// Request-handling processes get a Postgres `statement_timeout` matching the
-// HTTP request timeout, so a single slow query cannot hold a connection past
-// the point at which its response could be delivered. Applied as `SET LOCAL`
-// inside each transaction so the value is scoped to the transaction.
+// Request-handling processes get a Postgres `statement_timeout` slightly under
+// the HTTP request timeout, so a single slow query cannot hold a connection
+// past the point at which its response could be delivered, and the cancelation
+// still leaves enough headroom to write an error response before the socket is
+// closed. Applied as `SET LOCAL` inside each transaction so the value is scoped
+// to the transaction.
 const statementTimeout =
-  isApiProcess && cluster.isWorker ? env.REQUEST_TIMEOUT : undefined;
+  isApiProcess && cluster.isWorker
+    ? Math.max(env.REQUEST_TIMEOUT - StatementTimeoutMargin, 1000)
+    : undefined;
+
+/**
+ * Whether an error was caused by Postgres canceling a query, most commonly
+ * because it exceeded the configured `statement_timeout`.
+ *
+ * @param err the error to inspect.
+ * @returns true if the query was canceled by the database.
+ */
+export function isQueryCanceledError(err: unknown): boolean {
+  return (
+    err instanceof DatabaseError &&
+    !!err.parent &&
+    "code" in err.parent &&
+    err.parent.code === QueryCanceledErrorCode
+  );
+}
 
 export function createDatabaseInstance(
   databaseConfig: string | object,

--- a/server/storage/database.ts
+++ b/server/storage/database.ts
@@ -75,7 +75,12 @@ const isApiProcess =
 // to the transaction.
 const statementTimeout =
   isApiProcess && cluster.isWorker
-    ? Math.max(env.REQUEST_TIMEOUT - StatementTimeoutMargin, 1000)
+    ? Math.max(
+        env.REQUEST_TIMEOUT - StatementTimeoutMargin,
+        // Fall back to a fraction of the request timeout when it is shorter
+        // than the margin, so the query is always canceled first.
+        Math.round(env.REQUEST_TIMEOUT / 2)
+      )
     : undefined;
 
 /**


### PR DESCRIPTION
Requests that hit the Postgres statement timeout were being recorded as 404s in logging and tracing, and the client saw a reset connection rather than an error response.

- The statement timeout was set to exactly `REQUEST_TIMEOUT`, so the server socket timeout destroyed the connection at the same moment the query was canceled — it now sits just below it, leaving room to write the response
- Canceled queries are mapped to a 503 rather than falling through to a generic internal error
- The status code is corrected when the response can no longer be written, instead of leaving Koa's placeholder 404 for tracing to report
- Errors raised by the application keep their status and message when reported, rather than always being rewritten to a 500