### PR TITLE
fix: Avoid duplicate key errors when re-creating attachments by id

### DIFF
--- a/server/commands/attachmentCreator.test.ts
+++ b/server/commands/attachmentCreator.test.ts
@@ -1,0 +1,97 @@
+import { randomUUID } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Attachment } from "@server/models";
+import FileStorage from "@server/storage/files";
+import { AttachmentPreset } from "@shared/types";
+import { createContext } from "@server/context";
+import { buildTeam, buildUser } from "@server/test/factories";
+import attachmentCreator from "./attachmentCreator";
+
+describe("attachmentCreator", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the existing attachment without re-uploading when the id was already used", async () => {
+    const user = await buildUser();
+    const id = randomUUID();
+    const store = vi.spyOn(FileStorage, "store").mockResolvedValue(undefined);
+
+    const first = await attachmentCreator({
+      id,
+      name: "image.png",
+      type: "image/png",
+      buffer: Buffer.from("one"),
+      preset: AttachmentPreset.DocumentAttachment,
+      user,
+      ctx: createContext({ user }),
+    });
+
+    const second = await attachmentCreator({
+      id,
+      name: "image.png",
+      type: "image/png",
+      buffer: Buffer.from("one"),
+      preset: AttachmentPreset.DocumentAttachment,
+      user,
+      ctx: createContext({ user }),
+    });
+
+    expect(first?.id).toBe(id);
+    expect(second?.id).toBe(id);
+    expect(second?.key).toBe(first?.key);
+    expect(store).toHaveBeenCalledTimes(1);
+    expect(await Attachment.count({ where: { id } })).toBe(1);
+  });
+
+  it("derives the storage key from the supplied id so a retry reuses it", async () => {
+    const user = await buildUser();
+    const id = randomUUID();
+    vi.spyOn(FileStorage, "store").mockResolvedValue(undefined);
+
+    const attachment = await attachmentCreator({
+      id,
+      name: "image.png",
+      type: "image/png",
+      buffer: Buffer.from("one"),
+      preset: AttachmentPreset.DocumentAttachment,
+      user,
+      ctx: createContext({ user }),
+    });
+
+    expect(attachment?.key).toContain(id);
+  });
+
+  it("does not resolve an id belonging to another team", async () => {
+    const otherTeam = await buildTeam();
+    const otherUser = await buildUser({ teamId: otherTeam.id });
+    const user = await buildUser();
+    const id = randomUUID();
+    vi.spyOn(FileStorage, "store").mockResolvedValue(undefined);
+
+    await attachmentCreator({
+      id,
+      name: "secret.png",
+      type: "image/png",
+      buffer: Buffer.from("one"),
+      preset: AttachmentPreset.DocumentAttachment,
+      user: otherUser,
+      ctx: createContext({ user: otherUser }),
+    });
+
+    await expect(
+      attachmentCreator({
+        id,
+        name: "image.png",
+        type: "image/png",
+        buffer: Buffer.from("two"),
+        preset: AttachmentPreset.DocumentAttachment,
+        user,
+        ctx: createContext({ user }),
+      })
+    ).rejects.toThrow();
+
+    const attachment = await Attachment.findByPk(id);
+    expect(attachment?.teamId).toBe(otherTeam.id);
+  });
+});

--- a/server/commands/attachmentCreator.ts
+++ b/server/commands/attachmentCreator.ts
@@ -8,7 +8,7 @@ import type { APIContext } from "@server/types";
 import type { RequestInit } from "@server/utils/fetch";
 
 type BaseProps = {
-  /** The ID of the attachment */
+  /** The ID of the attachment, when provided creation is idempotent */
   id?: string;
   /** The name of the attachment */
   name: string;
@@ -45,9 +45,24 @@ export default async function attachmentCreator({
   fetchOptions,
   ...rest
 }: Props): Promise<Attachment | undefined> {
+  // Scoped to the team so a caller-supplied id can never resolve an attachment
+  // outside of it – an id that belongs elsewhere falls through to the insert
+  // and collides there, as it did before.
+  if (id) {
+    const existing = await Attachment.findOne({
+      where: { id, teamId: user.teamId },
+      transaction: ctx.context.transaction,
+    });
+
+    if (existing) {
+      return existing;
+    }
+  }
+
+  const modelId = id ?? randomUUID();
   const acl = AttachmentHelper.presetToAcl(preset);
   const key = AttachmentHelper.getKey({
-    id: randomUUID(),
+    id: modelId,
     name,
     userId: user.id,
   });
@@ -62,7 +77,7 @@ export default async function attachmentCreator({
       return;
     }
     attachment = await Attachment.createWithCtx(ctx, {
-      id,
+      id: modelId,
       key,
       acl,
       size: res.contentLength,
@@ -81,7 +96,7 @@ export default async function attachmentCreator({
     });
 
     attachment = await Attachment.createWithCtx(ctx, {
-      id,
+      id: modelId,
       key,
       acl,
       size: buffer.length,


### PR DESCRIPTION
Import tasks pass a known id to `attachmentCreator` so a retry can resume, relying on a caught unique constraint error to skip attachments that already landed. This was by far the loudest error in production — a single import retry produced over 7k of them in one hour.

- Return the existing attachment before touching storage when the id is already in use, rather than re-uploading the file in full and discarding it at the insert
- Derive the storage key from the supplied id, so a collision overwrites the same object instead of orphaning a new one — previously the key came from a fresh uuid, leaving every skipped attachment behind in the bucket
