### PR TITLE
fix: Anchor links not scrolling on shared documents

### DIFF
--- a/app/components/ScrollToTop.ts
+++ b/app/components/ScrollToTop.ts
@@ -20,6 +20,10 @@ export default function ScrollToTop({ children }: Props) {
     ) {
       return;
     }
+    // The destination has an anchor, scrolling is handled by the target itself
+    if (location.hash) {
+      return;
+    }
     // exception for when entering or exiting document edit, scroll position should not reset
     if (
       location.pathname.match(/\/edit\/?$/) ||
@@ -31,6 +35,7 @@ export default function ScrollToTop({ children }: Props) {
   }, [
     scrollContainerRef,
     location.pathname,
+    location.hash,
     previousLocationPathname,
     location.state?.retainScrollPosition,
   ]);


### PR DESCRIPTION
On a shared document the same page is reachable at two paths, so clicking a link to a heading in the same document changes the pathname — the editor scrolls to the anchor and `ScrollToTop` immediately resets it to the top.

- Skip the scroll reset when the destination location has a hash, leaving the target to handle its own scrolling

closes #13388