### PR TITLE
fix: Improve BadGatewayError reporting

### DIFF
--- a/app/utils/ApiClient.ts
+++ b/app/utils/ApiClient.ts
@@ -263,14 +263,28 @@ class ApiClient {
     // raw body is captured for diagnosis.
     if (response.status === 502) {
       const text = await response.text();
-      const err = new BadGatewayError(text);
 
-      Logger.error("BadGatewayError", err, {
-        url: urlToFetch,
-        requestTime: Math.round(timeEnd - timeStart),
-        responseText: text,
-        responseHeaders: Object.fromEntries(response.headers.entries()),
-      });
+      // Gateways often respond with an empty body, or an HTML error page that is
+      // too long to read as a title, so the endpoint leads the message.
+      const detail = text.trim().slice(0, 200);
+      const err = new BadGatewayError(
+        detail
+          ? `Bad gateway response from ${path}: ${detail}`
+          : `Bad gateway response from ${path} with empty body`
+      );
+
+      Logger.error(
+        "BadGatewayError",
+        err,
+        {
+          url: urlToFetch,
+          requestTime: Math.round(timeEnd - timeStart),
+          responseText: text,
+          responseHeaders: Object.fromEntries(response.headers.entries()),
+        },
+        // Grouped by endpoint, as the stack trace is identical for every 502.
+        ["BadGatewayError", path]
+      );
       throw err;
     }
 

--- a/app/utils/Logger.ts
+++ b/app/utils/Logger.ts
@@ -67,11 +67,16 @@ class Logger {
    * @param message A description of the error
    * @param error The error that occurred
    * @param extra Arbitrary data to be logged that will appear in prod logs
+   * @param fingerprint Overrides how the error is grouped when reported
    */
-  error(message: string, error: Error, extra?: Extra) {
+  error(message: string, error: Error, extra?: Extra, fingerprint?: string[]) {
     if (env.SENTRY_DSN) {
       Sentry.withScope(function (scope) {
         scope.setLevel("error");
+
+        if (fingerprint) {
+          scope.setFingerprint(fingerprint);
+        }
 
         for (const key in extra) {
           scope.setExtra(key, extra[key]);

--- a/app/utils/errors.ts
+++ b/app/utils/errors.ts
@@ -1,40 +1,70 @@
 import ExtendableError from "es6-error";
 
+// Note: `name` is assigned explicitly on each error rather than inherited from
+// the constructor name, which is mangled by the production build and would
+// otherwise be reported as a single letter.
+
 /** Error thrown when the user is not authorized to perform a request. */
-export class AuthorizationError extends ExtendableError {}
+export class AuthorizationError extends ExtendableError {
+  name = "AuthorizationError";
+}
 
 /** Error thrown when the server could not understand the request. */
-export class BadRequestError extends ExtendableError {}
+export class BadRequestError extends ExtendableError {
+  name = "BadRequestError";
+}
 
 /** Error thrown when a network-level failure prevents a request. */
-export class NetworkError extends ExtendableError {}
+export class NetworkError extends ExtendableError {
+  name = "NetworkError";
+}
 
 /** Error thrown when the requested resource could not be found. */
-export class NotFoundError extends ExtendableError {}
+export class NotFoundError extends ExtendableError {
+  name = "NotFoundError";
+}
 
 /** Error thrown when the request requires payment or an upgraded plan. */
-export class PaymentRequiredError extends ExtendableError {}
+export class PaymentRequiredError extends ExtendableError {
+  name = "PaymentRequiredError";
+}
 
 /** Error thrown when a request is made while the client is offline. */
-export class OfflineError extends ExtendableError {}
+export class OfflineError extends ExtendableError {
+  name = "OfflineError";
+}
 
 /** Error thrown when the service is temporarily unavailable. */
-export class ServiceUnavailableError extends ExtendableError {}
+export class ServiceUnavailableError extends ExtendableError {
+  name = "ServiceUnavailableError";
+}
 
 /** Error thrown when an upstream server returned an invalid response. */
-export class BadGatewayError extends ExtendableError {}
+export class BadGatewayError extends ExtendableError {
+  name = "BadGatewayError";
+}
 
 /** Error thrown when the request was well-formed but could not be processed. */
-export class UnprocessableEntityError extends ExtendableError {}
+export class UnprocessableEntityError extends ExtendableError {
+  name = "UnprocessableEntityError";
+}
 
 /** Error thrown when the client has exceeded the allowed request rate. */
-export class RateLimitExceededError extends ExtendableError {}
+export class RateLimitExceededError extends ExtendableError {
+  name = "RateLimitExceededError";
+}
 
 /** Error thrown when the client closed the connection before a response. */
-export class ClientClosedRequestError extends ExtendableError {}
+export class ClientClosedRequestError extends ExtendableError {
+  name = "ClientClosedRequestError";
+}
 
 /** Error thrown when a request fails for a generic reason. */
-export class RequestError extends ExtendableError {}
+export class RequestError extends ExtendableError {
+  name = "RequestError";
+}
 
 /** Error thrown when the client version is too old to use the API. */
-export class UpdateRequiredError extends ExtendableError {}
+export class UpdateRequiredError extends ExtendableError {
+  name = "UpdateRequiredError";
+}


### PR DESCRIPTION
502 responses were being reported without a usable title — the error class name is mangled by the production build and gateways commonly return an empty body.

- Assign an explicit `name` to client error classes so they survive minification
- Include the endpoint in the message, and truncate HTML gateway error pages
- Group 502s per endpoint, as the stack trace is identical for every one