### PR TITLE
fix: Stop retrying document persistence indefinitely

### DIFF
--- a/server/collaboration/PersistenceExtension.ts
+++ b/server/collaboration/PersistenceExtension.ts
@@ -18,8 +18,14 @@ import type { withContext } from "./types";
 
 @trace()
 export default class PersistenceExtension implements Extension {
+  /** The maximum number of times persisting a single document will be retried. */
+  private static maxPersistFailures = 5;
+
   /** The names of documents that have changed since they were last persisted. */
   private unsavedDocumentNames = new Set<string>();
+
+  /** The number of consecutive persistence failures, keyed by document name. */
+  private persistFailureCounts = new Map<string, number>();
 
   async onLoadDocument({
     documentName,
@@ -166,13 +172,27 @@ export default class PersistenceExtension implements Extension {
         isLastConnection: clientsCount === 0,
         clientVersion,
       });
+
+      this.persistFailureCounts.delete(documentName);
     } catch (err) {
-      // Restore the flag so that a subsequent store will retry the write.
-      this.unsavedDocumentNames.add(documentName);
+      const failures = (this.persistFailureCounts.get(documentName) ?? 0) + 1;
+      const giveUp = failures >= PersistenceExtension.maxPersistFailures;
+
+      if (giveUp) {
+        // Stop retrying, the error is unlikely to be transient. Further changes
+        // to the document will set the flag again and restart the count.
+        this.persistFailureCounts.delete(documentName);
+      } else {
+        // Restore the flag so that a subsequent store will retry the write.
+        this.persistFailureCounts.set(documentName, failures);
+        this.unsavedDocumentNames.add(documentName);
+      }
 
       Logger.error("Unable to persist document", toError(err), {
         documentId,
         userId: context.user?.id,
+        failures,
+        giveUp,
       });
     }
   }


### PR DESCRIPTION
- When persisting a collaborative document fails, the dirty flag was restored unconditionally, so a permanent error (e.g. content that can't round-trip the schema) retried forever while clients stayed connected.
- Adds a per-document consecutive failure counter with a limit of 5; the count resets on a successful write and the retry stops once the limit is hit.
- Error logs now include the failure count so give-ups are visible.

closes #13243