### PR TITLE
fix: Publish button should only show ellipsis when a dialog will open

### DIFF
--- a/app/scenes/Document/components/Header.tsx
+++ b/app/scenes/Document/components/Header.tsx
@@ -287,7 +287,7 @@ function DocumentHeader({
                 hideOnActionDisabled
                 hideIcon
               >
-                {t("Publish")}…
+                {document.collectionId ? t("Publish") : `${t("Publish")}…`}
               </Button>
             </Action>
           )}


### PR DESCRIPTION
The Publish button in the document header always showed a trailing ellipsis, implying further input is required. The publish action only opens the location picker dialog when the draft has no collection — otherwise it publishes immediately.

- Show the ellipsis only for drafts without a collection