### PR TITLE
feat: Attribute document creation to the auth type it was made with

### DIFF
--- a/server/commands/documentCreator.test.ts
+++ b/server/commands/documentCreator.test.ts
@@ -1,3 +1,4 @@
+import { AuthenticationType } from "@shared/types";
 import { ProsemirrorHelper } from "@server/models/helpers/ProsemirrorHelper";
 import {
   buildUser,
@@ -317,7 +318,10 @@ describe("documentCreator", () => {
       );
 
       expect(document.importId).toBe(fileOperation.id);
-      expect(document.sourceMetadata).toEqual(sourceMetadata);
+      expect(document.sourceMetadata).toEqual({
+        ...sourceMetadata,
+        authType: AuthenticationType.APP,
+      });
     });
   });
 

--- a/server/commands/documentCreator.ts
+++ b/server/commands/documentCreator.ts
@@ -173,10 +173,14 @@ export default async function documentCreator(
     lastModifiedById,
   }: Props
 ): Promise<Document> {
-  const { user } = ctx.state.auth;
+  const { user, type: authType } = ctx.state.auth;
   const { transaction } = ctx.state;
   const templateId = template ? template.id : undefined;
   const eventData = importId || apiImportId ? { source: "import" } : undefined;
+  // Note authType is applied last so that it always reflects the current
+  // request, even when metadata is inherited from another document.
+  const metadata =
+    authType || sourceMetadata ? { ...sourceMetadata, authType } : null;
 
   if (state && template) {
     throw new Error(
@@ -227,7 +231,7 @@ export default async function documentCreator(
     publishedAt,
     importId,
     apiImportId,
-    sourceMetadata,
+    sourceMetadata: metadata,
     fullWidth: fullWidth ?? template?.fullWidth,
     icon: icon ?? template?.icon,
     color: color ?? template?.color,

--- a/server/commands/documentDuplicator.test.ts
+++ b/server/commands/documentDuplicator.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { MentionType } from "@shared/types";
+import { AuthenticationType, MentionType } from "@shared/types";
 import { createContext } from "@server/context";
 import env from "@server/env";
 import { sequelize } from "@server/storage/database";
@@ -163,6 +163,7 @@ describe("documentDuplicator", () => {
       fileName: "test.md",
       externalId: "ext123",
       originalDocumentId: original.id,
+      authType: AuthenticationType.APP,
     });
   });
 


### PR DESCRIPTION
Follow-up to #13312, which added `authType` to revision source metadata.

- Stamps the requesting session's auth type onto a document's source metadata at creation time, covering the API, MCP tools, imports and duplication.
- The auth type is applied last when merging, so a duplicate records the auth type of the duplication request rather than inheriting the original's.