### PR TITLE
ci: Don't block merging on the dependency audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,8 +159,8 @@ jobs:
 
   # Always runs, so it can be used as the single required status check. Jobs
   # above are skipped when irrelevant to the changes, which is a pass here.
-  # Audit is intentionally excluded, it reports advisories that often have no
-  # fix available and should not block merging.
+  # Audit is intentionally excluded, it reports advisories that can have no
+  # fix available or affect dev only and should not block merging.
   ci:
     needs: [changes, lint, actionlint, types, test, test-server, bundle-size]
     if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/install
-      - run: yarn npm audit --severity high --recursive --environment production
+      - id: audit
+        continue-on-error: true
+        run: yarn npm audit --severity high --recursive --environment production
+      - name: Warn on vulnerabilities
+        if: ${{ steps.audit.outcome == 'failure' }}
+        run: echo "::warning title=Audit::yarn npm audit reported high severity vulnerabilities, see the step above for details."
 
   test:
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,12 +93,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/install
-      - id: audit
-        continue-on-error: true
-        run: yarn npm audit --severity high --recursive --environment production
-      - name: Warn on vulnerabilities
-        if: ${{ steps.audit.outcome == 'failure' }}
-        run: echo "::warning title=Audit::yarn npm audit reported high severity vulnerabilities, see the step above for details."
+      - run: yarn npm audit --severity high --recursive --environment production
 
   test:
     needs: changes
@@ -164,8 +159,10 @@ jobs:
 
   # Always runs, so it can be used as the single required status check. Jobs
   # above are skipped when irrelevant to the changes, which is a pass here.
+  # Audit is intentionally excluded, it reports advisories that often have no
+  # fix available and should not block merging.
   ci:
-    needs: [changes, lint, actionlint, types, audit, test, test-server, bundle-size]
+    needs: [changes, lint, actionlint, types, test, test-server, bundle-size]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
- The audit job still runs and still fails when high severity advisories are reported in production dependencies
- It is no longer part of the aggregate `ci` status check, so it doesn't block merging
- Advisories are frequently in transitive dependencies with no fix available yet, and shouldn't hold up unrelated work