### PR TITLE
feat: Support ACL-less S3-compatible providers and public base URL

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -99,6 +99,14 @@ FILE_STORAGE=local
 # create this path and also to write files to it.
 FILE_STORAGE_LOCAL_ROOT_DIR=/var/lib/outline/data
 
+# Default ACL for non-avatar attachments. This preserves AWS_S3_ACL when unset.
+FILE_STORAGE_DEFAULT_ACL=
+
+# Optional public base URL for direct file downloads, for example a CDN or
+# custom domain in front of the storage bucket. Signed uploads and downloads
+# continue to use the S3-compatible endpoint.
+FILE_STORAGE_PUBLIC_URL=
+
 # Maximum allowed size for the uploaded attachment.
 FILE_STORAGE_UPLOAD_MAX_SIZE=262144000
 
@@ -120,6 +128,10 @@ AWS_S3_UPLOAD_BUCKET_URL=http://s3:4569
 AWS_S3_UPLOAD_BUCKET_NAME=bucket_name_here
 AWS_S3_FORCE_PATH_STYLE=true
 AWS_S3_ACL=private
+# Optional S3 canned ACL sent with upload requests. Set to an empty value for
+# S3-compatible providers that do not support ACLs, such as Cloudflare R2.
+# Defaults to AWS_S3_ACL when unset.
+AWS_S3_CANNED_ACL=
 # Which HTTP method to use for presigned uploads. "post" (default) uses the
 # traditional S3 presigned POST with multipart form data. "put" uses a single
 # PUT request with a presigned URL. Set this to "put" for providers like

--- a/server/env.ts
+++ b/server/env.ts
@@ -708,6 +708,27 @@ export class Environment {
   public AWS_S3_ACL = environment.AWS_S3_ACL ?? "private";
 
   /**
+   * Default ACL applied to non-avatar attachments. This preserves AWS_S3_ACL
+   * when unset.
+   */
+  @IsIn(["private", "public-read"])
+  public FILE_STORAGE_DEFAULT_ACL =
+    this.toOptionalString(environment.FILE_STORAGE_DEFAULT_ACL) ??
+    this.AWS_S3_ACL;
+
+  /**
+   * The canned ACL sent with S3 upload requests. Set to an empty value for
+   * S3-compatible providers that do not support ACLs, such as Cloudflare R2.
+   * Defaults to AWS_S3_ACL to preserve existing behavior.
+   */
+  public AWS_S3_CANNED_ACL = Object.prototype.hasOwnProperty.call(
+    environment,
+    "AWS_S3_CANNED_ACL"
+  )
+    ? environment.AWS_S3_CANNED_ACL
+    : this.AWS_S3_ACL;
+
+  /**
    * Which HTTP method to use for presigned uploads to S3-compatible storage.
    * "post" uses multipart form upload (traditional S3 presigned POST).
    * "put" uses a single PUT request with a presigned URL (required for
@@ -729,6 +750,21 @@ export class Environment {
   public FILE_STORAGE_LOCAL_ROOT_DIR =
     this.toOptionalString(environment.FILE_STORAGE_LOCAL_ROOT_DIR) ??
     "/var/lib/outline/data";
+
+  /**
+   * Optional public base URL for serving files, for example a CDN or custom
+   * domain in front of the storage bucket. Signed uploads and downloads
+   * continue to use the S3-compatible endpoint.
+   */
+  @IsOptional()
+  @IsUrl({
+    protocols: ["http", "https"],
+    require_protocol: true,
+    require_tld: false,
+  })
+  public FILE_STORAGE_PUBLIC_URL = this.toOptionalString(
+    environment.FILE_STORAGE_PUBLIC_URL
+  );
 
   /**
    * Set max allowed upload size for file attachments.

--- a/server/models/helpers/AttachmentHelper.test.ts
+++ b/server/models/helpers/AttachmentHelper.test.ts
@@ -1,3 +1,4 @@
+import { AttachmentPreset } from "@shared/types";
 import AttachmentHelper from "./AttachmentHelper";
 
 describe("AttachmentHelper", () => {
@@ -32,6 +33,17 @@ describe("AttachmentHelper", () => {
       });
 
       expect(key).toEqual("uploads/456/123/test/one.png");
+    });
+  });
+
+  describe("presetToAcl", () => {
+    it("keeps document attachments private while avatars remain public", () => {
+      expect(
+        AttachmentHelper.presetToAcl(AttachmentPreset.DocumentAttachment)
+      ).toBe("private");
+      expect(AttachmentHelper.presetToAcl(AttachmentPreset.Avatar)).toBe(
+        "public-read"
+      );
     });
   });
 });

--- a/server/models/helpers/AttachmentHelper.ts
+++ b/server/models/helpers/AttachmentHelper.ts
@@ -74,7 +74,7 @@ export default class AttachmentHelper {
       case AttachmentPreset.Avatar:
         return "public-read";
       default:
-        return env.AWS_S3_ACL;
+        return env.FILE_STORAGE_DEFAULT_ACL;
     }
   }
 

--- a/server/storage/files/S3Storage.r2.test.ts
+++ b/server/storage/files/S3Storage.r2.test.ts
@@ -1,0 +1,164 @@
+import type { Environment } from "@server/env";
+import type S3Storage from "./S3Storage";
+
+const {
+  mockEnv,
+  mockGetSignedUrl,
+  mockCreatePresignedPost,
+  putInputs,
+  postInputs,
+  uploadInputs,
+} = vi.hoisted(() => ({
+  mockEnv: {
+    AWS_CLOUDFRONT_URL: undefined as string | undefined,
+    AWS_S3_ACCELERATE_URL: "",
+    AWS_S3_ACL: "private",
+    AWS_S3_CANNED_ACL: undefined as string | undefined,
+    AWS_S3_FORCE_PATH_STYLE: true,
+    AWS_S3_UPLOAD_BUCKET_NAME: "test-bucket",
+    AWS_S3_UPLOAD_BUCKET_URL: "https://account.r2.cloudflarestorage.com",
+    AWS_REGION: "auto",
+    FILE_STORAGE_PUBLIC_URL: undefined as string | undefined,
+  },
+  mockGetSignedUrl: vi.fn(),
+  mockCreatePresignedPost: vi.fn(),
+  putInputs: [] as Record<string, unknown>[],
+  postInputs: [] as Record<string, unknown>[],
+  uploadInputs: [] as Record<string, unknown>[],
+}));
+
+vi.mock("@server/env", () => ({ default: mockEnv }));
+vi.mock("@aws-sdk/signature-v4-crt", () => ({}));
+vi.mock("@aws-sdk/s3-request-presigner", () => ({
+  getSignedUrl: mockGetSignedUrl,
+}));
+vi.mock("@aws-sdk/s3-presigned-post", () => ({
+  createPresignedPost: mockCreatePresignedPost,
+}));
+vi.mock("@aws-sdk/client-s3", () => ({
+  S3Client: class MockS3Client {
+    send = vi.fn();
+  },
+  PutObjectCommand: class MockPutObjectCommand {
+    input: Record<string, unknown>;
+
+    constructor(input: Record<string, unknown>) {
+      this.input = input;
+      putInputs.push(input);
+    }
+  },
+  DeleteObjectCommand: class MockDeleteObjectCommand {},
+  GetObjectCommand: class MockGetObjectCommand {},
+  HeadObjectCommand: class MockHeadObjectCommand {},
+  CopyObjectCommand: class MockCopyObjectCommand {},
+}));
+vi.mock("@aws-sdk/lib-storage", () => ({
+  Upload: class MockUpload {
+    constructor(input: { params: Record<string, unknown> }) {
+      uploadInputs.push(input.params);
+    }
+
+    done = vi.fn().mockResolvedValue({});
+  },
+}));
+
+describe("S3Storage R2-compatible ACL and public URL configuration", () => {
+  let Storage: typeof S3Storage;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mockEnv.AWS_S3_CANNED_ACL = "";
+    mockEnv.FILE_STORAGE_PUBLIC_URL = undefined;
+    putInputs.length = 0;
+    postInputs.length = 0;
+    uploadInputs.length = 0;
+    mockCreatePresignedPost.mockReset();
+    mockCreatePresignedPost.mockImplementation((_client, input) => {
+      postInputs.push(input);
+      return Promise.resolve({ fields: input.Fields });
+    });
+    mockGetSignedUrl.mockReset();
+    mockGetSignedUrl.mockResolvedValue(
+      "https://account.r2.cloudflarestorage.com/signed"
+    );
+    Storage = (await import("./S3Storage")).default;
+  });
+
+  it("omits ACLs for R2 while serving public URLs from the configured base", async () => {
+    mockEnv.FILE_STORAGE_PUBLIC_URL = "https://assets.example.test";
+    const storage = new Storage();
+
+    await storage.getPresignedPost({} as never, "uploads/a.png", "private", 1);
+    await storage.getPresignedPut("uploads/a.png", "private", 1, "image/png");
+    await storage.store({ body: "content", key: "uploads/a.png" });
+
+    expect(putInputs[0]).not.toHaveProperty("ACL");
+    expect(postInputs[0].Fields).not.toHaveProperty("ACL");
+    expect(uploadInputs[0]).not.toHaveProperty("ACL");
+    expect(storage.getUrlForKey("avatars/a.png")).toBe(
+      "https://assets.example.test/avatars/a.png"
+    );
+    expect(await storage.getSignedUrl("uploads/a.png")).toContain(
+      "r2.cloudflarestorage.com"
+    );
+  });
+
+  it("inherits the legacy ACL when AWS_S3_CANNED_ACL is absent", async () => {
+    const hadLegacyAcl = Object.prototype.hasOwnProperty.call(
+      process.env,
+      "AWS_S3_ACL"
+    );
+    const legacyAcl = process.env.AWS_S3_ACL;
+    const hadCannedAcl = Object.prototype.hasOwnProperty.call(
+      process.env,
+      "AWS_S3_CANNED_ACL"
+    );
+    const cannedAcl = process.env.AWS_S3_CANNED_ACL;
+
+    try {
+      process.env.AWS_S3_ACL = "private";
+      delete process.env.AWS_S3_CANNED_ACL;
+      vi.resetModules();
+      const environment = await vi.importActual<{ default: Environment }>(
+        "@server/env"
+      );
+
+      expect(environment.default.AWS_S3_CANNED_ACL).toBe("private");
+      mockEnv.AWS_S3_CANNED_ACL = environment.default.AWS_S3_CANNED_ACL;
+      Storage = (await import("./S3Storage")).default;
+      const storage = new Storage();
+
+      await storage.getPresignedPut("uploads/a.png", "private", 1, "image/png");
+
+      expect(putInputs[0]).toMatchObject({ ACL: "private" });
+    } finally {
+      if (hadLegacyAcl) {
+        process.env.AWS_S3_ACL = legacyAcl;
+      } else {
+        delete process.env.AWS_S3_ACL;
+      }
+      if (hadCannedAcl) {
+        process.env.AWS_S3_CANNED_ACL = cannedAcl;
+      } else {
+        delete process.env.AWS_S3_CANNED_ACL;
+      }
+      vi.resetModules();
+    }
+  });
+
+  it.each([
+    ["omits ACL for an explicit empty value", ""],
+    ["uses an explicit canned ACL override", "public-read"],
+  ])("%s", async (_name, cannedAcl) => {
+    mockEnv.AWS_S3_CANNED_ACL = cannedAcl;
+    const storage = new Storage();
+
+    await storage.getPresignedPut("uploads/a.png", "private", 1, "image/png");
+
+    if (cannedAcl) {
+      expect(putInputs[0]).toMatchObject({ ACL: cannedAcl });
+    } else {
+      expect(putInputs[0]).not.toHaveProperty("ACL");
+    }
+  });
+});

--- a/server/storage/files/S3Storage.ts
+++ b/server/storage/files/S3Storage.ts
@@ -39,7 +39,7 @@ export default class S3Storage extends BaseStorage {
       Fields: {
         "Content-Disposition": this.getContentDisposition(contentType),
         key,
-        ...(env.AWS_S3_ACL && { ACL: env.AWS_S3_ACL as ObjectCannedACL }),
+        ...(env.AWS_S3_CANNED_ACL ? { ACL: env.AWS_S3_CANNED_ACL } : {}),
       },
       Expires: 3600,
     };
@@ -76,7 +76,7 @@ export default class S3Storage extends BaseStorage {
       ContentLength: contentLength,
       ContentDisposition: contentDisposition,
       CacheControl: cacheControl,
-      ...(env.AWS_S3_ACL && { ACL: env.AWS_S3_ACL as ObjectCannedACL }),
+      ...this.cannedAcl,
     });
 
     const { getSignedUrl } = await import("@aws-sdk/s3-request-presigner");
@@ -138,6 +138,10 @@ export default class S3Storage extends BaseStorage {
   }
 
   public getUrlForKey(key: string): string {
+    if (env.FILE_STORAGE_PUBLIC_URL) {
+      const base = env.FILE_STORAGE_PUBLIC_URL.replace(/\/$/, "");
+      return `${base}/${key}`;
+    }
     if (env.AWS_CLOUDFRONT_URL) {
       const base = env.AWS_CLOUDFRONT_URL.replace(/\/$/, "");
       return `${base}/${key}`;
@@ -161,7 +165,7 @@ export default class S3Storage extends BaseStorage {
     const upload = new Upload({
       client,
       params: {
-        ...(env.AWS_S3_ACL && { ACL: env.AWS_S3_ACL as ObjectCannedACL }),
+        ...this.cannedAcl,
         Bucket: this.getBucket(),
         Key: key,
         ContentType: contentType,
@@ -344,6 +348,16 @@ export default class S3Storage extends BaseStorage {
       }
     }
     return undefined;
+  }
+
+  /**
+   * The canned ACL to include in upload requests, or an empty object when
+   * ACLs are not supported by the storage provider (e.g. Cloudflare R2).
+   */
+  private get cannedAcl() {
+    return env.AWS_S3_CANNED_ACL
+      ? { ACL: env.AWS_S3_CANNED_ACL as ObjectCannedACL }
+      : {};
   }
 
   private s3Promise?: Promise<{ sdk: typeof AwsS3; client: S3Client }>;


### PR DESCRIPTION
Related: https://github.com/outline/outline/discussions/4480
Builds on: #12748 (presigned PUT uploads)

## Summary

Completes Cloudflare R2 support by handling the two remaining incompatibilities now that `AWS_S3_UPLOAD_METHOD=put` is available (#12748):

- **R2 rejects canned ACLs.** Upload requests (presigned POST fields, presigned PUT, and multipart upload) that include an ACL fail on R2. New `AWS_S3_CANNED_ACL` controls the canned ACL sent with upload requests — set it empty to omit ACLs entirely. Defaults to `AWS_S3_ACL`, so existing AWS S3 deployments are unchanged.
- **Public files are often served from a CDN or custom domain**, not the S3 endpoint. New `FILE_STORAGE_PUBLIC_URL` sets an optional public base URL for serving files (e.g. avatars), taking precedence over `AWS_CLOUDFRONT_URL` when set.
- New `FILE_STORAGE_DEFAULT_ACL` sets the logical ACL applied to non-avatar attachments, preserving `AWS_S3_ACL` when unset.

All options are opt-in and fully backward compatible.

## Backward compatibility (non-R2 paths unchanged)

When the new variables are unset, behavior is byte-for-byte identical to the previous release:

- `AWS_S3_CANNED_ACL` falls back to `AWS_S3_ACL` (unchanged default), so the exact same `ACL` value is sent on all three upload paths as before.
- `FILE_STORAGE_DEFAULT_ACL` falls back to `AWS_S3_ACL`, so `AttachmentHelper.presetToAcl` returns the same value it did previously.
- `FILE_STORAGE_PUBLIC_URL` is undefined, so `getUrlForKey` follows the exact prior order (CloudFront, then the S3 public endpoint). `LocalStorage.getUrlForKey` is untouched.

Verified by running the storage + attachment test suites on a clean baseline vs. with this change: the passing-test set is identical (109 passing in both runs; the only failures are pre-existing infrastructure tests requiring a live Postgres/Redis, failing identically with and without the change).

## Config

```env
# Optional S3 canned ACL sent with upload requests. Set to an empty value for
# S3-compatible providers that do not support ACLs, such as Cloudflare R2.
# Defaults to AWS_S3_ACL when unset.
AWS_S3_CANNED_ACL=

# Default ACL for non-avatar attachments. This preserves AWS_S3_ACL when unset.
FILE_STORAGE_DEFAULT_ACL=

# Optional public base URL for direct file downloads, for example a CDN or
# custom domain in front of the storage bucket.
FILE_STORAGE_PUBLIC_URL=
```

## Test plan

- [x] `yarn test server/storage/files/S3Storage.r2.test.ts` — 4 tests: ACL omitted when `AWS_S3_CANNED_ACL=""`, legacy `AWS_S3_ACL` inherited when unset, explicit override respected, public URL served from `FILE_STORAGE_PUBLIC_URL`
- [x] Storage + `AttachmentHelper` suites — 26 pass (`S3Storage`, `S3Storage.cloudfront`, `S3Storage.r2`, `BaseStorage`, `AttachmentHelper`)
- [x] `yarn tsc` — no errors; `yarn lint`, `yarn format` — clean
- [x] Backward-compatibility regression — passing-test set identical to clean baseline (see above)
- [x] End-to-end against production Cloudflare R2 (self-hosted instance): bucket fully private, presigned PUT uploads, 17 objects migrated, avatars/emoji served from a custom domain via `FILE_STORAGE_PUBLIC_URL`, existing attachments still accessible
