### PR TITLE
[Bug] "All members" set to "Can Edit" on Collection permissions defaults to read-only

### DIFF
--- a/app/components/Sharing/Collection/SharePopover.tsx
+++ b/app/components/Sharing/Collection/SharePopover.tsx
@@ -60,7 +60,7 @@ function SharePopover({
   const [pendingIds, setPendingIds] = React.useState<string[]>([]);
   const [invitedInSession, setInvitedInSession] = React.useState<string[]>([]);
   const [permission, setPermission] = React.useState<CollectionPermission>(
-    CollectionPermission.Read
+    collection.permission ?? CollectionPermission.Read
   );
 
   const share = shares.getByCollectionId(collection.id);


### PR DESCRIPTION
Initialize collection share popover's invite permission state from `collection.permission` instead of hardcoded `CollectionPermission.Read`, so when "All members" is "Can Edit", new invites also default to "Can Edit".

Found via automated repo scanning, fix written and reviewed before opening.
