### PR TITLE
fix: Tighten scoping of share subscription notifications

### DIFF
--- a/server/queues/tasks/ShareSubscriptionNotificationsTask.test.ts
+++ b/server/queues/tasks/ShareSubscriptionNotificationsTask.test.ts
@@ -1,8 +1,17 @@
 import { subHours } from "date-fns";
 import { randomString } from "@shared/random";
+import documentMover from "@server/commands/documentMover";
 import ShareDocumentUpdatedEmail from "@server/emails/templates/ShareDocumentUpdatedEmail";
-import { ShareSubscription } from "@server/models";
-import { buildDocument, buildShare } from "@server/test/factories";
+import { Collection, ShareSubscription } from "@server/models";
+import {
+  buildCollection,
+  buildDocument,
+  buildDraftDocument,
+  buildShare,
+  buildTeam,
+  buildUser,
+} from "@server/test/factories";
+import { withAPIContext } from "@server/test/support";
 import ShareSubscriptionNotificationsTask from "./ShareSubscriptionNotificationsTask";
 
 const ip = "127.0.0.1";
@@ -348,6 +357,126 @@ describe("ShareSubscriptionNotificationsTask", () => {
       documentId: sibling.id,
       teamId: sibling.teamId,
       actorId: sibling.createdById,
+      modelId: "revision-id",
+      ip,
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("should not send when updated child document is an unpublished draft", async () => {
+    const spy = vi.spyOn(ShareDocumentUpdatedEmail.prototype, "schedule");
+
+    const parent = await buildDocument();
+    const draft = await buildDraftDocument({
+      parentDocumentId: parent.id,
+      collectionId: parent.collectionId,
+      teamId: parent.teamId,
+      userId: parent.createdById,
+    });
+    const share = await buildShare({
+      documentId: parent.id,
+      teamId: parent.teamId,
+      includeChildDocuments: true,
+    });
+    await ShareSubscription.create({
+      shareId: share.id,
+      documentId: parent.id,
+      email: "subscriber@example.com",
+      emailFingerprint: "subscriber@example.com",
+      secret: randomString(32),
+      confirmedAt: new Date(),
+    });
+
+    const task = new ShareSubscriptionNotificationsTask();
+    await task.perform({
+      name: "revisions.create",
+      documentId: draft.id,
+      teamId: draft.teamId,
+      actorId: draft.createdById,
+      modelId: "revision-id",
+      ip,
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("should not send when subscribed document has moved out of the shared collection", async () => {
+    const spy = vi.spyOn(ShareDocumentUpdatedEmail.prototype, "schedule");
+
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const collection = await buildCollection({
+      teamId: team.id,
+      userId: user.id,
+    });
+    const other = await buildCollection({ teamId: team.id, userId: user.id });
+    const document = await buildDocument({
+      collectionId: collection.id,
+      teamId: team.id,
+      userId: user.id,
+    });
+    const share = await buildShare({
+      collectionId: collection.id,
+      teamId: team.id,
+      userId: user.id,
+      includeChildDocuments: true,
+    });
+    await ShareSubscription.create({
+      shareId: share.id,
+      documentId: document.id,
+      email: "subscriber@example.com",
+      emailFingerprint: "subscriber@example.com",
+      secret: randomString(32),
+      confirmedAt: new Date(),
+    });
+
+    await withAPIContext(user, (ctx) =>
+      documentMover(ctx, { document, collectionId: other.id })
+    );
+
+    const task = new ShareSubscriptionNotificationsTask();
+    await task.perform({
+      name: "revisions.create",
+      documentId: document.id,
+      teamId: document.teamId,
+      actorId: document.createdById,
+      modelId: "revision-id",
+      ip,
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("should not send when sharing is disabled on the collection", async () => {
+    const spy = vi.spyOn(ShareDocumentUpdatedEmail.prototype, "schedule");
+
+    const document = await buildDocument();
+    const share = await buildShare({
+      documentId: document.id,
+      teamId: document.teamId,
+    });
+    await ShareSubscription.create({
+      shareId: share.id,
+      documentId: document.id,
+      email: "subscriber@example.com",
+      emailFingerprint: "subscriber@example.com",
+      secret: randomString(32),
+      confirmedAt: new Date(),
+    });
+
+    const collection = await Collection.findByPk(document.collectionId!, {
+      rejectOnEmpty: true,
+    });
+    collection.sharing = false;
+    await collection.save();
+
+    const task = new ShareSubscriptionNotificationsTask();
+    await task.perform({
+      name: "revisions.create",
+      documentId: document.id,
+      teamId: document.teamId,
+      actorId: document.createdById,
       modelId: "revision-id",
       ip,
     });

--- a/server/queues/tasks/ShareSubscriptionNotificationsTask.ts
+++ b/server/queues/tasks/ShareSubscriptionNotificationsTask.ts
@@ -1,4 +1,6 @@
 import { subHours } from "date-fns";
+import { groupBy } from "es-toolkit/compat";
+import { loadPublicShare } from "@server/commands/shareLoader";
 import ShareDocumentUpdatedEmail from "@server/emails/templates/ShareDocumentUpdatedEmail";
 import Logger from "@server/logging/Logger";
 import { Document, Share, ShareSubscription } from "@server/models";
@@ -45,44 +47,48 @@ export default class ShareSubscriptionNotificationsTask extends BaseTask<Revisio
       ],
     });
 
-    for (const subscription of subscriptions) {
-      // Skip ancestor-scoped subscriptions when the share doesn't include
-      // child documents — the updated document wouldn't be accessible.
-      if (
-        subscription.documentId !== document.id &&
-        !subscription.share.includeChildDocuments
-      ) {
+    // Group by share so reachability is resolved once per share rather than
+    // once per subscriber.
+    for (const grouped of Object.values(groupBy(subscriptions, "shareId"))) {
+      const share = grouped[0].share;
+
+      // Only notify when the share would actually serve the updated document to
+      // an anonymous visitor — the document may have since become a draft,
+      // moved out of the shared tree, or had sharing disabled around it.
+      if (!(await this.isServedByShare(share, document))) {
         continue;
       }
 
-      // Throttle: only one notification per 6 hours
-      if (
-        subscription.lastNotifiedAt &&
-        subscription.lastNotifiedAt > subHours(new Date(), 6)
-      ) {
-        Logger.info(
-          "processor",
-          `suppressing share subscription notification to ${subscription.id} as recently notified`
-        );
-        continue;
-      }
-
-      const baseShareUrl = subscription.share.canonicalUrl;
+      const baseShareUrl = share.canonicalUrl;
       const shareUrl =
-        document.id !== subscription.share.documentId && document.path
+        document.id !== share.documentId && document.path
           ? `${baseShareUrl.replace(/\/$/, "")}${document.path}`
           : baseShareUrl;
 
-      await new ShareDocumentUpdatedEmail({
-        to: subscription.email,
-        shareSubscriptionId: subscription.id,
-        documentTitle: document.titleWithDefault,
-        shareUrl,
-        revisionId: event.modelId,
-      }).schedule();
+      for (const subscription of grouped) {
+        // Throttle: only one notification per 6 hours
+        if (
+          subscription.lastNotifiedAt &&
+          subscription.lastNotifiedAt > subHours(new Date(), 6)
+        ) {
+          Logger.info(
+            "processor",
+            `suppressing share subscription notification to ${subscription.id} as recently notified`
+          );
+          continue;
+        }
 
-      subscription.lastNotifiedAt = new Date();
-      await subscription.save();
+        await new ShareDocumentUpdatedEmail({
+          to: subscription.email,
+          shareSubscriptionId: subscription.id,
+          documentTitle: document.titleWithDefault,
+          shareUrl,
+          revisionId: event.modelId,
+        }).schedule();
+
+        subscription.lastNotifiedAt = new Date();
+        await subscription.save();
+      }
     }
   }
 
@@ -90,5 +96,29 @@ export default class ShareSubscriptionNotificationsTask extends BaseTask<Revisio
     return {
       priority: TaskPriority.Background,
     };
+  }
+
+  /**
+   * Whether the given share publicly serves the given document, using the same
+   * loader that backs the public share endpoints.
+   *
+   * @param share the published share to check.
+   * @param document the document to check reachability of.
+   * @returns true if an anonymous visitor could read the document.
+   */
+  private async isServedByShare(
+    share: Share,
+    document: Document
+  ): Promise<boolean> {
+    try {
+      await loadPublicShare({
+        id: share.id,
+        documentId: document.id,
+        teamId: share.teamId,
+      });
+      return true;
+    } catch (_err) {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
Share subscription notifications previously decided recipients by walking the document's parent chain, which could diverge from what a share actually serves.

- Resolve recipients through `loadPublicShare`, the same loader backing the public share endpoints, so notifications and access stay consistent
- Picks up the conditions the previous check missed, including tree membership, publish state, and sharing settings on the surrounding collection and team
- Group subscriptions by share so reachability is resolved once per share rather than once per subscriber