### PR TITLE
Add container image badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ If you'd like to run your own copy of Outline or contribute to development then 
 
 Please see the [documentation](https://docs.getoutline.com/s/hosting/) for running your own copy of Outline in a production configuration.
 
+Available container images:
+* Latest release: [![Container Image Release](https://img.shields.io/docker/v/outlinewiki/outline?sort=semver)](https://hub.docker.com/r/outlinewiki/outline)
+* Latest development version: [![Container Image Nightly](https://img.shields.io/docker/v/outlinewiki/outline?sort=date)](https://hub.docker.com/r/outlinewiki/outline)
+
 If you have questions or improvements for the docs please create a thread in [GitHub discussions](https://github.com/outline/outline/discussions).
 
 # Contributing

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ If you'd like to run your own copy of Outline or contribute to development then 
 Please see the [documentation](https://docs.getoutline.com/s/hosting/) for running your own copy of Outline in a production configuration.
 
 Available container images:
-* Latest release: [![Container Image Release](https://img.shields.io/docker/v/outlinewiki/outline?sort=semver)](https://hub.docker.com/r/outlinewiki/outline)
-* Latest development version: [![Container Image Nightly](https://img.shields.io/docker/v/outlinewiki/outline?sort=date)](https://hub.docker.com/r/outlinewiki/outline)
+* [![Container Image Release](https://img.shields.io/docker/v/outlinewiki/outline?sort=semver&label=Latest%20release)](https://hub.docker.com/r/outlinewiki/outline)
+* [![Container Image Nightly](https://img.shields.io/docker/v/outlinewiki/outline?sort=date&label=Latest%20development%20version)](https://hub.docker.com/r/outlinewiki/outline)
 
 If you have questions or improvements for the docs please create a thread in [GitHub discussions](https://github.com/outline/outline/discussions).
 


### PR DESCRIPTION
I think it might be a good idea to list the latest available version in the README, so hereby my proposal to add two badges for it:
* One to point to the latest stable release
* One to point to the latest nightly snapshot

**NOTE**: I am no text-writer, so I tried to keep it as clear as possible ;)