### PR TITLE
fix: Build canonical redirect url from team, not request host

### DIFF
--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -1,9 +1,11 @@
+import { randomUUID } from "node:crypto";
 import { IntegrationService, IntegrationType } from "@shared/types";
 import env from "@server/env";
 import {
   buildShare,
   buildDocument,
   buildIntegration,
+  buildTeam,
 } from "@server/test/factories";
 import { getTestServer } from "@server/test/support";
 
@@ -291,5 +293,56 @@ describe("scanner path 404s", () => {
     expect(res.status).toEqual(200);
     const body = await res.json();
     expect(body.issuer).toBeDefined();
+  });
+});
+
+describe("canonical host redirects", () => {
+  it("should redirect to the current subdomain when a previous one is used", async () => {
+    const id = randomUUID();
+    const subdomain = `current-${id}`;
+    const previousSubdomain = `previous-${id}`;
+    await buildTeam({
+      subdomain,
+      previousSubdomains: [previousSubdomain],
+    });
+
+    const res = await server.get("/search?query=hello", {
+      headers: { Host: `${previousSubdomain}.outline.dev` },
+      redirect: "manual",
+    });
+
+    expect(res.status).toEqual(302);
+    expect(res.headers.get("location")).toEqual(
+      `https://${subdomain}.outline.dev/search?query=hello`
+    );
+  });
+
+  it("should redirect to the custom domain when one is set", async () => {
+    const id = randomUUID();
+    const subdomain = `wombat-${id}`;
+    const domain = `docs-${id}.example.com`;
+    await buildTeam({ subdomain, domain });
+
+    const res = await server.get("/doc/getting-started", {
+      headers: { Host: `${subdomain}.outline.dev` },
+      redirect: "manual",
+    });
+
+    expect(res.status).toEqual(302);
+    expect(res.headers.get("location")).toEqual(
+      `https://${domain}/doc/getting-started`
+    );
+  });
+
+  it("should not redirect a request already on the canonical host", async () => {
+    const subdomain = `canonical-${randomUUID()}`;
+    await buildTeam({ subdomain });
+
+    const res = await server.get("/search", {
+      headers: { Host: `${subdomain}.outline.dev` },
+      redirect: "manual",
+    });
+
+    expect(res.status).toEqual(200);
   });
 });

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -244,23 +244,14 @@ router.get("*", async (ctx, next) => {
       }
     }
 
-    // Redirect all requests to custom domain if one is set
-    else if (team?.domain) {
-      if (team.domain !== ctx.hostname) {
-        ctx.redirect(ctx.href.replace(ctx.hostname, team.domain));
-        return;
-      }
-    }
-
-    // Redirect if subdomain is not the current team's subdomain
-    else if (team?.subdomain) {
-      const { teamSubdomain } = parseDomain(ctx.href);
-      if (team?.subdomain !== teamSubdomain) {
-        ctx.redirect(
-          ctx.href.replace(`//${teamSubdomain}.`, `//${team.subdomain}.`)
-        );
-        return;
-      }
+    // Redirect to the team's canonical url, taking into account custom domains
+    // and hosted subdomains, if the request arrived on a different host.
+    else if (team && !team.isTeamUrl(ctx.href)) {
+      const url = new URL(team.url);
+      url.pathname = ctx.path;
+      url.search = ctx.search;
+      ctx.redirect(url.toString());
+      return;
     }
   }
 


### PR DESCRIPTION
Requests arriving on the wrong host were redirected by string-replacing parts of the incoming request url, which meant the redirect target was partly derived from the request itself.

- Build the redirect from the team's canonical url and carry only the path and query across
- Use the existing `isTeamUrl` check so custom domains and hosted subdomains share one code path
