### PR TITLE
perf: Reduce Sentry span volume from browser tracing

### DIFF
--- a/app/utils/sentry.ts
+++ b/app/utils/sentry.ts
@@ -40,7 +40,15 @@ export function initSentry(history: History) {
     tunnel: env.SENTRY_TUNNEL,
     allowUrls: [env.URL, env.CDN_URL, env.COLLABORATION_URL],
     integrations: [Sentry.reactRouterV5BrowserTracingIntegration({ history })],
-    tracesSampleRate: env.ENVIRONMENT === "production" ? 0.1 : 1,
+    ignoreSpans: [
+      // Resource timing spans are emitted for every subresource of a pageload (scripts)
+      { op: /^resource\./ },
+      // Connection phases of a pageload, per Sentry's recommended defaults
+      { op: /^browser\.(cache|connect|DNS)$/ },
+      // Performance marks and measures are mostly emitted by third-party browser extensions
+      { op: /^(mark|measure)$/ },
+    ],
+    tracesSampleRate: env.ENVIRONMENT === "production" ? 0.05 : 1,
     ignoreErrors: [
       "Failed to fetch dynamically imported module",
       "Importing a module script failed",


### PR DESCRIPTION
We're at 80% of the Sentry span budget, and browser tracing accounts for effectively all of it — resource timing spans alone were ~84% of the total, since every code-split chunk loaded on a pageload becomes its own span.

- Drop resource timing, pageload connection phase, and performance mark/measure spans via `ignoreSpans`
- Halve the production traces sample rate

Net effect is roughly a 93% reduction in spans sent. Pageload and navigation transactions, API request spans, and long animation frame spans are all unaffected, so route performance and error trace context are preserved.