### PR TITLE
fix: Unpin button displayed when user lacks permission to delete pin

### DIFF
--- a/app/components/DocumentCard.tsx
+++ b/app/components/DocumentCard.tsx
@@ -41,8 +41,15 @@ function DocumentCard(props: Props) {
   const { collections } = useStores();
   const theme = useTheme();
   const { document, pin, isDraggable } = props;
-  const can = usePolicy(pin);
+  const canPin = usePolicy(pin);
+  const canDocument = usePolicy(document);
   const pinnedToHome = useRef(!pin?.collectionId).current;
+
+  // Pins in a collection are governed by the document policy, pins on home by
+  // the policy of the pin itself.
+  const canReorder = pin?.collectionId ? canDocument.pin : canPin.update;
+  const canUnpin = pin?.collectionId ? canDocument.unpin : canPin.delete;
+
   const collection = document.collectionId
     ? collections.get(document.collectionId)
     : undefined;
@@ -55,7 +62,7 @@ function DocumentCard(props: Props) {
     isDragging,
   } = useSortable({
     id: props.document.id,
-    disabled: !isDraggable || !can.update,
+    disabled: !isDraggable || !canReorder,
   });
 
   const hasEmojiInTitle = determineIconType(document.icon) === IconType.Emoji;
@@ -168,7 +175,7 @@ function DocumentCard(props: Props) {
               </DocumentMeta>
             </div>
           </Content>
-          {can.delete && !isDragging && pin && (
+          {canUnpin && !isDragging && pin && (
             <Actions dir={document.dir} gap={4}>
               <Tooltip content={t("Unpin")}>
                 <PinButton onClick={handleUnpin} aria-label={t("Unpin")}>

--- a/app/components/DocumentCard.tsx
+++ b/app/components/DocumentCard.tsx
@@ -18,6 +18,7 @@ import type Pin from "~/models/Pin";
 import Flex from "~/components/Flex";
 import NudeButton from "~/components/NudeButton";
 import Time from "~/components/Time";
+import usePolicy from "~/hooks/usePolicy";
 import useStores from "~/hooks/useStores";
 import CollectionIcon from "./Icons/CollectionIcon";
 import Text from "./Text";
@@ -31,8 +32,6 @@ type Props = {
   pin: Pin | undefined;
   /** The document related to the pin */
   document: Document;
-  /** Whether the user has permission to delete or reorder the pin */
-  canUpdatePin?: boolean;
   /** Whether this pin can be reordered by dragging */
   isDraggable?: boolean;
 };
@@ -41,7 +40,8 @@ function DocumentCard(props: Props) {
   const { t } = useTranslation();
   const { collections } = useStores();
   const theme = useTheme();
-  const { document, pin, canUpdatePin, isDraggable } = props;
+  const { document, pin, isDraggable } = props;
+  const can = usePolicy(pin);
   const pinnedToHome = useRef(!pin?.collectionId).current;
   const collection = document.collectionId
     ? collections.get(document.collectionId)
@@ -55,7 +55,7 @@ function DocumentCard(props: Props) {
     isDragging,
   } = useSortable({
     id: props.document.id,
-    disabled: !isDraggable || !canUpdatePin,
+    disabled: !isDraggable || !can.update,
   });
 
   const hasEmojiInTitle = determineIconType(document.icon) === IconType.Emoji;
@@ -168,15 +168,13 @@ function DocumentCard(props: Props) {
               </DocumentMeta>
             </div>
           </Content>
-          {canUpdatePin && (
+          {can.delete && !isDragging && pin && (
             <Actions dir={document.dir} gap={4}>
-              {!isDragging && pin && (
-                <Tooltip content={t("Unpin")}>
-                  <PinButton onClick={handleUnpin} aria-label={t("Unpin")}>
-                    <CloseIcon />
-                  </PinButton>
-                </Tooltip>
-              )}
+              <Tooltip content={t("Unpin")}>
+                <PinButton onClick={handleUnpin} aria-label={t("Unpin")}>
+                  <CloseIcon />
+                </PinButton>
+              </Tooltip>
             </Actions>
           )}
         </DocumentLink>

--- a/app/components/PinnedDocuments.tsx
+++ b/app/components/PinnedDocuments.tsx
@@ -41,8 +41,6 @@ type Props = {
   limit?: number;
   /** Number of placeholder pins to display */
   placeholderCount?: number;
-  /** Whether the user has permission to update pins */
-  canUpdate?: boolean;
   /**
    * When provided the section can be collapsed by the user, the preference is
    * persisted locally under this key.
@@ -54,7 +52,6 @@ function PinnedDocuments({
   limit,
   pins,
   placeholderCount,
-  canUpdate,
   collapseKey,
   ...rest
 }: Props) {
@@ -188,7 +185,6 @@ function PinnedDocuments({
                         <DocumentCard
                           key={documentId}
                           document={document}
-                          canUpdatePin={canUpdate}
                           isDraggable={items.length > 1}
                           pin={pin}
                           {...rest}

--- a/app/scenes/Collection/index.tsx
+++ b/app/scenes/Collection/index.tsx
@@ -186,11 +186,7 @@ const CollectionScene = observer(function CollectionScene_() {
             isEditing={isEditRoute || !user?.separateEditMode}
           />
 
-          <PinnedDocuments
-            pins={pins}
-            canUpdate={can.update}
-            placeholderCount={count}
-          />
+          <PinnedDocuments pins={pins} placeholderCount={count} />
 
           <Content>
             <Navigation

--- a/app/scenes/Home.tsx
+++ b/app/scenes/Home.tsx
@@ -14,11 +14,9 @@ import PinnedDocuments from "~/components/PinnedDocuments";
 import { ResizingHeightContainer } from "~/components/ResizingHeightContainer";
 import Scene from "~/components/Scene";
 import { Tab, Tabs } from "~/components/Tabs";
-import useCurrentTeam from "~/hooks/useCurrentTeam";
 import useCurrentUser from "~/hooks/useCurrentUser";
 import { usePinnedDocuments } from "~/hooks/usePinnedDocuments";
 import usePersistedState from "~/hooks/usePersistedState";
-import usePolicy from "~/hooks/usePolicy";
 import useStores from "~/hooks/useStores";
 import NewDocumentMenu from "~/menus/NewDocumentMenu";
 
@@ -31,12 +29,10 @@ enum HomeTab {
 
 function Home() {
   const { documents, ui } = useStores();
-  const team = useCurrentTeam();
   const user = useCurrentUser();
   const { t } = useTranslation();
   const userId = user?.id;
   const { pins, count } = usePinnedDocuments("home");
-  const can = usePolicy(team);
   const [homeTab, setHomeTab] = usePersistedState<HomeTab>(
     "home-tab",
     HomeTab.Viewed,
@@ -85,7 +81,6 @@ function Home() {
       <Heading>{t("Home")}</Heading>
       <PinnedDocuments
         pins={pins}
-        canUpdate={can.update}
         placeholderCount={count}
         collapseKey="home"
       />


### PR DESCRIPTION
The unpin button was gated on a permission that doesn't match what the API authorizes. `pins.delete` checks the pin policy only for pins on home — for a pin in a collection it authorizes `unpin` on the document instead, so the button was shown to team admins who then got a 403, and hidden from collection editors who were actually allowed.

- Gate the unpin button and drag-to-reorder on the same abilities the API checks: the document policy for collection pins, the pin policy for home pins
- Remove the redundant permission prop plumbing through the scenes