### PR TITLE
fix: Table cell background pasted as a text highlight

### DIFF
--- a/shared/editor/lib/table.test.ts
+++ b/shared/editor/lib/table.test.ts
@@ -1,5 +1,5 @@
 import { Schema } from "prosemirror-model";
-import { isValidCellAlignment, isValidCellMarks } from "./table";
+import { getCellAttrs, isValidCellAlignment, isValidCellMarks } from "./table";
 
 const schema = new Schema({
   nodes: {
@@ -163,5 +163,39 @@ describe("isValidCellMarks", () => {
   it("accepts registered marks without attrs", () => {
     expect(isValidCellMarks([{ type: "strong" }], schema)).toBe(true);
     expect(isValidCellMarks([{ type: "em" }], schema)).toBe(true);
+  });
+});
+
+// Shared tests run in both node and jsdom; reading cell attributes requires a DOM.
+describe.runIf(typeof document !== "undefined")("getCellAttrs", () => {
+  const cell = (attributes: Record<string, string>) => {
+    const element = document.createElement("td");
+    for (const [name, value] of Object.entries(attributes)) {
+      element.setAttribute(name, value);
+    }
+    return getCellAttrs(element);
+  };
+
+  it("reads the background written by the editor", () => {
+    expect(cell({ "data-bgcolor": "#FDEA9B" }).marks).toEqual([
+      { type: "background", attrs: { color: "#FDEA9B" } },
+    ]);
+  });
+
+  it("reads a background styled by an external application", () => {
+    expect(cell({ style: "background-color: #93c47d" }).marks).toEqual([
+      { type: "background", attrs: { color: "#93c47d" } },
+    ]);
+    expect(cell({ style: "background: yellow" }).marks).toEqual([
+      { type: "background", attrs: { color: "#ffff00" } },
+    ]);
+  });
+
+  it("ignores near-white and transparent cell backgrounds", () => {
+    expect(cell({ style: "background-color: #ffffff" }).marks).toBe(undefined);
+    expect(cell({ style: "background-color: transparent" }).marks).toBe(
+      undefined
+    );
+    expect(cell({}).marks).toBe(undefined);
   });
 });

--- a/shared/editor/lib/table.ts
+++ b/shared/editor/lib/table.ts
@@ -1,7 +1,7 @@
 import type { Attrs, Node, Schema } from "prosemirror-model";
 import type { MutableAttrs } from "prosemirror-tables";
 import { isBrowser } from "../../utils/browser";
-import { validateColorHex } from "../../utils/color";
+import { isNearWhite, toHexColor, validateColorHex } from "../../utils/color";
 import type { TableLayout, NodeAttrMark } from "../types";
 import { readableColor } from "polished";
 
@@ -77,6 +77,21 @@ export const isValidCellMarks = (
 };
 
 /**
+ * Reads a background color styled on a cell by an external application, such as
+ * a spreadsheet or word processor, so that it is retained when pasting.
+ *
+ * @param dom DOM node to read the background from
+ * @returns The background in hex notation, or null when there is none worth keeping
+ */
+function getCellBackground(dom: HTMLElement): string | null {
+  const background = dom.style.backgroundColor;
+  if (!background || isNearWhite(background)) {
+    return null;
+  }
+  return toHexColor(background);
+}
+
+/**
  * Helper to get cell attributes from a DOM node, used when pasting table content.
  *
  * @param dom DOM node to get attributes from
@@ -94,7 +109,7 @@ export function getCellAttrs(dom: HTMLElement | string): Attrs {
       : null;
   const colspan = Number(dom.getAttribute("colspan") || 1);
 
-  const bgColor = dom.getAttribute("data-bgcolor");
+  const bgColor = dom.getAttribute("data-bgcolor") ?? getCellBackground(dom);
 
   return {
     colspan,

--- a/shared/editor/marks/Highlight.test.ts
+++ b/shared/editor/marks/Highlight.test.ts
@@ -50,6 +50,14 @@ describe.runIf(typeof document !== "undefined")("highlight parsing", () => {
     expect(cell.content[0].content[0].marks).toBeUndefined();
   });
 
+  it("ignores a background inherited through transparent ancestors", () => {
+    const doc = parseHTML(
+      `<table><tbody><tr><td style="background-color: #FDEA9B"><p style="background-color: transparent"><span style="background-color: #FDEA9B">text</span></p></td></tr></tbody></table>`
+    );
+    const cell = doc.content[0].content[0].content[0];
+    expect(cell.content[0].content[0].marks).toBeUndefined();
+  });
+
   it("keeps a highlight that differs from the table cell background", () => {
     const doc = parseHTML(
       `<table><tbody><tr><td style="background-color: #93c47d"><p><span style="background-color: #FDEA9B">text</span></p></td></tr></tbody></table>`

--- a/shared/editor/marks/Highlight.test.ts
+++ b/shared/editor/marks/Highlight.test.ts
@@ -1,0 +1,62 @@
+import { DOMParser } from "prosemirror-model";
+import { schema } from "@shared/test/editor";
+
+/**
+ * Parses an HTML string with the editor schema, in the same way as pasted
+ * content, and returns the resulting document as JSON.
+ */
+function parseHTML(html: string) {
+  const element = document.createElement("div");
+  element.innerHTML = html;
+  return DOMParser.fromSchema(schema).parse(element).toJSON();
+}
+
+// Shared tests run in both node and jsdom; parsing HTML requires a DOM.
+describe.runIf(typeof document !== "undefined")("highlight parsing", () => {
+  it("parses a preset background color as the matching preset", () => {
+    const doc = parseHTML(
+      `<p><span style="background-color: #FDEA9B">text</span></p>`
+    );
+    expect(doc.content[0].content[0].marks).toEqual([
+      { type: "highlight", attrs: { color: "#FDEA9B" } },
+    ]);
+  });
+
+  it("matches a preset rendered translucently", () => {
+    const doc = parseHTML(
+      `<p><span style="background-color: rgba(253, 234, 155, 0.4)">text</span></p>`
+    );
+    expect(doc.content[0].content[0].marks).toEqual([
+      { type: "highlight", attrs: { color: "#FDEA9B" } },
+    ]);
+  });
+
+  it("ignores backgrounds that are not a preset color", () => {
+    const doc = parseHTML(
+      `<p><span style="background-color: rgb(147, 196, 125)">one</span><span style="background-color: #FDEA9C">two</span><span style="background-color: #ffffff">three</span><span style="background-color: transparent">four</span></p>`
+    );
+    expect(doc.content[0].content[0].marks).toBeUndefined();
+    expect(doc.content[0].content).toHaveLength(1);
+  });
+
+  it("ignores a background inherited from a shaded table cell", () => {
+    const doc = parseHTML(
+      `<table><tbody><tr><td style="background-color: #FDEA9B"><p><span style="background-color: #FDEA9B">text</span></p></td></tr></tbody></table>`
+    );
+    const cell = doc.content[0].content[0].content[0];
+    expect(cell.attrs.marks).toEqual([
+      { type: "background", attrs: { color: "#fdea9b" } },
+    ]);
+    expect(cell.content[0].content[0].marks).toBeUndefined();
+  });
+
+  it("keeps a highlight that differs from the table cell background", () => {
+    const doc = parseHTML(
+      `<table><tbody><tr><td style="background-color: #93c47d"><p><span style="background-color: #FDEA9B">text</span></p></td></tr></tbody></table>`
+    );
+    const cell = doc.content[0].content[0].content[0];
+    expect(cell.content[0].content[0].marks).toEqual([
+      { type: "highlight", attrs: { color: "#FDEA9B" } },
+    ]);
+  });
+});

--- a/shared/editor/marks/Highlight.ts
+++ b/shared/editor/marks/Highlight.ts
@@ -4,7 +4,32 @@ import { toggleMark } from "../commands/toggleMark";
 import { markInputRuleForPattern } from "../lib/markInputRule";
 import markRule from "../rules/mark";
 import Mark from "./Mark";
-import { presetColors, hexToRgba, validateColorHex } from "@shared/utils/color";
+import {
+  presetColors,
+  hexToRgba,
+  toHexColor,
+  validateColorHex,
+} from "@shared/utils/color";
+
+/**
+ * Whether an ancestor element already paints the same background, in which case
+ * the element is inheriting the shading of a container – such as a table cell –
+ * rather than highlighting text.
+ */
+function isInheritedBackground(dom: HTMLElement, color: string): boolean {
+  const hex = toHexColor(color);
+  let parent = dom.parentElement;
+
+  while (parent) {
+    const background = parent.style?.backgroundColor;
+    if (background) {
+      return !!hex && toHexColor(background) === hex;
+    }
+    parent = parent.parentElement;
+  }
+
+  return false;
+}
 
 export default class Highlight extends Mark {
   /** The default opacity of the highlight */
@@ -24,24 +49,22 @@ export default class Highlight extends Mark {
   }
 
   /**
-   * Finds the closest matching preset color for a given CSS color value.
+   * Finds the preset color matching a CSS color value. Opacity is ignored, so a
+   * preset rendered translucently still matches.
    *
    * @param cssColor - A CSS color value (hex, rgb, rgba, etc.).
-   * @returns The matching preset color hex, or null if no close match found.
+   * @returns The matching preset color hex, or null if none match.
    */
   static findMatchingPresetColor(cssColor: string): string | null {
     try {
-      const parsed = parseToRgb(cssColor);
-      const inputRgb = { r: parsed.red, g: parsed.green, b: parsed.blue };
+      const { red, green, blue } = parseToRgb(cssColor);
 
       for (const preset of Highlight.presetColors) {
         const presetRgb = hexToRgba(preset.hex);
-        // Allow some tolerance for color matching (e.g., due to opacity differences)
-        const tolerance = 30;
         if (
-          Math.abs(inputRgb.r - presetRgb.red) <= tolerance &&
-          Math.abs(inputRgb.g - presetRgb.green) <= tolerance &&
-          Math.abs(inputRgb.b - presetRgb.blue) <= tolerance
+          red === presetRgb.red &&
+          green === presetRgb.green &&
+          blue === presetRgb.blue
         ) {
           return preset.hex;
         }
@@ -79,28 +102,13 @@ export default class Highlight extends Mark {
           tag: "span[style]",
           getAttrs: (dom) => {
             const style = dom.style.backgroundColor;
-            if (!style) {
+            if (!style || isInheritedBackground(dom, style)) {
               return false;
             }
+            // Any background that is not one of the highlight colors is styling
+            // belonging to the source document, rather than a highlight.
             const matchedColor = Highlight.findMatchingPresetColor(style);
-            // Only apply highlight if we found a matching preset color
-            // or if the color is clearly a highlight (not white/transparent)
-            if (matchedColor) {
-              return { color: matchedColor };
-            }
-            // Check if it's a meaningful background color (not white/transparent)
-            try {
-              const parsed = parseToRgb(style);
-              // Skip very light colors that are likely page backgrounds
-              const isLight =
-                parsed.red > 250 && parsed.green > 250 && parsed.blue > 250;
-              if (!isLight) {
-                return { color: null };
-              }
-            } catch {
-              // Failed to parse
-            }
-            return false;
+            return matchedColor ? { color: matchedColor } : false;
           },
         },
       ],

--- a/shared/editor/marks/Highlight.ts
+++ b/shared/editor/marks/Highlight.ts
@@ -18,12 +18,18 @@ import {
  */
 function isInheritedBackground(dom: HTMLElement, color: string): boolean {
   const hex = toHexColor(color);
-  let parent = dom.parentElement;
+  if (!hex) {
+    return false;
+  }
 
+  let parent = dom.parentElement;
   while (parent) {
+    // Ancestors that paint nothing, such as a transparent background, are
+    // skipped so that the closest painted background is the one compared.
     const background = parent.style?.backgroundColor;
-    if (background) {
-      return !!hex && toHexColor(background) === hex;
+    const parentHex = background ? toHexColor(background) : null;
+    if (parentHex) {
+      return parentHex === hex;
     }
     parent = parent.parentElement;
   }

--- a/shared/utils/color.ts
+++ b/shared/utils/color.ts
@@ -67,6 +67,42 @@ export const rgbaToHex = ({ red, green, blue, alpha }: RgbaColor): string => {
   return "#" + toHex(red) + toHex(green) + toHex(blue) + alphaHex;
 };
 
+/**
+ * Converts a CSS color in any notation into hex notation.
+ *
+ * @param color - a color string in any notation understood by polished.
+ * @returns the color in hex notation, or null if it is not a color that can be
+ * parsed, or is fully transparent.
+ */
+export const toHexColor = (color: string): string | null => {
+  try {
+    const rgb = parseToRgb(color);
+    const alpha = "alpha" in rgb ? rgb.alpha : 1;
+    if (alpha === 0) {
+      return null;
+    }
+    return rgbaToHex({ ...rgb, alpha });
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Whether a color is close enough to white that it is likely a page or default
+ * background rather than deliberate styling.
+ *
+ * @param color - a color string in any notation understood by polished.
+ * @returns true if the color is near white.
+ */
+export const isNearWhite = (color: string): boolean => {
+  try {
+    const { red, green, blue } = parseToRgb(color);
+    return red > 250 && green > 250 && blue > 250;
+  } catch {
+    return false;
+  }
+};
+
 export interface ColorFormats {
   /** The color in uppercase hex notation, with an alpha pair when translucent. */
   hex: string;


### PR DESCRIPTION
Pasting a table from a spreadsheet or word processor dropped the cell background and instead applied a highlight to the text inside – rendered yellow whenever the source color did not match a preset.

- Cell backgrounds are read from pasted HTML onto the cell, ignoring white and transparent fills
- A background only becomes a highlight when it exactly matches one of the preset highlight colors, rather than a fuzzy match with a fallback
- A background that merely repeats the shading of an ancestor, such as a table cell, is ignored