### PR TITLE
fix: Sanitize user-provided name when building export storage keys

### DIFF
--- a/server/commands/collectionExporter.ts
+++ b/server/commands/collectionExporter.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import {
   FileOperationFormat,
   FileOperationType,
@@ -7,7 +6,6 @@ import {
 import { traceFunction } from "@server/logging/tracing";
 import type { Collection, Team, User } from "@server/models";
 import { FileOperation } from "@server/models";
-import { Buckets } from "@server/models/helpers/AttachmentHelper";
 import { type APIContext } from "@server/types";
 
 type Props = {
@@ -20,16 +18,6 @@ type Props = {
   ctx: APIContext;
 };
 
-function getKeyForFileOp(
-  teamId: string,
-  format: FileOperationFormat,
-  name: string
-) {
-  return `${
-    Buckets.uploads
-  }/${teamId}/${randomUUID()}/${name}-export.${format.replace(/outline-/, "")}.zip`;
-}
-
 async function collectionExporter({
   collection,
   team,
@@ -40,11 +28,11 @@ async function collectionExporter({
   ctx,
 }: Props) {
   const collectionId = collection?.id;
-  const key = getKeyForFileOp(
-    user.teamId,
+  const key = FileOperation.getExportKey({
+    name: collection?.name || team.name,
+    teamId: user.teamId,
     format,
-    collection?.name || team.name
-  );
+  });
   const fileOperation = await FileOperation.createWithCtx(ctx, {
     type: FileOperationType.Export,
     state: FileOperationState.Creating,

--- a/server/models/FileOperation.test.ts
+++ b/server/models/FileOperation.test.ts
@@ -1,11 +1,47 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { FileOperationFormat } from "@shared/types";
 import {
   buildFileOperation,
   buildTeam,
   buildUser,
 } from "@server/test/factories";
+import { ValidateKey } from "@server/validation";
 import FileOperation from "./FileOperation";
 
 describe("FileOperation", () => {
+  describe("getExportKey", () => {
+    it("should write to the uploads bucket", () => {
+      const teamId = randomUUID();
+      const key = FileOperation.getExportKey({
+        name: "My Collection",
+        teamId,
+        format: FileOperationFormat.MarkdownZip,
+      });
+
+      expect(key).toEqual(
+        expect.stringMatching(
+          new RegExp(
+            `^uploads/${teamId}/[^/]+/My Collection-export\\.markdown\\.zip$`
+          )
+        )
+      );
+      expect(ValidateKey.isValid(key)).toBe(true);
+    });
+
+    it("should not allow the name to traverse to another bucket", () => {
+      const key = FileOperation.getExportKey({
+        name: `../../../public/${randomUUID()}/${randomUUID()}/x`,
+        teamId: randomUUID(),
+        format: FileOperationFormat.MarkdownZip,
+      });
+
+      expect(key.split("/")).toHaveLength(4);
+      // The key must still point inside the uploads bucket once normalized.
+      expect(path.posix.normalize(key).startsWith("uploads/")).toBe(true);
+    });
+  });
+
   describe("findByPk", () => {
     it("should not allow a passed where to override the id", async () => {
       const team = await buildTeam();

--- a/server/models/FileOperation.ts
+++ b/server/models/FileOperation.ts
@@ -21,6 +21,7 @@ import { v4 as uuidv4 } from "uuid";
 import type { CollectionPermission, FileOperationFormat } from "@shared/types";
 import { FileOperationState, FileOperationType } from "@shared/types";
 import FileStorage from "@server/storage/files";
+import { ValidateKey } from "@server/validation";
 import Collection from "./Collection";
 import Document from "./Document";
 import Team from "./Team";
@@ -277,6 +278,14 @@ class FileOperation extends ParanoidModel<
     });
   }
 
+  /**
+   * Get the storage key to write an export archive to.
+   *
+   * @param name The user-provided name of the exported source
+   * @param teamId The team id
+   * @param format The format of the export
+   * @returns a storage key
+   */
   static getExportKey({
     name,
     teamId,
@@ -286,9 +295,11 @@ class FileOperation extends ParanoidModel<
     teamId: string;
     format: FileOperationFormat;
   }) {
-    return `${
-      Buckets.uploads
-    }/${teamId}/${uuidv4()}/${name}-export.${format.replace(/outline-/, "")}.zip`;
+    const fileName = ValidateKey.sanitizeSegment(
+      `${name}-export.${format.replace(/outline-/, "")}.zip`
+    );
+
+    return `${Buckets.uploads}/${teamId}/${uuidv4()}/${fileName}`;
   }
 }
 

--- a/server/models/FileOperation.ts
+++ b/server/models/FileOperation.ts
@@ -281,10 +281,10 @@ class FileOperation extends ParanoidModel<
   /**
    * Get the storage key to write an export archive to.
    *
-   * @param name The user-provided name of the exported source
-   * @param teamId The team id
-   * @param format The format of the export
-   * @returns a storage key
+   * @param name the user-provided name of the exported source.
+   * @param teamId the team id.
+   * @param format the format of the export.
+   * @returns a storage key.
    */
   static getExportKey({
     name,

--- a/server/storage/files/LocalStorage.ts
+++ b/server/storage/files/LocalStorage.ts
@@ -182,6 +182,12 @@ export default class LocalStorage extends BaseStorage {
       "FILE_STORAGE_LOCAL_ROOT_DIR is required"
     );
 
+    // resolve-path only rejects a path that climbs above the root, it will
+    // silently normalize one that moves between buckets inside it.
+    if (key.split(/[\\/]/).includes("..")) {
+      throw ValidationError(`Invalid file key ${key}`);
+    }
+
     return safeResolvePath(env.FILE_STORAGE_LOCAL_ROOT_DIR, key);
   }
 }

--- a/server/validation.test.ts
+++ b/server/validation.test.ts
@@ -68,3 +68,22 @@ describe("#ValidateKey.sanitize", () => {
     );
   });
 });
+
+describe("#ValidateKey.sanitizeSegment", () => {
+  it("should leave an ordinary name untouched", () => {
+    expect(ValidateKey.sanitizeSegment("My Document")).toEqual("My Document");
+  });
+
+  it("should remove path separators", () => {
+    expect(ValidateKey.sanitizeSegment("../../../public/foo")).not.toContain(
+      "/"
+    );
+    expect(ValidateKey.sanitizeSegment("..\\..\\public\\foo")).not.toContain(
+      "\\"
+    );
+  });
+
+  it("should remove problematic characters", () => {
+    expect(ValidateKey.sanitizeSegment("test#:*?")).toEqual("test");
+  });
+});

--- a/server/validation.ts
+++ b/server/validation.ts
@@ -219,6 +219,16 @@ export class ValidateKey {
       .concat(`/${sanitize(filename.replace(/#/g, ""))}`);
   };
 
+  /**
+   * Sanitizes a string for use as a single segment of a key, removing any
+   * characters that would allow it to change the location the key points to.
+   *
+   * @param name
+   * @returns the sanitized segment
+   */
+  public static sanitizeSegment = (name: string) =>
+    sanitize(name.replace(/#/g, ""));
+
   public static message = "Must be of the form <bucket>/<uuid>/<uuid>/<name>?";
 }
 

--- a/server/validation.ts
+++ b/server/validation.ts
@@ -223,8 +223,8 @@ export class ValidateKey {
    * Sanitizes a string for use as a single segment of a key, removing any
    * characters that would allow it to change the location the key points to.
    *
-   * @param name
-   * @returns the sanitized segment
+   * @param name the string to sanitize.
+   * @returns the sanitized segment.
    */
   public static sanitizeSegment = (name: string) =>
     sanitize(name.replace(/#/g, ""));


### PR DESCRIPTION
- Export keys interpolated a document title or collection name straight into the storage path, so a name containing path separators could move the archive out of the uploads bucket and into public — where `files.get` serves content with no authorization, no share record, and no way to revoke.
- Sanitize the name down to a single path segment in `getExportKey`, and drop the duplicated key builder in collectionExporter so document and collection exports share one implementation.
- Affects local file storage only: S3 object keys are opaque, the ACL is not derived from the key prefix, and the unauthenticated route is not mounted for S3 deployments.