### PR TITLE
fix: Stale workflow failing on Print outputs step

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,4 +27,7 @@ jobs:
           stale-pr-label: stale
           exempt-issue-labels: "security,pinned,A1"
       - name: Print outputs
-        run: echo "${{ steps.stale.outputs['staled-issues-prs'] }},${{ steps.stale.outputs['closed-issues-prs'] }}"
+        env:
+          STALED: ${{ steps.stale.outputs['staled-issues-prs'] }}
+          CLOSED: ${{ steps.stale.outputs['closed-issues-prs'] }}
+        run: echo "$STALED,$CLOSED"


### PR DESCRIPTION
The nightly "Close Stale PRs" job has been failing every run on its final step.

- The action's `staled-issues-prs` output is a JSON blob, and it was interpolated straight into the shell script — its quotes and the parentheses in the embedded timestamp got parsed as shell syntax, exiting 2.
- Pass both outputs through `env` so they're runtime variables rather than text substituted into the script.

The stale action itself was working correctly; only the trailing diagnostic echo failed, which was enough to mark the whole job red.