### PR TITLE
fix: Focus link editor input when opened with Cmd+K

### DIFF
--- a/app/editor/components/LinkEditor.tsx
+++ b/app/editor/components/LinkEditor.tsx
@@ -80,6 +80,15 @@ const LinkEditor: React.FC<Props> = ({
     }
   }, [trimmedQuery, request]);
 
+  // Focus imperatively rather than with the autoFocus attribute, which only
+  // applies on mount – the editor can already be open when focus is requested.
+  useEffect(() => {
+    if (autoFocus) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [autoFocus]);
+
   useOnClickOutside(wrapperRef, (ev) => {
     // If the link is totally empty or only spaces then remove the mark
     if (!trimmedQuery) {
@@ -214,7 +223,6 @@ const LinkEditor: React.FC<Props> = ({
           onKeyDown={handleKeyDown}
           onChange={handleSearch}
           onFocus={handleSearch}
-          autoFocus={autoFocus}
           readOnly={!view.editable}
         />
         {actions.map((action, index) => {

--- a/app/editor/components/SelectionToolbar.tsx
+++ b/app/editor/components/SelectionToolbar.tsx
@@ -199,9 +199,7 @@ export function SelectionToolbar(props: Props) {
         ev.preventDefault();
         ev.stopPropagation();
         setAutoFocusLinkInput(true);
-        setActiveToolbar(
-          activeToolbar === Toolbar.Link ? Toolbar.Menu : Toolbar.Link
-        );
+        setActiveToolbar(Toolbar.Link);
       }
     },
     view.dom,

--- a/app/editor/components/SelectionToolbar.tsx
+++ b/app/editor/components/SelectionToolbar.tsx
@@ -126,21 +126,20 @@ export function SelectionToolbar(props: Props) {
     isNoticeSelection,
   ]);
 
-  React.useLayoutEffect(() => {
-    if (autoFocusLinkInput && activeToolbar !== Toolbar.Link) {
-      setAutoFocusLinkInput(false);
-    }
-  }, [activeToolbar, autoFocusLinkInput]);
-
+  // Focus is re-armed when the link editor closes rather than whenever the
+  // active toolbar isn't the link editor – the two pieces of state are not
+  // always updated in the same render.
   const prevActiveToolbar = React.useRef(activeToolbar);
   React.useLayoutEffect(() => {
     if (
       prevActiveToolbar.current === Toolbar.Link &&
-      activeToolbar !== Toolbar.Link &&
-      !readOnly &&
-      isActive
+      activeToolbar !== Toolbar.Link
     ) {
-      view.focus();
+      setAutoFocusLinkInput(false);
+
+      if (!readOnly && isActive) {
+        view.focus();
+      }
     }
     prevActiveToolbar.current = activeToolbar;
   }, [activeToolbar, readOnly, isActive, view]);


### PR DESCRIPTION
Pressing Cmd+K did not reliably land focus in the link editor input.

- Cmd+K now always opens the link editor instead of toggling back to the formatting menu when it's already showing (Escape and the back button still return to formatting controls)
- Focus the input imperatively rather than with `autoFocus`, which React only applies on mount — so it also works when the link editor is already open for an existing link
- Any existing URL is selected on focus, so typing replaces it