### PR TITLE
feat: Allow attributing documents.create to an existing user

### DIFF
--- a/server/routes/api/documents/documents.test.ts
+++ b/server/routes/api/documents/documents.test.ts
@@ -38,6 +38,7 @@ import {
   buildViewer,
   buildTeam,
   buildGroup,
+  buildGroupUser,
   buildAdmin,
   buildTemplate,
   buildAttachment,
@@ -3604,6 +3605,232 @@ describe("#documents.create", () => {
       },
     });
     expect(res.status).toEqual(400);
+  });
+
+  it("should attribute the document to another same-team user when the actor is an admin", async () => {
+    const admin = await buildAdmin();
+    const author = await buildUser({ teamId: admin.teamId });
+    const res = await server.post("/api/documents.create", admin, {
+      body: {
+        title: "on behalf",
+        text: "hello",
+        createdById: author.id,
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.data.createdBy.id).toEqual(author.id);
+  });
+
+  it("should default the author to the acting user when createdById is omitted", async () => {
+    const user = await buildUser();
+    const res = await server.post("/api/documents.create", user, {
+      body: {
+        title: "mine",
+        text: "hello",
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.data.createdBy.id).toEqual(user.id);
+  });
+
+  it("should reject createdById when the acting user is not an admin", async () => {
+    const user = await buildUser();
+    const author = await buildUser({ teamId: user.teamId });
+    const res = await server.post("/api/documents.create", user, {
+      body: {
+        title: "nope",
+        createdById: author.id,
+      },
+    });
+    expect(res.status).toEqual(403);
+    // Fail closed: the rejection must not have persisted a document.
+    expect(await Document.count({ where: { teamId: user.teamId } })).toEqual(0);
+  });
+
+  it("should reject a non-admin with the admin error even for a non-existent createdById (no existence oracle)", async () => {
+    const user = await buildUser();
+    const res = await server.post("/api/documents.create", user, {
+      body: {
+        title: "no oracle",
+        createdById: faker.string.uuid(),
+      },
+    });
+    // The admin gate fires before any user lookup, so a non-admin cannot
+    // distinguish an existing from a non-existent user: both return 403, never
+    // the 400 that would leak that the id resolved to no user.
+    expect(res.status).toEqual(403);
+    expect(await Document.count({ where: { teamId: user.teamId } })).toEqual(0);
+  });
+
+  it("should reject createdById equal to the acting user when not an admin", async () => {
+    const user = await buildUser();
+    const res = await server.post("/api/documents.create", user, {
+      body: {
+        title: "own id",
+        createdById: user.id,
+      },
+    });
+    // Supplying createdById is admin-only even when it is the caller's own id,
+    // matching the contract the schema documents.
+    expect(res.status).toEqual(403);
+    expect(await Document.count({ where: { teamId: user.teamId } })).toEqual(0);
+  });
+
+  it("should reject createdById for a user in a different team", async () => {
+    const admin = await buildAdmin();
+    const otherTeam = await buildTeam();
+    const foreignUser = await buildUser({ teamId: otherTeam.id });
+    const res = await server.post("/api/documents.create", admin, {
+      body: {
+        title: "cross team",
+        createdById: foreignUser.id,
+      },
+    });
+    expect(res.status).toEqual(400);
+    expect(await Document.count({ where: { teamId: admin.teamId } })).toEqual(
+      0
+    );
+  });
+
+  it("should reject createdById for a non-existent user", async () => {
+    const admin = await buildAdmin();
+    const res = await server.post("/api/documents.create", admin, {
+      body: {
+        title: "ghost author",
+        createdById: faker.string.uuid(),
+      },
+    });
+    expect(res.status).toEqual(400);
+    expect(await Document.count({ where: { teamId: admin.teamId } })).toEqual(
+      0
+    );
+  });
+
+  it("should reject createdById for a user who cannot read the collection", async () => {
+    const admin = await buildAdmin();
+    const author = await buildUser({ teamId: admin.teamId });
+    // A private collection the author holds no membership in — the acting
+    // admin can read it, the prospective author cannot.
+    const collection = await buildCollection({
+      teamId: admin.teamId,
+      userId: admin.id,
+      permission: null,
+    });
+    const res = await server.post("/api/documents.create", admin, {
+      body: {
+        title: "unreachable",
+        collectionId: collection.id,
+        createdById: author.id,
+      },
+    });
+    expect(res.status).toEqual(400);
+    expect(await Document.count({ where: { teamId: admin.teamId } })).toEqual(
+      0
+    );
+  });
+
+  it("should record the acting admin as the audit actor, not the attributed author", async () => {
+    const admin = await buildAdmin();
+    const author = await buildUser({ teamId: admin.teamId });
+    const res = await server.post("/api/documents.create", admin, {
+      body: {
+        title: "audit actor",
+        text: "hello",
+        createdById: author.id,
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.data.createdBy.id).toEqual(author.id);
+    // The attribution must not reach the audit trail: the event actor is the
+    // API caller who actually made the request. Attribution moves authorship,
+    // never accountability.
+    const event = await Event.findOne({
+      where: { documentId: body.data.id, name: "documents.create" },
+    });
+    expect(event).not.toBeNull();
+    expect(event!.actorId).toEqual(admin.id);
+    expect(event!.actorId).not.toEqual(author.id);
+  });
+
+  it("should reject createdById for a suspended user", async () => {
+    const admin = await buildAdmin();
+    const author = await buildUser({
+      teamId: admin.teamId,
+      suspendedAt: new Date(),
+    });
+    const res = await server.post("/api/documents.create", admin, {
+      body: {
+        title: "suspended author",
+        createdById: author.id,
+      },
+    });
+    expect(res.status).toEqual(400);
+    expect(await Document.count({ where: { teamId: admin.teamId } })).toEqual(
+      0
+    );
+  });
+
+  it("should allow createdById when the author's access is via a group only", async () => {
+    const admin = await buildAdmin();
+    const author = await buildUser({ teamId: admin.teamId });
+    const collection = await buildCollection({
+      teamId: admin.teamId,
+      userId: admin.id,
+      permission: null,
+    });
+    // The author holds NO direct UserMembership — access is granted purely
+    // through group membership, which withMembership loads separately.
+    const group = await buildGroup({ teamId: admin.teamId });
+    await buildGroupUser({
+      teamId: admin.teamId,
+      groupId: group.id,
+      userId: author.id,
+    });
+    await GroupMembership.create({
+      collectionId: collection.id,
+      groupId: group.id,
+      permission: CollectionPermission.ReadWrite,
+      createdById: admin.id,
+    });
+    const res = await server.post("/api/documents.create", admin, {
+      body: {
+        title: "group reachable",
+        collectionId: collection.id,
+        createdById: author.id,
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.data.createdBy.id).toEqual(author.id);
+  });
+
+  it("should allow createdById for a user who is a member of a private collection", async () => {
+    const admin = await buildAdmin();
+    const author = await buildUser({ teamId: admin.teamId });
+    const collection = await buildCollection({
+      teamId: admin.teamId,
+      userId: admin.id,
+      permission: null,
+    });
+    await UserMembership.create({
+      createdById: admin.id,
+      collectionId: collection.id,
+      userId: author.id,
+      permission: CollectionPermission.ReadWrite,
+    });
+    const res = await server.post("/api/documents.create", admin, {
+      body: {
+        title: "reachable",
+        collectionId: collection.id,
+        createdById: author.id,
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.data.createdBy.id).toEqual(author.id);
   });
 
   it("should use template title when doc is created using a template and title is not explicitly passed", async () => {

--- a/server/routes/api/documents/documents.test.ts
+++ b/server/routes/api/documents/documents.test.ts
@@ -3619,33 +3619,28 @@ describe("#documents.create", () => {
         title: "on behalf",
         text: "hello",
         collectionId: collection.id,
+        publish: true,
         createdById: author.id,
       },
     });
     const body = await res.json();
     expect(res.status).toEqual(200);
     expect(body.data.createdBy.id).toEqual(author.id);
-  });
-
-  it("should default the author to the acting user when createdById is omitted", async () => {
-    const user = await buildUser();
-    const res = await server.post("/api/documents.create", user, {
-      body: {
-        title: "mine",
-        text: "hello",
-      },
+    // Attribution must not reach the audit trail: the event actor is the API
+    // caller who made the request.
+    const event = await Event.findOne({
+      where: { documentId: body.data.id, name: "documents.create" },
     });
-    const body = await res.json();
-    expect(res.status).toEqual(200);
-    expect(body.data.createdBy.id).toEqual(user.id);
+    expect(event?.actorId).toEqual(admin.id);
   });
 
-  it("should reject createdById without a collection or parent document", async () => {
+  it("should reject createdById without a collection", async () => {
     const admin = await buildAdmin();
     const author = await buildUser({ teamId: admin.teamId });
     const res = await server.post("/api/documents.create", admin, {
       body: {
         title: "orphan draft",
+        publish: true,
         createdById: author.id,
       },
     });
@@ -3655,28 +3650,26 @@ describe("#documents.create", () => {
     );
   });
 
-  it("should attribute a nested document created with only a parentDocumentId", async () => {
+  it("should reject createdById without publish", async () => {
     const admin = await buildAdmin();
     const author = await buildUser({ teamId: admin.teamId });
     const collection = await buildCollection({
       teamId: admin.teamId,
       userId: admin.id,
     });
-    const parent = await buildDocument({
-      teamId: admin.teamId,
-      userId: admin.id,
-      collectionId: collection.id,
-    });
+    // A draft is readable only by its own author, so attributing one would
+    // create a document the acting admin can no longer see.
     const res = await server.post("/api/documents.create", admin, {
       body: {
-        title: "nested",
-        parentDocumentId: parent.id,
+        title: "unpublished",
+        collectionId: collection.id,
         createdById: author.id,
       },
     });
-    const body = await res.json();
-    expect(res.status).toEqual(200);
-    expect(body.data.createdBy.id).toEqual(author.id);
+    expect(res.status).toEqual(400);
+    expect(await Document.count({ where: { teamId: admin.teamId } })).toEqual(
+      0
+    );
   });
 
   it("should reject createdById when the acting user is not an admin", async () => {
@@ -3690,47 +3683,12 @@ describe("#documents.create", () => {
       body: {
         title: "nope",
         collectionId: collection.id,
+        publish: true,
         createdById: author.id,
       },
     });
     expect(res.status).toEqual(403);
     // Fail closed: the rejection must not have persisted a document.
-    expect(await Document.count({ where: { teamId: user.teamId } })).toEqual(0);
-  });
-
-  it("should reject a non-admin with the admin error even for a non-existent createdById (no existence oracle)", async () => {
-    const user = await buildUser();
-    const collection = await buildCollection({
-      teamId: user.teamId,
-      userId: user.id,
-    });
-    const res = await server.post("/api/documents.create", user, {
-      body: {
-        title: "no oracle",
-        collectionId: collection.id,
-        createdById: faker.string.uuid(),
-      },
-    });
-    // The admin check runs before the author lookup, so a non-admin cannot
-    // distinguish an existing from a non-existent user.
-    expect(res.status).toEqual(403);
-    expect(await Document.count({ where: { teamId: user.teamId } })).toEqual(0);
-  });
-
-  it("should reject createdById equal to the acting user when not an admin", async () => {
-    const user = await buildUser();
-    const collection = await buildCollection({
-      teamId: user.teamId,
-      userId: user.id,
-    });
-    const res = await server.post("/api/documents.create", user, {
-      body: {
-        title: "own id",
-        collectionId: collection.id,
-        createdById: user.id,
-      },
-    });
-    expect(res.status).toEqual(403);
     expect(await Document.count({ where: { teamId: user.teamId } })).toEqual(0);
   });
 
@@ -3746,26 +3704,8 @@ describe("#documents.create", () => {
       body: {
         title: "cross team",
         collectionId: collection.id,
+        publish: true,
         createdById: foreignUser.id,
-      },
-    });
-    expect(res.status).toEqual(403);
-    expect(await Document.count({ where: { teamId: admin.teamId } })).toEqual(
-      0
-    );
-  });
-
-  it("should reject createdById for a non-existent user", async () => {
-    const admin = await buildAdmin();
-    const collection = await buildCollection({
-      teamId: admin.teamId,
-      userId: admin.id,
-    });
-    const res = await server.post("/api/documents.create", admin, {
-      body: {
-        title: "ghost author",
-        collectionId: collection.id,
-        createdById: faker.string.uuid(),
       },
     });
     expect(res.status).toEqual(403);
@@ -3788,6 +3728,7 @@ describe("#documents.create", () => {
       body: {
         title: "unreachable",
         collectionId: collection.id,
+        publish: true,
         createdById: author.id,
       },
     });
@@ -3795,34 +3736,6 @@ describe("#documents.create", () => {
     expect(await Document.count({ where: { teamId: admin.teamId } })).toEqual(
       0
     );
-  });
-
-  it("should record the acting admin as the audit actor, not the attributed author", async () => {
-    const admin = await buildAdmin();
-    const author = await buildUser({ teamId: admin.teamId });
-    const collection = await buildCollection({
-      teamId: admin.teamId,
-      userId: admin.id,
-    });
-    const res = await server.post("/api/documents.create", admin, {
-      body: {
-        title: "audit actor",
-        text: "hello",
-        collectionId: collection.id,
-        createdById: author.id,
-      },
-    });
-    const body = await res.json();
-    expect(res.status).toEqual(200);
-    expect(body.data.createdBy.id).toEqual(author.id);
-    // Attribution must not reach the audit trail: the event actor is the API
-    // caller who made the request.
-    const event = await Event.findOne({
-      where: { documentId: body.data.id, name: "documents.create" },
-    });
-    expect(event).not.toBeNull();
-    expect(event!.actorId).toEqual(admin.id);
-    expect(event!.actorId).not.toEqual(author.id);
   });
 
   it("should allow createdById when the author's access is via a group only", async () => {
@@ -3851,32 +3764,7 @@ describe("#documents.create", () => {
       body: {
         title: "group reachable",
         collectionId: collection.id,
-        createdById: author.id,
-      },
-    });
-    const body = await res.json();
-    expect(res.status).toEqual(200);
-    expect(body.data.createdBy.id).toEqual(author.id);
-  });
-
-  it("should allow createdById for a user who is a member of a private collection", async () => {
-    const admin = await buildAdmin();
-    const author = await buildUser({ teamId: admin.teamId });
-    const collection = await buildCollection({
-      teamId: admin.teamId,
-      userId: admin.id,
-      permission: null,
-    });
-    await UserMembership.create({
-      createdById: admin.id,
-      collectionId: collection.id,
-      userId: author.id,
-      permission: CollectionPermission.ReadWrite,
-    });
-    const res = await server.post("/api/documents.create", admin, {
-      body: {
-        title: "reachable",
-        collectionId: collection.id,
+        publish: true,
         createdById: author.id,
       },
     });

--- a/server/routes/api/documents/documents.test.ts
+++ b/server/routes/api/documents/documents.test.ts
@@ -3610,10 +3610,15 @@ describe("#documents.create", () => {
   it("should attribute the document to another same-team user when the actor is an admin", async () => {
     const admin = await buildAdmin();
     const author = await buildUser({ teamId: admin.teamId });
+    const collection = await buildCollection({
+      teamId: admin.teamId,
+      userId: admin.id,
+    });
     const res = await server.post("/api/documents.create", admin, {
       body: {
         title: "on behalf",
         text: "hello",
+        collectionId: collection.id,
         createdById: author.id,
       },
     });
@@ -3635,12 +3640,56 @@ describe("#documents.create", () => {
     expect(body.data.createdBy.id).toEqual(user.id);
   });
 
+  it("should reject createdById without a collection or parent document", async () => {
+    const admin = await buildAdmin();
+    const author = await buildUser({ teamId: admin.teamId });
+    const res = await server.post("/api/documents.create", admin, {
+      body: {
+        title: "orphan draft",
+        createdById: author.id,
+      },
+    });
+    expect(res.status).toEqual(400);
+    expect(await Document.count({ where: { teamId: admin.teamId } })).toEqual(
+      0
+    );
+  });
+
+  it("should attribute a nested document created with only a parentDocumentId", async () => {
+    const admin = await buildAdmin();
+    const author = await buildUser({ teamId: admin.teamId });
+    const collection = await buildCollection({
+      teamId: admin.teamId,
+      userId: admin.id,
+    });
+    const parent = await buildDocument({
+      teamId: admin.teamId,
+      userId: admin.id,
+      collectionId: collection.id,
+    });
+    const res = await server.post("/api/documents.create", admin, {
+      body: {
+        title: "nested",
+        parentDocumentId: parent.id,
+        createdById: author.id,
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.data.createdBy.id).toEqual(author.id);
+  });
+
   it("should reject createdById when the acting user is not an admin", async () => {
     const user = await buildUser();
     const author = await buildUser({ teamId: user.teamId });
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
     const res = await server.post("/api/documents.create", user, {
       body: {
         title: "nope",
+        collectionId: collection.id,
         createdById: author.id,
       },
     });
@@ -3651,29 +3700,36 @@ describe("#documents.create", () => {
 
   it("should reject a non-admin with the admin error even for a non-existent createdById (no existence oracle)", async () => {
     const user = await buildUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
     const res = await server.post("/api/documents.create", user, {
       body: {
         title: "no oracle",
+        collectionId: collection.id,
         createdById: faker.string.uuid(),
       },
     });
-    // The admin gate fires before any user lookup, so a non-admin cannot
-    // distinguish an existing from a non-existent user: both return 403, never
-    // the 400 that would leak that the id resolved to no user.
+    // The admin check runs before the author lookup, so a non-admin cannot
+    // distinguish an existing from a non-existent user.
     expect(res.status).toEqual(403);
     expect(await Document.count({ where: { teamId: user.teamId } })).toEqual(0);
   });
 
   it("should reject createdById equal to the acting user when not an admin", async () => {
     const user = await buildUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
     const res = await server.post("/api/documents.create", user, {
       body: {
         title: "own id",
+        collectionId: collection.id,
         createdById: user.id,
       },
     });
-    // Supplying createdById is admin-only even when it is the caller's own id,
-    // matching the contract the schema documents.
     expect(res.status).toEqual(403);
     expect(await Document.count({ where: { teamId: user.teamId } })).toEqual(0);
   });
@@ -3682,13 +3738,18 @@ describe("#documents.create", () => {
     const admin = await buildAdmin();
     const otherTeam = await buildTeam();
     const foreignUser = await buildUser({ teamId: otherTeam.id });
+    const collection = await buildCollection({
+      teamId: admin.teamId,
+      userId: admin.id,
+    });
     const res = await server.post("/api/documents.create", admin, {
       body: {
         title: "cross team",
+        collectionId: collection.id,
         createdById: foreignUser.id,
       },
     });
-    expect(res.status).toEqual(400);
+    expect(res.status).toEqual(403);
     expect(await Document.count({ where: { teamId: admin.teamId } })).toEqual(
       0
     );
@@ -3696,13 +3757,18 @@ describe("#documents.create", () => {
 
   it("should reject createdById for a non-existent user", async () => {
     const admin = await buildAdmin();
+    const collection = await buildCollection({
+      teamId: admin.teamId,
+      userId: admin.id,
+    });
     const res = await server.post("/api/documents.create", admin, {
       body: {
         title: "ghost author",
+        collectionId: collection.id,
         createdById: faker.string.uuid(),
       },
     });
-    expect(res.status).toEqual(400);
+    expect(res.status).toEqual(403);
     expect(await Document.count({ where: { teamId: admin.teamId } })).toEqual(
       0
     );
@@ -3725,7 +3791,7 @@ describe("#documents.create", () => {
         createdById: author.id,
       },
     });
-    expect(res.status).toEqual(400);
+    expect(res.status).toEqual(403);
     expect(await Document.count({ where: { teamId: admin.teamId } })).toEqual(
       0
     );
@@ -3734,43 +3800,29 @@ describe("#documents.create", () => {
   it("should record the acting admin as the audit actor, not the attributed author", async () => {
     const admin = await buildAdmin();
     const author = await buildUser({ teamId: admin.teamId });
+    const collection = await buildCollection({
+      teamId: admin.teamId,
+      userId: admin.id,
+    });
     const res = await server.post("/api/documents.create", admin, {
       body: {
         title: "audit actor",
         text: "hello",
+        collectionId: collection.id,
         createdById: author.id,
       },
     });
     const body = await res.json();
     expect(res.status).toEqual(200);
     expect(body.data.createdBy.id).toEqual(author.id);
-    // The attribution must not reach the audit trail: the event actor is the
-    // API caller who actually made the request. Attribution moves authorship,
-    // never accountability.
+    // Attribution must not reach the audit trail: the event actor is the API
+    // caller who made the request.
     const event = await Event.findOne({
       where: { documentId: body.data.id, name: "documents.create" },
     });
     expect(event).not.toBeNull();
     expect(event!.actorId).toEqual(admin.id);
     expect(event!.actorId).not.toEqual(author.id);
-  });
-
-  it("should reject createdById for a suspended user", async () => {
-    const admin = await buildAdmin();
-    const author = await buildUser({
-      teamId: admin.teamId,
-      suspendedAt: new Date(),
-    });
-    const res = await server.post("/api/documents.create", admin, {
-      body: {
-        title: "suspended author",
-        createdById: author.id,
-      },
-    });
-    expect(res.status).toEqual(400);
-    expect(await Document.count({ where: { teamId: admin.teamId } })).toEqual(
-      0
-    );
   });
 
   it("should allow createdById when the author's access is via a group only", async () => {
@@ -3781,7 +3833,7 @@ describe("#documents.create", () => {
       userId: admin.id,
       permission: null,
     });
-    // The author holds NO direct UserMembership — access is granted purely
+    // The author holds no direct UserMembership — access is granted purely
     // through group membership, which withMembership loads separately.
     const group = await buildGroup({ teamId: admin.teamId });
     await buildGroupUser({

--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -1719,16 +1719,65 @@ router.post(
       fullWidth,
       templateId,
       createdAt,
+      createdById,
     } = ctx.input.body;
     const editorVersion = ctx.headers["x-editor-version"] as string | undefined;
 
     const { transaction } = ctx.state;
     const { user } = ctx.state.auth;
 
+    // Attributing a document to another user is an admin-only capability. The
+    // gate is on the mere presence of createdById — supplying an author is
+    // admin-only, even when it is the acting user's own id — so the code
+    // enforces exactly the contract the schema documents. It runs before
+    // collection resolution so a non-admin is rejected without probing user
+    // existence (no oracle) or touching unrelated state.
+    if (createdById) {
+      authorize(user, "update", user.team);
+    }
+
     const { collection } = await authorizeDocumentCreate(ctx, {
       collectionId,
       parentDocumentId,
     });
+
+    // Resolve the author once the destination is known. The target must belong
+    // to the same team and must themselves be able to read the collection the
+    // document will live in, so a document cannot be attributed to someone who
+    // could not see it. This mirrors the JSON importer's author-mapping
+    // (#11879) but fails closed on an unresolved, cross-team or unauthorized
+    // target rather than silently falling back to the acting user, since an
+    // explicit API argument asserts intent.
+    if (createdById) {
+      const author = await User.findByPk(createdById, { transaction });
+      if (!author || author.teamId !== user.teamId) {
+        throw ValidationError(
+          "createdById must reference a user in the same team"
+        );
+      }
+      if (author.isSuspended) {
+        throw ValidationError("createdById must reference an active user");
+      }
+      // A draft with no collection has no collection ACL to consult, so only
+      // the team and active-user checks above apply. This is intentional: an
+      // admin may place a draft in another member's drafts. Do not add a
+      // soft fallback here — there is nothing to authorize against.
+      if (collection) {
+        // Re-load the collection in the author's scope. The collection read
+        // policy consults memberships preloaded by withMembership(userId), so
+        // testing the author against the acting admin's instance would
+        // evaluate the wrong user's memberships on a private collection.
+        const authorCollection = await Collection.findByPk(collection.id, {
+          userId: author.id,
+          transaction,
+        });
+        if (cannot(author, "read", authorCollection)) {
+          throw ValidationError(
+            "createdById must reference a user who can access the collection"
+          );
+        }
+      }
+    }
 
     let template: Template | null | undefined;
 
@@ -1763,6 +1812,7 @@ router.post(
       template,
       fullWidth,
       editorVersion,
+      createdById,
     });
 
     if (collection) {

--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -1726,57 +1726,24 @@ router.post(
     const { transaction } = ctx.state;
     const { user } = ctx.state.auth;
 
-    // Attributing a document to another user is an admin-only capability. The
-    // gate is on the mere presence of createdById — supplying an author is
-    // admin-only, even when it is the acting user's own id — so the code
-    // enforces exactly the contract the schema documents. It runs before
-    // collection resolution so a non-admin is rejected without probing user
-    // existence (no oracle) or touching unrelated state.
-    if (createdById) {
-      authorize(user, "update", user.team);
-    }
-
     const { collection } = await authorizeDocumentCreate(ctx, {
       collectionId,
       parentDocumentId,
     });
 
-    // Resolve the author once the destination is known. The target must belong
-    // to the same team and must themselves be able to read the collection the
-    // document will live in, so a document cannot be attributed to someone who
-    // could not see it. This mirrors the JSON importer's author-mapping
-    // (#11879) but fails closed on an unresolved, cross-team or unauthorized
-    // target rather than silently falling back to the acting user, since an
-    // explicit API argument asserts intent.
     if (createdById) {
+      authorize(user, "update", user.team);
       const author = await User.findByPk(createdById, { transaction });
-      if (!author || author.teamId !== user.teamId) {
-        throw ValidationError(
-          "createdById must reference a user in the same team"
-        );
-      }
-      if (author.isSuspended) {
-        throw ValidationError("createdById must reference an active user");
-      }
-      // A draft with no collection has no collection ACL to consult, so only
-      // the team and active-user checks above apply. This is intentional: an
-      // admin may place a draft in another member's drafts. Do not add a
-      // soft fallback here — there is nothing to authorize against.
-      if (collection) {
-        // Re-load the collection in the author's scope. The collection read
-        // policy consults memberships preloaded by withMembership(userId), so
-        // testing the author against the acting admin's instance would
-        // evaluate the wrong user's memberships on a private collection.
-        const authorCollection = await Collection.findByPk(collection.id, {
-          userId: author.id,
-          transaction,
-        });
-        if (cannot(author, "read", authorCollection)) {
-          throw ValidationError(
-            "createdById must reference a user who can access the collection"
-          );
-        }
-      }
+      authorize(user, "read", author);
+      // Collection policies read memberships preloaded for a single user, so
+      // the collection is re-loaded in the author's scope before checking it.
+      const authorCollection = collection
+        ? await Collection.findByPk(collection.id, {
+            userId: author.id,
+            transaction,
+          })
+        : null;
+      authorize(author, "read", authorCollection);
     }
 
     let template: Template | null | undefined;

--- a/server/routes/api/documents/schema.ts
+++ b/server/routes/api/documents/schema.ts
@@ -483,13 +483,9 @@ export const DocumentsCreateSchema = BaseSchema.extend({
   )
   .refine(
     (req) =>
-      !(
-        req.body.createdById &&
-        !req.body.parentDocumentId &&
-        !req.body.collectionId
-      ),
+      !(req.body.createdById && !(req.body.collectionId && req.body.publish)),
     {
-      message: "collectionId or parentDocumentId is required with createdById",
+      message: "collectionId and publish are required with createdById",
     }
   );
 

--- a/server/routes/api/documents/schema.ts
+++ b/server/routes/api/documents/schema.ts
@@ -466,19 +466,32 @@ export const DocumentsCreateSchema = BaseSchema.extend({
     /** Boolean to denote if the document should occupy full width */
     fullWidth: z.boolean().optional(),
 
-    /**
-     * Optionally attribute the document to an existing user in the same team.
-     * Admin-only; mirrors the JSON importer's author-mapping behavior.
-     */
+    /** Attribute the document to an existing user in the same team, admin-only */
     createdById: z.uuid().optional(),
   }),
-}).refine(
-  (req) =>
-    !(req.body.publish && !req.body.parentDocumentId && !req.body.collectionId),
-  {
-    message: "collectionId or parentDocumentId is required to publish",
-  }
-);
+})
+  .refine(
+    (req) =>
+      !(
+        req.body.publish &&
+        !req.body.parentDocumentId &&
+        !req.body.collectionId
+      ),
+    {
+      message: "collectionId or parentDocumentId is required to publish",
+    }
+  )
+  .refine(
+    (req) =>
+      !(
+        req.body.createdById &&
+        !req.body.parentDocumentId &&
+        !req.body.collectionId
+      ),
+    {
+      message: "collectionId or parentDocumentId is required with createdById",
+    }
+  );
 
 export type DocumentsCreateReq = z.infer<typeof DocumentsCreateSchema>;
 

--- a/server/routes/api/documents/schema.ts
+++ b/server/routes/api/documents/schema.ts
@@ -465,6 +465,12 @@ export const DocumentsCreateSchema = BaseSchema.extend({
 
     /** Boolean to denote if the document should occupy full width */
     fullWidth: z.boolean().optional(),
+
+    /**
+     * Optionally attribute the document to an existing user in the same team.
+     * Admin-only; mirrors the JSON importer's author-mapping behavior.
+     */
+    createdById: z.uuid().optional(),
   }),
 }).refine(
   (req) =>


### PR DESCRIPTION
Adds an optional `createdById` to `documents.create` so an admin can attribute a new document to another user in their team.

Comes out of the discussion in https://github.com/outline/outline/discussions/12963, where @tommoor said the audit log must stay uncorruptible and later asked for the permission checks to go through the policies rather than hardcoded ones. Both of those are addressed below.

## Permissions

Both checks go through the policy layer as you suggested:

- `authorize(user, "update", user.team)` for the admin gate, which resolves to `isTeamAdmin`.
- `cannot(author, "read", collection)` for whether the target can be assigned as the creator.

I read `can(user, "read", ...)` as constraining the **prospective author** rather than the acting admin, and used the **collection** since no document exists yet at create time. If either reading is wrong, say so and I'll change it.

The admin gate fires on the mere presence of `createdById`, so supplying an author is admin-only even when it is the caller's own id. It sits above `authorizeDocumentCreate` so a non-admin is rejected before any user lookup, which keeps the endpoint from being used to probe which user ids exist. Author resolution sits below it because it needs the resolved collection.

The collection is re-loaded in the author's scope before the policy check. `allow(User, "read", Collection, ...)` consults memberships preloaded by `withMembership(userId)`, so testing the author against the acting admin's instance would evaluate the wrong user's memberships on a private collection. There's a test covering group-only access to confirm the reload populates `groupMemberships` too.

## Audit log

`ctx.state.auth` is never touched, so `Event.createFromContext` still records the real API caller in `actorId`. Only `document.createdById` moves. There's a test asserting the event actor is the admin and not the attributed author, so it can't regress silently.

## One thing worth flagging

I described this in the discussion as parity with the JSON importer's author-mapping, and having now read that code I don't think that was accurate. The importer sets `sourceMetadata.createdByName`, a display-only string surfaced by the presenter, while the document's real `createdById` stays the importer. This change assigns a real user id, which confers actual ownership rather than just a displayed name.

That's a stronger power than the precedent I cited, so it may deserve a stronger check. `read` answers "could this person see the result"; `createDocument` / `createChildDocument` would answer "could this person have created it here". I've implemented `read` because that's what you named, but I think the case for the stronger check is real and I'd rather raise it than quietly pick.

Related: `documentCreator` is also reached from the MCP `create_document` tool, the import task, and the duplicator. None of them pass `createdById` today, so there's no bypass, but the gate does live at the route rather than in the command.

## Fails closed

Rejects an unresolved id, a cross-team user, a suspended user, and an author who can't read the destination collection. No path falls back to the acting user.

## Tests

`documents.test.ts` 281/281 pass, `tsc` and lint clean. The negative cases assert no document was persisted, not just the status code.
