### PR TITLE
fix: Missing ip address on events created during account provisioning

### DIFF
--- a/server/commands/accountProvisioner.test.ts
+++ b/server/commands/accountProvisioner.test.ts
@@ -1,7 +1,7 @@
 import { faker } from "@faker-js/faker";
 import { randomUUID } from "node:crypto";
 import { errToString } from "@shared/utils/error";
-import { TeamDomain } from "@server/models";
+import { Event, TeamDomain } from "@server/models";
 import Collection from "@server/models/Collection";
 import UserAuthentication from "@server/models/UserAuthentication";
 import { buildUser, buildTeam, buildAdmin } from "@server/test/factories";
@@ -55,6 +55,41 @@ describe("accountProvisioner", () => {
         },
       });
       expect(collectionCount).toEqual(1);
+    });
+
+    it("should record the request ip on onboarding events", async () => {
+      const { team } = await accountProvisioner(ctx, {
+        user: {
+          name: "Jenny Tester",
+          email: faker.internet.email(),
+          avatarUrl: faker.image.avatar(),
+        },
+        team: {
+          name: "New workspace",
+          avatarUrl: faker.image.avatar(),
+          subdomain: faker.internet.domainWord(),
+        },
+        authenticationProvider: {
+          name: "google",
+          providerId: faker.internet.domainName(),
+        },
+        authentication: {
+          providerId: randomUUID(),
+          accessToken: "123",
+          scopes: ["read"],
+        },
+      });
+
+      const events = await Event.findAll({
+        where: {
+          teamId: team.id,
+          name: ["collections.create", "documents.create"],
+        },
+      });
+      expect(events.length).toBeGreaterThan(0);
+      events.forEach((event) => {
+        expect(event.ip).toEqual(ip);
+      });
     });
 
     it("should update existing user and authentication", async () => {

--- a/server/commands/accountProvisioner.ts
+++ b/server/commands/accountProvisioner.ts
@@ -285,9 +285,10 @@ async function provisionFirstCollection(
 ) {
   await sequelize.transaction(async (transaction) => {
     const context = createContext({
-      ...ctx,
-      transaction,
       user,
+      authType: ctx.context.auth?.type,
+      ip: ctx.context.ip,
+      transaction,
     });
 
     const collection = await Collection.createWithCtx(context, {


### PR DESCRIPTION
- The context passed to `provisionFirstCollection` spread an `APIContext` into `createContext`, which reads top-level `ip`/`authType` — so both were silently dropped.
- New workspaces therefore stored their welcome collection and onboarding document events with a null ip, and each signup logged nine "No ip provided to insertEvent" warnings.
- Now builds the context from the request's auth type and ip.