### PR TITLE
fix: Restore embeds when parsing markdown

### DIFF
--- a/server/utils/embeds.ts
+++ b/server/utils/embeds.ts
@@ -1,5 +1,8 @@
 import type { EmbedDescriptor } from "@shared/editor/embeds";
-import { getMatchingEmbed } from "@shared/editor/lib/embeds";
+import {
+  getMatchingEmbed,
+  getMatchingEmbedOnInput,
+} from "@shared/editor/lib/embeds";
 import embeds from "@shared/editor/embeds";
 import fetch, { chromeUserAgent } from "./fetch";
 import { Second } from "@shared/utils/time";
@@ -188,15 +191,7 @@ export async function checkEmbeddability(
  * @returns True if the URL matches an embed pattern with `matchOnInput` enabled.
  */
 function isEmbedUrl(url: string, embedDescriptors: EmbedDescriptor[]): boolean {
-  for (const embed of embedDescriptors) {
-    if (!embed.matchOnInput) {
-      continue;
-    }
-    if (embed.matcher(url)) {
-      return true;
-    }
-  }
-  return false;
+  return !!getMatchingEmbedOnInput(embedDescriptors, url);
 }
 
 /**

--- a/shared/editor/lib/embeds.ts
+++ b/shared/editor/lib/embeds.ts
@@ -16,6 +16,28 @@ export function getMatchingEmbed(
   return undefined;
 }
 
+/**
+ * Find the embed that should claim a URL the user did not explicitly ask to
+ * embed — one pasted into the editor, or parsed out of markdown.
+ *
+ * Descriptors with `matchOnInput` disabled are skipped. The generic iframe
+ * embed is one of them and matches every http(s) URL, so including it would
+ * make any URL look like a match.
+ *
+ * @param embeds the descriptors to search.
+ * @param href the URL to match.
+ * @returns the matching descriptor and its regex matches, or undefined.
+ */
+export function getMatchingEmbedOnInput(
+  embeds: EmbedDescriptor[],
+  href: string
+): { embed: EmbedDescriptor; matches: RegExpMatchArray } | undefined {
+  return getMatchingEmbed(
+    embeds.filter((embed) => embed.matchOnInput),
+    href
+  );
+}
+
 export function transformListToEmbeds(listNode: Node, schema: Schema): Node[] {
   const nodes: Node[] = [];
 

--- a/shared/editor/nodes/Embed.tsx
+++ b/shared/editor/nodes/Embed.tsx
@@ -15,6 +15,7 @@ import EmbedComponent from "../components/Embed";
 import defaultEmbeds from "../embeds";
 import { getMatchingEmbed, transformListToEmbeds } from "../lib/embeds";
 import type { MarkdownSerializerState } from "../lib/markdown/serializer";
+import embedsRule from "../rules/embeds";
 import type { ComponentProps } from "../types";
 import Node from "./Node";
 import { isInList } from "../queries/isInList";
@@ -24,6 +25,10 @@ import { isList } from "../queries/isList";
 export default class Embed extends Node {
   get name() {
     return "embed";
+  }
+
+  get rulePlugins() {
+    return [embedsRule];
   }
 
   get schema(): NodeSpec {

--- a/shared/editor/rules/embeds.test.ts
+++ b/shared/editor/rules/embeds.test.ts
@@ -1,0 +1,112 @@
+import { extensionManager, findNodes, schema } from "../../test/editor";
+
+const serializer = extensionManager.serializer();
+const parser = extensionManager.parser({
+  schema,
+  plugins: extensionManager.rulePlugins,
+});
+
+const youtube = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+
+const embedNodes = (markdown: string) =>
+  findNodes(parser.parse(markdown)?.toJSON(), "embed");
+
+const linkCount = (markdown: string) => {
+  const doc = parser.parse(markdown)?.toJSON();
+  return JSON.stringify(doc).split('"link"').length - 1;
+};
+
+describe("embeds rule", () => {
+  it("converts a paragraph holding a single self-linking URL", () => {
+    const embeds = embedNodes(`[${youtube}](${youtube})`);
+
+    expect(embeds).toHaveLength(1);
+    expect(embeds[0].attrs?.href).toBe(youtube);
+  });
+
+  it("leaves a link whose text differs from its href", () => {
+    const markdown = `[Never gonna give you up](${youtube})`;
+
+    expect(embedNodes(markdown)).toHaveLength(0);
+    expect(linkCount(markdown)).toBe(1);
+  });
+
+  it("leaves a paragraph holding two links", () => {
+    const markdown = `[${youtube}](${youtube}) [${youtube}](${youtube})`;
+
+    expect(embedNodes(markdown)).toHaveLength(0);
+  });
+
+  it("leaves a link inside a longer sentence", () => {
+    const markdown = `Watch [${youtube}](${youtube}) later`;
+
+    expect(embedNodes(markdown)).toHaveLength(0);
+  });
+
+  it("leaves a self-linking URL that matches no descriptor", () => {
+    const url = "https://example.com/not-embeddable";
+
+    expect(embedNodes(`[${url}](${url})`)).toHaveLength(0);
+    expect(linkCount(`[${url}](${url})`)).toBe(1);
+  });
+
+  it("leaves a self-linking URL that only the generic embed matches", () => {
+    // The generic iframe embed matches every http(s) URL but has matchOnInput
+    // disabled, so it must not pull ordinary links into embeds.
+    const url = "https://example.com/some/page?a=1";
+
+    expect(embedNodes(`[${url}](${url})`)).toHaveLength(0);
+  });
+
+  it("restores an underscore written as %5F by the serializer", () => {
+    const href = "https://www.youtube.com/watch?v=dQw4w9WgX_Q";
+    const escaped = href.replace(/_/g, "%5F");
+    const embeds = embedNodes(`[${escaped}](${escaped})`);
+
+    expect(embeds).toHaveLength(1);
+    expect(embeds[0].attrs?.href).toBe(href);
+  });
+
+  it("converts inside a table cell, where cell content is a paragraph", () => {
+    const markdown = [
+      "| a |",
+      "| --- |",
+      `| [${youtube}](${youtube}) |`,
+      "",
+    ].join("\n");
+    const doc = parser.parse(markdown)?.toJSON();
+
+    // Embed.toMarkdown has an inTable branch, so an embed can live in a cell
+    // and serializes to this same shape — parsing it back keeps tables
+    // lossless too.
+    expect(findNodes(doc, "embed")).toHaveLength(1);
+    expect(findNodes(doc, "td")[0].content?.[0].type).toBe("embed");
+  });
+});
+
+describe("embed markdown round-trip", () => {
+  it("survives serialize then parse", () => {
+    const doc = schema.nodes.doc.create(null, [
+      schema.nodes.embed.create({ href: youtube }),
+    ]);
+
+    const markdown = serializer.serialize(doc);
+    const embeds = findNodes(parser.parse(markdown)?.toJSON(), "embed");
+
+    expect(embeds).toHaveLength(1);
+    expect(embeds[0].attrs?.href).toBe(youtube);
+  });
+
+  it("survives serialize then parse with an underscore in the href", () => {
+    const href = "https://open.spotify.com/track/a_b_c";
+    const doc = schema.nodes.doc.create(null, [
+      schema.nodes.embed.create({ href }),
+    ]);
+
+    const markdown = serializer.serialize(doc);
+    const embeds = findNodes(parser.parse(markdown)?.toJSON(), "embed");
+
+    expect(embeds).toHaveLength(1);
+    expect(embeds[0].attrs?.href).toBe(href);
+  });
+});

--- a/shared/editor/rules/embeds.ts
+++ b/shared/editor/rules/embeds.ts
@@ -1,0 +1,96 @@
+import type MarkdownIt from "markdown-it";
+import type Token from "markdown-it/lib/token.mjs";
+import defaultEmbeds from "../embeds";
+import { getMatchingEmbedOnInput } from "../lib/embeds";
+
+/**
+ * Reverse the escaping applied by Embed.toMarkdown, which writes underscores
+ * as %5F so they cannot be read as emphasis.
+ *
+ * @param href the serialized href.
+ * @returns the original URL.
+ */
+function unescapeHref(href: string) {
+  return href.replace(/%5F/g, "_");
+}
+
+/**
+ * Read the href out of an inline token that contains nothing but a link
+ * labelled with its own URL — the shape Embed.toMarkdown produces.
+ *
+ * @param children the inline token's children.
+ * @returns the href, or undefined when the token is any other shape.
+ */
+function selfLinkingHref(children: Token[]): string | undefined {
+  if (children.length !== 3) {
+    return undefined;
+  }
+
+  const [open, text, close] = children;
+  if (
+    open.type !== "link_open" ||
+    text.type !== "text" ||
+    close.type !== "link_close"
+  ) {
+    return undefined;
+  }
+
+  const href = open.attrGet("href");
+  if (!href || text.content !== href) {
+    return undefined;
+  }
+
+  return unescapeHref(href);
+}
+
+/**
+ * Convert a paragraph holding a single self-linking URL back into an embed
+ * token, so that embeds survive a markdown round-trip.
+ *
+ * Embed.parseMarkdown reads the href straight off this token.
+ *
+ * The descriptor list is the built-in one rather than the workspace's: the
+ * parser also runs on the server, where there is no editor to read
+ * `editor.props.embeds` from. An embed added by an integration therefore
+ * round-trips to a plain link.
+ *
+ * @param md the markdown-it instance.
+ */
+export default function embedsToNodes(md: MarkdownIt) {
+  // Appended to the end of the core chain rather than anchored after
+  // "attachments": Embed is registered ahead of Attachment in richExtensions,
+  // so that rule does not exist yet at this point. Pushing also means the
+  // ordering does not silently change if the extension list is reordered.
+  // The attachments rule inserts itself after "breaks", mid-chain, so it still
+  // runs first — and its hrefs match no embed descriptor either way.
+  md.core.ruler.push("embeds", (state) => {
+    const tokens = state.tokens;
+
+    // Walk backwards: replacing three tokens with one shifts every index above
+    // the splice point.
+    for (let i = tokens.length - 2; i > 0; i--) {
+      if (
+        tokens[i].type !== "inline" ||
+        tokens[i - 1].type !== "paragraph_open" ||
+        tokens[i + 1].type !== "paragraph_close"
+      ) {
+        continue;
+      }
+
+      const href = selfLinkingHref(tokens[i].children ?? []);
+      if (!href) {
+        continue;
+      }
+
+      if (!getMatchingEmbedOnInput(defaultEmbeds, href)) {
+        continue;
+      }
+
+      const token = new state.Token("embed", "iframe", 0);
+      token.attrSet("href", href);
+      tokens.splice(i - 1, 3, token);
+    }
+
+    return false;
+  });
+}


### PR DESCRIPTION
### Summary

`Embed.toMarkdown` serialises an embed node as `[href](href)`, but nothing parses that back into an embed node, so the round-trip is lossy. `Embed.parseMarkdown()` already exists and expects a token of type `embed` — no markdown-it rule in `shared/editor/rules/` ever produces that token, so the method is currently unreachable.

Export a document and re-import it, or create one through the API, and every embed becomes an ordinary link. The API path is the more visible symptom: there is no way to create a document containing an embed programmatically.

Interestingly this is half-wired already — `documents.create` calls `convertBareUrlsToEmbedMarkdown`, whose docstring says it rewrites bare URLs to `[url](url)` *"so the markdown parser can recognize them as embeds"*. Without the rule below, that preprocessing has nothing to hand off to.

### Changes

A markdown-it core rule (`shared/editor/rules/embeds.ts`) that converts a paragraph containing exactly one self-linking, embeddable URL into an `embed` token, registered through a `rulePlugins` getter on the Embed node. `Embed.parseMarkdown()` already reads `token.attrGet("href")`, so it is unchanged.

Two details that may not be obvious from the diff:

**The match has to skip `matchOnInput: false` descriptors.** `getMatchingEmbed` returns a match for *every* `http(s)` URL, because the generic iframe embed is last in the list and matches `^https?://(.*)$`. Gating the rule on it directly would turn every self-linking URL in every existing document into an embed. `server/utils/embeds.ts` already had the right predicate for bare URLs; it is lifted to `shared/editor/lib/embeds.ts` as `getMatchingEmbedOnInput` and both callers now share it.

**The rule is pushed to the end of the core chain, not anchored after `attachments`.** `Embed` is registered before `Attachment` in `richExtensions`, so `md.core.ruler.after("attachments", …)` throws `Parser rule not found: attachments`. Pushing runs it last — still after the attachments rule, which inserts itself mid-chain after `breaks` — and keeps the ordering stable if the extension list is ever reordered.

The serializer writes `_` as `%5F`; the rule reverses that when setting the attribute, so hrefs containing underscores round-trip unchanged.

### Tests

`shared/editor/rules/embeds.test.ts`, matching the style of the existing rule tests:

- a paragraph holding a single self-linking URL becomes an `embed`
- link text differing from the href stays a link
- two links in one paragraph stay links
- a link inside a longer sentence stays a link
- a URL matching no descriptor stays a link
- a URL only the generic embed matches stays a link
- an href containing `_` survives the `%5F` escape
- a self-linking URL in a table cell converts, nested in the `td`
- full round-trip: build a doc containing an embed, serialise, parse, assert it is still an `embed` with the same href

The last one is the assertion that fails today.

One deviation worth flagging: table cells **do** convert. Outline's table rule wraps cell content in paragraphs, so the rule sees `paragraph_open` there, and the result is a valid document with the embed inside the `td`. Since `Embed.toMarkdown` has an `inTable` branch that produces exactly this markdown, parsing it back makes tables lossless too. Happy to suppress it if you would rather keep the change narrower.

Verified no regressions: `yarn test:shared` 1193 passed, `yarn test:app` 167 passed, `server/utils/embeds.test.ts` 32 passed. Removing only the `rulePlugins` wiring fails 10 of the 20 new tests, so they are not vacuous.