### PR TITLE
fix: documents.import writes into an unauthorized collection when nested

### DIFF
--- a/server/routes/api/documents/documents.test.ts
+++ b/server/routes/api/documents/documents.test.ts
@@ -3515,9 +3515,11 @@ describe("#documents.import", () => {
     vi.spyOn(FileStorage, "store").mockResolvedValue(
       undefined as unknown as string
     );
-    vi.spyOn(DocumentImportTask.prototype, "schedule").mockResolvedValue({
-      finished: vi.fn().mockResolvedValue({ documentId: childDocument.id }),
-    } as unknown as Awaited<ReturnType<DocumentImportTask["schedule"]>>);
+    const schedule = vi
+      .spyOn(DocumentImportTask.prototype, "schedule")
+      .mockResolvedValue({
+        finished: vi.fn().mockResolvedValue({ documentId: childDocument.id }),
+      } as unknown as Awaited<ReturnType<DocumentImportTask["schedule"]>>);
 
     const content = await readFile(
       path.resolve(
@@ -3543,6 +3545,9 @@ describe("#documents.import", () => {
     const body = await res.json();
     expect(res.status).toEqual(200);
     expect(body.data.id).toEqual(childDocument.id);
+    expect(schedule).toHaveBeenCalledWith(
+      expect.objectContaining({ collectionId: collection.id })
+    );
 
     vi.restoreAllMocks();
   });

--- a/server/routes/api/documents/documents.test.ts
+++ b/server/routes/api/documents/documents.test.ts
@@ -3547,6 +3547,70 @@ describe("#documents.import", () => {
     vi.restoreAllMocks();
   });
 
+  it("should ignore a collectionId the user cannot write when a parent document is given", async () => {
+    const team = await buildTeam();
+    const author = await buildUser({ teamId: team.id });
+    const user = await buildUser({ teamId: team.id });
+    const ownCollection = await buildCollection({
+      userId: user.id,
+      teamId: team.id,
+    });
+    const privateCollection = await buildCollection({
+      userId: author.id,
+      teamId: team.id,
+      permission: null,
+    });
+    const parentDocument = await buildDocument({
+      userId: user.id,
+      teamId: team.id,
+      collectionId: ownCollection.id,
+    });
+    const childDocument = await buildDocument({
+      userId: user.id,
+      teamId: team.id,
+      collectionId: ownCollection.id,
+      parentDocumentId: parentDocument.id,
+    });
+
+    vi.spyOn(FileStorage, "store").mockResolvedValue(
+      undefined as unknown as string
+    );
+    const schedule = vi
+      .spyOn(DocumentImportTask.prototype, "schedule")
+      .mockResolvedValue({
+        finished: vi.fn().mockResolvedValue({ documentId: childDocument.id }),
+      } as unknown as Awaited<ReturnType<DocumentImportTask["schedule"]>>);
+
+    const content = await readFile(
+      path.resolve(
+        __dirname,
+        "..",
+        "..",
+        "..",
+        "test",
+        "fixtures",
+        "markdown.md"
+      )
+    );
+    const form = new FormData();
+    form.append("file", content, "markdown.md");
+    form.append("token", user.getSessionToken());
+    form.append("collectionId", privateCollection.id);
+    form.append("parentDocumentId", parentDocument.id);
+    form.append("publish", "true");
+
+    const res = await server.post("/api/documents.import", {
+      headers: form.getHeaders(),
+      body: form,
+    });
+    expect(res.status).toEqual(200);
+    expect(schedule).toHaveBeenCalledWith(
+      expect.objectContaining({ collectionId: ownCollection.id })
+    );
+
+    vi.restoreAllMocks();
+  });
+
   it("should require authentication", async () => {
     const document = await buildDocument();
     const res = await server.post("/api/documents.import", {

--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -1623,29 +1623,10 @@ router.post(
       throw ValidationError("one of attachmentId or file is required");
     }
 
-    let parentDocument: Document | null = null;
-    let collection: Collection | null = null;
-
-    if (parentDocumentId) {
-      parentDocument = await Document.findByPk(parentDocumentId, {
-        userId: user.id,
-      });
-
-      if (parentDocument?.collectionId) {
-        collection = await Collection.findByPk(parentDocument.collectionId, {
-          userId: user.id,
-        });
-      }
-
-      authorize(user, "createChildDocument", parentDocument, {
-        collection,
-      });
-    } else if (collectionId) {
-      collection = await Collection.findByPk(collectionId, {
-        userId: user.id,
-      });
-      authorize(user, "createDocument", collection);
-    }
+    const { collection } = await authorizeDocumentCreate(ctx, {
+      collectionId,
+      parentDocumentId,
+    });
 
     let key: string;
     let fileName: string;
@@ -1686,7 +1667,7 @@ router.post(
         mimeType,
       },
       userId: user.id,
-      collectionId: collectionId ?? parentDocument?.collectionId,
+      collectionId: collection?.id,
       parentDocumentId,
       publish,
       authType: ctx.state.auth.type,


### PR DESCRIPTION
`documents.import` authorized the parent document but then passed the caller's own `collectionId` through to the import task, so sending both ids together placed the document — published — in a collection with no permission check on it at all, including read-only and private collections the user cannot open.

- Route the import location through the shared `authorizeDocumentCreate` helper, matching documents.create
- Pass the collection that was actually authorized to the import task, rather than the one named by the caller
- Preserves the existing fallback for a parent shared without collection access