### PR TITLE
fix: Crash inserting a template with no content from the block menu

### DIFF
--- a/app/editor/components/BlockMenu.tsx
+++ b/app/editor/components/BlockMenu.tsx
@@ -34,7 +34,7 @@ function useTemplateMenuItem(): MenuItem | undefined {
     }
 
     const allTemplates = templatesStore.orderedData.filter(
-      (template) => template.isActive
+      (template) => template.isActive && !!template.data
     );
     const hasTemplates = allTemplates.some(
       (template) =>

--- a/server/presenters/template.ts
+++ b/server/presenters/template.ts
@@ -1,3 +1,4 @@
+import { ProsemirrorDataHelper } from "@shared/utils/ProsemirrorDataHelper";
 import type { Template } from "@server/models";
 import presentUser from "./user";
 
@@ -7,7 +8,7 @@ function presentTemplate(template: Template) {
     url: template.path,
     urlId: template.urlId,
     title: template.title,
-    data: template.content,
+    data: template.content ?? ProsemirrorDataHelper.getEmpty(),
     icon: template.icon,
     color: template.color,
     createdAt: template.createdAt,

--- a/server/routes/api/templates/templates.test.ts
+++ b/server/routes/api/templates/templates.test.ts
@@ -1,4 +1,5 @@
 import { CollectionPermission } from "@shared/types";
+import { ProsemirrorDataHelper } from "@shared/utils/ProsemirrorDataHelper";
 import { UserMembership } from "@server/models";
 import {
   buildAdmin,
@@ -26,6 +27,21 @@ describe("#templates.list", () => {
     expect(res.status).toEqual(200);
     expect(body.data.length).toEqual(1);
     expect(body.data[0].id).toEqual(template.id);
+  });
+
+  it("should return an empty document for templates without content", async () => {
+    const user = await buildUser();
+    await buildTemplate({
+      userId: user.id,
+      teamId: user.teamId,
+      content: null,
+    });
+
+    const res = await server.post("/api/templates.list", user);
+
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.data[0].data).toEqual(ProsemirrorDataHelper.getEmpty());
   });
 
   it("should list templates in collection", async () => {


### PR DESCRIPTION
Template content is nullable in the database, but the presenter passed it through raw — so a template without content reached the client with no data at all, and inserting it from the editor block menu threw.

- Templates API now always returns a valid document, falling back to an empty one
- Templates without content are no longer offered in the editor block menu

Fixes OUTLINE-CLOUD-CZM