### PR TITLE
chore(deps): bump sonner from 1.7.4 to 2.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -254,7 +254,7 @@
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3",
     "socket.io-redis": "^6.1.1",
-    "sonner": "^1.7.4",
+    "sonner": "^2.0.8",
     "stoppable": "^1.1.0",
     "string-replace-to-array": "^2.1.1",
     "styled-components": "^5.3.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15750,7 +15750,7 @@ __metadata:
     socket.io: "npm:^4.8.3"
     socket.io-client: "npm:^4.8.3"
     socket.io-redis: "npm:^6.1.1"
-    sonner: "npm:^1.7.4"
+    sonner: "npm:^2.0.8"
     stoppable: "npm:^1.1.0"
     string-replace-to-array: "npm:^2.1.1"
     styled-components: "npm:^5.3.11"
@@ -18846,13 +18846,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sonner@npm:^1.7.4":
-  version: 1.7.4
-  resolution: "sonner@npm:1.7.4"
+"sonner@npm:^2.0.8":
+  version: 2.0.8
+  resolution: "sonner@npm:2.0.8"
   peerDependencies:
+    "@types/react": ^18.0.0 || ^19.0.0
     react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-  checksum: 10c0/2856a43c1afaacec5ca74c7f6bb8eb439edf1fdadb045bd201590f809e6e9b711eabcf7d1e8f3448cf414e1333d97e3e16372a989011a3190f20952947b1f60a
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/cc271f78dca7e7d7ce34a724883f3292ba671b5ed3d41732430df28c38a8f6a47e8e59da5fdd0b258ac07136db0cdaf02f8cda9afb9cc9f12d81b6c319b427f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Upgrades sonner across the major version boundary to pick up ~18 months of fixes.

- No call site changes needed — the ~115 `toast.*` usages and the single `Toaster` are unaffected
- Removed v2 props (`unstyled`, `loadingIcon`, `pauseWhenPageIsHidden`) were unused, and the renamed theme data attribute isn't selected on
- The styled-components overrides in Toasts still hold: className is forwarded to the same element, and the close button / expanded selectors are unchanged
- React API surface is identical to v1, so the existing React 17 peer mismatch is unchanged
