### PR TITLE
fix: Consistently sanitize urls in editor components

### DIFF
--- a/shared/editor/components/Image.tsx
+++ b/shared/editor/components/Image.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next";
 import { find } from "es-toolkit/compat";
 import Flex from "../../components/Flex";
 import { s } from "../../styles";
-import { isExternalUrl, sanitizeImageSrc } from "../../utils/urls";
+import { isExternalUrl, sanitizeImageSrc, sanitizeUrl } from "../../utils/urls";
 import { EditorStyleHelper } from "../styles/EditorStyleHelper";
 import type { ComponentProps } from "../types";
 import {
@@ -113,7 +113,7 @@ const Image = (props: Props) => {
 
   const sanitizedSrc = sanitizeImageSrc(src);
   const linkMarkType = props.view.state.schema.marks.link;
-  const imgLink =
+  const imageLink =
     find(node.attrs.marks ?? [], (mark) => mark.type === linkMarkType.name)
       ?.attrs.href ||
     // Coalescing to `undefined` to avoid empty string in href because empty string
@@ -166,7 +166,7 @@ const Image = (props: Props) => {
         <GlobeIcon />
       </Button>
     ),
-    imgLink && (
+    imageLink && (
       <Button
         key="zoom"
         // `mousedown` on ancestor `div.ProseMirror` was preventing the `onClick` handler from firing
@@ -222,7 +222,7 @@ const Image = (props: Props) => {
           </Error>
         ) : (
           <a
-            href={imgLink}
+            href={sanitizeUrl(imageLink)}
             // Do not show hover preview when the image is selected
             className={!isSelected ? "use-hover-preview" : ""}
             target="_blank"

--- a/shared/editor/components/PDF.tsx
+++ b/shared/editor/components/PDF.tsx
@@ -4,6 +4,7 @@ import useDragResize from "./hooks/useDragResize";
 import { ResizeLeft, ResizeRight } from "./ResizeHandle";
 import type { ComponentProps } from "../types";
 import { isFirefox } from "../../utils/browser";
+import { sanitizeUrl } from "../../utils/urls";
 import Flex from "../../components/Flex";
 import { s } from "../../styles";
 import { Preview, Subtitle, Title } from "./Widget";
@@ -65,7 +66,7 @@ export default function PdfViewer(props: Props) {
           embedRef.current.src = "";
           requestAnimationFrame(() => {
             if (embedRef.current) {
-              embedRef.current.src = href;
+              embedRef.current.src = sanitizeUrl(href) ?? "";
             }
           });
         }
@@ -103,7 +104,7 @@ export default function PdfViewer(props: Props) {
       </Flex>
       <embed
         title={name}
-        src={href}
+        src={sanitizeUrl(href)}
         ref={embedRef}
         style={{
           width: "100%",

--- a/shared/editor/nodes/Attachment.tsx
+++ b/shared/editor/nodes/Attachment.tsx
@@ -230,6 +230,7 @@ export default class Attachment extends Node {
         const link = document.createElement("a");
         link.href = href;
         link.target = "_blank";
+        link.rel = "noopener noreferrer";
         document.body.appendChild(link);
         link.click();
 

--- a/shared/editor/nodes/Attachment.tsx
+++ b/shared/editor/nodes/Attachment.tsx
@@ -221,10 +221,14 @@ export default class Attachment extends Node {
           return false;
         }
         const { node } = state.selection;
+        const href = sanitizeUrl(node.attrs.href);
+        if (!href) {
+          return false;
+        }
 
         // create a temporary link node and click it
         const link = document.createElement("a");
-        link.href = node.attrs.href;
+        link.href = href;
         link.target = "_blank";
         document.body.appendChild(link);
         link.click();


### PR DESCRIPTION
Node attributes are authored content, but a few render sinks were reading href and src straight from them without passing through the existing sanitize helpers. Applies them at the point of use:

- Attachment download command
- PDF preview embed, including the resize reload path
- Link wrapper around an image
