### PR TITLE
fix: support self-hosted GitLab instances for snippet embeds

### DIFF
--- a/server/routes/embeds.ts
+++ b/server/routes/embeds.ts
@@ -1,8 +1,12 @@
 import escape from "escape-html";
 import type { Context, Next } from "koa";
+import { IntegrationService } from "@shared/types";
+import type { IntegrationType } from "@shared/types";
 import env from "@server/env";
 import { InvalidRequestError } from "@server/errors";
 import { allowScriptSrc, allowStyleSrc } from "@server/middlewares/csp";
+import { Integration } from "@server/models";
+import { getTeamFromContext } from "@server/utils/passport";
 
 /**
  * Resize observer script that sends a message to the parent window when content is resized. Inject
@@ -32,6 +36,42 @@ const iframeCheckScript = (
 </script>`;
 
 /**
+ * Resolves whether the given host is allowed to be embedded as a GitLab
+ * snippet, checking gitlab.com as well as any self-hosted GitLab instance
+ * configured for the team the request belongs to.
+ *
+ * @param ctx The koa context.
+ * @param host The host of the URL being embedded.
+ * @returns The allowed host, or undefined if the host is not permitted.
+ */
+async function resolveGitLabHost(ctx: Context, host: string) {
+  if (host === "gitlab.com") {
+    return host;
+  }
+
+  const team = await getTeamFromContext(ctx);
+  if (!team) {
+    return undefined;
+  }
+
+  const integration = (await Integration.findOne({
+    where: { teamId: team.id, service: IntegrationService.GitLab },
+  })) as Integration<IntegrationType.Embed> | null;
+
+  const customUrl = integration?.settings?.gitlab?.url;
+
+  if (!customUrl) {
+    return undefined;
+  }
+
+  try {
+    return new URL(customUrl).host === host ? host : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Render an embed for a GitLab or GitHub snippet, injecting the necessary scripts to handle resizing
  * and iframe checks.
  *
@@ -53,19 +93,18 @@ export const renderEmbed = async (ctx: Context, next: Next) => {
     ctx.throw(InvalidRequestError("Invalid URL provided"));
   }
 
-  if (
-    parsed.host === "gitlab.com" &&
-    parsed.protocol === "https:" &&
-    ctx.path === "/embeds/gitlab"
-  ) {
-    const snippetLink = `${url}.js`;
+  if (parsed.protocol === "https:" && ctx.path === "/embeds/gitlab") {
+    const allowedHost = await resolveGitLabHost(ctx, parsed.host);
 
-    allowScriptSrc(ctx, ["gitlab.com"]);
-    allowStyleSrc(ctx, ["gitlab.com"]);
-    ctx.set("X-Frame-Options", "sameorigin");
+    if (allowedHost) {
+      const snippetLink = `${url}.js`;
 
-    ctx.type = "html";
-    ctx.body = `
+      allowScriptSrc(ctx, [allowedHost]);
+      allowStyleSrc(ctx, [allowedHost]);
+      ctx.set("X-Frame-Options", "sameorigin");
+
+      ctx.type = "html";
+      ctx.body = `
 <html>
 <head>
 <style>body { margin: 0; .gitlab-embed-snippets { margin: 0; } }</style>
@@ -77,7 +116,8 @@ ${iframeCheckScript(ctx)}
 ${resizeObserverScript(ctx)}
 </body>
 `;
-    return;
+      return;
+    }
   }
 
   if (

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -4,6 +4,7 @@ import {
   buildShare,
   buildDocument,
   buildIntegration,
+  buildTeam,
 } from "@server/test/factories";
 import { getTestServer } from "@server/test/support";
 
@@ -194,6 +195,35 @@ describe("content security policy", () => {
     expect(res.status).toEqual(200);
     expect(csp).toContain(source);
     expect(csp).toContain("nonce-");
+  });
+
+  it("should allow the gitlab embed script source for a team's self-hosted instance", async () => {
+    const team = await buildTeam({ domain: "outline.example.com" });
+    await buildIntegration({
+      teamId: team.id,
+      type: IntegrationType.Embed,
+      service: IntegrationService.GitLab,
+      settings: { gitlab: { url: "https://gitlab.example.com" } },
+    });
+
+    const url = "https://gitlab.example.com/group/project/-/snippets/1";
+    const res = await server.get(
+      `/embeds/gitlab?url=${encodeURIComponent(url)}`
+    );
+    const csp = res.headers.get("content-security-policy") ?? "";
+
+    expect(res.status).toEqual(200);
+    expect(csp).toContain("gitlab.example.com");
+  });
+
+  it("should not allow a gitlab embed script source for an unconfigured self-hosted instance", async () => {
+    const url = "https://gitlab.example.com/group/project/-/snippets/1";
+    const res = await server.get(
+      `/embeds/gitlab?url=${encodeURIComponent(url)}`
+    );
+    const csp = res.headers.get("content-security-policy") ?? "";
+
+    expect(csp).not.toContain("gitlab.example.com");
   });
 
   it("should still send a policy for responses that do not render the app", async () => {

--- a/shared/editor/embeds/index.tsx
+++ b/shared/editor/embeds/index.tsx
@@ -1,3 +1,4 @@
+import { escapeRegExp } from "es-toolkit/compat";
 import { BrowserIcon } from "outline-icons";
 import * as React from "react";
 import styled from "styled-components";
@@ -72,6 +73,13 @@ export class EmbedDescriptor {
   /** A regex that will be used to match the embed from a URL. */
   regexMatch?: RegExp[];
   /**
+   * A function that will be used to build an additional regex from the team's
+   * configured integration URL (e.g. a self-hosted instance), used to match
+   * the embed alongside `regexMatch`. Falls back to a plain domain match
+   * against `settings.url` when not provided.
+   */
+  buildSettingsRegex?: (url: string) => RegExp;
+  /**
    * A function that will be used to transform the URL. The resulting string is passed as the src
    * to the iframe. You can perform any transformations you want here, including changing the domain
    *
@@ -106,6 +114,7 @@ export class EmbedDescriptor {
     this.hideToolbar = options.hideToolbar;
     this.matchOnInput = options.matchOnInput ?? true;
     this.regexMatch = options.regexMatch;
+    this.buildSettingsRegex = options.buildSettingsRegex;
     this.transformMatch = options.transformMatch;
     this.attrs = options.attrs;
     this.visible = options.visible;
@@ -114,8 +123,9 @@ export class EmbedDescriptor {
 
   matcher(url: string): false | RegExpMatchArray {
     const regexes = this.regexMatch ?? [];
-    const settingsDomainRegex = this.settings?.url
-      ? urlRegex(this.settings?.url)
+    const settingsUrl = this.settings?.gitlab?.url ?? this.settings?.url;
+    const settingsDomainRegex = settingsUrl
+      ? (this.buildSettingsRegex?.(settingsUrl) ?? urlRegex(settingsUrl))
       : undefined;
 
     if (settingsDomainRegex) {
@@ -317,10 +327,15 @@ const embeds: EmbedDescriptor[] = [
   new EmbedDescriptor({
     id: "gitlab-snippet",
     title: "GitLab Snippet",
+    name: IntegrationService.GitLab,
     keywords: "code",
     regexMatch: [
       new RegExp(`^https://gitlab\\.com/(([a-zA-Z\\d-]+)/)*-/snippets/\\d+$`),
     ],
+    buildSettingsRegex: (url) =>
+      new RegExp(
+        `^${escapeRegExp(url.replace(/\/+$/, ""))}/(([a-zA-Z\\d-]+)/)*-/snippets/\\d+$`
+      ),
     icon: <Img src="/images/gitlab.png" alt="GitLab" />,
     component: GitLabSnippet,
   }),


### PR DESCRIPTION
## Summary

Pasting a GitLab snippet link from a self-hosted (self-managed) GitLab instance is rejected as an "unsupported URL", while the identical link pattern on `gitlab.com` is accepted and embedded correctly.

The GitLab issue/merge-request integration already supports a custom instance URL end-to-end (`settings.gitlab.url`, see `plugins/gitlab/server/gitlab.ts` and `plugins/gitlab/shared/GitLabUtils.ts`), including SSRF protection via `validateUrlNotPrivate`. The **snippet embed** feature, however, is a separate code path that was never wired up to this setting:

- `shared/editor/embeds/index.tsx`: the `gitlab-snippet` `EmbedDescriptor` had no `name`, so `useEmbeds()` never injected the team's integration settings into it, and its `regexMatch` was hardcoded to `gitlab.com`.
- `server/routes/embeds.ts`: the `/embeds/gitlab` route (which renders the CSP-allowed iframe wrapper) also hardcoded `parsed.host === "gitlab.com"`.

## Changes

- `EmbedDescriptor` gains an optional `buildSettingsRegex` hook so a descriptor can build a properly anchored regex (host + path) from the team's configured integration URL, instead of the existing generic whole-domain `settings.url` match (which would be too broad for snippets — it would also swallow issue/MR links meant for the unfurl preview).
- `gitlab-snippet` now sets `name: IntegrationService.GitLab` and a `buildSettingsRegex` that mirrors the default gitlab.com pattern against the team's custom host.
- `server/routes/embeds.ts` now resolves the requesting team (`getTeamFromContext`) and checks its GitLab integration's `settings.gitlab.url` before allow-listing a non-gitlab.com host for the CSP script/style sources. `gitlab.com` keeps working exactly as before, unauthenticated.

## Test plan

- [x] `yarn tsc --noEmit` passes
- [x] `yarn lint` passes on changed files
- [x] `yarn format --check` passes on changed files
- [x] Added `server/routes/index.test.ts` cases for the self-hosted allow/deny paths
- [ ] Could not run the full test suite in this environment (no local Postgres available), please run CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)