### PR TITLE
fix: Custom color picker should open on the current color

### DIFF
--- a/app/components/IconPicker/components/IconColorPicker.tsx
+++ b/app/components/IconPicker/components/IconColorPicker.tsx
@@ -31,6 +31,7 @@ const IconColorPicker = ({ activeColor, onSelect }: Props) => {
       <PresetColors activeColor={selectedColor} onClick={handleSelect} />
       <SwatchButton
         color={color}
+        pickerColor={selectedColor}
         active={!isBuiltInColor}
         size={SWATCH_SIZE}
         onChange={handleSelect}

--- a/app/components/SwatchButton.tsx
+++ b/app/components/SwatchButton.tsx
@@ -20,6 +20,8 @@ import EventBoundary from "@shared/components/EventBoundary";
 type SwatchButtonProps = {
   /** The current color value in hex format. If no color is passed a radial gradient will be shown */
   color?: string;
+  /** The color selected in the picker when opened. Defaults to `color` */
+  pickerColor?: string;
   /** Whether the swatch button is currently active/selected */
   active?: boolean;
   /** The size of the button in pixels */
@@ -34,6 +36,7 @@ type SwatchButtonProps = {
 
 export const SwatchButton: React.FC<SwatchButtonProps> = ({
   color,
+  pickerColor,
   active = false,
   size = 24,
   onChange,
@@ -56,7 +59,7 @@ export const SwatchButton: React.FC<SwatchButtonProps> = ({
   const pickerContent = (
     <StyledColorPicker
       alpha={false}
-      activeColor={color}
+      activeColor={pickerColor ?? color}
       onSelect={(c) => onChange(c)}
     />
   );


### PR DESCRIPTION
- The custom swatch in the icon picker intentionally passes no color so it renders its gradient, but that also left the picker inside with no active color, so it opened on an unrelated default.
- Adds an optional `pickerColor` prop to the swatch button so the button appearance and the picker's starting value can differ.
- The icon color picker now passes the currently selected color through, so opening the custom picker starts from whatever is active.