### PR TITLE
perf: Avoid N+1 queries when deleting a document subtree

### DIFF
--- a/server/models/Collection.test.ts
+++ b/server/models/Collection.test.ts
@@ -376,6 +376,36 @@ describe("#removeDocument", () => {
     expect(collectionDocuments.count).toBe(0);
   });
 
+  it("should remove a document with deeply nested child documents", async () => {
+    const collection = await buildCollection();
+    const document = await buildDocument({ collectionId: collection.id });
+    await collection.reload();
+
+    let parentDocumentId = document.id;
+    for (let depth = 0; depth < 5; depth++) {
+      const child = await buildDocument({
+        parentDocumentId,
+        collectionId: collection.id,
+        teamId: collection.teamId,
+        lastModifiedById: collection.createdById,
+        createdById: collection.createdById,
+        title: `Child document ${depth}`,
+        text: "content",
+      });
+      await collection.addDocumentToStructure(child);
+      parentDocumentId = child.id;
+    }
+
+    await collection.deleteDocument(document);
+    expect(collection.documentStructure!.length).toBe(0);
+    const collectionDocuments = await Document.findAndCountAll({
+      where: {
+        collectionId: collection.id,
+      },
+    });
+    expect(collectionDocuments.count).toBe(0);
+  });
+
   it("should remove a child document", async () => {
     const collection = await buildCollection();
     const document = await buildDocument({ collectionId: collection.id });

--- a/server/models/Collection.ts
+++ b/server/models/Collection.ts
@@ -1,6 +1,6 @@
 /* oxlint-disable lines-between-class-members */
 import fractionalIndex from "fractional-index";
-import { find, findIndex, isNil, remove, uniq } from "es-toolkit/compat";
+import { find, findIndex, isNil, keyBy, remove, uniq } from "es-toolkit/compat";
 import type {
   Identifier,
   Transaction,
@@ -860,24 +860,27 @@ class Collection extends ParanoidModel<
   deleteDocument = async (document: Document, options?: FindOptions) => {
     await this.removeDocumentInStructure(document, options);
 
-    // Helper to destroy all child documents for a document
-    const loopChildren = async (
-      documentId: string,
-      opts?: FindOptions<Document>
-    ) => {
+    // IDs come back breadth-first so reversing them destroys the deepest
+    // descendants first.
+    const childDocumentIds = (
+      await document.findAllChildDocumentIds(undefined, options)
+    ).reverse();
+
+    if (childDocumentIds.length) {
       const childDocuments = await Document.findAll({
+        ...options,
         where: {
-          parentDocumentId: documentId,
+          id: childDocumentIds,
         },
       });
+      const childDocumentsById = keyBy(childDocuments, (child) => child.id);
 
-      for (const child of childDocuments) {
-        await loopChildren(child.id, opts);
-        await child.destroy(opts);
+      // Destroyed one at a time to ensure model hooks run for each document.
+      for (const childDocumentId of childDocumentIds) {
+        await childDocumentsById[childDocumentId]?.destroy(options);
       }
-    };
+    }
 
-    await loopChildren(document.id, options);
     await document.destroy(options);
   };
 


### PR DESCRIPTION
Deleting a document walked its subtree with one query per document, so large subtrees could exceed the request statement_timeout and fail with a 503.

- Resolve the whole subtree in a single recursive query using the existing `findAllChildDocumentIds` helper, and load the children in one query
- Documents are still destroyed one at a time so model hooks run for each, and deepest-first ordering is unchanged
- Fixes the subtree lookup dropping the options it was passed, which meant it ran outside the request transaction