### PR TITLE
fix: Suppress global shortcuts when focus is in a keyboard control

### DIFF
--- a/app/hooks/useKeyDown.ts
+++ b/app/hooks/useKeyDown.ts
@@ -1,7 +1,7 @@
 import { useContext, useEffect } from "react";
 import { isModKey } from "@shared/utils/keyboard";
 import { SplitViewContext } from "~/components/SplitView/context";
-import isTextInput from "~/utils/isTextInput";
+import { isKeyboardWidget } from "~/utils/isKeyboardWidget";
 import { getFocusedSplitPane } from "~/utils/splitView";
 
 type Callback = (event: KeyboardEvent) => void;
@@ -9,6 +9,10 @@ type Callback = (event: KeyboardEvent) => void;
 export type KeyFilter = ((event: KeyboardEvent) => boolean) | string;
 
 export type Options = {
+  /**
+   * Fire even when focus is inside a control that handles its own keyboard
+   * input, such as a text input, menu, or dialog.
+   */
   allowInInput?: boolean;
   /** Require the platform modifier key (Cmd on macOS, Ctrl elsewhere) to be held. */
   metaKey?: boolean;
@@ -128,7 +132,7 @@ window.addEventListener("keydown", (event) => {
     }
 
     if (
-      !isTextInput(event.target as HTMLElement) ||
+      !isKeyboardWidget(event.target) ||
       registered.options?.allowInInput ||
       isModKey(event)
     ) {

--- a/app/utils/isKeyboardWidget.ts
+++ b/app/utils/isKeyboardWidget.ts
@@ -1,0 +1,39 @@
+import isTextInput from "./isTextInput";
+
+// ARIA roles for widgets that implement their own keyboard interaction, such as
+// arrow key navigation, typeahead, or dismissal. Focus usually sits on a
+// descendant of the widget, so ancestors are checked as well.
+// https://www.w3.org/WAI/ARIA/apg/patterns/
+const widgetRoles = [
+  "menu",
+  "menubar",
+  "listbox",
+  "combobox",
+  "tree",
+  "treegrid",
+  "grid",
+  "dialog",
+  "alertdialog",
+  "radiogroup",
+  "slider",
+  "spinbutton",
+];
+
+const widgetSelector = widgetRoles.map((role) => `[role="${role}"]`).join(",");
+
+/**
+ * Checks whether the given event target is, or is contained by, a control that
+ * handles its own keyboard input – a text input, or a widget such as a menu,
+ * listbox, or dialog. Global keyboard shortcuts should not fire while such a
+ * control holds focus, otherwise they compete with it for the same keys.
+ *
+ * @param target the event target to check.
+ * @returns true if the target handles its own keyboard input.
+ */
+export function isKeyboardWidget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) {
+    return false;
+  }
+
+  return isTextInput(target) || !!target.closest(widgetSelector);
+}


### PR DESCRIPTION
Single-letter shortcuts such as "m" to move a document were still active while a menu or dialog held focus, competing with the control's own key handling.

- Generalizes the text input check in `useKeyDown` to any element inside a control that handles its own keys
- Matches on the ARIA composite widget roles, so it covers menus, dialogs, popovers, select and suggestion lists without depending on the underlying menu library
- Existing escape hatches are unchanged — shortcuts registered with `allowInInput`, or those requiring the platform modifier, still fire