### PR TITLE
perf: Use FOR NO KEY UPDATE for collection structure locks

### DIFF
--- a/server/commands/documentMover.ts
+++ b/server/commands/documentMover.ts
@@ -45,7 +45,7 @@ async function documentMover(
   const collection = await Collection.findByPk(document.collectionId!, {
     includeDocumentStructure: true,
     transaction,
-    lock: Transaction.LOCK.UPDATE,
+    lock: Transaction.LOCK.NO_KEY_UPDATE,
     paranoid: false,
   });
 
@@ -54,7 +54,7 @@ async function documentMover(
     newCollection = await Collection.findByPk(collectionId, {
       includeDocumentStructure: true,
       transaction,
-      lock: Transaction.LOCK.UPDATE,
+      lock: Transaction.LOCK.NO_KEY_UPDATE,
     });
   } else if (!collectionId) {
     newCollection = null;

--- a/server/models/Document.ts
+++ b/server/models/Document.ts
@@ -495,7 +495,7 @@ class Document extends ArchivableModel<
     const collection = await Collection.findByPk(model.collectionId, {
       includeDocumentStructure: true,
       transaction,
-      lock: Transaction.LOCK.UPDATE,
+      lock: Transaction.LOCK.NO_KEY_UPDATE,
     });
     if (!collection) {
       return;
@@ -515,7 +515,7 @@ class Document extends ArchivableModel<
       const collection = await Collection.findByPk(model.collectionId!, {
         includeDocumentStructure: true,
         transaction,
-        lock: transaction.LOCK.UPDATE,
+        lock: transaction.LOCK.NO_KEY_UPDATE,
       });
       if (!collection) {
         return;
@@ -1254,7 +1254,7 @@ class Document extends ArchivableModel<
       ? await Collection.findByPk(this.collectionId, {
           includeDocumentStructure: true,
           transaction,
-          lock: transaction?.LOCK.UPDATE,
+          lock: transaction?.LOCK.NO_KEY_UPDATE,
         })
       : undefined;
 
@@ -1288,7 +1288,7 @@ class Document extends ArchivableModel<
       ? await Collection.findByPk(this.collectionId, {
           includeDocumentStructure: true,
           transaction,
-          lock: transaction?.LOCK.UPDATE,
+          lock: transaction?.LOCK.NO_KEY_UPDATE,
         })
       : undefined;
 
@@ -1313,7 +1313,7 @@ class Document extends ArchivableModel<
       ? await Collection.findByPk(collectionId, {
           includeDocumentStructure: true,
           transaction,
-          lock: transaction?.LOCK.UPDATE,
+          lock: transaction?.LOCK.NO_KEY_UPDATE,
         })
       : undefined;
 
@@ -1368,7 +1368,7 @@ class Document extends ArchivableModel<
       const collection = await Collection.findByPk(this.collectionId, {
         includeDocumentStructure: true,
         transaction,
-        lock: transaction?.LOCK.UPDATE,
+        lock: transaction?.LOCK.NO_KEY_UPDATE,
         paranoid: false,
       });
 

--- a/server/queues/processors/FileOperationDeletedProcessor.ts
+++ b/server/queues/processors/FileOperationDeletedProcessor.ts
@@ -50,7 +50,7 @@ export default class FileOperationDeletedProcessor extends BaseProcessor {
 
       const collections = await Collection.findAll({
         transaction,
-        lock: transaction.LOCK.UPDATE,
+        lock: transaction.LOCK.NO_KEY_UPDATE,
         where: {
           teamId: fileOperation.teamId,
           importId: fileOperation.id,

--- a/server/queues/processors/ImportsProcessor.ts
+++ b/server/queues/processors/ImportsProcessor.ts
@@ -252,7 +252,7 @@ export default abstract class ImportsProcessor<
 
     const collections = await Collection.findAll({
       transaction,
-      lock: transaction.LOCK.UPDATE,
+      lock: transaction.LOCK.NO_KEY_UPDATE,
       where: {
         teamId: importModel.teamId,
         apiImportId: importModel.id,

--- a/server/routes/api/collections/collections.ts
+++ b/server/routes/api/collections/collections.ts
@@ -955,7 +955,7 @@ router.post(
 
     let collection = await Collection.findByPk(id, {
       transaction,
-      lock: transaction.LOCK.UPDATE,
+      lock: transaction.LOCK.NO_KEY_UPDATE,
     });
     authorize(user, "move", collection);
 


### PR DESCRIPTION
Collection row locks taken while mutating document structure used `FOR UPDATE`, the only row lock mode that conflicts with the `FOR KEY SHARE` Postgres takes on a parent row when validating a foreign key. Any insert referencing a collection — creating a document, adding a member — therefore queued behind someone renaming an unrelated document in that collection.

- Switch all collection row locks to FOR NO KEY UPDATE, matching what document publish already did
- Covers document create/update/unpublish/archive/restore/delete, document move, collection move, and the import/file operation processors
- Still self-conflicts, so structure writers on a collection stay mutually excluded; none of these paths mutate the collection id