### PR TITLE
fix: Guests can enumerate users and groups through mention suggestions

### DIFF
--- a/server/routes/api/suggestions/suggestions.test.ts
+++ b/server/routes/api/suggestions/suggestions.test.ts
@@ -1,0 +1,56 @@
+import { buildGroup, buildGuestUser, buildUser } from "@server/test/factories";
+import { getTestServer } from "@server/test/support";
+
+const server = getTestServer();
+
+describe("#suggestions.mention", () => {
+  it("should return users and groups in the team", async () => {
+    const user = await buildUser();
+    const other = await buildUser({ teamId: user.teamId, name: "Elizabeth" });
+    const group = await buildGroup({ teamId: user.teamId, name: "Elephants" });
+
+    const res = await server.post("/api/suggestions.mention", user);
+    const body = await res.json();
+
+    expect(res.status).toEqual(200);
+    expect(body.data.users.map((u: { id: string }) => u.id)).toContain(
+      other.id
+    );
+    expect(body.data.groups.map((g: { id: string }) => g.id)).toContain(
+      group.id
+    );
+  });
+
+  it("should not return users or groups for a guest", async () => {
+    const user = await buildUser();
+    await buildUser({ teamId: user.teamId, name: "Elizabeth" });
+    await buildGroup({ teamId: user.teamId, name: "Elephants" });
+    const guest = await buildGuestUser({ teamId: user.teamId });
+
+    const res = await server.post("/api/suggestions.mention", guest);
+    const body = await res.json();
+
+    expect(res.status).toEqual(200);
+    expect(body.data.users).toEqual([]);
+    expect(body.data.groups).toEqual([]);
+  });
+
+  it("should not allow a guest to probe for users by email", async () => {
+    const user = await buildUser();
+    const other = await buildUser({ teamId: user.teamId });
+    const guest = await buildGuestUser({ teamId: user.teamId });
+
+    const res = await server.post("/api/suggestions.mention", guest, {
+      body: { query: other.email },
+    });
+    const body = await res.json();
+
+    expect(res.status).toEqual(200);
+    expect(body.data.users).toEqual([]);
+  });
+
+  it("should require authentication", async () => {
+    const res = await server.post("/api/suggestions.mention");
+    expect(res.status).toEqual(401);
+  });
+});

--- a/server/routes/api/suggestions/suggestions.ts
+++ b/server/routes/api/suggestions/suggestions.ts
@@ -36,45 +36,49 @@ router.post(
         limit,
         statusFilter: [StatusFilter.Published],
       }),
-      User.findAll({
-        where: {
-          teamId: actor.teamId,
-          suspendedAt: {
-            [Op.eq]: null,
-          },
-          [Op.and]: query
-            ? {
-                [Op.or]: [
-                  Sequelize.literal(
-                    `unaccent(LOWER(email)) like unaccent(LOWER(:query))`
-                  ),
-                  Sequelize.literal(
+      can(actor, "listUsers", actor.team)
+        ? User.findAll({
+            where: {
+              teamId: actor.teamId,
+              suspendedAt: {
+                [Op.eq]: null,
+              },
+              [Op.and]: query
+                ? {
+                    [Op.or]: [
+                      Sequelize.literal(
+                        `unaccent(LOWER(email)) like unaccent(LOWER(:query))`
+                      ),
+                      Sequelize.literal(
+                        `unaccent(LOWER(name)) like unaccent(LOWER(:query))`
+                      ),
+                    ],
+                  }
+                : {},
+            },
+            order: [["name", "ASC"]],
+            replacements: { query: QueryHelper.likeContains(query ?? "") },
+            offset,
+            limit,
+          })
+        : [],
+      can(actor, "listGroups", actor.team)
+        ? Group.findAll({
+            where: {
+              teamId: actor.teamId,
+              disableMentions: false,
+              [Op.and]: query
+                ? Sequelize.literal(
                     `unaccent(LOWER(name)) like unaccent(LOWER(:query))`
-                  ),
-                ],
-              }
-            : {},
-        },
-        order: [["name", "ASC"]],
-        replacements: { query: QueryHelper.likeContains(query ?? "") },
-        offset,
-        limit,
-      }),
-      Group.findAll({
-        where: {
-          teamId: actor.teamId,
-          disableMentions: false,
-          [Op.and]: query
-            ? Sequelize.literal(
-                `unaccent(LOWER(name)) like unaccent(LOWER(:query))`
-              )
-            : {},
-        },
-        order: [["name", "ASC"]],
-        replacements: { query: QueryHelper.likeContains(query ?? "") },
-        offset,
-        limit,
-      }),
+                  )
+                : {},
+            },
+            order: [["name", "ASC"]],
+            replacements: { query: QueryHelper.likeContains(query ?? "") },
+            offset,
+            limit,
+          })
+        : [],
       SearchProviderManager.getProvider().searchCollectionsForUser(actor, {
         query,
         offset,


### PR DESCRIPTION
`suggestions.mention` queried users and groups scoped only by team, while `users.list` and `groups.list` both authorize against policies that exclude guests.

- Gate both reads on the same `listUsers`/`listGroups` policies, resolving to empty for guests
- Membership in the result set was previously unconditional, and the query matched on email, so a guest invited to a single document could enumerate every name, id and role in the workspace and probe whether an address belonged to a member
- Documents and collections in the same response already scope to the actor, so guests keep those suggestions and mention autocomplete still works for them

Follows on from #13083, which covered the user listing endpoint but not this second reader.