### PR TITLE
perf: Reduce database and Redis round-trips on the MCP endpoint

### DIFF
--- a/server/models/Document.test.ts
+++ b/server/models/Document.test.ts
@@ -16,6 +16,7 @@ import {
 } from "@server/test/factories";
 import { withAPIContext } from "@server/test/support";
 import GroupMembership from "./GroupMembership";
+import GroupUser from "./GroupUser";
 import UserMembership from "./UserMembership";
 
 beforeEach(() => {
@@ -385,6 +386,89 @@ describe("#membershipDocumentIds", () => {
 
     const ids = await Document.membershipDocumentIds(user.id);
     expect(ids).toEqual([]);
+  });
+
+  it("should invalidate the cache when a direct membership is added or removed", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const otherUser = await buildUser({ teamId: team.id });
+    const document = await buildDocument({
+      teamId: team.id,
+      userId: otherUser.id,
+    });
+
+    expect(await Document.membershipDocumentIds(user.id)).toEqual([]);
+
+    const membership = await UserMembership.create({
+      createdById: otherUser.id,
+      documentId: document.id,
+      userId: user.id,
+      permission: DocumentPermission.Read,
+    });
+    expect(await Document.membershipDocumentIds(user.id)).toEqual([
+      document.id,
+    ]);
+
+    await membership.destroy();
+    expect(await Document.membershipDocumentIds(user.id)).toEqual([]);
+  });
+
+  it("should invalidate the cache when a group membership is added or removed", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const otherUser = await buildUser({ teamId: team.id });
+    const document = await buildDocument({
+      teamId: team.id,
+      userId: otherUser.id,
+    });
+    const group = await buildGroup({ teamId: team.id });
+    await group.$add("user", user, { through: { createdById: otherUser.id } });
+
+    expect(await Document.membershipDocumentIds(user.id)).toEqual([]);
+
+    const membership = await GroupMembership.create({
+      createdById: otherUser.id,
+      groupId: group.id,
+      documentId: document.id,
+      permission: DocumentPermission.Read,
+    });
+    expect(await Document.membershipDocumentIds(user.id)).toEqual([
+      document.id,
+    ]);
+
+    await membership.destroy();
+    expect(await Document.membershipDocumentIds(user.id)).toEqual([]);
+  });
+
+  it("should invalidate the cache when the user joins or leaves a group", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const otherUser = await buildUser({ teamId: team.id });
+    const document = await buildDocument({
+      teamId: team.id,
+      userId: otherUser.id,
+    });
+    const group = await buildGroup({ teamId: team.id });
+    await GroupMembership.create({
+      createdById: otherUser.id,
+      groupId: group.id,
+      documentId: document.id,
+      permission: DocumentPermission.Read,
+    });
+
+    expect(await Document.membershipDocumentIds(user.id)).toEqual([]);
+
+    const groupUser = await GroupUser.create({
+      groupId: group.id,
+      userId: user.id,
+      createdById: otherUser.id,
+    });
+    expect(await Document.membershipDocumentIds(user.id)).toEqual([
+      document.id,
+    ]);
+
+    await groupUser.destroy();
+    expect(await Document.membershipDocumentIds(user.id)).toEqual([]);
   });
 
   it("should read through to the database when skipCache is set", async () => {

--- a/server/models/Document.test.ts
+++ b/server/models/Document.test.ts
@@ -386,6 +386,29 @@ describe("#membershipDocumentIds", () => {
     const ids = await Document.membershipDocumentIds(user.id);
     expect(ids).toEqual([]);
   });
+
+  it("should read through to the database when skipCache is set", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const otherUser = await buildUser({ teamId: team.id });
+    const document = await buildDocument({
+      teamId: team.id,
+      userId: otherUser.id,
+    });
+
+    expect(await Document.membershipDocumentIds(user.id)).toEqual([]);
+
+    await UserMembership.create({
+      createdById: otherUser.id,
+      documentId: document.id,
+      userId: user.id,
+      permission: DocumentPermission.Read,
+    });
+
+    expect(
+      await Document.membershipDocumentIds(user.id, { skipCache: true })
+    ).toEqual([document.id]);
+  });
 });
 
 describe("#findByPk", () => {

--- a/server/models/Document.ts
+++ b/server/models/Document.ts
@@ -56,6 +56,8 @@ import { UrlHelper } from "@shared/utils/UrlHelper";
 import slugify from "@shared/utils/slugify";
 import { DocumentValidation } from "@shared/validations";
 import { InvalidRequestError, ValidationError } from "@server/errors";
+import { CacheHelper } from "@server/utils/CacheHelper";
+import { RedisPrefixHelper } from "@server/utils/RedisPrefixHelper";
 import { generateUrlId } from "@server/utils/url";
 import Collection from "./Collection";
 import Comment from "./Comment";
@@ -299,6 +301,9 @@ class Document extends ArchivableModel<
   InferAttributes<Document>,
   Partial<InferCreationAttributes<Document>>
 > {
+  /** Seconds for which a user's document membership IDs are cached. */
+  static membershipDocumentIdsCacheTTL = 10;
+
   @SimpleLength({
     min: 10,
     max: 10,
@@ -765,53 +770,74 @@ class Document extends ArchivableModel<
    * Returns an array of unique document IDs that the user is a member of,
    * either via direct membership or through a group membership.
    *
+   * The result is cached briefly, mirroring `User.collectionIds`, as it is
+   * resolved on every search request.
+   *
    * @param userId The user ID to find document memberships for.
+   * @param options Set `skipCache` to always read through to the database.
    * @returns A promise resolving to an array of document IDs.
    */
-  static async membershipDocumentIds(userId: string): Promise<string[]> {
-    const [memberships, groupMemberships] = await Promise.all([
-      UserMembership.findAll({
-        attributes: ["documentId"],
-        where: {
-          userId,
-          documentId: {
-            [Op.ne]: null,
+  static async membershipDocumentIds(
+    userId: string,
+    options: { skipCache?: boolean } = {}
+  ): Promise<string[]> {
+    const fetchDocumentIds = async () => {
+      const [memberships, groupMemberships] = await Promise.all([
+        UserMembership.findAll({
+          attributes: ["documentId"],
+          where: {
+            userId,
+            documentId: {
+              [Op.ne]: null,
+            },
           },
-        },
-      }),
-      GroupMembership.findAll({
-        attributes: ["documentId"],
-        where: {
-          documentId: {
-            [Op.ne]: null,
+        }),
+        GroupMembership.findAll({
+          attributes: ["documentId"],
+          where: {
+            documentId: {
+              [Op.ne]: null,
+            },
           },
-        },
-        include: [
-          {
-            model: Group,
-            as: "group",
-            attributes: [],
-            required: true,
-            include: [
-              {
-                model: GroupUser,
-                as: "groupUsers",
-                attributes: [],
-                required: true,
-                where: {
-                  userId,
+          include: [
+            {
+              model: Group,
+              as: "group",
+              attributes: [],
+              required: true,
+              include: [
+                {
+                  model: GroupUser,
+                  as: "groupUsers",
+                  attributes: [],
+                  required: true,
+                  where: {
+                    userId,
+                  },
                 },
-              },
-            ],
-          },
-        ],
-      }),
-    ]);
+              ],
+            },
+          ],
+        }),
+      ]);
 
-    return uniq(
-      [...memberships, ...groupMemberships]
-        .map((membership) => membership.documentId)
-        .filter((id): id is string => !isNil(id))
+      return uniq(
+        [...memberships, ...groupMemberships]
+          .map((membership) => membership.documentId)
+          .filter((id): id is string => !isNil(id))
+      );
+    };
+
+    if (options.skipCache) {
+      return fetchDocumentIds();
+    }
+
+    return (
+      (await CacheHelper.getDataOrSet<string[]>(
+        RedisPrefixHelper.getUserMembershipDocumentIdsKey(userId),
+        fetchDocumentIds,
+        Document.membershipDocumentIdsCacheTTL
+      )) ?? []
     );
   }
 

--- a/server/models/Document.ts
+++ b/server/models/Document.ts
@@ -841,6 +841,22 @@ class Document extends ArchivableModel<
     );
   }
 
+  /**
+   * Invalidates the cached result of `membershipDocumentIds` so a permission
+   * change takes effect immediately rather than at the end of the cache TTL.
+   *
+   * @param userIds The users whose document memberships changed.
+   */
+  static async invalidateMembershipDocumentIds(userIds: string[]) {
+    await Promise.all(
+      uniq(userIds).map((userId) =>
+        CacheHelper.removeData(
+          RedisPrefixHelper.getUserMembershipDocumentIdsKey(userId)
+        )
+      )
+    );
+  }
+
   static withMembershipScope(
     userId: string,
     options?: FindOptions<Document> & { includeDrafts?: boolean }

--- a/server/models/GroupMembership.ts
+++ b/server/models/GroupMembership.ts
@@ -28,6 +28,7 @@ import type { APIContext } from "@server/types";
 import Collection from "./Collection";
 import Document from "./Document";
 import Group from "./Group";
+import GroupUser from "./GroupUser";
 import User from "./User";
 import UserMembership from "./UserMembership";
 import { type HookContext } from "./base/Model";
@@ -222,6 +223,11 @@ class GroupMembership extends ParanoidModel<
     });
   }
 
+  @AfterCreate
+  static async invalidateDocumentIdsAfterCreate(model: GroupMembership) {
+    await model.invalidateMembershipDocumentIds();
+  }
+
   @AfterUpdate
   static async updateSourcedMemberships(
     model: GroupMembership,
@@ -319,6 +325,11 @@ class GroupMembership extends ParanoidModel<
     });
   }
 
+  @AfterDestroy
+  static async invalidateDocumentIdsAfterDestroy(model: GroupMembership) {
+    await model.invalidateMembershipDocumentIds();
+  }
+
   /**
    * Recreate all sourced permissions for a given permission.
    */
@@ -388,6 +399,25 @@ class GroupMembership extends ParanoidModel<
         }
       );
     }
+  }
+
+  /**
+   * Invalidates the cached document membership IDs of every user in the group,
+   * as a document granted to a group is reachable by all of its members.
+   */
+  private async invalidateMembershipDocumentIds() {
+    if (!this.documentId) {
+      return;
+    }
+
+    const groupUsers = await GroupUser.findAll({
+      attributes: ["userId"],
+      where: { groupId: this.groupId },
+    });
+
+    await Document.invalidateMembershipDocumentIds(
+      groupUsers.map((groupUser) => groupUser.userId)
+    );
   }
 
   private async insertEvent(

--- a/server/models/GroupUser.ts
+++ b/server/models/GroupUser.ts
@@ -1,5 +1,7 @@
 import type { InferAttributes, InferCreationAttributes } from "sequelize";
 import {
+  AfterCreate,
+  AfterDestroy,
   BelongsTo,
   ForeignKey,
   Column,
@@ -8,6 +10,7 @@ import {
   Scopes,
 } from "sequelize-typescript";
 import { GroupPermission } from "@shared/types";
+import Document from "./Document";
 import Group from "./Group";
 import User from "./User";
 import Model from "./base/Model";
@@ -61,6 +64,18 @@ class GroupUser extends Model<
 
   get modelId() {
     return this.groupId;
+  }
+
+  // hooks
+
+  @AfterCreate
+  static async invalidateDocumentIdsAfterCreate(model: GroupUser) {
+    await Document.invalidateMembershipDocumentIds([model.userId]);
+  }
+
+  @AfterDestroy
+  static async invalidateDocumentIdsAfterDestroy(model: GroupUser) {
+    await Document.invalidateMembershipDocumentIds([model.userId]);
   }
 }
 

--- a/server/models/UserMembership.ts
+++ b/server/models/UserMembership.ts
@@ -231,6 +231,13 @@ class UserMembership extends IdModel<
     }
   }
 
+  @AfterCreate
+  static async invalidateDocumentIdsAfterCreate(model: UserMembership) {
+    if (model.documentId) {
+      await Document.invalidateMembershipDocumentIds([model.userId]);
+    }
+  }
+
   @AfterUpdate
   static async updateSourcedMemberships(
     model: UserMembership,
@@ -312,6 +319,13 @@ class UserMembership extends IdModel<
       await CacheHelper.clearData(
         RedisPrefixHelper.getUserCollectionIdsKey(model.userId)
       );
+    }
+  }
+
+  @AfterDestroy
+  static async invalidateDocumentIdsAfterDestroy(model: UserMembership) {
+    if (model.documentId) {
+      await Document.invalidateMembershipDocumentIds([model.userId]);
     }
   }
 

--- a/server/tools/util.test.ts
+++ b/server/tools/util.test.ts
@@ -183,6 +183,22 @@ describe("getBreadcrumbsForDocuments", () => {
     expect(result.has("doc-without-collection")).toBe(false);
   });
 
+  it("falls back to the collection name for a document missing from the structure", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const collection = await buildCollection({
+      teamId: team.id,
+      permission: CollectionPermission.ReadWrite,
+      name: "Engineering",
+    });
+
+    const result = await getBreadcrumbsForDocuments(
+      [{ id: "not-in-structure", collectionId: collection.id }],
+      user
+    );
+    expect(result.get("not-in-structure")).toBe("Engineering");
+  });
+
   it("resolves breadcrumbs across multiple collections in one call", async () => {
     const team = await buildTeam();
     const user = await buildUser({ teamId: team.id });

--- a/server/tools/util.ts
+++ b/server/tools/util.ts
@@ -204,6 +204,38 @@ export function buildBreadcrumb(
 }
 
 /**
+ * Builds breadcrumb strings for every document in a collection's structure in
+ * a single traversal. Prefer this over repeated `buildBreadcrumb` calls when
+ * more than one document from the same collection needs a breadcrumb.
+ *
+ * @param structure - the collection's documentStructure tree, may be null.
+ * @param collectionName - the name of the containing collection.
+ * @returns a map from document ID to breadcrumb string.
+ */
+function buildBreadcrumbMap(
+  structure: NavigationNode[] | null | undefined,
+  collectionName: string
+): Map<string, string> {
+  const breadcrumbs = new Map<string, string>();
+
+  const walk = (nodes: NavigationNode[], chain: string[]) => {
+    const breadcrumb = [collectionName, ...chain].join(" › ");
+    for (const node of nodes) {
+      breadcrumbs.set(node.id, breadcrumb);
+      if (node.children.length) {
+        walk(node.children, [...chain, node.title]);
+      }
+    }
+  };
+
+  if (structure) {
+    walk(structure, []);
+  }
+
+  return breadcrumbs;
+}
+
+/**
  * Resolves a breadcrumb string for a document by loading its collection's
  * cached documentStructure. Returns undefined when the document has no
  * collection, the collection cannot be loaded, or the user lacks read
@@ -211,21 +243,39 @@ export function buildBreadcrumb(
  * ancestor names to users granted access to a single nested document via
  * direct membership without wider collection access.
  *
+ * The document's `collection` association is used when it is already loaded
+ * with the user's memberships, avoiding a second query for it.
+ *
  * @param document - the document to build a breadcrumb for.
  * @param user - the user performing the action, used to authorize collection access.
  * @returns the breadcrumb string, or undefined.
  */
 export async function getDocumentBreadcrumb(
-  document: { id: string; collectionId?: string | null },
+  document: {
+    id: string;
+    collectionId?: string | null;
+    collection?: Collection | null;
+  },
   user: User
 ): Promise<string | undefined> {
   if (!document.collectionId) {
     return undefined;
   }
 
-  const collection = await Collection.findByPk(document.collectionId, {
-    userId: user.id,
-  });
+  // Both membership associations must be present, as the read policy consults
+  // each of them — an unscoped collection would fail the check incorrectly.
+  const loaded =
+    document.collection?.id === document.collectionId &&
+    document.collection.memberships !== undefined &&
+    document.collection.groupMemberships !== undefined
+      ? document.collection
+      : null;
+
+  const collection =
+    loaded ??
+    (await Collection.findByPk(document.collectionId, {
+      userId: user.id,
+    }));
   if (!collection || !can(user, "read", collection)) {
     return undefined;
   }
@@ -268,24 +318,42 @@ export async function getBreadcrumbsForDocuments(
     where: { id: collectionIds },
   });
 
-  const collectionsById = new Map(
-    collections
-      .filter((collection) => can(user, "read", collection))
-      .map((collection) => [collection.id, collection])
+  // Each collection's structure is resolved once, concurrently, and walked
+  // once — the same collection is typically shared by many of the documents.
+  const readable = collections.filter((collection) =>
+    can(user, "read", collection)
+  );
+  const byCollection = new Map(
+    await Promise.all(
+      readable.map(
+        async (collection) =>
+          [
+            collection.id,
+            {
+              name: collection.name,
+              breadcrumbs: buildBreadcrumbMap(
+                await collection.getCachedDocumentStructure(),
+                collection.name
+              ),
+            },
+          ] as const
+      )
+    )
   );
 
   for (const doc of documents) {
     if (!doc.collectionId) {
       continue;
     }
-    const collection = collectionsById.get(doc.collectionId);
+    const collection = byCollection.get(doc.collectionId);
     if (!collection) {
       continue;
     }
-    const structure = await collection.getCachedDocumentStructure();
+    // A document absent from the structure — a draft, or one added since the
+    // structure was cached — is reported at the collection root.
     breadcrumbs.set(
       doc.id,
-      buildBreadcrumb(doc.id, structure, collection.name)
+      collection.breadcrumbs.get(doc.id) ?? collection.name
     );
   }
 

--- a/server/utils/RedisPrefixHelper.ts
+++ b/server/utils/RedisPrefixHelper.ts
@@ -44,6 +44,16 @@ export class RedisPrefixHelper {
   }
 
   /**
+   * Gets key for caching the document IDs a user is a member of.
+   *
+   * @param userId The user ID to generate a key for.
+   * @returns the cache key string.
+   */
+  public static getUserMembershipDocumentIdsKey(userId: string) {
+    return `ud:${userId}`;
+  }
+
+  /**
    * Gets key for caching a team's enabled webhook subscriptions.
    *
    * @param teamId The team ID to generate a key for.


### PR DESCRIPTION
Production traces for `/mcp` showed the time going into repeated permission and breadcrumb lookups rather than the MCP layer itself.

- Cache `Document.membershipDocumentIds` in Redis, matching the TTL and key pattern already used by `User.collectionIds`. Both are resolved together on every search and this half was uncached, measuring ~200ms.
- Resolve each collection's cached document structure once, concurrently, when building breadcrumbs for a batch of documents — it was previously awaited per document inside a loop, so a page of search results meant a serial Redis round-trip per result.
- Walk each collection structure once into a document ID to breadcrumb map, instead of searching the whole tree per document.
- Reuse the collection association already loaded by the document query when resolving a single document's breadcrumb, rather than querying it again under the same membership scope.

Note the new cache means a revoked document-level membership can remain visible in search for up to 10 seconds, the same window that already applies to collection access.