### PR TITLE
fix: Make the whole toggle title clickable in read only mode

### DIFF
--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -2738,6 +2738,9 @@ li > .${EditorStyleHelper.toggleBlock} {
       margin-top: 0;
     }
     > .${EditorStyleHelper.toggleBlockHead} {
+      /* The title acts as a fold/unfold control when the document is read-only */
+      ${props.readOnly ? "cursor: var(--pointer);" : ""}
+
       > * {
         margin-top: 0;
       }

--- a/shared/editor/nodes/ToggleBlock.ts
+++ b/shared/editor/nodes/ToggleBlock.ts
@@ -542,19 +542,6 @@ export default class ToggleBlock extends Node {
             { nodeId: id, target: "container_toggle>:firstChild" }
           )
         );
-
-        // If doc is read-only, add a decoration to show pointer cursor on the head
-        // to indicate it's clickable for toggling
-        if (this.editor.props.readOnly) {
-          decorations.push(
-            Decoration.inline(
-              block.pos + 1,
-              block.pos + 1 + block.node.firstChild!.nodeSize,
-              { style: "cursor: pointer" },
-              { nodeId: id, target: "container_toggle>:firstChild" }
-            )
-          );
-        }
       });
 
     return DecorationSet.create(doc, decorations);

--- a/shared/editor/nodes/ToggleBlockView.ts
+++ b/shared/editor/nodes/ToggleBlockView.ts
@@ -45,7 +45,7 @@ export class ToggleBlockView implements NodeView {
 
     this.contentDOM = document.createElement("div");
     this.contentDOM.className = EditorStyleHelper.toggleBlockContent;
-    this.contentDOM.addEventListener("mousedown", this.handleToggleHeadClick);
+    this.contentDOM.addEventListener("click", this.handleToggleHeadClick);
 
     this.dom.appendChild(this.button);
     this.dom.appendChild(this.contentDOM);
@@ -68,33 +68,32 @@ export class ToggleBlockView implements NodeView {
   };
 
   private handleToggleHeadClick = (event: MouseEvent) => {
+    // When editable, clicking the title places the caret rather than toggling.
+    if (this.view.editable || event.button !== 0) {
+      return;
+    }
+
+    const target = event.target as HTMLElement;
     const head = this.contentDOM.querySelector(
       `.${EditorStyleHelper.toggleBlockHead}`
     );
-    if (!head || !head.contains(event.target as HTMLElement)) {
+    if (!head || !head.contains(target)) {
       return;
     }
 
-    const pos = this.getPos();
-    if (pos === undefined) {
+    // Let interactive elements within the title handle their own clicks.
+    const interactive = target.closest("a, button, input, label");
+    if (interactive && head.contains(interactive)) {
       return;
     }
 
-    if (!this.view.editable) {
-      // pos points "before" the toggle block node
-      // pos + 1 points "before" the toggle block head node(para | heading)
-      // pos + 2 points at "start" of the toggle block head node
-      const $headPos = this.view.state.doc.resolve(pos + 2);
-      const headStartCoords = this.view.coordsAtPos($headPos.start());
-      const headEndCoords = this.view.coordsAtPos($headPos.end());
-      if (
-        event.clientX >= headStartCoords.left &&
-        event.clientX <= headEndCoords.left
-      ) {
-        event.preventDefault();
-        this.handleToggle();
-      }
+    // Selecting text within the title should not fold or unfold it.
+    if (window.getSelection()?.isCollapsed === false) {
+      return;
     }
+
+    event.preventDefault();
+    this.handleToggle();
   };
 
   private handleToggle = () => {
@@ -168,10 +167,7 @@ export class ToggleBlockView implements NodeView {
 
   destroy() {
     this.button.removeEventListener("mousedown", this.handleToggleButtonClick);
-    this.contentDOM.removeEventListener(
-      "mousedown",
-      this.handleToggleHeadClick
-    );
+    this.contentDOM.removeEventListener("click", this.handleToggleHeadClick);
     window.removeEventListener("storage", this.boundBroadcastFoldState);
   }
 }


### PR DESCRIPTION
Clicking a toggle's title in a read only document only folded it when the click landed within a narrow horizontal range of the text, so clicks past the end of the title, in the padding to the right, or on a wrapped second line did nothing.

- Any click within the title row now folds or unfolds the toggle
- Links, the heading anchor, and other interactive elements in the title keep their own behaviour
- Selecting text in the title no longer toggles it, so titles can still be copied and commented on
- Pointer cursor now comes from a CSS rule covering the full row rather than a per-node decoration