### PR TITLE
fix: Duplicate team subdomain surfaced as a 500 error

### DIFF
--- a/server/commands/teamCreator.ts
+++ b/server/commands/teamCreator.ts
@@ -57,12 +57,13 @@ async function findAvailableSubdomain(
     lower: true,
     strict: true,
   });
-  let subdomain =
+  const baseSubdomain =
     normalizedSubdomain.length < 3 ||
     RESERVED_SUBDOMAINS.includes(normalizedSubdomain)
       ? "team"
       : normalizedSubdomain;
 
+  let subdomain = baseSubdomain;
   let append = 0;
 
   for (;;) {
@@ -74,7 +75,7 @@ async function findAvailableSubdomain(
 
     if (existing) {
       // subdomain was invalid or already used, try another
-      subdomain = `${normalizedSubdomain}${++append}`;
+      subdomain = `${baseSubdomain}${++append}`;
     } else {
       break;
     }

--- a/server/commands/teamProvisioner.ts
+++ b/server/commands/teamProvisioner.ts
@@ -1,4 +1,3 @@
-import { UniqueConstraintError } from "sequelize";
 import teamCreator from "@server/commands/teamCreator";
 import { createContext } from "@server/context";
 import env from "@server/env";
@@ -10,7 +9,10 @@ import {
 import Logger from "@server/logging/Logger";
 import { traceFunction } from "@server/logging/tracing";
 import { Team, AuthenticationProvider } from "@server/models";
-import { sequelize } from "@server/storage/database";
+import {
+  retryOnUniqueConstraintError,
+  sequelize,
+} from "@server/storage/database";
 import type { APIContext } from "@server/types";
 
 type TeamProvisionerResult = {
@@ -149,25 +151,6 @@ async function teamProvisioner(
     authenticationProvider: team.authenticationProviders[0],
     isNewTeam: true,
   };
-}
-
-async function retryOnUniqueConstraintError<T>(
-  fn: () => Promise<T>,
-  attempts = 3
-): Promise<T> {
-  for (let attempt = 1; ; attempt++) {
-    try {
-      return await fn();
-    } catch (err) {
-      if (!(err instanceof UniqueConstraintError) || attempt >= attempts) {
-        throw err;
-      }
-      Logger.info("commands", "Retrying team creation after unique conflict", {
-        attempt,
-        fields: err.fields,
-      });
-    }
-  }
 }
 
 export default traceFunction({

--- a/server/commands/teamProvisioner.ts
+++ b/server/commands/teamProvisioner.ts
@@ -1,3 +1,4 @@
+import { UniqueConstraintError } from "sequelize";
 import teamCreator from "@server/commands/teamCreator";
 import { createContext } from "@server/context";
 import env from "@server/env";
@@ -128,15 +129,19 @@ async function teamProvisioner(
     throw InvalidAuthenticationError();
   }
 
-  // We cannot find an existing team, so we create a new one
-  const team = await sequelize.transaction((transaction) =>
-    teamCreator(createContext({ transaction }), {
-      name,
-      domain,
-      subdomain,
-      avatarUrl,
-      authenticationProviders: [authenticationProvider],
-    })
+  // We cannot find an existing team, so we create a new one. Two concurrent
+  // signups can pick the same available subdomain, so retry on a conflict –
+  // the next attempt will see the committed team and choose another.
+  const team = await retryOnUniqueConstraintError(() =>
+    sequelize.transaction((transaction) =>
+      teamCreator(createContext({ transaction }), {
+        name,
+        domain,
+        subdomain,
+        avatarUrl,
+        authenticationProviders: [authenticationProvider],
+      })
+    )
   );
 
   return {
@@ -144,6 +149,25 @@ async function teamProvisioner(
     authenticationProvider: team.authenticationProviders[0],
     isNewTeam: true,
   };
+}
+
+async function retryOnUniqueConstraintError<T>(
+  fn: () => Promise<T>,
+  attempts = 3
+): Promise<T> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (!(err instanceof UniqueConstraintError) || attempt >= attempts) {
+        throw err;
+      }
+      Logger.info("commands", "Retrying team creation after unique conflict", {
+        attempt,
+        fields: err.fields,
+      });
+    }
+  }
 }
 
 export default traceFunction({

--- a/server/commands/teamUpdater.test.ts
+++ b/server/commands/teamUpdater.test.ts
@@ -1,5 +1,7 @@
 import type { CustomTheme } from "@shared/types";
+import { randomString } from "@shared/random";
 import { CommentingAccess, TeamPreference } from "@shared/types";
+import env from "@server/env";
 import { buildTeam, buildUser } from "@server/test/factories";
 import { withAPIContext } from "@server/test/support";
 import teamUpdater from "./teamUpdater";
@@ -137,6 +139,45 @@ describe("teamUpdater", () => {
       );
 
       expect(updatedTeam.name).toEqual("Updated Team Name");
+    });
+  });
+
+  describe("subdomain", () => {
+    beforeEach(() => {
+      vi.spyOn(env, "isCloudHosted", "get").mockReturnValue(true);
+    });
+
+    it("should update subdomain when available", async () => {
+      const subdomain = `available-${randomString({ length: 10, charset: "alphabetic", capitalization: "lowercase" })}`;
+      const team = await buildTeam();
+      const user = await buildUser({ teamId: team.id });
+
+      const updatedTeam = await withAPIContext(user, (ctx) =>
+        teamUpdater(ctx, {
+          params: { subdomain },
+          user,
+          team,
+        })
+      );
+
+      expect(updatedTeam.subdomain).toEqual(subdomain);
+    });
+
+    it("should throw a validation error when subdomain is taken", async () => {
+      const subdomain = `taken-${randomString({ length: 10, charset: "alphabetic", capitalization: "lowercase" })}`;
+      await buildTeam({ subdomain });
+      const team = await buildTeam();
+      const user = await buildUser({ teamId: team.id });
+
+      await expect(
+        withAPIContext(user, (ctx) =>
+          teamUpdater(ctx, {
+            params: { subdomain },
+            user,
+            team,
+          })
+        )
+      ).rejects.toThrow("Subdomain is already in use");
     });
   });
 });

--- a/server/commands/teamUpdater.test.ts
+++ b/server/commands/teamUpdater.test.ts
@@ -1,9 +1,8 @@
 import type { CustomTheme } from "@shared/types";
 import { randomString } from "@shared/random";
 import { CommentingAccess, TeamPreference } from "@shared/types";
-import env from "@server/env";
 import { buildTeam, buildUser } from "@server/test/factories";
-import { withAPIContext } from "@server/test/support";
+import { setCloudHosted, withAPIContext } from "@server/test/support";
 import teamUpdater from "./teamUpdater";
 
 describe("teamUpdater", () => {
@@ -143,9 +142,7 @@ describe("teamUpdater", () => {
   });
 
   describe("subdomain", () => {
-    beforeEach(() => {
-      vi.spyOn(env, "isCloudHosted", "get").mockReturnValue(true);
-    });
+    beforeEach(setCloudHosted);
 
     it("should update subdomain when available", async () => {
       const subdomain = `available-${randomString({ length: 10, charset: "alphabetic", capitalization: "lowercase" })}`;

--- a/server/commands/teamUpdater.ts
+++ b/server/commands/teamUpdater.ts
@@ -1,8 +1,9 @@
 import { has, isEqual } from "es-toolkit/compat";
 import { TeamPreference } from "@shared/types";
 import env from "@server/env";
-import type { Team, User } from "@server/models";
-import { TeamDomain } from "@server/models";
+import { ValidationError } from "@server/errors";
+import type { User } from "@server/models";
+import { Team, TeamDomain } from "@server/models";
 import type { APIContext } from "@server/types";
 
 type Props = {
@@ -16,7 +17,21 @@ const teamUpdater = async (ctx: APIContext, { params, user, team }: Props) => {
   team.setAttributes(attributes);
 
   if (subdomain !== undefined && env.isCloudHosted) {
-    team.subdomain = subdomain === "" ? null : subdomain;
+    const newSubdomain = subdomain === "" ? null : subdomain;
+
+    if (newSubdomain && newSubdomain !== team.subdomain) {
+      const existing = await Team.findOne({
+        where: { subdomain: newSubdomain },
+        paranoid: false,
+        transaction: ctx.state.transaction,
+      });
+
+      if (existing) {
+        throw ValidationError("Subdomain is already in use");
+      }
+    }
+
+    team.subdomain = newSubdomain;
   }
 
   if (allowedDomains !== undefined) {

--- a/server/storage/database.ts
+++ b/server/storage/database.ts
@@ -1,6 +1,6 @@
 import cluster from "node:cluster";
 import path from "node:path";
-import { DatabaseError } from "sequelize";
+import { DatabaseError, UniqueConstraintError } from "sequelize";
 import type {
   InferAttributes,
   InferCreationAttributes,
@@ -97,6 +97,37 @@ export function isQueryCanceledError(err: unknown): boolean {
     "code" in err.parent &&
     err.parent.code === QueryCanceledErrorCode
   );
+}
+
+/**
+ * Run the given function, retrying it when it fails due to a unique constraint
+ * violation. Useful for operations that choose a unique value based on a prior
+ * read, where a concurrent request may claim the same value first.
+ *
+ * @param fn the function to run, this should include any transaction as a
+ * violation leaves the surrounding transaction unusable.
+ * @param attempts the maximum number of times to run the function.
+ * @returns the result of the function.
+ * @throws the last error if it is not a unique constraint violation, or the
+ * maximum number of attempts has been reached.
+ */
+export async function retryOnUniqueConstraintError<T>(
+  fn: () => Promise<T>,
+  attempts = 3
+): Promise<T> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (!(err instanceof UniqueConstraintError) || attempt >= attempts) {
+        throw err;
+      }
+      Logger.info("database", "Retrying after unique constraint violation", {
+        attempt,
+        fields: err.fields,
+      });
+    }
+  }
 }
 
 export function createDatabaseInstance(

--- a/server/test/support.ts
+++ b/server/test/support.ts
@@ -42,6 +42,13 @@ export function setSelfHosted() {
 }
 
 /**
+ * Set the environment to be cloud hosted.
+ */
+export function setCloudHosted() {
+  env.URL = sharedEnv.URL = "https://app.outline.dev";
+}
+
+/**
  * Mock scheduling for all task subclasses in the current test file.
  *
  * @returns the schedule mock for assertions.


### PR DESCRIPTION
- Choosing a subdomain that is already taken in settings hit the unique constraint directly, returning an unhelpful 500 (and noise in Sentry). It now returns a validation error explaining the subdomain is in use.
- Two concurrent signups could pick the same available subdomain between the availability check and the insert — team creation is now retried on a conflict so the next attempt picks another.
- Fixed the collision fallback in `findAvailableSubdomain` appending to the unvalidated subdomain, which could re-introduce a reserved or too-short value that had just been rejected.