### PR TITLE
History changes are not always shown

### DIFF
--- a/app/scenes/Document/components/History/History.tsx
+++ b/app/scenes/Document/components/History/History.tsx
@@ -156,8 +156,11 @@ function History() {
       "desc"
     ).slice(0, limit);
 
-    setRevisionsOffset(revisionsOffset + revisionsPage.length);
-    setEventsOffset(eventsOffset + pageEvents.length - revisionsPage.length);
+    const revisionsInPage = pageEvents.filter(
+      (item) => item instanceof Revision
+    ).length;
+    setRevisionsOffset(revisionsOffset + revisionsInPage);
+    setEventsOffset(eventsOffset + (pageEvents.length - revisionsInPage));
     return pageEvents;
   }, [document, revisions, events, revisionsOffset, eventsOffset]);
 


### PR DESCRIPTION
Fix pagination offsets in fetchHistory to count items of each type in the merged+sliced page, not the raw fetched counts

Found via automated repo scanning, fix written and reviewed before opening.
