### PR TITLE
fix: Run MCP create_document inside a transaction

### DIFF
--- a/server/tools/documents.ts
+++ b/server/tools/documents.ts
@@ -426,22 +426,27 @@ export function documentTools(server: McpServer, scopes: string[]) {
                   authType: ctx.state.auth.type,
                   ip: ctx.context.ip,
                 })
-              : await documentCreator(ctx, {
-                  title: input.title,
-                  text: input.text,
-                  icon: input.icon,
-                  color: input.color,
-                  parentDocumentId,
-                  publish: input.publish !== false,
-                  collectionId: collection?.id,
-                  template,
-                  fullWidth: input.fullWidth,
-                  sourceMetadata: input.sourceFileName
-                    ? {
-                        fileName: input.sourceFileName,
-                        mimeType: "text/markdown",
-                      }
-                    : undefined,
+              : await sequelize.transaction(async (transaction) => {
+                  ctx.state.transaction = transaction;
+                  ctx.context.transaction = transaction;
+
+                  return documentCreator(ctx, {
+                    title: input.title,
+                    text: input.text,
+                    icon: input.icon,
+                    color: input.color,
+                    parentDocumentId,
+                    publish: input.publish !== false,
+                    collectionId: collection?.id,
+                    template,
+                    fullWidth: input.fullWidth,
+                    sourceMetadata: input.sourceFileName
+                      ? {
+                          fileName: input.sourceFileName,
+                          mimeType: "text/markdown",
+                        }
+                      : undefined,
+                  });
                 });
 
           const breadcrumb = await getDocumentBreadcrumb(document, user);


### PR DESCRIPTION
The MCP `create_document` tool called documentCreator outside a transaction, unlike its sibling tools and the REST route.

- Wraps the non-HTML branch in a transaction, matching move_document and update_document
- Makes creation atomic and stops the "No transaction provided" warnings logged twice per call
- The HTML branch is unchanged; it hands off to a worker task