### PR TITLE
fix: Revert framer async load

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,6 +1,6 @@
 // oxlint-disable-next-line import/no-unresolved
 import "vite/modulepreload-polyfill";
-import { LazyMotion } from "framer-motion";
+import { LazyMotion, domMax } from "framer-motion";
 import { KBarProvider } from "kbar";
 import { Provider } from "mobx-react";
 import { configure as configureMobx } from "mobx";
@@ -32,11 +32,6 @@ import { ActionContextProvider } from "./hooks/useActionContext";
 
 // Load plugins as soon as possible
 void PluginManager.loadPlugins();
-
-// Motion features are loaded async to keep them out of the initial bundle,
-// animations begin once loaded.
-const loadMotionFeatures = () =>
-  import("~/utils/motionFeatures").then((mod) => mod.default);
 
 initI18n(env.DEFAULT_LANGUAGE);
 
@@ -76,7 +71,7 @@ if (element) {
                   <ErrorBoundary showTitle>
                     <KBarProvider actions={[]} options={commandBarOptions}>
                       <LazyPolyfill>
-                        <LazyMotion features={loadMotionFeatures}>
+                        <LazyMotion features={domMax}>
                           <PageScroll>
                             <PageTheme />
                             <ScrollToTop>

--- a/app/utils/motionFeatures.ts
+++ b/app/utils/motionFeatures.ts
@@ -1,3 +1,0 @@
-import { domMax } from "framer-motion";
-
-export default domMax;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -215,6 +215,11 @@ export default ({ mode }: ConfigEnv) =>
                 priority: 20,
               },
               {
+                name: "vendor-framer-motion",
+                test: /node_modules[\\/]framer-motion/,
+                priority: 20,
+              },
+              {
                 name: "vendor-styled",
                 test: /node_modules[\\/](styled-components|stylis)/,
                 priority: 22,


### PR DESCRIPTION
The commit made these two modules land in different chunks, with a load order that breaks the invariant, reverting.