### PR TITLE
perf: Index-friendly popularity score scan, spread runs over an hour

### DIFF
--- a/server/migrations/20260804130000-add-documents-active-popularity-index.js
+++ b/server/migrations/20260804130000-add-documents-active-popularity-index.js
@@ -1,0 +1,19 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    // Covers the popularity score task, which walks the id space of documents
+    // that already carry a score so they decay back to zero. Partial so it only
+    // indexes the small subset with a non-zero score.
+    await queryInterface.sequelize.query(
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS "documents_active_popularity_score" ON "documents" ("id") WHERE "popularityScore" > 0;'
+    );
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(
+      'DROP INDEX CONCURRENTLY IF EXISTS "documents_active_popularity_score";'
+    );
+  },
+};

--- a/server/migrations/20260804130000-add-documents-active-popularity-index.js
+++ b/server/migrations/20260804130000-add-documents-active-popularity-index.js
@@ -3,11 +3,11 @@
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up(queryInterface) {
-    // Covers the popularity score task, which walks a slice of teams to find
-    // documents that already carry a score so they decay back to zero. Partial
-    // so it only indexes the small subset with a non-zero score.
+    // Covers the popularity score task's scan for documents that already
+    // carry a score so they decay back to zero. Partial so it only indexes
+    // the small subset with a non-zero score.
     await queryInterface.sequelize.query(
-      'CREATE INDEX CONCURRENTLY IF NOT EXISTS "documents_active_popularity_score" ON "documents" ("teamId", "id") WHERE "popularityScore" > 0;'
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS "documents_active_popularity_score" ON "documents" ("id") WHERE "popularityScore" > 0;'
     );
   },
 

--- a/server/migrations/20260804130000-add-documents-active-popularity-index.js
+++ b/server/migrations/20260804130000-add-documents-active-popularity-index.js
@@ -3,11 +3,11 @@
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up(queryInterface) {
-    // Covers the popularity score task, which walks the id space of documents
-    // that already carry a score so they decay back to zero. Partial so it only
-    // indexes the small subset with a non-zero score.
+    // Covers the popularity score task, which walks a slice of teams to find
+    // documents that already carry a score so they decay back to zero. Partial
+    // so it only indexes the small subset with a non-zero score.
     await queryInterface.sequelize.query(
-      'CREATE INDEX CONCURRENTLY IF NOT EXISTS "documents_active_popularity_score" ON "documents" ("id") WHERE "popularityScore" > 0;'
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS "documents_active_popularity_score" ON "documents" ("teamId", "id") WHERE "popularityScore" > 0;'
     );
   },
 

--- a/server/queues/tasks/UpdateDocumentsPopularityScoreTask.test.ts
+++ b/server/queues/tasks/UpdateDocumentsPopularityScoreTask.test.ts
@@ -243,6 +243,74 @@ describe("UpdateDocumentsPopularityScoreTask", () => {
     expect(Number(updatedDocument?.popularityScore)).toBe(0);
   });
 
+  it("should only process teams within its partition", async () => {
+    const team = await buildTeam();
+    const document = await buildDocument({
+      teamId: team.id,
+      publishedAt: new Date(),
+    });
+    await DocumentInsight.create({
+      documentId: document.id,
+      teamId: team.id,
+      date: dayStr(new Date()),
+      viewCount: 5,
+    });
+
+    // Partition 0 of 2 covers the lower half of the UUID space
+    const partitionIndex =
+      team.id < "80000000-0000-0000-0000-000000000000" ? 0 : 1;
+
+    await task.perform({
+      limit: 10000,
+      partition: { partitionIndex: 1 - partitionIndex, partitionCount: 2 },
+    });
+
+    const untouched = await Document.findByPk(document.id);
+    expect(Number(untouched?.popularityScore)).toBe(0);
+
+    await task.perform({
+      limit: 10000,
+      partition: { partitionIndex, partitionCount: 2 },
+    });
+
+    const updated = await Document.findByPk(document.id);
+    expect(Number(updated?.popularityScore)).toBeGreaterThan(0);
+  });
+
+  it("should skip execution based on when the run was scheduled", async () => {
+    // Partitions execute hours after they are scheduled, so the interval check
+    // must use the scheduled time rather than the current hour.
+    vi.spyOn(Date.prototype, "getHours").mockRestore();
+
+    const team = await buildTeam();
+    const document = await buildDocument({
+      teamId: team.id,
+      publishedAt: new Date(),
+    });
+    await DocumentInsight.create({
+      documentId: document.id,
+      teamId: team.id,
+      date: dayStr(new Date()),
+      viewCount: 5,
+    });
+
+    const offInterval = new Date();
+    offInterval.setHours(1, 0, 0, 0);
+
+    await task.perform({ ...props, scheduledAt: offInterval.getTime() });
+
+    const untouched = await Document.findByPk(document.id);
+    expect(Number(untouched?.popularityScore)).toBe(0);
+
+    const onInterval = new Date();
+    onInterval.setHours(0, 0, 0, 0);
+
+    await task.perform({ ...props, scheduledAt: onInterval.getTime() });
+
+    const updated = await Document.findByPk(document.id);
+    expect(Number(updated?.popularityScore)).toBeGreaterThan(0);
+  });
+
   it("should only process published and non-deleted documents", async () => {
     const team = await buildTeam();
 

--- a/server/queues/tasks/UpdateDocumentsPopularityScoreTask.test.ts
+++ b/server/queues/tasks/UpdateDocumentsPopularityScoreTask.test.ts
@@ -243,7 +243,7 @@ describe("UpdateDocumentsPopularityScoreTask", () => {
     expect(Number(updatedDocument?.popularityScore)).toBe(0);
   });
 
-  it("should only process teams within its partition", async () => {
+  it("should only process documents within its partition", async () => {
     const team = await buildTeam();
     const document = await buildDocument({
       teamId: team.id,
@@ -258,7 +258,7 @@ describe("UpdateDocumentsPopularityScoreTask", () => {
 
     // Partition 0 of 2 covers the lower half of the UUID space
     const partitionIndex =
-      team.id < "80000000-0000-0000-0000-000000000000" ? 0 : 1;
+      document.id < "80000000-0000-0000-0000-000000000000" ? 0 : 1;
 
     await task.perform({
       limit: 10000,

--- a/server/queues/tasks/UpdateDocumentsPopularityScoreTask.ts
+++ b/server/queues/tasks/UpdateDocumentsPopularityScoreTask.ts
@@ -183,29 +183,55 @@ export default class UpdateDocumentsPopularityScoreTask extends CronTask {
     // window). Must be valid: published and not deleted. Process in chunks to
     // avoid long-running queries. Read from replica to avoid excessive locking.
     let lastId = startUuid;
+    let isFirstChunk = true;
     let insertedCount = 0;
     const chunkSize = 1000;
 
     while (true) {
-      // Step 1: Read document IDs from readonly replica to avoid locking
-      const documentIds = await sequelizeReadOnly.query<{ id: string }>(
+      // The first chunk starts at the inclusive lower bound of the partition,
+      // subsequent chunks resume after the last candidate seen.
+      const idOperator = isFirstChunk ? ">=" : ">";
+
+      // Step 1: Read candidate document IDs from readonly replica to avoid
+      // locking. The two sources are queried separately so that each can be
+      // served by an index — combining them into a single OR forces a scan of
+      // every document in the partition. Limiting each branch and then the
+      // union still yields the globally lowest `chunkSize` ids, so keyset
+      // pagination remains correct.
+      const candidates = await sequelizeReadOnly.query<{
+        id: string;
+        eligible: boolean;
+      }>(
         `
-        SELECT d.id
-        FROM documents d
-        WHERE d."publishedAt" IS NOT NULL
-          AND d."deletedAt" IS NULL
-          ${lastId ? (insertedCount === 0 ? "AND d.id >= :lastId" : "AND d.id > :lastId") : ""}
-          ${endUuid ? "AND d.id <= :endUuid" : ""}
-          AND (
-            d."popularityScore" > 0
-            OR EXISTS (
-              SELECT 1 FROM document_insights di
-              WHERE di."documentId" = d.id
-                AND di.date >= :thresholdDate::date
-                AND di.date <= :today::date
-            )
+        WITH candidates AS (
+          (
+            SELECT DISTINCT di."documentId" AS id
+            FROM document_insights di
+            WHERE di."documentId" ${idOperator} :lastId
+              AND di."documentId" <= :endUuid
+              AND di.date >= :thresholdDate::date
+              AND di.date <= :today::date
+            ORDER BY id
+            LIMIT :limit
           )
-        ORDER BY d.id
+          UNION
+          (
+            SELECT d.id
+            FROM documents d
+            WHERE d.id ${idOperator} :lastId
+              AND d.id <= :endUuid
+              AND d."popularityScore" > 0
+            ORDER BY id
+            LIMIT :limit
+          )
+        )
+        SELECT c.id, (d.id IS NOT NULL) AS eligible
+        FROM candidates c
+        LEFT JOIN documents d
+          ON d.id = c.id
+          AND d."publishedAt" IS NOT NULL
+          AND d."deletedAt" IS NULL
+        ORDER BY c.id
         LIMIT :limit
         `,
         {
@@ -220,29 +246,34 @@ export default class UpdateDocumentsPopularityScoreTask extends CronTask {
         }
       );
 
-      if (documentIds.length === 0) {
+      if (candidates.length === 0) {
         break;
       }
 
-      // Step 2: Insert the IDs into the working table on primary
-      const ids = documentIds.map((d) => d.id);
-      const result = await sequelize.query<{ documentId: string }>(
-        `
-        INSERT INTO ${this.workingTable} ("documentId")
-        SELECT * FROM unnest(ARRAY[:ids]::uuid[])
-        ON CONFLICT ("documentId") DO NOTHING
-        RETURNING "documentId"
-        `,
-        {
-          replacements: { ids },
-          type: QueryTypes.SELECT,
-        }
-      );
+      // Step 2: Insert the eligible IDs into the working table on primary
+      const ids = candidates.filter((c) => c.eligible).map((c) => c.id);
 
-      insertedCount += result.length;
-      lastId = documentIds[documentIds.length - 1].id;
+      if (ids.length > 0) {
+        const result = await sequelize.query<{ documentId: string }>(
+          `
+          INSERT INTO ${this.workingTable} ("documentId")
+          SELECT * FROM unnest(ARRAY[:ids]::uuid[])
+          ON CONFLICT ("documentId") DO NOTHING
+          RETURNING "documentId"
+          `,
+          {
+            replacements: { ids },
+            type: QueryTypes.SELECT,
+          }
+        );
 
-      if (documentIds.length < chunkSize) {
+        insertedCount += result.length;
+      }
+
+      lastId = candidates[candidates.length - 1].id;
+      isFirstChunk = false;
+
+      if (candidates.length < chunkSize) {
         break;
       }
     }

--- a/server/queues/tasks/UpdateDocumentsPopularityScoreTask.ts
+++ b/server/queues/tasks/UpdateDocumentsPopularityScoreTask.ts
@@ -3,7 +3,7 @@ import { setTimeout } from "node:timers/promises";
 import { subDays } from "date-fns";
 import { QueryTypes } from "sequelize";
 import { toError } from "@shared/utils/error";
-import { Minute } from "@shared/utils/time";
+import { Hour } from "@shared/utils/time";
 import env from "@server/env";
 import Logger from "@server/logging/Logger";
 import { TaskPriority } from "./base/BaseTask";
@@ -43,6 +43,12 @@ const INTER_BATCH_DELAY_MS = 500;
  */
 const WORKING_TABLE_PREFIX = "popularity_score_working";
 
+/**
+ * Number of hours over which to spread a single run. Partitions are scheduled
+ * one minute apart across this window, so each handles a small slice of teams.
+ */
+const SPREAD_HOURS = 6;
+
 interface DocumentScore {
   documentId: string;
   score: number;
@@ -54,13 +60,15 @@ export default class UpdateDocumentsPopularityScoreTask extends CronTask {
    */
   private workingTable: string = "";
 
-  public async perform({ partition }: Props) {
-    // Only run every X hours, skip other hours
-    const currentHour = new Date().getHours();
-    if (currentHour % env.POPULARITY_UPDATE_INTERVAL_HOURS !== 0) {
+  public async perform({ partition, scheduledAt }: Props) {
+    // Only run every X hours, skip other hours. Partitions of a single run are
+    // spread over several hours, so this is based on when the run was
+    // scheduled rather than when this partition happens to execute.
+    const scheduledHour = new Date(scheduledAt ?? Date.now()).getHours();
+    if (scheduledHour % env.POPULARITY_UPDATE_INTERVAL_HOURS !== 0) {
       Logger.debug(
         "task",
-        `Skipping popularity score update, will run at next ${env.POPULARITY_UPDATE_INTERVAL_HOURS}-hour interval (current hour: ${currentHour})`
+        `Skipping popularity score update, will run at next ${env.POPULARITY_UPDATE_INTERVAL_HOURS}-hour interval (scheduled hour: ${scheduledHour})`
       );
       return;
     }
@@ -178,22 +186,19 @@ export default class UpdateDocumentsPopularityScoreTask extends CronTask {
       )
     `);
 
-    const [startUuid, endUuid] = this.getPartitionBounds(partition);
+    const [startTeamId, endTeamId] = this.getPartitionBounds(partition);
 
     // Populate with documents that have recent activity OR a current non-zero
     // score (so dormant docs decay back to zero once activity falls out of the
     // window). Must be valid: published and not deleted. Process in chunks to
     // avoid long-running queries. Read from replica to avoid excessive locking.
-    let lastId = startUuid;
-    let isFirstChunk = true;
+    // The nil UUID is never generated, so no real document can be skipped by
+    // starting the cursor there.
+    let lastId = "00000000-0000-0000-0000-000000000000";
     let insertedCount = 0;
     const chunkSize = 1000;
 
     while (true) {
-      // The first chunk starts at the inclusive lower bound of the partition,
-      // subsequent chunks resume after the last candidate seen.
-      const idOperator = isFirstChunk ? ">=" : ">";
-
       // Step 1: Read candidate document IDs from readonly replica to avoid
       // locking. The two sources are queried separately so that each can be
       // served by an index — combining them into a single OR forces a scan of
@@ -209,10 +214,11 @@ export default class UpdateDocumentsPopularityScoreTask extends CronTask {
           (
             SELECT DISTINCT di."documentId" AS id
             FROM document_insights di
-            WHERE di."documentId" ${idOperator} :lastId
-              AND di."documentId" <= :endUuid
+            WHERE di."teamId" >= :startTeamId
+              AND di."teamId" <= :endTeamId
               AND di.date >= :thresholdDate::date
               AND di.date <= :today::date
+              AND di."documentId" > :lastId
             ORDER BY id
             LIMIT :limit
           )
@@ -220,9 +226,10 @@ export default class UpdateDocumentsPopularityScoreTask extends CronTask {
           (
             SELECT d.id
             FROM documents d
-            WHERE d.id ${idOperator} :lastId
-              AND d.id <= :endUuid
+            WHERE d."teamId" >= :startTeamId
+              AND d."teamId" <= :endTeamId
               AND d."popularityScore" > 0
+              AND d.id > :lastId
             ORDER BY id
             LIMIT :limit
           )
@@ -241,7 +248,8 @@ export default class UpdateDocumentsPopularityScoreTask extends CronTask {
             thresholdDate,
             today,
             lastId,
-            endUuid,
+            startTeamId,
+            endTeamId,
             limit: chunkSize,
           },
           type: QueryTypes.SELECT,
@@ -273,7 +281,6 @@ export default class UpdateDocumentsPopularityScoreTask extends CronTask {
       }
 
       lastId = candidates[candidates.length - 1].id;
-      isFirstChunk = false;
 
       if (candidates.length < chunkSize) {
         break;
@@ -519,7 +526,7 @@ export default class UpdateDocumentsPopularityScoreTask extends CronTask {
   public get cron() {
     return {
       interval: TaskInterval.Hour,
-      partitionWindow: 30 * Minute.ms,
+      partitionWindow: SPREAD_HOURS * Hour.ms,
     };
   }
 

--- a/server/queues/tasks/UpdateDocumentsPopularityScoreTask.ts
+++ b/server/queues/tasks/UpdateDocumentsPopularityScoreTask.ts
@@ -45,9 +45,10 @@ const WORKING_TABLE_PREFIX = "popularity_score_working";
 
 /**
  * Number of hours over which to spread a single run. Partitions are scheduled
- * one minute apart across this window, so each handles a small slice of teams.
+ * one minute apart across this window, so each handles a small slice of
+ * documents.
  */
-const SPREAD_HOURS = 6;
+const SPREAD_HOURS = 1;
 
 interface DocumentScore {
   documentId: string;
@@ -186,7 +187,7 @@ export default class UpdateDocumentsPopularityScoreTask extends CronTask {
       )
     `);
 
-    const [startTeamId, endTeamId] = this.getPartitionBounds(partition);
+    const [startId, endId] = this.getPartitionBounds(partition);
 
     // Populate with documents that have recent activity OR a current non-zero
     // score (so dormant docs decay back to zero once activity falls out of the
@@ -214,10 +215,10 @@ export default class UpdateDocumentsPopularityScoreTask extends CronTask {
           (
             SELECT DISTINCT di."documentId" AS id
             FROM document_insights di
-            WHERE di."teamId" >= :startTeamId
-              AND di."teamId" <= :endTeamId
-              AND di.date >= :thresholdDate::date
+            WHERE di.date >= :thresholdDate::date
               AND di.date <= :today::date
+              AND di."documentId" >= :startId
+              AND di."documentId" <= :endId
               AND di."documentId" > :lastId
             ORDER BY id
             LIMIT :limit
@@ -226,9 +227,9 @@ export default class UpdateDocumentsPopularityScoreTask extends CronTask {
           (
             SELECT d.id
             FROM documents d
-            WHERE d."teamId" >= :startTeamId
-              AND d."teamId" <= :endTeamId
-              AND d."popularityScore" > 0
+            WHERE d."popularityScore" > 0
+              AND d.id >= :startId
+              AND d.id <= :endId
               AND d.id > :lastId
             ORDER BY id
             LIMIT :limit
@@ -248,8 +249,8 @@ export default class UpdateDocumentsPopularityScoreTask extends CronTask {
             thresholdDate,
             today,
             lastId,
-            startTeamId,
-            endTeamId,
+            startId,
+            endId,
             limit: chunkSize,
           },
           type: QueryTypes.SELECT,
@@ -476,14 +477,17 @@ export default class UpdateDocumentsPopularityScoreTask extends CronTask {
   }
 
   /**
-   * Drops any stale working tables from previous dates that were left behind
-   * by runs interrupted before cleanup could occur (e.g. worker killed mid-run).
-   * Only removes tables from before the current date to avoid race conditions
-   * with concurrent runs.
+   * Drops any stale working tables that were left behind by runs interrupted
+   * before cleanup could occur (e.g. worker killed mid-run). Only removes
+   * tables created well before the current run's window to avoid race
+   * conditions with concurrent runs.
    */
   private async cleanupStaleWorkingTables(): Promise<void> {
     try {
-      const todayStr = new Date().toISOString().slice(0, 10).replace(/-/g, "");
+      const cutoff = new Date(Date.now() - (SPREAD_HOURS + 2) * Hour.ms)
+        .toISOString()
+        .slice(0, 19)
+        .replace(/[-:T]/g, "");
       const tables = await sequelize.query<{ tablename: string }>(
         `SELECT tablename FROM pg_tables
          WHERE schemaname = 'public'
@@ -499,8 +503,8 @@ export default class UpdateDocumentsPopularityScoreTask extends CronTask {
       const prefixLen = WORKING_TABLE_PREFIX.length + 1; // +1 for underscore
 
       for (const { tablename } of tables) {
-        const dateStr = tablename.slice(prefixLen, prefixLen + 8);
-        if (dateStr < todayStr) {
+        const timestamp = tablename.slice(prefixLen, prefixLen + 14);
+        if (timestamp < cutoff) {
           Logger.info("task", `Dropping stale working table: ${tablename}`);
           await sequelize.query(`DROP TABLE IF EXISTS "${tablename}" CASCADE`);
         }

--- a/server/queues/tasks/UpdateDocumentsPopularityScoreTask.ts
+++ b/server/queues/tasks/UpdateDocumentsPopularityScoreTask.ts
@@ -87,9 +87,11 @@ export default class UpdateDocumentsPopularityScoreTask extends CronTask {
       await this.cleanupStaleWorkingTables();
 
       // Setup: Create working table and populate with active document IDs
-      await this.setupWorkingTable(thresholdDate, today, partition);
-
-      const activeCount = await this.getWorkingTableCount();
+      const activeCount = await this.setupWorkingTable(
+        thresholdDate,
+        today,
+        partition
+      );
 
       if (activeCount === 0) {
         Logger.info("task", "No documents with recent activity found");
@@ -107,11 +109,6 @@ export default class UpdateDocumentsPopularityScoreTask extends CronTask {
       let batchNumber = 0;
 
       while (true) {
-        const remaining = await this.getWorkingTableCount();
-        if (remaining === 0) {
-          break;
-        }
-
         batchNumber++;
 
         try {
@@ -120,13 +117,16 @@ export default class UpdateDocumentsPopularityScoreTask extends CronTask {
 
           Logger.debug(
             "task",
-            `Batch ${batchNumber}: updated ${updated} documents, ${remaining - updated} remaining`
+            `Batch ${batchNumber}: updated ${updated} documents`
           );
 
-          // Add delay between batches to reduce sustained pressure on the database
-          if (remaining - updated > 0) {
-            await setTimeout(INTER_BATCH_DELAY_MS);
+          // A short batch means the working table is drained.
+          if (updated < BATCH_SIZE) {
+            break;
           }
+
+          // Add delay between batches to reduce sustained pressure on the database
+          await setTimeout(INTER_BATCH_DELAY_MS);
         } catch (error) {
           totalErrors++;
           Logger.error(
@@ -159,12 +159,14 @@ export default class UpdateDocumentsPopularityScoreTask extends CronTask {
    * Creates an unlogged working table and populates it with document IDs
    * that have recent activity. Unlogged tables are faster because they
    * skip WAL logging, and data loss on crash is acceptable here.
+   *
+   * @returns the number of documents added to the working table.
    */
   private async setupWorkingTable(
     thresholdDate: string,
     today: string,
     partition: PartitionInfo
-  ): Promise<void> {
+  ): Promise<number> {
     // Drop any existing table first to avoid type conflicts from previous crashed runs
     await sequelize.query(`DROP TABLE IF EXISTS ${this.workingTable} CASCADE`);
 
@@ -287,17 +289,8 @@ export default class UpdateDocumentsPopularityScoreTask extends CronTask {
     await sequelize.query(`
       CREATE INDEX ON ${this.workingTable} (processed) WHERE NOT processed
     `);
-  }
 
-  /**
-   * Returns count of unprocessed documents in working table
-   */
-  private async getWorkingTableCount(): Promise<number> {
-    const [result] = await sequelize.query<{ count: string }>(
-      `SELECT COUNT(*) as count FROM ${this.workingTable} WHERE NOT processed`,
-      { type: QueryTypes.SELECT }
-    );
-    return parseInt(result.count, 10);
+    return insertedCount;
   }
 
   /**

--- a/server/queues/tasks/base/CronTask.ts
+++ b/server/queues/tasks/base/CronTask.ts
@@ -68,9 +68,7 @@ export type Props = {
   /**
    * Epoch milliseconds at which the run this partition belongs to was
    * scheduled. Tasks spread over a long `partitionWindow` should derive any
-   * time-of-day decisions from this rather than the execution time, which may
-   * be hours later. Optional for backwards compatibility with jobs enqueued
-   * before this field existed.
+   * time-of-day decisions from this rather than the execution time.
    */
   scheduledAt?: number;
 };

--- a/server/queues/tasks/base/CronTask.ts
+++ b/server/queues/tasks/base/CronTask.ts
@@ -65,6 +65,14 @@ export type PartitionInfo = {
 export type Props = {
   limit: number;
   partition: PartitionInfo;
+  /**
+   * Epoch milliseconds at which the run this partition belongs to was
+   * scheduled. Tasks spread over a long `partitionWindow` should derive any
+   * time-of-day decisions from this rather than the execution time, which may
+   * be hours later. Optional for backwards compatibility with jobs enqueued
+   * before this field existed.
+   */
+  scheduledAt?: number;
 };
 
 export abstract class CronTask extends BaseTask<Props> {

--- a/server/routes/api/cron/cron.ts
+++ b/server/routes/api/cron/cron.ts
@@ -28,6 +28,8 @@ const cronHandler = async (ctx: APIContext<T.CronSchemaReq>) => {
 
   receivedPeriods.add(period);
 
+  const scheduledAt = Date.now();
+
   for (const name in tasks) {
     const TaskClass = tasks[name];
     if (!(TaskClass.prototype instanceof CronTask)) {
@@ -72,7 +74,10 @@ const cronHandler = async (ctx: APIContext<T.CronSchemaReq>) => {
             }/${partitions}) with delay of ${delay / 1000}s`
           );
 
-          await taskInstance.schedule({ limit, partition }, { delay });
+          await taskInstance.schedule(
+            { limit, partition, scheduledAt },
+            { delay }
+          );
         }
       } else {
         await taskInstance.schedule(
@@ -82,6 +87,7 @@ const cronHandler = async (ctx: APIContext<T.CronSchemaReq>) => {
               partitionIndex: 0,
               partitionCount: 1,
             },
+            scheduledAt,
           },
           { delay: taskDelay }
         );

--- a/server/services/cron.ts
+++ b/server/services/cron.ts
@@ -19,7 +19,11 @@ export default function init() {
       const taskInstance = new TaskClass() as CronTask;
 
       if (taskInstance.cron.interval === schedule) {
-        await taskInstance.schedule({ limit: 10000, partition });
+        await taskInstance.schedule({
+          limit: 10000,
+          partition,
+          scheduledAt: Date.now(),
+        });
       }
     }
   }

--- a/server/services/cron.ts
+++ b/server/services/cron.ts
@@ -8,6 +8,7 @@ export default function init() {
       partitionIndex: 0,
       partitionCount: 1,
     };
+    const scheduledAt = Date.now();
 
     for (const name in tasks) {
       const TaskClass = tasks[name];
@@ -22,7 +23,7 @@ export default function init() {
         await taskInstance.schedule({
           limit: 10000,
           partition,
-          scheduledAt: Date.now(),
+          scheduledAt,
         });
       }
     }


### PR DESCRIPTION
Reduces the hourly DB latency spike caused by the popularity score task, which previously scanned every published document per run.

- Rewrite the candidate scan as a UNION of two index-served branches (recent insights + already-scored documents) instead of an OR predicate that forced a full scan; adds a partial index on scored documents
- Ineligible candidates (drafts/deleted) still advance the pagination cursor via a post-filter, so chunking cannot stall
- Drop the `COUNT(*)` previously run before every batch; the loop now drains on a short batch
- Spread each run's 60 partitions one minute apart across an hour, and gate the run interval on the scheduled time via a new `scheduledAt` prop so tail partitions crossing the hour boundary don't skip
- Stale working-table cleanup now compares full timestamps with a safety margin instead of date-only