### PR TITLE
Add Invited by and Joined columns to the users table

### DIFF
--- a/app/components/Table.tsx
+++ b/app/components/Table.tsx
@@ -31,6 +31,7 @@ import {
 import NudeButton from "~/components/NudeButton";
 import PlaceholderText from "~/components/PlaceholderText";
 import { SelectionCheckbox } from "~/components/SelectionCheckbox";
+import useMobile from "~/hooks/useMobile";
 import usePrevious from "~/hooks/usePrevious";
 import { transparentize } from "polished";
 
@@ -52,6 +53,8 @@ export type Column<TData> = {
   id: string;
   component: (data: TData) => React.ReactNode;
   width: string;
+  /** Whether the column is hidden on narrow viewports (defaults to false). */
+  hideOnMobile?: boolean;
 } & (DataColumn<TData> | ActionColumn);
 
 /** The minimum shape of a row, rows are identified by the model identifier. */
@@ -122,14 +125,19 @@ function TableViewInner<TData extends RowData>({
   selectableCount = 0,
 }: Props<TData> & { selectableCount?: number }) {
   const { t } = useTranslation();
+  const isMobile = useMobile();
   const selection = useModelSelection();
   const virtualContainerRef = React.useRef<HTMLDivElement>(null);
   const [virtualContainerTop, setVirtualContainerTop] =
     React.useState<number>();
 
   const allColumns = React.useMemo(() => {
+    const visibleColumns = isMobile
+      ? columns.filter((column) => !column.hideOnMobile)
+      : columns;
+
     if (!selection || !isRowSelectable) {
-      return columns;
+      return visibleColumns;
     }
 
     const selectColumn: Column<TData> = {
@@ -153,8 +161,8 @@ function TableViewInner<TData extends RowData>({
       width: "28px",
     };
 
-    return [selectColumn, ...columns];
-  }, [columns, selection, isRowSelectable, selectableCount, t]);
+    return [selectColumn, ...visibleColumns];
+  }, [columns, isMobile, selection, isRowSelectable, selectableCount, t]);
 
   const columnHelper = React.useMemo(() => createColumnHelper<TData>(), []);
   const observedColumns = React.useMemo(

--- a/app/models/User.ts
+++ b/app/models/User.ts
@@ -19,6 +19,7 @@ import type Group from "./Group";
 import type UserMembership from "./UserMembership";
 import ParanoidModel from "./base/ParanoidModel";
 import Field from "./decorators/Field";
+import Relation from "./decorators/Relation";
 import type { Searchable } from "./interfaces/Searchable";
 
 class User extends ParanoidModel implements Searchable {
@@ -79,6 +80,13 @@ class User extends ParanoidModel implements Searchable {
 
   @observable
   isSuspended: boolean;
+
+  @observable
+  invitedById: string | undefined;
+
+  /** The user that invited this user, if they were invited. */
+  @Relation(() => User)
+  invitedBy: User | undefined;
 
   @computed
   get searchContent(): string[] {

--- a/app/scenes/Settings/components/UsersTable.tsx
+++ b/app/scenes/Settings/components/UsersTable.tsx
@@ -16,6 +16,7 @@ import { ContextMenu } from "~/components/Menu/ContextMenu";
 import { ActionContextProvider } from "~/hooks/useActionContext";
 import { useUserMenuActions } from "~/hooks/useUserMenuActions";
 import Time from "~/components/Time";
+import { UserHoverCard } from "~/components/UserHoverCard";
 import useCurrentUser from "~/hooks/useCurrentUser";
 import useMobile from "~/hooks/useMobile";
 import UserMenu from "~/menus/UserMenu";
@@ -124,6 +125,37 @@ export function UsersTable({ canManage, ...rest }: Props) {
                 ) : null,
               width: "2fr",
             },
+        canManage && !isMobile
+          ? {
+              type: "data",
+              id: "invitedBy",
+              header: t("Invited by"),
+              accessor: (user) => user.invitedBy?.name,
+              component: (user) =>
+                user.invitedBy ? (
+                  <UserHoverCard user={user.invitedBy}>
+                    <Text selectable ellipsis>
+                      {user.invitedBy.name}
+                    </Text>
+                  </UserHoverCard>
+                ) : null,
+              sortable: false,
+              width: "2fr",
+            }
+          : undefined,
+        isMobile
+          ? undefined
+          : {
+              type: "data",
+              id: "createdAt",
+              header: t("Joined"),
+              accessor: (user) => user.createdAt,
+              component: (user) =>
+                user.createdAt ? (
+                  <Time dateTime={user.createdAt} addSuffix shorten />
+                ) : null,
+              width: "2fr",
+            },
         {
           type: "data",
           id: "role",
@@ -144,7 +176,7 @@ export function UsersTable({ canManage, ...rest }: Props) {
               {user.isSuspended && <Badge>{t("Suspended")}</Badge>}
             </HStack>
           ),
-          width: "2fr",
+          width: "1.4fr",
         },
         canManage
           ? {

--- a/app/scenes/Settings/components/UsersTable.tsx
+++ b/app/scenes/Settings/components/UsersTable.tsx
@@ -102,7 +102,7 @@ export function UsersTable({ canManage, ...rest }: Props) {
           ),
           width: "4fr",
         },
-        canManage && !isMobile
+        canManage
           ? {
               type: "data",
               id: "email",
@@ -110,22 +110,22 @@ export function UsersTable({ canManage, ...rest }: Props) {
               accessor: (user) => user.email,
               component: (user) => <>{user.email}</>,
               width: "4fr",
+              hideOnMobile: true,
             }
           : undefined,
-        isMobile
-          ? undefined
-          : {
-              type: "data",
-              id: "lastActiveAt",
-              header: t("Last active"),
-              accessor: (user) => user.lastActiveAt,
-              component: (user) =>
-                user.lastActiveAt ? (
-                  <Time dateTime={user.lastActiveAt} addSuffix shorten />
-                ) : null,
-              width: "2fr",
-            },
-        canManage && !isMobile
+        {
+          type: "data",
+          id: "lastActiveAt",
+          header: t("Last active"),
+          accessor: (user) => user.lastActiveAt,
+          component: (user) =>
+            user.lastActiveAt ? (
+              <Time dateTime={user.lastActiveAt} addSuffix shorten />
+            ) : null,
+          width: "2fr",
+          hideOnMobile: true,
+        },
+        canManage
           ? {
               type: "data",
               id: "invitedBy",
@@ -141,21 +141,21 @@ export function UsersTable({ canManage, ...rest }: Props) {
                 ) : null,
               sortable: false,
               width: "2fr",
+              hideOnMobile: true,
             }
           : undefined,
-        isMobile
-          ? undefined
-          : {
-              type: "data",
-              id: "createdAt",
-              header: t("Joined"),
-              accessor: (user) => user.createdAt,
-              component: (user) =>
-                user.createdAt ? (
-                  <Time dateTime={user.createdAt} addSuffix shorten />
-                ) : null,
-              width: "2fr",
-            },
+        {
+          type: "data",
+          id: "createdAt",
+          header: t("Joined"),
+          accessor: (user) => user.createdAt,
+          component: (user) =>
+            user.createdAt ? (
+              <Time dateTime={user.createdAt} addSuffix shorten />
+            ) : null,
+          width: "2fr",
+          hideOnMobile: true,
+        },
         {
           type: "data",
           id: "role",

--- a/server/presenters/user.ts
+++ b/server/presenters/user.ts
@@ -27,6 +27,7 @@ type UserPresentation = {
   preferences?: UserPreferences | null;
   notificationSettings?: NotificationSettings;
   timezone?: string | null;
+  invitedBy?: UserPresentation;
 };
 
 export default function presentUser(
@@ -56,6 +57,11 @@ export default function presentUser(
 
   if (options.includeEmail) {
     userData.email = user.email;
+  }
+
+  // Only included when the association has been eager-loaded by the caller.
+  if (user.invitedBy) {
+    userData.invitedBy = presentUser(user.invitedBy);
   }
 
   return userData;

--- a/server/routes/api/users/users.test.ts
+++ b/server/routes/api/users/users.test.ts
@@ -38,6 +38,38 @@ describe("#users.list", () => {
     expect(body.data[0].id).toEqual(user.id);
   });
 
+  it("should return the inviting user for admins", async () => {
+    const admin = await buildAdmin();
+    const invite = await buildInvite({ teamId: admin.teamId });
+
+    const res = await server.post("/api/users.list", admin, {
+      body: { filter: "all" },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+
+    const invited = body.data.find(
+      (item: { id: string }) => item.id === invite.id
+    );
+    expect(invited.invitedBy.id).toEqual(invite.invitedById);
+  });
+
+  it("should not return the inviting user for non-admins", async () => {
+    const invite = await buildInvite();
+    const user = await buildUser({ teamId: invite.teamId });
+
+    const res = await server.post("/api/users.list", user, {
+      body: { filter: "all" },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+
+    const invited = body.data.find(
+      (item: { id: string }) => item.id === invite.id
+    );
+    expect(invited.invitedBy).toEqual(undefined);
+  });
+
   it("should treat LIKE wildcards in the query as literal characters", async () => {
     const user = await buildUser({
       name: "Underscore",

--- a/server/routes/api/users/users.ts
+++ b/server/routes/api/users/users.ts
@@ -131,10 +131,10 @@ router.post(
         [Op.and]: {
           [Op.or]: [
             Sequelize.literal(
-              `unaccent(LOWER(email)) like unaccent(LOWER(:query))`
+              `unaccent(LOWER("user"."email")) like unaccent(LOWER(:query))`
             ),
             Sequelize.literal(
-              `unaccent(LOWER(name)) like unaccent(LOWER(:query))`
+              `unaccent(LOWER("user"."name")) like unaccent(LOWER(:query))`
             ),
           ],
         },
@@ -161,6 +161,10 @@ router.post(
       User.findAll({
         where,
         replacements,
+        // Only admins can see who invited a user.
+        include: actor.isAdmin
+          ? [{ association: "invitedBy", required: false }]
+          : undefined,
         order: [[sort, direction]],
         offset: ctx.state.pagination.offset,
         limit: ctx.state.pagination.limit,

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -1324,6 +1324,8 @@
   "All roles": "All roles",
   "Admins": "Admins",
   "Editors": "Editors",
+  "Invited by": "Invited by",
+  "Joined": "Joined",
   "All status": "All status",
   "Active": "Active",
   "Could not load emojis": "Could not load emojis",


### PR DESCRIPTION
- Adds an "Invited by" column to the members table, showing who invited each user with a profile card on hover. Visible to admins only, the inviting user is eager-loaded in `users.list` and presented as a nested relation.
- Adds a sortable "Joined" column showing when the user was created.
- Narrows the role column to make room.
- Adds a `hideOnMobile` flag to the table column definition, handled centrally in the table component, replacing the per-column conditionals previously used in the users table.