### PR TITLE
fix: Preserve custom port in client-side redirects

### DIFF
--- a/server/utils/redirectOnClient.ts
+++ b/server/utils/redirectOnClient.ts
@@ -1,19 +1,21 @@
 import { escape } from "es-toolkit/compat";
 import type { Context } from "koa";
+import { addMissingUrlPort } from "@shared/utils/urls";
 
 /**
  * Performs a redirect on the browser so that the user's auth cookies are
  * included in the request. Assigned to the Koa context as `redirectOnClient`.
  *
- * @param url the URL to redirect to.
+ * @param redirectTo the URL to redirect to.
  * @param method the HTTP method to use for the redirect. Use POST when
  * preventing links in emails from being clicked by bots. Otherwise, use GET.
  */
 export function redirectOnClient(
   this: Context,
-  url: string,
+  redirectTo: string,
   method: "GET" | "POST" = "GET"
 ) {
+  const url = addMissingUrlPort(redirectTo);
   this.type = "text/html";
 
   if (method === "POST") {

--- a/shared/utils/urls.test.ts
+++ b/shared/utils/urls.test.ts
@@ -117,6 +117,62 @@ describe("isInternalUrl", () => {
   });
 });
 
+describe("addMissingUrlPort", () => {
+  const url = env.URL;
+
+  beforeEach(() => {
+    env.URL = "https://example.com:3000";
+  });
+
+  afterEach(() => {
+    env.URL = url;
+  });
+
+  it("should add the port to a url without one", () => {
+    expect(urlsUtils.addMissingUrlPort("https://example.com/drafts")).toBe(
+      "https://example.com:3000/drafts"
+    );
+  });
+
+  it("should not change a url that already has a port", () => {
+    expect(urlsUtils.addMissingUrlPort("https://example.com:4000/drafts")).toBe(
+      "https://example.com:4000/drafts"
+    );
+  });
+
+  it("should not change a relative url", () => {
+    expect(urlsUtils.addMissingUrlPort("/drafts")).toBe("/drafts");
+  });
+
+  it("should not change a url when no port is configured", () => {
+    env.URL = "https://example.com";
+    expect(urlsUtils.addMissingUrlPort("https://example.com/drafts")).toBe(
+      "https://example.com/drafts"
+    );
+  });
+
+  it("should not add the default https port", () => {
+    env.URL = "https://example.com:443";
+    expect(urlsUtils.addMissingUrlPort("https://example.com/drafts")).toBe(
+      "https://example.com/drafts"
+    );
+  });
+
+  it("should not add the default http port", () => {
+    env.URL = "http://example.com:80";
+    expect(urlsUtils.addMissingUrlPort("http://example.com/drafts")).toBe(
+      "http://example.com/drafts"
+    );
+  });
+
+  it("should add a port that is not the default for the protocol", () => {
+    env.URL = "http://example.com:443";
+    expect(urlsUtils.addMissingUrlPort("http://example.com/drafts")).toBe(
+      "http://example.com:443/drafts"
+    );
+  });
+});
+
 describe("isExternalUrl", () => {
   it("should return false if empty url", () => {
     expect(urlsUtils.isExternalUrl("")).toBe(false);

--- a/shared/utils/urls.ts
+++ b/shared/utils/urls.ts
@@ -305,6 +305,40 @@ export function getUrls(text: string) {
 }
 
 /**
+ * Adds the port that the application is publicly reachable on to a url that
+ * does not specify one. A proxy commonly forwards a Host header without the
+ * public port, so urls derived from an incoming request would otherwise point
+ * at the wrong address.
+ *
+ * @param url the url to modify, may be relative.
+ * @returns the url with the port added, if one was missing.
+ */
+export function addMissingUrlPort(url: string): string {
+  let port;
+  try {
+    port = new URL(env.URL).port;
+  } catch (_err) {
+    return url;
+  }
+
+  if (!port) {
+    return url;
+  }
+
+  try {
+    const parsed = new URL(url);
+    if (parsed.port) {
+      return url;
+    }
+    parsed.port = port;
+    return parsed.toString();
+  } catch (_err) {
+    // Relative urls are resolved against the current origin and need no port.
+    return url;
+  }
+}
+
+/**
  * Removes the fragment (hash) from a url, if present.
  *
  * @param url The url to modify.


### PR DESCRIPTION
When the app is served on a non-standard port behind a proxy, the forwarded Host header usually omits it, so redirects built from the incoming request sent the browser to the default port instead.

- Add `addMissingUrlPort` to apply the port the app is publicly reachable on to urls that don't specify one
- Use it in `redirectOnClient`, covering the email magic sign-in callback along with share, notification, user and subscription links

closes #13394