### PR TITLE
feat: Inject the Google Maps Embed API key from the environment

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -294,6 +294,13 @@ NOTION_CLIENT_SECRET=
 IFRAMELY_URL=
 IFRAMELY_API_KEY=
 
+# Renders Google Maps embeds that use the Maps Embed API, which requires a key on
+# every request. Injected into the iframe at render time so it stays out of
+# document content. It is a browser key and is visible in the page source by
+# design – restrict it by HTTP referrer rather than treating it as a secret.
+# DOCS: https://developers.google.com/maps/documentation/embed/get-api-key
+GOOGLE_MAPS_EMBED_API_KEY=
+
 
 # ––––––––––––––––––––––––––––––––––––––
 # –––––––––––––  DEBUGGING  ––––––––––––

--- a/server/env.ts
+++ b/server/env.ts
@@ -870,6 +870,20 @@ export class Environment {
     this.toOptionalString(environment.SEARCH_PROVIDER) ?? "postgres";
 
   /**
+   * API key used to render Google Maps embeds. Injected into the iframe src at
+   * render time so that authors do not have to paste it into document content,
+   * where it would end up in exports, backups and public shares.
+   *
+   * This is a browser key and is visible in the rendered page source by design;
+   * restrict it by HTTP referrer rather than treating it as a secret.
+   */
+  @Public
+  @IsOptional()
+  public GOOGLE_MAPS_EMBED_API_KEY = this.toOptionalString(
+    environment.GOOGLE_MAPS_EMBED_API_KEY
+  );
+
+  /**
    * The product name
    */
   @Public

--- a/shared/editor/embeds/index.test.ts
+++ b/shared/editor/embeds/index.test.ts
@@ -1,0 +1,57 @@
+import { getMatchingEmbed } from "../lib/embeds";
+import embeds from "./index";
+
+/**
+ * The generic iframe embed is last in the list and matches any http(s) URL, so
+ * asserting on the id of the winning descriptor — rather than on the Google Maps
+ * matcher in isolation — also covers the case where an earlier descriptor claims
+ * the URL first.
+ */
+const matchingEmbedId = (url: string) =>
+  getMatchingEmbed(embeds, url)?.embed.id;
+
+describe("google-maps", () => {
+  const accepted = [
+    // "Share > Embed a map" dialog
+    "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2624.9",
+    "http://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2624.9",
+    "https://google.com/maps/embed?pb=!1m18!1m12!1m3!1d2624.9",
+    // Maps Embed API
+    "https://www.google.com/maps/embed/v1/place?key=K&q=Eiffel+Tower,Paris",
+    "https://www.google.com/maps/embed/v1/view?key=K&center=59.4,17.9&zoom=8",
+    "https://www.google.com/maps/embed/v1/directions?key=K&origin=A&destination=B&waypoints=C%7CD",
+    "https://www.google.com/maps/embed/v1/streetview?key=K&location=46.4,2.9",
+    "https://www.google.com/maps/embed/v1/search?key=K&q=record+stores+in+Seattle",
+    // My Maps
+    "https://www.google.com/maps/d/embed?mid=1a2b3c",
+  ];
+
+  const rejected = [
+    // An iframe src always carries parameters
+    "https://www.google.com/maps/embed/v1/directions",
+    "https://www.google.com/maps/embed",
+    // An ordinary maps link, not an embed
+    "https://www.google.com/maps/dir/Berlin/Prague/",
+    // Mode is not one of the documented five
+    "https://www.google.com/maps/embed/v1/hack?key=K",
+    "https://www.google.com/maps/embed/v1/../../evil?x=1",
+    // Lookalike hosts
+    "https://www.google.com.evil.tld/maps/embed?pb=1",
+    "https://evil-www.google.com.co/maps/embed?pb=1",
+  ];
+
+  it.each(accepted)("matches %s", (url) => {
+    expect(matchingEmbedId(url)).toBe("google-maps");
+  });
+
+  it.each(rejected)("does not match %s", (url) => {
+    expect(matchingEmbedId(url)).not.toBe("google-maps");
+  });
+
+  it("passes the URL through unchanged as the iframe src", () => {
+    const url = "https://www.google.com/maps/embed/v1/place?key=K&q=Paris";
+    const match = getMatchingEmbed(embeds, url);
+
+    expect(match?.embed.transformMatch?.(match.matches)).toBe(url);
+  });
+});

--- a/shared/editor/embeds/index.test.ts
+++ b/shared/editor/embeds/index.test.ts
@@ -22,8 +22,10 @@ describe("google-maps", () => {
     "https://www.google.com/maps/embed/v1/directions?key=K&origin=A&destination=B&waypoints=C%7CD",
     "https://www.google.com/maps/embed/v1/streetview?key=K&location=46.4,2.9",
     "https://www.google.com/maps/embed/v1/search?key=K&q=record+stores+in+Seattle",
-    // My Maps
+    // My Maps, with and without the multi-account /u/<n> segment
     "https://www.google.com/maps/d/embed?mid=1a2b3c",
+    "https://www.google.com/maps/d/u/0/embed?mid=1a2b3c",
+    "https://www.google.com/maps/d/u/12/embed?mid=1a2b3c",
   ];
 
   const rejected = [
@@ -35,6 +37,9 @@ describe("google-maps", () => {
     // Mode is not one of the documented five
     "https://www.google.com/maps/embed/v1/hack?key=K",
     "https://www.google.com/maps/embed/v1/../../evil?x=1",
+    // The My Maps account segment is an index, not an arbitrary path
+    "https://www.google.com/maps/d/u/x/embed?mid=1a2b3c",
+    "https://www.google.com/maps/d/evil/embed?mid=1a2b3c",
     // Lookalike hosts
     "https://www.google.com.evil.tld/maps/embed?pb=1",
     "https://evil-www.google.com.co/maps/embed?pb=1",

--- a/shared/editor/embeds/index.test.ts
+++ b/shared/editor/embeds/index.test.ts
@@ -123,6 +123,34 @@ describe("google-maps api key injection", () => {
     expect(src(url)).toBe(url);
   });
 
+  it("keeps the key in the query string when the URL has a fragment", () => {
+    setKey("AIzaSyTest");
+
+    expect(
+      src("https://www.google.com/maps/embed/v1/view?center=1,2#map")
+    ).toBe(
+      "https://www.google.com/maps/embed/v1/view?center=1,2&key=AIzaSyTest#map"
+    );
+  });
+
+  it("does not mistake a key= inside a fragment for a real one", () => {
+    setKey("AIzaSyTest");
+
+    expect(
+      src("https://www.google.com/maps/embed/v1/view?center=1,2#key=nope")
+    ).toBe(
+      "https://www.google.com/maps/embed/v1/view?center=1,2&key=AIzaSyTest#key=nope"
+    );
+  });
+
+  it("does not emit ?&key= when the query string is empty", () => {
+    setKey("AIzaSyTest");
+
+    expect(src("https://www.google.com/maps/embed/v1/view?")).toBe(
+      "https://www.google.com/maps/embed/v1/view?key=AIzaSyTest"
+    );
+  });
+
   it("returns the URL untouched when no key is configured", () => {
     setKey(undefined);
     const url = "https://www.google.com/maps/embed/v1/view?center=1,2";

--- a/shared/editor/embeds/index.test.ts
+++ b/shared/editor/embeds/index.test.ts
@@ -1,3 +1,4 @@
+import env from "../../env";
 import { getMatchingEmbed } from "../lib/embeds";
 import embeds from "./index";
 
@@ -58,5 +59,74 @@ describe("google-maps", () => {
     const match = getMatchingEmbed(embeds, url);
 
     expect(match?.embed.transformMatch?.(match.matches)).toBe(url);
+  });
+});
+
+describe("google-maps api key injection", () => {
+  // shared/env resolves to process.env on the server and window.env in the
+  // browser; mutating the resolved object covers both test environments.
+  // Assigning undefined is not the same as unsetting — process.env coerces it
+  // to the string "undefined" — so absence has to be expressed with delete.
+  const original = env.GOOGLE_MAPS_EMBED_API_KEY;
+
+  const setKey = (value?: string) => {
+    if (value === undefined) {
+      delete env.GOOGLE_MAPS_EMBED_API_KEY;
+      return;
+    }
+    env.GOOGLE_MAPS_EMBED_API_KEY = value;
+  };
+
+  const src = (url: string) => {
+    const match = getMatchingEmbed(embeds, url);
+    return match?.embed.transformMatch?.(match.matches);
+  };
+
+  afterEach(() => {
+    setKey(original);
+  });
+
+  it("appends the configured key to a Maps Embed API URL", () => {
+    setKey("AIzaSyTest");
+
+    expect(src("https://www.google.com/maps/embed/v1/view?center=1,2")).toBe(
+      "https://www.google.com/maps/embed/v1/view?center=1,2&key=AIzaSyTest"
+    );
+  });
+
+  it("percent-encodes the key", () => {
+    setKey("a b&c");
+
+    expect(src("https://www.google.com/maps/embed/v1/view?center=1,2")).toBe(
+      "https://www.google.com/maps/embed/v1/view?center=1,2&key=a%20b%26c"
+    );
+  });
+
+  it("leaves a key already present in the URL alone", () => {
+    setKey("AIzaSyTest");
+    const url = "https://www.google.com/maps/embed/v1/view?key=Inline&zoom=8";
+
+    expect(src(url)).toBe(url);
+  });
+
+  it("does not touch the legacy share URL, which takes no key", () => {
+    setKey("AIzaSyTest");
+    const url = "https://www.google.com/maps/embed?pb=!1m18!1m12";
+
+    expect(src(url)).toBe(url);
+  });
+
+  it("does not touch My Maps, which takes no key", () => {
+    setKey("AIzaSyTest");
+    const url = "https://www.google.com/maps/d/embed?mid=1a2b3c";
+
+    expect(src(url)).toBe(url);
+  });
+
+  it("returns the URL untouched when no key is configured", () => {
+    setKey(undefined);
+    const url = "https://www.google.com/maps/embed/v1/view?center=1,2";
+
+    expect(src(url)).toBe(url);
   });
 });

--- a/shared/editor/embeds/index.tsx
+++ b/shared/editor/embeds/index.tsx
@@ -336,7 +336,14 @@ const embeds: EmbedDescriptor[] = [
     id: "google-maps",
     title: "Google Maps",
     keywords: "maps",
-    regexMatch: [new RegExp("^https?://www\\.google\\.com/maps/embed\\?(.*)$")],
+    // Covers the `pb=` URL from the "Share > Embed a map" dialog, the five
+    // Maps Embed API modes, and My Maps. The mode segment is an allowlist so
+    // that invented paths under /maps/embed/ are not accepted.
+    regexMatch: [
+      new RegExp(
+        "^https?://(?:www\\.)?google\\.com/maps(?:/d)?/embed(?:/v1/(?:place|view|directions|streetview|search))?\\?(.*)$"
+      ),
+    ],
     transformMatch: (matches: RegExpMatchArray) => matches[0],
     icon: <Img src="/images/google-maps.png" alt="Google Maps" />,
   }),

--- a/shared/editor/embeds/index.tsx
+++ b/shared/editor/embeds/index.tsx
@@ -337,11 +337,13 @@ const embeds: EmbedDescriptor[] = [
     title: "Google Maps",
     keywords: "maps",
     // Covers the `pb=` URL from the "Share > Embed a map" dialog, the five
-    // Maps Embed API modes, and My Maps. The mode segment is an allowlist so
-    // that invented paths under /maps/embed/ are not accepted.
+    // Maps Embed API modes, and My Maps — including the /u/<n> account segment
+    // that My Maps adds in a multi-account session. Both the account index and
+    // the mode segment are constrained so that invented paths under
+    // /maps/embed/ are not accepted.
     regexMatch: [
       new RegExp(
-        "^https?://(?:www\\.)?google\\.com/maps(?:/d)?/embed(?:/v1/(?:place|view|directions|streetview|search))?\\?(.*)$"
+        "^https?://(?:www\\.)?google\\.com/maps(?:/d(?:/u/\\d+)?)?/embed(?:/v1/(?:place|view|directions|streetview|search))?\\?(.*)$"
       ),
     ],
     transformMatch: (matches: RegExpMatchArray) => matches[0],

--- a/shared/editor/embeds/index.tsx
+++ b/shared/editor/embeds/index.tsx
@@ -346,7 +346,24 @@ const embeds: EmbedDescriptor[] = [
         "^https?://(?:www\\.)?google\\.com/maps(?:/d(?:/u/\\d+)?)?/embed(?:/v1/(?:place|view|directions|streetview|search))?\\?(.*)$"
       ),
     ],
-    transformMatch: (matches: RegExpMatchArray) => matches[0],
+    // The key goes on the iframe src, never on the node's href, so it stays
+    // out of document content, exports and shares, and rotating it does not
+    // mean editing documents.
+    transformMatch: (matches: RegExpMatchArray) => {
+      const url = matches[0];
+      const key = env.GOOGLE_MAPS_EMBED_API_KEY;
+
+      // Only the Maps Embed API takes a key; the legacy `?pb=` share URL and
+      // My Maps do not. A key already in the URL wins, so documents written
+      // before this existed keep working.
+      if (!key || !url.includes("/maps/embed/v1/") || /[?&]key=/.test(url)) {
+        return url;
+      }
+
+      // The matcher requires a query string, so there is always a `?` to
+      // append to.
+      return `${url}&key=${encodeURIComponent(key)}`;
+    },
     icon: <Img src="/images/google-maps.png" alt="Google Maps" />,
   }),
   new EmbedDescriptor({

--- a/shared/editor/embeds/index.tsx
+++ b/shared/editor/embeds/index.tsx
@@ -354,15 +354,29 @@ const embeds: EmbedDescriptor[] = [
       const key = env.GOOGLE_MAPS_EMBED_API_KEY;
 
       // Only the Maps Embed API takes a key; the legacy `?pb=` share URL and
-      // My Maps do not. A key already in the URL wins, so documents written
-      // before this existed keep working.
-      if (!key || !url.includes("/maps/embed/v1/") || /[?&]key=/.test(url)) {
+      // My Maps do not.
+      if (!key || !url.includes("/maps/embed/v1/")) {
         return url;
       }
 
-      // The matcher requires a query string, so there is always a `?` to
-      // append to.
-      return `${url}&key=${encodeURIComponent(key)}`;
+      // Separate any fragment before touching the query: a parameter appended
+      // after `#` is never sent, and a `key=` that appears inside a fragment
+      // is not one either.
+      const hashIndex = url.indexOf("#");
+      const query = hashIndex === -1 ? url : url.slice(0, hashIndex);
+      const fragment = hashIndex === -1 ? "" : url.slice(hashIndex);
+
+      // A key already in the URL wins, so documents written before this
+      // existed keep working.
+      if (/[?&]key=/.test(query)) {
+        return url;
+      }
+
+      // The matcher requires a `?`, but it may be the last character, in which
+      // case there is no preceding parameter to separate from.
+      const separator = query.endsWith("?") ? "" : "&";
+
+      return `${query}${separator}key=${encodeURIComponent(key)}${fragment}`;
     },
     icon: <Img src="/images/google-maps.png" alt="Google Maps" />,
   }),

--- a/shared/editor/embeds/index.tsx
+++ b/shared/editor/embeds/index.tsx
@@ -353,15 +353,29 @@ const embeds: EmbedDescriptor[] = [
       const key = env.GOOGLE_MAPS_EMBED_API_KEY;
 
       // Only the Maps Embed API takes a key; the legacy `?pb=` share URL and
-      // My Maps do not. A key already in the URL wins, so documents written
-      // before this existed keep working.
-      if (!key || !url.includes("/maps/embed/v1/") || /[?&]key=/.test(url)) {
+      // My Maps do not.
+      if (!key || !url.includes("/maps/embed/v1/")) {
         return url;
       }
 
-      // The matcher requires a query string, so there is always a `?` to
-      // append to.
-      return `${url}&key=${encodeURIComponent(key)}`;
+      // Separate any fragment before touching the query: a parameter appended
+      // after `#` is never sent, and a `key=` that appears inside a fragment
+      // is not one either.
+      const hashIndex = url.indexOf("#");
+      const query = hashIndex === -1 ? url : url.slice(0, hashIndex);
+      const fragment = hashIndex === -1 ? "" : url.slice(hashIndex);
+
+      // A key already in the URL wins, so documents written before this
+      // existed keep working.
+      if (/[?&]key=/.test(query)) {
+        return url;
+      }
+
+      // The matcher requires a `?`, but it may be the last character, in which
+      // case there is no preceding parameter to separate from.
+      const separator = query.endsWith("?") ? "" : "&";
+
+      return `${query}${separator}key=${encodeURIComponent(key)}${fragment}`;
     },
     icon: <Img src="/images/google-maps.png" alt="Google Maps" />,
   }),

--- a/shared/editor/embeds/index.tsx
+++ b/shared/editor/embeds/index.tsx
@@ -336,11 +336,13 @@ const embeds: EmbedDescriptor[] = [
     title: "Google Maps",
     keywords: "maps",
     // Covers the `pb=` URL from the "Share > Embed a map" dialog, the five
-    // Maps Embed API modes, and My Maps. The mode segment is an allowlist so
-    // that invented paths under /maps/embed/ are not accepted.
+    // Maps Embed API modes, and My Maps — including the /u/<n> account segment
+    // that My Maps adds in a multi-account session. Both the account index and
+    // the mode segment are constrained so that invented paths under
+    // /maps/embed/ are not accepted.
     regexMatch: [
       new RegExp(
-        "^https?://(?:www\\.)?google\\.com/maps(?:/d)?/embed(?:/v1/(?:place|view|directions|streetview|search))?\\?(.*)$"
+        "^https?://(?:www\\.)?google\\.com/maps(?:/d(?:/u/\\d+)?)?/embed(?:/v1/(?:place|view|directions|streetview|search))?\\?(.*)$"
       ),
     ],
     transformMatch: (matches: RegExpMatchArray) => matches[0],

--- a/shared/editor/embeds/index.tsx
+++ b/shared/editor/embeds/index.tsx
@@ -335,7 +335,14 @@ const embeds: EmbedDescriptor[] = [
     id: "google-maps",
     title: "Google Maps",
     keywords: "maps",
-    regexMatch: [new RegExp("^https?://www\\.google\\.com/maps/embed\\?(.*)$")],
+    // Covers the `pb=` URL from the "Share > Embed a map" dialog, the five
+    // Maps Embed API modes, and My Maps. The mode segment is an allowlist so
+    // that invented paths under /maps/embed/ are not accepted.
+    regexMatch: [
+      new RegExp(
+        "^https?://(?:www\\.)?google\\.com/maps(?:/d)?/embed(?:/v1/(?:place|view|directions|streetview|search))?\\?(.*)$"
+      ),
+    ],
     transformMatch: (matches: RegExpMatchArray) => matches[0],
     icon: <Img src="/images/google-maps.png" alt="Google Maps" />,
   }),

--- a/shared/editor/embeds/index.tsx
+++ b/shared/editor/embeds/index.tsx
@@ -345,7 +345,24 @@ const embeds: EmbedDescriptor[] = [
         "^https?://(?:www\\.)?google\\.com/maps(?:/d(?:/u/\\d+)?)?/embed(?:/v1/(?:place|view|directions|streetview|search))?\\?(.*)$"
       ),
     ],
-    transformMatch: (matches: RegExpMatchArray) => matches[0],
+    // The key goes on the iframe src, never on the node's href, so it stays
+    // out of document content, exports and shares, and rotating it does not
+    // mean editing documents.
+    transformMatch: (matches: RegExpMatchArray) => {
+      const url = matches[0];
+      const key = env.GOOGLE_MAPS_EMBED_API_KEY;
+
+      // Only the Maps Embed API takes a key; the legacy `?pb=` share URL and
+      // My Maps do not. A key already in the URL wins, so documents written
+      // before this existed keep working.
+      if (!key || !url.includes("/maps/embed/v1/") || /[?&]key=/.test(url)) {
+        return url;
+      }
+
+      // The matcher requires a query string, so there is always a `?` to
+      // append to.
+      return `${url}&key=${encodeURIComponent(key)}`;
+    },
     icon: <Img src="/images/google-maps.png" alt="Google Maps" />,
   }),
   new EmbedDescriptor({


### PR DESCRIPTION
> **Stacked on #13338.** That PR fixes the matcher so Maps Embed API URLs are recognised at all; without it a `/maps/embed/v1/…` URL never reaches `transformMatch` and this change is unreachable. The diff here currently shows both commits — happy to rebase once #13338 lands, or to fold them together if you would rather have one PR.

### Summary

The Maps Embed API requires a `key` parameter on every `/maps/embed/v1/*` URL. Without this, every author has to paste the key into the document body — which puts it into document content, exports, backups and public shares, and means rotating it is an edit to every document that contains a map.

The key is a client-side key by design and will always be visible in the rendered page source; the control is the HTTP referrer restriction, not secrecy. But there is still no reason for it to live in document content.

### Changes

A new optional `GOOGLE_MAPS_EMBED_API_KEY`, annotated `@Public` so it reaches `window.env`, plus an `.env.sample` entry pointing at [Get an API key](https://developers.google.com/maps/documentation/embed/get-api-key) and noting the referrer restriction.

`transformMatch` on the `google-maps` descriptor appends it. Reading public env from shared editor code follows the existing pattern in `shared/editor/rules/links.ts`, which already reads `env.URL` and the S3 URLs.

This lands in the right place because `Embed.toDOM` feeds `transformMatch` to the iframe `src` while `data-canonical-url` keeps the original href — so the stored node attribute and the serialised markdown stay clean, and the key appears only in the rendered DOM.

Three guards:

- only `/maps/embed/v1/` URLs — the legacy `pb=` share URL and My Maps take no key
- a key already in the URL wins, so documents written before this keep working with whatever the author pasted
- with nothing configured the URL is returned untouched and Google renders its own error, which names what is missing

The `v1` URL always carries a query string, because the matcher requires `?`, so appending with `&` is safe.

### Tests

Six cases added to `shared/editor/embeds/index.test.ts`: appended to a `v1` URL, percent-encoded, inline key wins, legacy `pb=` untouched, My Maps untouched, absent key untouched.

Verified the variable actually reaches the client rather than only `process.env` — ran the server with the key set and inspected `env.public`: present, and it survives the JSON serialisation into `window.env`. Worth noting for anyone checking the same thing that `PublicEnvironmentRegister` registers on `process.nextTick`, so reading `env.public` synchronously at import time shows an empty object.

`yarn test:shared` 1193 passed; `yarn lint`, `oxfmt` and `yarn tsc` clean.

### Deployment note

A referrer-restricted key ends up in the page source of every document containing a map, including anonymous public shares. That is expected for this API — the request still originates from the Outline domain, so the restriction applies — but it is worth being explicit about in the docs if this lands.