### PR TITLE
fix: upload file attachments from Slab imports represented as links

### DIFF
--- a/server/queues/tasks/APIImportTask.ts
+++ b/server/queues/tasks/APIImportTask.ts
@@ -345,6 +345,7 @@ export default abstract class APIImportTask<
       ...ProsemirrorHelper.getImages(docNode),
       ...ProsemirrorHelper.getVideos(docNode),
       ...ProsemirrorHelper.getAttachments(docNode),
+      ...ProsemirrorHelper.getExternalFileLinks(docNode),
     ];
 
     if (!nodes.length) {
@@ -356,11 +357,20 @@ export default abstract class APIImportTask<
     // perf: dedup url.
     const attachmentsData = uniqBy(
       nodes.map((node) => {
+        const linkMark = node.marks.find((m) => m.type.name === "link");
         const url = String(
-          node.type.name === "attachment" ? node.attrs.href : node.attrs.src
+          node.type.name === "attachment"
+            ? node.attrs.href
+            : linkMark
+              ? linkMark.attrs.href
+              : node.attrs.src
         );
         const name = String(
-          node.type.name === "image" ? node.attrs.alt : node.attrs.title
+          node.type.name === "image"
+            ? node.attrs.alt
+            : linkMark
+              ? node.text
+              : node.attrs.title
         ).trim();
 
         return { url, name: name.length !== 0 ? name : node.type.name };
@@ -471,11 +481,30 @@ export default abstract class APIImportTask<
       const nodes: Node[] = [];
 
       fragment.forEach((node) => {
-        nodes.push(
-          attachmentTypes.includes(node.type.name)
-            ? transformAttachmentNode(node)
-            : node.copy(transformFragment(node.content))
-        );
+        if (attachmentTypes.includes(node.type.name)) {
+          nodes.push(transformAttachmentNode(node));
+        } else {
+          // Check for a text node whose link mark href needs rewriting.
+          const linkMark = node.marks.find((m) => m.type.name === "link");
+          const attachmentModel = linkMark
+            ? urlToAttachment[linkMark.attrs.href as string]
+            : undefined;
+          if (attachmentModel) {
+            const json = node.toJSON() as ProsemirrorData;
+            const markJson = (json.marks ?? []).find(
+              (m) => m.type === "link"
+            );
+            if (markJson) {
+              markJson.attrs = {
+                ...markJson.attrs,
+                href: attachmentModel.redirectUrl,
+              };
+            }
+            nodes.push(Node.fromJSON(schema, json));
+          } else {
+            nodes.push(node.copy(transformFragment(node.content)));
+          }
+        }
       });
 
       return Fragment.fromArray(nodes);

--- a/shared/utils/ProsemirrorHelper.ts
+++ b/shared/utils/ProsemirrorHelper.ts
@@ -368,6 +368,37 @@ export class ProsemirrorHelper {
   }
 
   /**
+   * Iterates through the document to find text nodes whose link mark points to
+   * a file with a known attachment extension (e.g. .pdf, .xlsx). These are
+   * produced when a markdown importer converts file attachments that were
+   * represented as plain hyperlinks in the source (e.g. Slab exports).
+   *
+   * @param doc Prosemirror document node
+   * @returns Array<Node> of text nodes carrying a file-attachment link mark
+   */
+  static getExternalFileLinks(doc: Node): Node[] {
+    const fileExtensions = /\.(pdf|xlsx|xls|docx|doc|pptx|ppt|zip|csv|txt)$/i;
+    const nodes: Node[] = [];
+
+    doc.descendants((node) => {
+      const linkMark = node.marks.find((m) => m.type.name === "link");
+      if (linkMark) {
+        try {
+          const pathname = new URL(linkMark.attrs.href as string).pathname;
+          if (fileExtensions.test(pathname)) {
+            nodes.push(node);
+          }
+        } catch {
+          // ignore invalid URLs
+        }
+      }
+      return true;
+    });
+
+    return nodes;
+  }
+
+  /**
    * Iterates through the document to find all of the tasks and their completion state.
    *
    * @param doc Prosemirror document node


### PR DESCRIPTION
## What

Fixes #13305

When a Slab workspace export is imported, non-image file attachments (PDFs, Excel spreadsheets, Word docs, etc.) are represented as plain markdown hyperlinks rather than dedicated attachment blocks:

```markdown
[report.pdf](https://uploads.slab.com/...) ✗ not an attachment node
![photo.png](https://uploads.slab.com/...) ✓ image node — already works
```

After `DocumentConverter.convert()`, image links become ProseMirror `image` nodes (collected by `getImages()`), but plain file hyperlinks become inline **link marks** on text nodes. Because `uploadAttachments()` only traversed `image`, `video`, and `attachment` nodes, these link-mark nodes were invisible to the upload pipeline — the imported document kept the expiring Slab CDN URLs.

## How

- **`ProsemirrorHelper.getExternalFileLinks()`** — new helper that walks the document and collects text nodes whose link mark href ends with a known file extension (`.pdf`, `.xlsx`, `.docx`, `.pptx`, `.zip`, etc.)
- `uploadAttachments()` now includes those nodes alongside images/videos/attachments
- URL extraction falls back to `linkMark.attrs.href`; name uses the link text (`node.text`)
- `replaceAttachmentUrls()` → `transformFragment` gains a third branch: when a node has a link mark pointing to a URL we just re-hosted, the mark's `href` is rewritten to `attachment.redirectUrl`

Images were unaffected before and remain unaffected now; the new code path is only hit for text nodes whose link mark resolves to a known attachment URL.