### PR TITLE
Speed up creating a new document

### DIFF
--- a/app/menus/NewDocumentMenu.tsx
+++ b/app/menus/NewDocumentMenu.tsx
@@ -6,6 +6,7 @@ import Button from "~/components/Button";
 import Tooltip from "~/components/Tooltip";
 import useCurrentTeam from "~/hooks/useCurrentTeam";
 import usePolicy from "~/hooks/usePolicy";
+import { preloadEditor } from "~/routes/scenes";
 import { newDocumentPath } from "~/utils/routeHelpers";
 
 function NewDocumentMenu() {
@@ -19,7 +20,13 @@ function NewDocumentMenu() {
 
   return (
     <Tooltip content={t("New document")} shortcut="n" placement="bottom">
-      <Button as={Link} to={newDocumentPath()} icon={<PlusIcon />}>
+      <Button
+        as={Link}
+        to={newDocumentPath()}
+        icon={<PlusIcon />}
+        onPointerEnter={preloadEditor}
+        onFocus={preloadEditor}
+      >
         {t("New doc")}
       </Button>
     </Tooltip>

--- a/app/routes/scenes.ts
+++ b/app/routes/scenes.ts
@@ -12,3 +12,15 @@ export const Drafts = lazy(() => import("~/scenes/Drafts"));
 export const Home = lazy(() => import("~/scenes/Home"));
 export const Search = lazy(() => import("~/scenes/Search"));
 export const Trash = lazy(() => import("~/scenes/Trash"));
+
+/**
+ * Warms the chunks required to render a document with an editable editor. Each
+ * of these is behind a separate lazy boundary that would otherwise only begin
+ * downloading once the previous one has rendered, so preloading them in
+ * parallel removes a request waterfall from the critical path.
+ */
+export function preloadEditor() {
+  void Document.preload();
+  void import("~/scenes/Document/components/MultiplayerEditor");
+  void import("~/editor");
+}

--- a/app/scenes/Document/components/MultiplayerEditor.tsx
+++ b/app/scenes/Document/components/MultiplayerEditor.tsx
@@ -1,5 +1,6 @@
 import { HocuspocusProvider, WebSocketStatus } from "@hocuspocus/provider";
 import { throttle } from "es-toolkit/compat";
+import { Node as ProsemirrorNode } from "prosemirror-model";
 import {
   useState,
   useLayoutEffect,
@@ -17,6 +18,7 @@ import * as Y from "yjs";
 import { EditorUpdateError } from "@shared/collaboration/CloseEvents";
 import History from "@shared/editor/extensions/History";
 import EDITOR_VERSION from "@shared/editor/version";
+import { ProsemirrorDataHelper } from "@shared/utils/ProsemirrorDataHelper";
 import { supportsPassiveListener } from "@shared/utils/browser";
 import type { Props as EditorProps } from "~/components/Editor";
 import Editor from "~/components/Editor";
@@ -328,7 +330,8 @@ function MultiplayerEditor(
   // while the collaborative document is loading, we render a version of the
   // document from the last text cache in read-only mode if we have it.
   const isLocalReady = !hasLocalPersistence || isLocalSynced;
-  const showCache = !isLocalReady && !isRemoteSynced;
+  const showCache =
+    !isLocalReady && !isRemoteSynced && hasContent(props.defaultValue);
 
   return (
     <>
@@ -363,6 +366,30 @@ function MultiplayerEditor(
       />
     </>
   );
+}
+
+/**
+ * Whether the last known content of the document is worth displaying while the
+ * collaborative document loads. An empty document, such as one that was just
+ * created, renders identically either way so there is nothing to wait for.
+ *
+ * @param value the cached editor content.
+ * @returns true if the content is non-empty.
+ */
+function hasContent(value: Props["defaultValue"]): boolean {
+  if (!value) {
+    return false;
+  }
+
+  if (typeof value === "string") {
+    return !!value.trim();
+  }
+
+  if (value instanceof ProsemirrorNode) {
+    return !!value.textContent.trim();
+  }
+
+  return !ProsemirrorDataHelper.isEmpty(value);
 }
 
 export default forwardRef<SharedEditor, Props>(MultiplayerEditor);

--- a/app/scenes/Document/hooks/useDocumentSidebar.tsx
+++ b/app/scenes/Document/hooks/useDocumentSidebar.tsx
@@ -91,7 +91,10 @@ export default function useDocumentSidebar() {
     path: matchDocumentHistory,
   });
   const panel = ui.getRightSidebar(pane);
-  const isOpen = panel !== null;
+  // A history panel outside of a history route is closed by the effect below,
+  // so it is treated as closed here – otherwise the sidebar renders open for a
+  // frame and then animates away again.
+  const isOpen = panel !== null && (panel !== "history" || isHistoryRoute);
   const wasOpenRef = React.useRef(isOpen);
 
   React.useEffect(() => {

--- a/app/scenes/DocumentNew.tsx
+++ b/app/scenes/DocumentNew.tsx
@@ -11,6 +11,7 @@ import PlaceholderDocument from "~/components/PlaceholderDocument";
 import useCurrentUser from "~/hooks/useCurrentUser";
 import useQuery from "~/hooks/useQuery";
 import useStores from "~/hooks/useStores";
+import { preloadEditor } from "~/routes/scenes";
 import { documentEditPath, documentPath } from "~/utils/routeHelpers";
 
 function DocumentNew() {
@@ -25,6 +26,10 @@ function DocumentNew() {
   const id = match.params.collectionSlug || query.get("collectionId");
 
   useEffect(() => {
+    // Download the editor while the document is being created on the server so
+    // that the two do not happen one after the other.
+    preloadEditor();
+
     async function createDocument() {
       const index = parseInt(query.get("index") || "0", 10);
       const parentDocumentId = query.get("parentDocumentId") ?? undefined;

--- a/app/scenes/DocumentNew.tsx
+++ b/app/scenes/DocumentNew.tsx
@@ -26,8 +26,7 @@ function DocumentNew() {
   const id = match.params.collectionSlug || query.get("collectionId");
 
   useEffect(() => {
-    // Download the editor while the document is being created on the server so
-    // that the two do not happen one after the other.
+    // Download the editor while the document is being created on the server
     preloadEditor();
 
     async function createDocument() {


### PR DESCRIPTION
Creating a document from the "New doc" button had three lazy chunks downloading one after another — each only starting once the previous had rendered, and none of them until the create request had resolved — followed by a wait on the collaborative sync before anything could be typed.

- Preload the document scene, multiplayer editor and editor chunks in parallel, on hover of the button and again while the document is being created
- Render the editable editor immediately when the document has no cached content, instead of holding it hidden behind a read-only cache editor until the websocket has connected, authenticated and loaded
- Fix an unrelated flash where a stale `history` panel in the persisted UI state rendered the right sidebar open for a frame before animating it away again