### PR TITLE
fix: Comments sidebar opens on load when document has a draft comment

### DIFF
--- a/app/components/Editor.tsx
+++ b/app/components/Editor.tsx
@@ -208,11 +208,12 @@ function Editor(props: Props, ref: React.RefObject<SharedEditor> | null) {
         const commentIds = comments.orderedData.map((c) => c.id);
         const commentMarkIds = commentMarks?.map((c) => c.id);
 
-        // Comment marks that arrive through a remote or sync transaction, such
-        // as the initial load of a collaborative document containing a draft
-        // comment, should not steal focus – only marks created locally should.
+        // Only marks created by a local change should steal focus. Marks that
+        // arrive through a remote or sync transaction, or that are discovered
+        // by a rescan outside of a change event – such as the initial load of
+        // a document containing a draft comment – should not.
         const focus =
-          previousCommentIds.current !== undefined && !event?.remote;
+          previousCommentIds.current !== undefined && !!event && !event.remote;
         const newCommentIds = difference(
           commentMarkIds,
           previousCommentIds.current ?? [],


### PR DESCRIPTION
An unsent draft comment mark could open the comments sidebar when navigating to a document.

- Comment mark diffing runs both from the editor change handler and from a rescan on ref attach — the rescan passes no change event, which the focus check treated as a local change.
- Reachable in read-only mode, where the initial sync of document content fires no change event at all, so the draft mark is first seen by the rescan and steals focus.
- Focusing now requires an actual non-remote change event; locally created marks still focus and open the sidebar.