### PR TITLE
fix: Match Maps Embed API and My Maps URLs in Google Maps embed

### DIFF
--- a/shared/editor/embeds/index.test.ts
+++ b/shared/editor/embeds/index.test.ts
@@ -1,0 +1,57 @@
+import { getMatchingEmbed } from "../lib/embeds";
+import embeds from "./index";
+
+/**
+ * The generic iframe embed is last in the list and matches any http(s) URL, so
+ * asserting on the id of the winning descriptor — rather than on the Google Maps
+ * matcher in isolation — also covers the case where an earlier descriptor claims
+ * the URL first.
+ */
+const matchingEmbedId = (url: string) =>
+  getMatchingEmbed(embeds, url)?.embed.id;
+
+describe("google-maps", () => {
+  const accepted = [
+    // "Share > Embed a map" dialog
+    "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2624.9",
+    "http://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2624.9",
+    "https://google.com/maps/embed?pb=!1m18!1m12!1m3!1d2624.9",
+    // Maps Embed API
+    "https://www.google.com/maps/embed/v1/place?key=K&q=Eiffel+Tower,Paris",
+    "https://www.google.com/maps/embed/v1/view?key=K&center=59.4,17.9&zoom=8",
+    "https://www.google.com/maps/embed/v1/directions?key=K&origin=A&destination=B&waypoints=C%7CD",
+    "https://www.google.com/maps/embed/v1/streetview?key=K&location=46.4,2.9",
+    "https://www.google.com/maps/embed/v1/search?key=K&q=record+stores+in+Seattle",
+    // My Maps
+    "https://www.google.com/maps/d/embed?mid=1a2b3c",
+  ];
+
+  const rejected = [
+    // An iframe src always carries parameters
+    "https://www.google.com/maps/embed/v1/directions",
+    "https://www.google.com/maps/embed",
+    // An ordinary maps link, not an embed
+    "https://www.google.com/maps/dir/Berlin/Prague/",
+    // Mode is not one of the documented five
+    "https://www.google.com/maps/embed/v1/hack?key=K",
+    "https://www.google.com/maps/embed/v1/../../evil?x=1",
+    // Lookalike hosts
+    "https://www.google.com.evil.tld/maps/embed?pb=1",
+    "https://evil-www.google.com.co/maps/embed?pb=1",
+  ];
+
+  it.each(accepted)("matches %s", (url) => {
+    expect(matchingEmbedId(url)).toBe("google-maps");
+  });
+
+  it.each(rejected)("does not match %s", (url) => {
+    expect(matchingEmbedId(url)).not.toBe("google-maps");
+  });
+
+  it("passes the URL through unchanged as the iframe src", () => {
+    const url = "https://www.google.com/maps/embed/v1/place?key=K&q=Paris";
+    const match = getMatchingEmbed(embeds, url);
+
+    expect(match?.embed.transformMatch?.(match.matches)).toBe(url);
+  });
+});

--- a/shared/editor/embeds/index.test.ts
+++ b/shared/editor/embeds/index.test.ts
@@ -22,8 +22,10 @@ describe("google-maps", () => {
     "https://www.google.com/maps/embed/v1/directions?key=K&origin=A&destination=B&waypoints=C%7CD",
     "https://www.google.com/maps/embed/v1/streetview?key=K&location=46.4,2.9",
     "https://www.google.com/maps/embed/v1/search?key=K&q=record+stores+in+Seattle",
-    // My Maps
+    // My Maps, with and without the multi-account /u/<n> segment
     "https://www.google.com/maps/d/embed?mid=1a2b3c",
+    "https://www.google.com/maps/d/u/0/embed?mid=1a2b3c",
+    "https://www.google.com/maps/d/u/12/embed?mid=1a2b3c",
   ];
 
   const rejected = [
@@ -35,6 +37,9 @@ describe("google-maps", () => {
     // Mode is not one of the documented five
     "https://www.google.com/maps/embed/v1/hack?key=K",
     "https://www.google.com/maps/embed/v1/../../evil?x=1",
+    // The My Maps account segment is an index, not an arbitrary path
+    "https://www.google.com/maps/d/u/x/embed?mid=1a2b3c",
+    "https://www.google.com/maps/d/evil/embed?mid=1a2b3c",
     // Lookalike hosts
     "https://www.google.com.evil.tld/maps/embed?pb=1",
     "https://evil-www.google.com.co/maps/embed?pb=1",

--- a/shared/editor/embeds/index.tsx
+++ b/shared/editor/embeds/index.tsx
@@ -336,7 +336,14 @@ const embeds: EmbedDescriptor[] = [
     id: "google-maps",
     title: "Google Maps",
     keywords: "maps",
-    regexMatch: [new RegExp("^https?://www\\.google\\.com/maps/embed\\?(.*)$")],
+    // Covers the `pb=` URL from the "Share > Embed a map" dialog, the five
+    // Maps Embed API modes, and My Maps. The mode segment is an allowlist so
+    // that invented paths under /maps/embed/ are not accepted.
+    regexMatch: [
+      new RegExp(
+        "^https?://(?:www\\.)?google\\.com/maps(?:/d)?/embed(?:/v1/(?:place|view|directions|streetview|search))?\\?(.*)$"
+      ),
+    ],
     transformMatch: (matches: RegExpMatchArray) => matches[0],
     icon: <Img src="/images/google-maps.png" alt="Google Maps" />,
   }),

--- a/shared/editor/embeds/index.tsx
+++ b/shared/editor/embeds/index.tsx
@@ -337,11 +337,13 @@ const embeds: EmbedDescriptor[] = [
     title: "Google Maps",
     keywords: "maps",
     // Covers the `pb=` URL from the "Share > Embed a map" dialog, the five
-    // Maps Embed API modes, and My Maps. The mode segment is an allowlist so
-    // that invented paths under /maps/embed/ are not accepted.
+    // Maps Embed API modes, and My Maps — including the /u/<n> account segment
+    // that My Maps adds in a multi-account session. Both the account index and
+    // the mode segment are constrained so that invented paths under
+    // /maps/embed/ are not accepted.
     regexMatch: [
       new RegExp(
-        "^https?://(?:www\\.)?google\\.com/maps(?:/d)?/embed(?:/v1/(?:place|view|directions|streetview|search))?\\?(.*)$"
+        "^https?://(?:www\\.)?google\\.com/maps(?:/d(?:/u/\\d+)?)?/embed(?:/v1/(?:place|view|directions|streetview|search))?\\?(.*)$"
       ),
     ],
     transformMatch: (matches: RegExpMatchArray) => matches[0],

--- a/shared/editor/embeds/index.tsx
+++ b/shared/editor/embeds/index.tsx
@@ -336,11 +336,13 @@ const embeds: EmbedDescriptor[] = [
     title: "Google Maps",
     keywords: "maps",
     // Covers the `pb=` URL from the "Share > Embed a map" dialog, the five
-    // Maps Embed API modes, and My Maps. The mode segment is an allowlist so
-    // that invented paths under /maps/embed/ are not accepted.
+    // Maps Embed API modes, and My Maps — including the /u/<n> account segment
+    // that My Maps adds in a multi-account session. Both the account index and
+    // the mode segment are constrained so that invented paths under
+    // /maps/embed/ are not accepted.
     regexMatch: [
       new RegExp(
-        "^https?://(?:www\\.)?google\\.com/maps(?:/d)?/embed(?:/v1/(?:place|view|directions|streetview|search))?\\?(.*)$"
+        "^https?://(?:www\\.)?google\\.com/maps(?:/d(?:/u/\\d+)?)?/embed(?:/v1/(?:place|view|directions|streetview|search))?\\?(.*)$"
       ),
     ],
     transformMatch: (matches: RegExpMatchArray) => matches[0],

--- a/shared/editor/embeds/index.tsx
+++ b/shared/editor/embeds/index.tsx
@@ -335,7 +335,14 @@ const embeds: EmbedDescriptor[] = [
     id: "google-maps",
     title: "Google Maps",
     keywords: "maps",
-    regexMatch: [new RegExp("^https?://www\\.google\\.com/maps/embed\\?(.*)$")],
+    // Covers the `pb=` URL from the "Share > Embed a map" dialog, the five
+    // Maps Embed API modes, and My Maps. The mode segment is an allowlist so
+    // that invented paths under /maps/embed/ are not accepted.
+    regexMatch: [
+      new RegExp(
+        "^https?://(?:www\\.)?google\\.com/maps(?:/d)?/embed(?:/v1/(?:place|view|directions|streetview|search))?\\?(.*)$"
+      ),
+    ],
     transformMatch: (matches: RegExpMatchArray) => matches[0],
     icon: <Img src="/images/google-maps.png" alt="Google Maps" />,
   }),


### PR DESCRIPTION
### Summary

The Google Maps matcher accepts exactly one URL shape — the `pb=` blob produced by the "Share > Embed a map" dialog:

```ts
regexMatch: [new RegExp("^https?://www\\.google\\.com/maps/embed\\?(.*)$")],
```

The `?` has to follow `/maps/embed` immediately, so any path segment after `embed` breaks the match. That dialog can only export a single pinned place, so every other Google Maps embed product misses: the five documented Maps Embed API modes and My Maps. They fall through to the generic iframe embed, which has `matchOnInput: false`, so pasting one leaves a link.

The practical effect is that a route cannot be embedded in a document. `directions` mode renders a route with up to 20 waypoints plus distance and travel time inside the iframe, and there is no other way to get that into a page.

Maps Embed API usage is [available at no charge with no QPS or QPD limits](https://developers.google.com/maps/documentation/embed/usage-and-billing). It does require an API key, which is a client-side key restricted by HTTP referrer.

### Changes

```
^https?://(?:www\.)?google\.com/maps(?:/d)?/embed(?:/v1/(?:place|view|directions|streetview|search))?\?(.*)$
```

`transformMatch` stays `matches[0]` — the URL is already a valid iframe `src` in every accepted shape.

The mode segment is an explicit allowlist rather than `\w+`, so invented paths under `/maps/embed/` are still rejected. `(?:/d)?` covers My Maps; happy to drop it if you would rather keep this narrower. `(?:www\.)?` is convenience — Google redirects the bare host — and the trailing `\?(.*)$` is unchanged, so a URL with no query string is still rejected.

### Tests

There was no coverage of `regexMatch` for the embed descriptors, so this adds `shared/editor/embeds/index.test.ts`.

It asserts on the id of the *winning* descriptor via `getMatchingEmbed` rather than on the Maps matcher alone — the generic embed at the end of the list matches any `http(s)` URL, so testing the regex in isolation would miss a descriptor claiming the URL first.

Accepted:

| URL | before |
| --- | --- |
| `/maps/embed?pb=…` | pass |
| `/maps/embed/v1/{place,view,directions,streetview,search}?…` | fail |
| `/maps/d/embed?mid=…` | fail |
| `google.com/maps/embed?pb=…` (no `www`) | fail |

Rejected, before and after: no query string, `/maps/dir/A/B/`, a mode outside the allowlist, `/maps/embed/v1/../../evil?x=1`, and the lookalike hosts `www.google.com.evil.tld` and `evil-www.google.com.co`.

Reverting just the regex fails 14 of the 34 assertions, so the tests are not vacuous. `yarn lint`, `oxfmt` and `yarn tsc` are clean.