### PR TITLE
Choose which columns are visible in settings tables

### DIFF
--- a/app/components/Table.tsx
+++ b/app/components/Table.tsx
@@ -14,7 +14,7 @@ import {
 } from "@tanstack/react-table";
 import { useWindowVirtualizer } from "@tanstack/react-virtual";
 import { observer } from "mobx-react";
-import { CollapsedIcon } from "outline-icons";
+import { CollapsedIcon, SettingsIcon } from "outline-icons";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { Waypoint } from "react-waypoint";
@@ -30,8 +30,19 @@ import {
 } from "~/components/ModelSelectionContext";
 import NudeButton from "~/components/NudeButton";
 import PlaceholderText from "~/components/PlaceholderText";
+import {
+  Menu,
+  MenuButton,
+  MenuContent,
+  MenuTrigger,
+} from "~/components/primitives/Menu";
+import { MenuProvider } from "~/components/primitives/Menu/MenuContext";
 import { SelectionCheckbox } from "~/components/SelectionCheckbox";
+import Tooltip from "~/components/Tooltip";
+import useMobile from "~/hooks/useMobile";
+import usePersistedState from "~/hooks/usePersistedState";
 import usePrevious from "~/hooks/usePrevious";
+import { preventDefault } from "~/utils/events";
 import { transparentize } from "polished";
 
 const HEADER_HEIGHT = 40;
@@ -60,6 +71,11 @@ export type RowData = {
 };
 
 export type Props<TData> = {
+  /**
+   * Unique identifier for this table. When provided the visibility of columns
+   * can be toggled from a context menu on the header and is persisted locally.
+   */
+  id?: string;
   data: TData[];
   columns: Column<TData>[];
   sort: ColumnSort;
@@ -109,6 +125,7 @@ function Table<TData extends RowData>(props: Props<TData>) {
 }
 
 function TableViewInner<TData extends RowData>({
+  id,
   data,
   columns,
   sort,
@@ -123,13 +140,41 @@ function TableViewInner<TData extends RowData>({
 }: Props<TData> & { selectableCount?: number }) {
   const { t } = useTranslation();
   const selection = useModelSelection();
+  const isMobile = useMobile();
   const virtualContainerRef = React.useRef<HTMLDivElement>(null);
   const [virtualContainerTop, setVirtualContainerTop] =
     React.useState<number>();
 
+  const [hiddenColumns, setHiddenColumns] = usePersistedState<string[]>(
+    `hiddenTableColumns-${id}`,
+    []
+  );
+
+  const handleToggleColumn = React.useCallback(
+    (columnId: string) => {
+      setHiddenColumns((hidden) =>
+        hidden.includes(columnId)
+          ? hidden.filter((hiddenId) => hiddenId !== columnId)
+          : [...hidden, columnId]
+      );
+    },
+    [setHiddenColumns]
+  );
+
+  const visibleColumns = React.useMemo(
+    () =>
+      id
+        ? columns.filter(
+            (column) =>
+              column.type !== "data" || !hiddenColumns.includes(column.id)
+          )
+        : columns,
+    [id, columns, hiddenColumns]
+  );
+
   const allColumns = React.useMemo(() => {
     if (!selection || !isRowSelectable) {
-      return columns;
+      return visibleColumns;
     }
 
     const selectColumn: Column<TData> = {
@@ -153,8 +198,8 @@ function TableViewInner<TData extends RowData>({
       width: "28px",
     };
 
-    return [selectColumn, ...columns];
-  }, [columns, selection, isRowSelectable, selectableCount, t]);
+    return [selectColumn, ...visibleColumns];
+  }, [visibleColumns, selection, isRowSelectable, selectableCount, t]);
 
   const columnHelper = React.useMemo(() => createColumnHelper<TData>(), []);
   const observedColumns = React.useMemo(
@@ -251,61 +296,83 @@ function TableViewInner<TData extends RowData>({
     <>
       <InnerTable role="table">
         <THead role="rowgroup" $topPos={stickyOffset}>
-          {table.getHeaderGroups().map((headerGroup) => (
-            <TR role="row" key={headerGroup.id} $columns={gridColumns}>
-              {headerGroup.headers.map((header) => {
-                const sorted = header.column.getIsSorted();
-                const canSort = header.column.getCanSort();
-                const toggleSorting = header.column.getToggleSortingHandler();
-                const handleSortKeyDown = (
-                  ev: React.KeyboardEvent<HTMLDivElement>
-                ) => {
-                  if (!ev.repeat && (ev.key === "Enter" || ev.key === " ")) {
-                    ev.preventDefault();
-                    toggleSorting?.(ev);
-                  }
-                };
-
-                return (
-                  <TH
-                    role="columnheader"
-                    key={header.id}
-                    aria-sort={
-                      !canSort
-                        ? undefined
-                        : sorted === "asc"
-                          ? "ascending"
-                          : sorted === "desc"
-                            ? "descending"
-                            : "none"
+          {table.getHeaderGroups().map((headerGroup) => {
+            const headerRow = (
+              <TR role="row" $columns={gridColumns}>
+                {headerGroup.headers.map((header) => {
+                  const sorted = header.column.getIsSorted();
+                  const canSort = header.column.getCanSort();
+                  const toggleSorting = header.column.getToggleSortingHandler();
+                  const handleSortKeyDown = (
+                    ev: React.KeyboardEvent<HTMLDivElement>
+                  ) => {
+                    if (!ev.repeat && (ev.key === "Enter" || ev.key === " ")) {
+                      ev.preventDefault();
+                      toggleSorting?.(ev);
                     }
-                  >
-                    <SortWrapper
-                      align="center"
-                      gap={4}
-                      onClick={toggleSorting}
-                      onKeyDown={canSort ? handleSortKeyDown : undefined}
-                      role={canSort ? "button" : undefined}
-                      tabIndex={canSort ? 0 : undefined}
-                      $sortable={canSort}
+                  };
+
+                  return (
+                    <TH
+                      role="columnheader"
+                      key={header.id}
+                      aria-sort={
+                        !canSort
+                          ? undefined
+                          : sorted === "asc"
+                            ? "ascending"
+                            : sorted === "desc"
+                              ? "descending"
+                              : "none"
+                      }
                     >
-                      {flexRender(
-                        header.column.columnDef.header,
-                        header.getContext()
-                      )}
-                      {sorted === "asc" ? (
-                        <AscSortIcon />
-                      ) : sorted === "desc" ? (
-                        <DescSortIcon />
-                      ) : (
-                        <div />
-                      )}
-                    </SortWrapper>
-                  </TH>
-                );
-              })}
-            </TR>
-          ))}
+                      <SortWrapper
+                        align="center"
+                        gap={4}
+                        onClick={toggleSorting}
+                        onKeyDown={canSort ? handleSortKeyDown : undefined}
+                        role={canSort ? "button" : undefined}
+                        tabIndex={canSort ? 0 : undefined}
+                        $sortable={canSort}
+                      >
+                        {flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                        {sorted === "asc" ? (
+                          <AscSortIcon />
+                        ) : sorted === "desc" ? (
+                          <DescSortIcon />
+                        ) : (
+                          <div />
+                        )}
+                      </SortWrapper>
+                    </TH>
+                  );
+                })}
+              </TR>
+            );
+
+            return id && !isMobile ? (
+              <ColumnVisibilityMenu
+                key={headerGroup.id}
+                columns={columns}
+                hiddenColumns={hiddenColumns}
+                onToggleColumn={handleToggleColumn}
+              >
+                {headerRow}
+              </ColumnVisibilityMenu>
+            ) : (
+              <React.Fragment key={headerGroup.id}>{headerRow}</React.Fragment>
+            );
+          })}
+          {id && !isMobile && (
+            <ColumnVisibilityButton
+              columns={columns}
+              hiddenColumns={hiddenColumns}
+              onToggleColumn={handleToggleColumn}
+            />
+          )}
         </THead>
 
         <TBody
@@ -381,6 +448,96 @@ function TableViewInner<TData extends RowData>({
 
 // The observer wrapper does not preserve the generic signature of the table.
 const TableView = observer(TableViewInner) as typeof TableViewInner;
+
+type ColumnVisibilityProps<TData> = {
+  columns: Column<TData>[];
+  hiddenColumns: string[];
+  onToggleColumn: (columnId: string) => void;
+};
+
+/**
+ * Menu items that toggle the visibility of individual columns. Only columns
+ * that display data can be hidden, and at least one must remain visible.
+ */
+function ColumnVisibilityItems<TData>({
+  columns,
+  hiddenColumns,
+  onToggleColumn,
+}: ColumnVisibilityProps<TData>) {
+  const dataColumns = columns.filter(
+    (column): column is Column<TData> & DataColumn<TData> =>
+      column.type === "data"
+  );
+  const visibleCount = dataColumns.filter(
+    (column) => !hiddenColumns.includes(column.id)
+  ).length;
+
+  return (
+    <>
+      {dataColumns.map((column) => {
+        const visible = !hiddenColumns.includes(column.id);
+
+        return (
+          <MenuButton
+            key={column.id}
+            label={column.header}
+            selected={visible}
+            disabled={visible && visibleCount === 1}
+            onSelect={preventDefault}
+            onClick={() => onToggleColumn(column.id)}
+          />
+        );
+      })}
+    </>
+  );
+}
+
+/** Column visibility options, opened by right-clicking the header row. */
+function ColumnVisibilityMenu<TData>({
+  children,
+  ...rest
+}: ColumnVisibilityProps<TData> & { children: React.ReactNode }) {
+  const { t } = useTranslation();
+  const label = t("Columns");
+
+  return (
+    <MenuProvider variant="context">
+      <Menu>
+        <MenuTrigger aria-label={label}>{children}</MenuTrigger>
+        <MenuContent aria-label={label} onCloseAutoFocus={preventDefault}>
+          <ColumnVisibilityItems {...rest} />
+        </MenuContent>
+      </Menu>
+    </MenuProvider>
+  );
+}
+
+/** Column visibility options, opened by a button at the end of the header row. */
+function ColumnVisibilityButton<TData>(props: ColumnVisibilityProps<TData>) {
+  const { t } = useTranslation();
+  const label = t("Columns");
+
+  return (
+    <MenuProvider variant="dropdown">
+      <Menu>
+        <Tooltip content={label} placement="bottom">
+          <MenuTrigger aria-label={label}>
+            <ColumnOptions>
+              <SettingsIcon size={18} />
+            </ColumnOptions>
+          </MenuTrigger>
+        </Tooltip>
+        <MenuContent
+          align="end"
+          aria-label={label}
+          onCloseAutoFocus={preventDefault}
+        >
+          <ColumnVisibilityItems {...props} />
+        </MenuContent>
+      </Menu>
+    </MenuProvider>
+  );
+}
 
 const SelectableRow = observer(function SelectableRow_({
   selection,
@@ -519,6 +676,21 @@ const SortWrapper = styled(Flex)<{ $sortable: boolean }>`
   }
 `;
 
+const ColumnOptions = styled(NudeButton)`
+  position: absolute;
+  top: ${(HEADER_HEIGHT - 24) / 2}px;
+  right: 0;
+  color: ${s("placeholder")};
+  background: ${s("background")};
+
+  &:hover,
+  &:focus-visible,
+  &[aria-expanded="true"] {
+    color: ${s("textSecondary")};
+    background: ${s("sidebarControlHoverBackground")};
+  }
+`;
+
 const InnerTable = styled.div`
   width: 100%;
 `;
@@ -529,7 +701,7 @@ const THead = styled.div<{ $topPos: number }>`
   height: ${HEADER_HEIGHT}px;
   z-index: 1;
   font-size: 14px;
-  color: ${s("textSecondary")};
+  color: ${s("text")};
   font-weight: 500;
 
   border-bottom: 1px solid
@@ -551,6 +723,11 @@ const TR = styled.div<{ $columns: string }>`
     ${(props) => transparentize(0.3, props.theme.divider)};
 
   &:last-child {
+    border-bottom: 0;
+  }
+
+  /* The header has its own border, avoid doubling the divider beneath it. */
+  ${THead} & {
     border-bottom: 0;
   }
 

--- a/app/components/UserLabel.tsx
+++ b/app/components/UserLabel.tsx
@@ -1,0 +1,45 @@
+import { observer } from "mobx-react";
+import type * as React from "react";
+import Text from "@shared/components/Text";
+import Avatar, { AvatarSize } from "~/components/Avatar/Avatar";
+import { HStack } from "~/components/primitives/HStack";
+import { UserHoverCard } from "~/components/UserHoverCard";
+import type User from "~/models/User";
+
+type Props = {
+  /** The user to display, nothing is rendered when undefined. */
+  user: User | null | undefined;
+  /** Whether the user is the primary content of the row, shown with a larger avatar. */
+  primary?: boolean;
+  /** Additional content displayed after the user's name. */
+  children?: React.ReactNode;
+};
+
+/**
+ * Displays a user's avatar alongside their name, with a card summarizing their
+ * profile shown on hover.
+ */
+export const UserLabel = observer(function UserLabel_({
+  user,
+  primary,
+  children,
+}: Props) {
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <UserHoverCard user={user}>
+      <HStack>
+        <Avatar
+          model={user}
+          size={primary ? AvatarSize.Large : AvatarSize.Small}
+        />
+        <Text selectable ellipsis>
+          {user.name}
+        </Text>
+        {children}
+      </HStack>
+    </UserHoverCard>
+  );
+});

--- a/app/scenes/Settings/components/ApiKeysTable.tsx
+++ b/app/scenes/Settings/components/ApiKeysTable.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import styled from "styled-components";
 import type ApiKey from "~/models/ApiKey";
-import { Avatar, AvatarSize } from "~/components/Avatar";
 import Badge from "~/components/Badge";
 import CopyToClipboard from "~/components/CopyToClipboard";
 import { HEADER_HEIGHT } from "~/components/Header";
@@ -14,6 +13,7 @@ import {
   SortableTable,
 } from "~/components/SortableTable";
 import { type Column as TableColumn } from "~/components/Table";
+import { UserLabel } from "~/components/UserLabel";
 import Text from "~/components/Text";
 import Time from "~/components/Time";
 import Tooltip from "~/components/Tooltip";
@@ -115,13 +115,7 @@ export const ApiKeysTable = observer(function ApiKeysTable(props: Props) {
         id: "userId",
         header: t("Created by"),
         accessor: (apiKey) => apiKey.user?.name,
-        component: (apiKey) =>
-          apiKey.user ? (
-            <HStack>
-              <Avatar model={apiKey.user} size={AvatarSize.Medium} />
-              <Text selectable>{apiKey.user.name}</Text>
-            </HStack>
-          ) : null,
+        component: (apiKey) => <UserLabel user={apiKey.user} />,
         width: "2fr",
       },
       {
@@ -168,6 +162,7 @@ export const ApiKeysTable = observer(function ApiKeysTable(props: Props) {
 
   return (
     <SortableTable
+      id="apiKeys"
       columns={columns}
       rowHeight={ROW_HEIGHT}
       stickyOffset={STICKY_OFFSET}

--- a/app/scenes/Settings/components/EmojisTable.tsx
+++ b/app/scenes/Settings/components/EmojisTable.tsx
@@ -4,13 +4,13 @@ import * as React from "react";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import type Emoji from "~/models/Emoji";
-import { Avatar, AvatarSize } from "~/components/Avatar";
 import { HEADER_HEIGHT } from "~/components/Header";
 import {
   type Props as TableProps,
   SortableTable,
 } from "~/components/SortableTable";
 import { type Column as TableColumn } from "~/components/Table";
+import { UserLabel } from "~/components/UserLabel";
 import { ContextMenu } from "~/components/Menu/ContextMenu";
 import { useEmojiMenuActions } from "~/hooks/useEmojiMenuActions";
 import Time from "~/components/Time";
@@ -87,16 +87,7 @@ const EmojisTable = observer(function EmojisTable({
           header: t("Added by"),
           accessor: (emoji) => emoji.createdBy,
           sortable: false,
-          component: (emoji) => (
-            <HStack>
-              {emoji.createdBy && (
-                <>
-                  <Avatar model={emoji.createdBy} size={AvatarSize.Small} />
-                  {emoji.createdBy.name}
-                </>
-              )}
-            </HStack>
-          ),
+          component: (emoji) => <UserLabel user={emoji.createdBy} />,
           width: "2fr",
         },
         {
@@ -121,6 +112,7 @@ const EmojisTable = observer(function EmojisTable({
 
   return (
     <SortableTable
+      id="emojis"
       columns={columns}
       rowHeight={ROW_HEIGHT}
       stickyOffset={STICKY_OFFSET}

--- a/app/scenes/Settings/components/GroupMembersTable.tsx
+++ b/app/scenes/Settings/components/GroupMembersTable.tsx
@@ -7,7 +7,6 @@ import { GroupPermission } from "@shared/types";
 import { GroupPermissionHelper } from "@shared/utils/GroupPermissionHelper";
 import type Group from "~/models/Group";
 import type User from "~/models/User";
-import { Avatar, AvatarSize } from "~/components/Avatar";
 import Badge from "~/components/Badge";
 import { HEADER_HEIGHT } from "~/components/Header";
 import { ContextMenu } from "~/components/Menu/ContextMenu";
@@ -16,6 +15,7 @@ import {
   SortableTable,
 } from "~/components/SortableTable";
 import { type Column as TableColumn } from "~/components/Table";
+import { UserLabel } from "~/components/UserLabel";
 import Text from "~/components/Text";
 import Time from "~/components/Time";
 import { ActionContextProvider } from "~/hooks/useActionContext";
@@ -94,11 +94,9 @@ export const GroupMembersTable = observer(function GroupMembersTable({
           header: t("Name"),
           accessor: (user) => user.name,
           component: (user) => (
-            <HStack>
-              <Avatar model={user} size={AvatarSize.Large} />
-              <Text selectable>{user.name}</Text>
+            <UserLabel user={user} primary>
               {user.isAdmin && <Badge primary>{t("Admin")}</Badge>}
-            </HStack>
+            </UserLabel>
           ),
           width: "3fr",
         },
@@ -132,9 +130,11 @@ export const GroupMembersTable = observer(function GroupMembersTable({
               user.id
             )?.permission;
             return permission ? (
-              <Badge primary={permission === GroupPermission.Admin}>
-                {GroupPermissionHelper.displayName(permission, t)}
-              </Badge>
+              <HStack>
+                <Badge primary={permission === GroupPermission.Admin}>
+                  {GroupPermissionHelper.displayName(permission, t)}
+                </Badge>
+              </HStack>
             ) : null;
           },
           width: "1fr",
@@ -155,6 +155,7 @@ export const GroupMembersTable = observer(function GroupMembersTable({
 
   return (
     <SortableTable
+      id="groupMembers"
       columns={columns}
       rowHeight={ROW_HEIGHT}
       stickyOffset={STICKY_OFFSET}

--- a/app/scenes/Settings/components/GroupsTable.tsx
+++ b/app/scenes/Settings/components/GroupsTable.tsx
@@ -208,6 +208,7 @@ export function GroupsTable(props: Props) {
 
   return (
     <SortableTable
+      id="groups"
       columns={columns}
       rowHeight={ROW_HEIGHT}
       stickyOffset={STICKY_OFFSET}

--- a/app/scenes/Settings/components/SharesTable.tsx
+++ b/app/scenes/Settings/components/SharesTable.tsx
@@ -4,21 +4,19 @@ import * as React from "react";
 import { useMemo, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import type Share from "~/models/Share";
-import { Avatar, AvatarSize } from "~/components/Avatar";
 import Badge from "~/components/Badge";
-import Flex from "~/components/Flex";
 import { HEADER_HEIGHT } from "~/components/Header";
 import {
   type Props as TableProps,
   SortableTable,
 } from "~/components/SortableTable";
 import { type Column as TableColumn } from "~/components/Table";
+import { UserLabel } from "~/components/UserLabel";
 import { ContextMenu } from "~/components/Menu/ContextMenu";
 import { useShareMenuActions } from "~/hooks/useShareMenuActions";
 import Time from "~/components/Time";
 import ShareMenu from "~/menus/ShareMenu";
 import { useFormatNumber } from "~/hooks/useFormatNumber";
-import { HStack } from "~/components/primitives/HStack";
 
 const ROW_HEIGHT = 50;
 
@@ -80,16 +78,7 @@ export function SharesTable({ data, canManage, ...rest }: Props) {
           header: t("Shared by"),
           accessor: (share) => share.createdBy,
           sortable: false,
-          component: (share) => (
-            <HStack>
-              {share.createdBy && (
-                <>
-                  <Avatar model={share.createdBy} size={AvatarSize.Small} />
-                  {share.createdBy.name}
-                </>
-              )}
-            </HStack>
-          ),
+          component: (share) => <UserLabel user={share.createdBy} />,
           width: "2fr",
         },
         {
@@ -137,11 +126,7 @@ export function SharesTable({ data, canManage, ...rest }: Props) {
           ? {
               type: "action",
               id: "action",
-              component: (share) => (
-                <Flex align="center">
-                  <ShareMenu share={share} />
-                </Flex>
-              ),
+              component: (share) => <ShareMenu share={share} />,
               width: "50px",
             }
           : undefined,
@@ -151,6 +136,7 @@ export function SharesTable({ data, canManage, ...rest }: Props) {
 
   return (
     <SortableTable
+      id="shares"
       data={data}
       columns={columns}
       rowHeight={ROW_HEIGHT}

--- a/app/scenes/Settings/components/TemplatesTable.tsx
+++ b/app/scenes/Settings/components/TemplatesTable.tsx
@@ -8,7 +8,6 @@ import Flex from "@shared/components/Flex";
 import Icon from "@shared/components/Icon";
 import { hover } from "@shared/styles";
 import type Template from "~/models/Template";
-import { Avatar, AvatarSize } from "~/components/Avatar";
 import ButtonLink from "~/components/ButtonLink";
 import { HEADER_HEIGHT } from "~/components/Header";
 import CollectionIcon from "~/components/Icons/CollectionIcon";
@@ -18,6 +17,7 @@ import {
   SortableTable,
 } from "~/components/SortableTable";
 import { type Column as TableColumn } from "~/components/Table";
+import { UserLabel } from "~/components/UserLabel";
 import Text from "~/components/Text";
 import Time from "~/components/Time";
 import { ActionContextProvider } from "~/hooks/useActionContext";
@@ -99,12 +99,7 @@ export function TemplatesTable(props: Props) {
           header: t("Updated by"),
           accessor: (template) => template.updatedBy?.name,
           sortable: false,
-          component: (template) => (
-            <Flex align="center" gap={8}>
-              <Avatar model={template.updatedBy} size={AvatarSize.Small} />{" "}
-              {template.updatedBy?.name}{" "}
-            </Flex>
-          ),
+          component: (template) => <UserLabel user={template.updatedBy} />,
           width: "2fr",
         },
         {
@@ -135,6 +130,7 @@ export function TemplatesTable(props: Props) {
 
   return (
     <SortableTable
+      id="templates"
       columns={columns}
       rowHeight={ROW_HEIGHT}
       stickyOffset={STICKY_OFFSET}

--- a/app/scenes/Settings/components/UsersTable.tsx
+++ b/app/scenes/Settings/components/UsersTable.tsx
@@ -161,6 +161,7 @@ export function UsersTable({ canManage, ...rest }: Props) {
 
   return (
     <SortableTable
+      id="users"
       columns={columns}
       rowHeight={ROW_HEIGHT}
       stickyOffset={STICKY_OFFSET}

--- a/plugins/webhooks/client/components/WebhookSubscriptionsTable.tsx
+++ b/plugins/webhooks/client/components/WebhookSubscriptionsTable.tsx
@@ -2,7 +2,6 @@ import { observer } from "mobx-react";
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type WebhookSubscription from "~/models/WebhookSubscription";
-import { Avatar, AvatarSize } from "~/components/Avatar";
 import { HEADER_HEIGHT } from "~/components/Header";
 import { ContextMenu } from "~/components/Menu/ContextMenu";
 import {
@@ -10,6 +9,7 @@ import {
   SortableTable,
 } from "~/components/SortableTable";
 import { type Column as TableColumn } from "~/components/Table";
+import { UserLabel } from "~/components/UserLabel";
 import styled from "styled-components";
 import { ellipsis } from "@shared/styles";
 import Text from "~/components/Text";
@@ -90,13 +90,7 @@ export const WebhookSubscriptionsTable = observer(
           id: "createdById",
           header: t("Created by"),
           accessor: (webhook) => webhook.createdBy?.name,
-          component: (webhook) =>
-            webhook.createdBy ? (
-              <HStack>
-                <Avatar model={webhook.createdBy} size={AvatarSize.Medium} />
-                <Text selectable>{webhook.createdBy.name}</Text>
-              </HStack>
-            ) : null,
+          component: (webhook) => <UserLabel user={webhook.createdBy} />,
           width: "2fr",
         },
         {
@@ -122,6 +116,7 @@ export const WebhookSubscriptionsTable = observer(
 
     return (
       <SortableTable
+        id="webhooks"
         columns={columns}
         rowHeight={ROW_HEIGHT}
         stickyOffset={STICKY_OFFSET}

--- a/shared/i18n/locales/en_US/translation.json
+++ b/shared/i18n/locales/en_US/translation.json
@@ -615,6 +615,7 @@
   "Star document": "Star document",
   "Select a color": "Select a color",
   "Select all": "Select all",
+  "Columns": "Columns",
   "Highlight some text and use the <1></1> control to add placeholders that can be filled out when creating new documents": "Highlight some text and use the <1></1> control to add placeholders that can be filled out when creating new documents",
   "You’re editing a template": "You’re editing a template",
   "Template created, go ahead and customize it": "Template created, go ahead and customize it",


### PR DESCRIPTION
Settings tables can now be tailored to show only the columns you care about.

- Right-click the header row, or use the new button at its end, to toggle individual columns — matching how Finder handles column headers
- Choices are persisted locally per table; at least one column must stay visible
- Centralizes the avatar + name pairing used by "Created by" style columns into `UserLabel`, so the name shows the profile hover card too
- Fixes the misaligned action column in shared links, a doubled divider under the header, and darkens the header labels