### PR TITLE
fix: Unhandled rejection when a Redlock lock release fails

### DIFF
--- a/server/services/websockets.ts
+++ b/server/services/websockets.ts
@@ -136,7 +136,16 @@ export default function init(
       Logger.debug("websockets", `Authenticated socket ${socket.id}`);
 
       socket.emit("authenticated", true);
-      void authenticated(io, socket, user);
+      void authenticated(io, socket, user).catch((err) => {
+        Logger.error("Failed to join rooms for authenticated socket", err, {
+          socketId: socket.id,
+          userId: user.id,
+        });
+
+        // The socket receives no events without its rooms, disconnect so that
+        // the client reconnects and tries again.
+        socket.disconnect();
+      });
     } catch (err) {
       const message = errToString(err);
       Logger.debug("websockets", `Authentication error socket ${socket.id}`, {

--- a/server/services/websockets.ts
+++ b/server/services/websockets.ts
@@ -5,7 +5,7 @@ import cookie from "cookie";
 import type Koa from "koa";
 import IO from "socket.io";
 import { createAdapter } from "socket.io-redis";
-import { errToString } from "@shared/utils/error";
+import { errToString, toError } from "@shared/utils/error";
 import env from "@server/env";
 import { AuthenticationError } from "@server/errors";
 import Logger from "@server/logging/Logger";
@@ -137,10 +137,14 @@ export default function init(
 
       socket.emit("authenticated", true);
       void authenticated(io, socket, user).catch((err) => {
-        Logger.error("Failed to join rooms for authenticated socket", err, {
-          socketId: socket.id,
-          userId: user.id,
-        });
+        Logger.error(
+          "Failed to join rooms for authenticated socket",
+          toError(err),
+          {
+            socketId: socket.id,
+            userId: user.id,
+          }
+        );
 
         // The socket receives no events without its rooms, disconnect so that
         // the client reconnects and tries again.

--- a/server/utils/MutexLock.ts
+++ b/server/utils/MutexLock.ts
@@ -119,9 +119,7 @@ export class MutexLock {
       }
       return false;
     } catch (err) {
-      Logger.warn("Failed to release Redlock lock", {
-        message: toError(err).message,
-      });
+      Logger.warn("Failed to release Redlock lock", toError(err));
       return false;
     } finally {
       // @ts-expect-error Attach resource for use in shutdown

--- a/server/utils/MutexLock.ts
+++ b/server/utils/MutexLock.ts
@@ -5,6 +5,7 @@ import Redlock, {
   type RedlockAbortSignal,
   type Settings,
 } from "redlock";
+import { toError } from "@shared/utils/error";
 import Redis from "@server/storage/redis";
 import Logger from "@server/logging/Logger";
 import ShutdownHelper, { ShutdownOrder } from "./ShutdownHelper";
@@ -103,15 +104,24 @@ export class MutexLock {
   }
 
   /**
-   * Safely release a lock
+   * Safely release a lock. Releasing is best-effort – a lock that has already
+   * expired or been taken over by another process cannot be released, and that
+   * is not an error for the caller.
    *
    * @param lock The lock to release
+   * @returns A promise that resolves to true if the lock was released
    */
-  public static release(lock: Lock) {
+  public static async release(lock: Lock): Promise<boolean> {
     try {
       if (lock && lock.expiration > new Date().getTime()) {
-        return lock.release();
+        await lock.release();
+        return true;
       }
+      return false;
+    } catch (err) {
+      Logger.warn("Failed to release Redlock lock", {
+        message: toError(err).message,
+      });
       return false;
     } finally {
       // @ts-expect-error Attach resource for use in shutdown


### PR DESCRIPTION
Fixes a crash where an `ExecutionError` ("unable to achieve a quorum") from redlock took down the web process.

- Releasing a lock is now best-effort — a lock that already expired or was taken over by another process can't be released, and that shouldn't replace the successful return value of the caller. It's logged as a warning instead.
- Catch failures when joining rooms after websocket authentication. This was a floating promise, so any rejection became an unhandled rejection. The socket is now disconnected, as it receives no events without its rooms, and the client reconnects.