### PR TITLE
perf: Keep Policy.flattenedAbilities alive

### DIFF
--- a/app/models/Policy.ts
+++ b/app/models/Policy.ts
@@ -18,7 +18,7 @@ class Policy extends Model {
   /**
    * Abilities flattened to an object with boolean values.
    */
-  @computed
+  @computed({ keepAlive: true })
   get flattenedAbilities() {
     const abilities: Record<string, boolean> = {};
     for (const [key, value] of Object.entries(this.abilities)) {


### PR DESCRIPTION
Most callers of `policies.abilities()` are non-reactive — drag-and-drop `canDrop` callbacks, action `visible()` predicates, websocket handlers. With no observers, the computed had no cache and fully recomputed on every read, which also triggered a MobX `computedRequiresReaction` warning on every drag hover and command bar keystroke.

- Mark the computed `keepAlive` so it retains its cache and referential stability
- Silences the warning; matches the existing pattern in `Collection` and `NavigableModel`