### PR TITLE
fix: Back off repeated confirmation emails for share subscriptions

### DIFF
--- a/server/models/ShareSubscription.ts
+++ b/server/models/ShareSubscription.ts
@@ -11,6 +11,7 @@ import {
   Scopes,
 } from "sequelize-typescript";
 import { subHours } from "date-fns";
+import { Hour } from "@shared/utils/time";
 import { ValidationError } from "@server/errors";
 import Document from "./Document";
 import Share from "./Share";
@@ -76,6 +77,9 @@ class ShareSubscription extends IdModel<
   /** Maximum number of unique email subscriptions allowed per IP address. */
   static maxSubscriptionsPerIP = 3;
 
+  /** Minimum time in milliseconds to wait before a confirmation email may be resent. */
+  static minResendInterval = Hour.ms;
+
   /**
    * Enforce a per-IP rate limit on subscription creation to prevent abuse.
    *
@@ -117,6 +121,21 @@ class ShareSubscription extends IdModel<
    */
   get isUnsubscribed(): boolean {
     return !!this.unsubscribedAt;
+  }
+
+  /**
+   * Whether a confirmation email may be sent again for this subscription. The
+   * required wait doubles as the subscription ages, so an unconfirmed address
+   * cannot be mailed repeatedly.
+   */
+  get canResendConfirmation(): boolean {
+    const now = Date.now();
+    const age = now - this.createdAt.getTime();
+    const sinceLastSend = now - this.updatedAt.getTime();
+
+    return (
+      sinceLastSend >= Math.max(age / 2, ShareSubscription.minResendInterval)
+    );
   }
 
   /**

--- a/server/routes/api/shares/shares.test.ts
+++ b/server/routes/api/shares/shares.test.ts
@@ -1511,6 +1511,71 @@ describe("#shares.subscribe", () => {
     expect(subscription.confirmedAt).toBeNull();
   });
 
+  it("should resend confirmation for a stale unconfirmed subscription", async () => {
+    const share = await buildShare();
+    const subscription = await ShareSubscription.create({
+      shareId: share.id,
+      documentId: share.documentId!,
+      email: "user@example.com",
+      emailFingerprint:
+        ShareSubscription.normalizeEmailFingerprint("user@example.com"),
+      secret: randomString(32),
+    });
+    const staleDate = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    await ShareSubscription.update(
+      { createdAt: staleDate, updatedAt: staleDate },
+      { where: { id: subscription.id }, silent: true }
+    );
+    const previousSecret = subscription.secret;
+
+    const res = await server.post("/api/shares.subscribe", {
+      body: {
+        shareId: share.id,
+        documentId: share.documentId!,
+        email: "user@example.com",
+      },
+    });
+    expect(res.status).toEqual(200);
+
+    await subscription.reload();
+    expect(subscription.secret).not.toBe(previousSecret);
+  });
+
+  it("should back off resending confirmation as the subscription ages", async () => {
+    const share = await buildShare();
+    const subscription = await ShareSubscription.create({
+      shareId: share.id,
+      documentId: share.documentId!,
+      email: "user@example.com",
+      emailFingerprint:
+        ShareSubscription.normalizeEmailFingerprint("user@example.com"),
+      secret: randomString(32),
+    });
+    // Created ten days ago with a confirmation resent two hours ago
+    await ShareSubscription.update(
+      {
+        createdAt: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000),
+        updatedAt: new Date(Date.now() - 2 * 60 * 60 * 1000),
+      },
+      { where: { id: subscription.id }, silent: true }
+    );
+    const previousSecret = subscription.secret;
+
+    const res = await server.post("/api/shares.subscribe", {
+      body: {
+        shareId: share.id,
+        documentId: share.documentId!,
+        email: "user@example.com",
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.success).toBe(true);
+
+    await subscription.reload();
+    expect(subscription.secret).toBe(previousSecret);
+  });
+
   it("should fail for unpublished share", async () => {
     const share = await buildShare({ published: false });
     const res = await server.post("/api/shares.subscribe", {

--- a/server/routes/api/shares/shares.ts
+++ b/server/routes/api/shares/shares.ts
@@ -2,7 +2,6 @@ import Router from "koa-router";
 import { isUndefined } from "es-toolkit/compat";
 import type { FindOptions, WhereAttributeHash, WhereOptions } from "sequelize";
 import { Op } from "sequelize";
-import { subMinutes } from "date-fns";
 import { randomString } from "@shared/random";
 import { errToId } from "@shared/utils/error";
 import { QueryNotices, TeamPreference } from "@shared/types";
@@ -524,8 +523,8 @@ router.post(
         existing.secret = randomString(32);
         existing.email = email;
         await existing.save({ transaction });
-      } else if (existing.createdAt > subMinutes(new Date(), 60)) {
-        // Recently created, not yet confirmed — don't spam
+      } else if (!existing.canResendConfirmation) {
+        // Confirmation was sent recently, not yet confirmed — don't spam
         ctx.body = { success: true };
         return;
       } else {


### PR DESCRIPTION
Requesting a subscription for an address that already has an unconfirmed subscription would resend the confirmation email on a fixed hourly window, with no upper bound on how many could be sent over time.

- Replaces the fixed window with a `canResendConfirmation` check on the model, derived from the existing created and updated timestamps — no schema change
- The required wait now doubles as the subscription ages (1h, 2h, 4h, …), so the first resend is unchanged for a genuine request but repeats taper off quickly