### PR TITLE
chore(deps): dedupe js-yaml onto a single version

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -13422,18 +13422,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.1.0":
-  version: 4.3.0
-  resolution: "js-yaml@npm:4.3.0"
-  dependencies:
-    argparse: "npm:^2.0.1"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
-  languageName: node
-  linkType: hard
-
-"js-yaml@npm:^4.3.1":
+"js-yaml@npm:^4.1.0, js-yaml@npm:^4.3.1":
   version: 4.3.1
   resolution: "js-yaml@npm:4.3.1"
   dependencies:


### PR DESCRIPTION
- The transitive `^4.1.0` descriptor was still resolving to an older release while the direct dependency had already moved forward
- Re-resolved so both descriptors share a single lockfile entry

Lockfile only — no package.json or config changes.