### PR TITLE
perf: Take document row lock after text processing

### DIFF
--- a/server/commands/documentUpdater.ts
+++ b/server/commands/documentUpdater.ts
@@ -65,19 +65,6 @@ export default async function documentUpdater(
   const { transaction } = ctx.state;
   const cId = collectionId || document.collectionId;
 
-  // Serialize concurrent updates to the same document by taking a row-level
-  // lock before mutating. The wait is already bounded by the transaction's
-  // statement_timeout.
-  if (transaction) {
-    await Document.unscoped().findOne({
-      attributes: ["id"],
-      where: { id: document.id },
-      transaction,
-      lock: transaction.LOCK.UPDATE,
-      paranoid: false,
-    });
-  }
-
   if (title !== undefined) {
     document.title = title.trim();
   }
@@ -108,6 +95,19 @@ export default async function documentUpdater(
       editMode,
       findText
     );
+  }
+
+  // Serialize concurrent updates to the same document by taking a row-level
+  // lock before writing. The wait is already bounded by the transaction's
+  // statement_timeout.
+  if (transaction) {
+    await Document.unscoped().findOne({
+      attributes: ["id"],
+      where: { id: document.id },
+      transaction,
+      lock: transaction.LOCK.UPDATE,
+      paranoid: false,
+    });
   }
 
   const changed = document.changed();


### PR DESCRIPTION
- The `documents.update` path took a row-level lock on the document before processing incoming text.
- Attachment replacement decodes base64 images and uploads them to S3, so the lock was held across network I/O for the whole request.
- Move the lock to just before the write, so it is held for as little of the transaction as possible. Serialization of concurrent saves is unchanged.