### PR TITLE
feat: Highlight trigger text while suggestion menu is open

### DIFF
--- a/app/editor/extensions/BlockMenu.tsx
+++ b/app/editor/extensions/BlockMenu.tsx
@@ -59,6 +59,8 @@ export default class BlockMenuExtension extends Suggestion {
                   () => {
                     button.onclick = action(() => {
                       this.state.query = "";
+                      this.state.trigger = null;
+                      this.state.triggerPos = null;
                       this.state.open = true;
                     });
                     return button;

--- a/app/editor/extensions/Suggestion.ts
+++ b/app/editor/extensions/Suggestion.ts
@@ -4,7 +4,9 @@ import { InputRule } from "prosemirror-inputrules";
 import type { NodeType, Schema } from "prosemirror-model";
 import type { EditorState, Plugin } from "prosemirror-state";
 import Extension from "@shared/editor/lib/Extension";
+import type { ExtensionState } from "@shared/editor/plugins/SuggestionsMenuPlugin";
 import {
+  applyMatch,
   isTriggerMarked,
   SuggestionsMenuPlugin,
 } from "@shared/editor/plugins/SuggestionsMenuPlugin";
@@ -116,20 +118,19 @@ export default class Suggestion<
           (this.enabledInMarks ||
             !isTriggerMarked(state, end, match, this.triggerLength))
         ) {
-          const open = match[0].length <= this.triggerLength + 1;
-          const query = match[1];
-
           // Input rules run while ProseMirror is reading a DOM change, at which
           // point its view descriptors are marked dirty and do not match the
           // DOM. Opening the menu here would render it – and measure the caret –
-          // inside that window, so defer until the view has re-synced.
+          // inside that window, so defer until the view has re-synced. The
+          // cursor is read at that point too, as the typed character has not
+          // been inserted yet when the rule runs.
           setTimeout(
-            action(() => {
-              if (open) {
-                this.state.open = true;
-              }
-              this.state.query = query;
-            }),
+            () =>
+              applyMatch(this.state, match, {
+                triggerLength: this.triggerLength,
+                cursorPos: this.editor.view.state.selection.from,
+                canOpen: true,
+              }),
             0
           );
         }
@@ -142,12 +143,11 @@ export default class Suggestion<
 
   protected triggerLength: number;
 
-  protected state: {
-    open: boolean;
-    query: string;
-  } = observable({
+  protected state: ExtensionState = observable({
     open: false,
     query: "",
+    trigger: null,
+    triggerPos: null,
   });
 
   /** Whether the suggestion menu is currently open. */

--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -585,6 +585,13 @@ width: 100%;
   }
 }
 
+.${EditorStyleHelper.suggestionTrigger} {
+  background: ${props.theme.mentionBackground};
+  border-radius: 4px;
+  box-shadow: 0 0 0 2px ${props.theme.mentionBackground};
+  box-decoration-break: clone;
+}
+
 > div {
   background: transparent;
 }

--- a/shared/editor/plugins/SuggestionsMenuPlugin.ts
+++ b/shared/editor/plugins/SuggestionsMenuPlugin.ts
@@ -1,14 +1,20 @@
-import { action } from "mobx";
+import { action, reaction } from "mobx";
 import type { EditorState } from "prosemirror-state";
 import { Plugin } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
+import { Decoration, DecorationSet } from "prosemirror-view";
 import { getMarksBetween } from "@shared/editor/queries/getMarksBetween";
+import { EditorStyleHelper } from "@shared/editor/styles/EditorStyleHelper";
 
 const MAX_MATCH = 500;
 
-type ExtensionState = {
+export type ExtensionState = {
   open: boolean;
   query: string;
+  /** The trigger that opened the menu, if it was opened by one. */
+  trigger: string | null;
+  /** The document position of the trigger that opened the menu. */
+  triggerPos: number | null;
 };
 
 /**
@@ -36,6 +42,38 @@ export function isTriggerMarked(
   return getMarksBetween(triggerStart, triggerEnd, state).length > 0;
 }
 
+/**
+ * Update the extension state to reflect a suggestion match.
+ *
+ * @param extensionState The state to update.
+ * @param match The regex match where group 1 is the search term.
+ * @param options The trigger length, the cursor position at the end of the
+ * match, and whether the menu may be opened by this match.
+ */
+export const applyMatch = action(
+  (
+    extensionState: ExtensionState,
+    match: RegExpMatchArray,
+    options: { triggerLength: number; cursorPos: number; canOpen: boolean }
+  ) => {
+    const { triggerLength, cursorPos, canOpen } = options;
+    const query = match[1] ?? "";
+    const triggerEnd = match[0].length - query.length;
+
+    // The menu only opens on a freshly typed trigger, that is a match made up
+    // of the optional preceding character and the trigger itself.
+    if (canOpen && match[0].length <= triggerLength + 1) {
+      extensionState.open = true;
+    }
+    extensionState.query = query;
+    extensionState.trigger = match[0].slice(
+      triggerEnd - triggerLength,
+      triggerEnd
+    );
+    extensionState.triggerPos = cursorPos - query.length - triggerLength;
+  }
+);
+
 export class SuggestionsMenuPlugin extends Plugin {
   constructor(
     extensionState: ExtensionState,
@@ -43,12 +81,54 @@ export class SuggestionsMenuPlugin extends Plugin {
     enabledInMarks: boolean,
     triggerLength: number
   ) {
-    // The menu only opens on a freshly typed trigger, that is a match made up
-    // of the optional preceding character and the trigger itself.
-    const maxOpenLength = triggerLength + 1;
-
     super({
+      // The open state lives outside of the editor state, so ProseMirror is not
+      // otherwise aware that the decorations need recalculating.
+      view: (view) => {
+        const dispose = reaction(
+          () => [
+            extensionState.open,
+            extensionState.trigger,
+            extensionState.triggerPos,
+          ],
+          () => {
+            // Avoid interrupting an in-progress IME composition, the decoration
+            // will be added once the composition is committed.
+            if (!view.composing) {
+              view.dispatch(view.state.tr.setMeta("addToHistory", false));
+            }
+          }
+        );
+        return { destroy: dispose };
+      },
       props: {
+        decorations: (state) => {
+          const { open, trigger, triggerPos } = extensionState;
+          const { selection } = state;
+          if (!open || trigger === null || triggerPos === null) {
+            return null;
+          }
+
+          const to = selection.from;
+
+          // The cursor may have moved away from the trigger, or the trigger may
+          // have been edited, while the menu is open.
+          if (
+            !selection.empty ||
+            to < triggerPos + trigger.length ||
+            triggerPos < selection.$from.start() ||
+            state.doc.textBetween(triggerPos, triggerPos + trigger.length) !==
+              trigger
+          ) {
+            return null;
+          }
+
+          return DecorationSet.create(state.doc, [
+            Decoration.inline(triggerPos, to, {
+              class: EditorStyleHelper.suggestionTrigger,
+            }),
+          ]);
+        },
         handleDOMEvents: {
           // IME composition (e.g. Korean, Japanese, Chinese) fires compositionupdate
           // as each character is being built up. ProseMirror's view.composing flag
@@ -68,18 +148,17 @@ export class SuggestionsMenuPlugin extends Plugin {
                 "\ufffc"
               );
               const match = openRegex.exec(textBefore);
-              action(() => {
-                if (
-                  match &&
-                  (enabledInMarks ||
-                    !isTriggerMarked(state, fromPos, match, triggerLength))
-                ) {
-                  if (match[0].length <= maxOpenLength) {
-                    extensionState.open = true;
-                  }
-                  extensionState.query = match[1];
-                }
-              })();
+              if (
+                match &&
+                (enabledInMarks ||
+                  !isTriggerMarked(state, fromPos, match, triggerLength))
+              ) {
+                applyMatch(extensionState, match, {
+                  triggerLength,
+                  cursorPos: fromPos,
+                  canOpen: true,
+                });
+              }
             }, 0);
             return false;
           },
@@ -104,7 +183,11 @@ export class SuggestionsMenuPlugin extends Plugin {
                     (enabledInMarks ||
                       !isTriggerMarked(state, fromPos, match, triggerLength))
                   ) {
-                    extensionState.query = match[1];
+                    applyMatch(extensionState, match, {
+                      triggerLength,
+                      cursorPos: fromPos,
+                      canOpen: false,
+                    });
                   } else {
                     extensionState.open = false;
                   }
@@ -132,19 +215,20 @@ export class SuggestionsMenuPlugin extends Plugin {
                 fromPos,
                 fromPos,
                 openRegex,
-                action((state, match) => {
+                (state, match) => {
                   if (
                     match &&
                     (enabledInMarks ||
                       !isTriggerMarked(state, fromPos, match, triggerLength))
                   ) {
-                    if (match[0].length <= maxOpenLength) {
-                      extensionState.open = true;
-                    }
-                    extensionState.query = match[1];
+                    applyMatch(extensionState, match, {
+                      triggerLength,
+                      cursorPos: fromPos,
+                      canOpen: true,
+                    });
                   }
                   return null;
-                })
+                }
               );
             }, 0);
           }

--- a/shared/editor/plugins/SuggestionsMenuPlugin.ts
+++ b/shared/editor/plugins/SuggestionsMenuPlugin.ts
@@ -1,19 +1,30 @@
 import { action, reaction } from "mobx";
 import type { EditorState } from "prosemirror-state";
-import { Plugin } from "prosemirror-state";
+import { Plugin, PluginKey } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 import { Decoration, DecorationSet } from "prosemirror-view";
+import { mapDecorations } from "@shared/editor/lib/multiplayer";
 import { getMarksBetween } from "@shared/editor/queries/getMarksBetween";
 import { EditorStyleHelper } from "@shared/editor/styles/EditorStyleHelper";
 
 const MAX_MATCH = 500;
+
+interface PluginState {
+  decorations: DecorationSet;
+}
+
+/** The document range covered by the trigger and its search term. */
+interface TriggerRange {
+  from: number;
+  to: number;
+}
 
 export type ExtensionState = {
   open: boolean;
   query: string;
   /** The trigger that opened the menu, if it was opened by one. */
   trigger: string | null;
-  /** The document position of the trigger that opened the menu. */
+  /** The document position of the trigger at the time it was matched. */
   triggerPos: number | null;
 };
 
@@ -74,16 +85,71 @@ export const applyMatch = action(
   }
 );
 
-export class SuggestionsMenuPlugin extends Plugin {
+export class SuggestionsMenuPlugin extends Plugin<PluginState> {
   constructor(
     extensionState: ExtensionState,
     openRegex: RegExp,
     enabledInMarks: boolean,
     triggerLength: number
   ) {
+    const key = new PluginKey<PluginState>("suggestions-menu");
+
     super({
-      // The open state lives outside of the editor state, so ProseMirror is not
-      // otherwise aware that the decorations need recalculating.
+      key,
+      // The decoration is held in plugin state so that it is mapped through
+      // changes to the document, including those made by other users.
+      state: {
+        init: (): PluginState => ({ decorations: DecorationSet.empty }),
+        apply: (tr, pluginState): PluginState => {
+          const range: TriggerRange | undefined | null = tr.getMeta(key);
+
+          if (range !== undefined) {
+            return {
+              decorations: range
+                ? DecorationSet.create(tr.doc, [
+                    // The end is inclusive so that the decoration grows as the
+                    // search term is typed.
+                    Decoration.inline(
+                      range.from,
+                      range.to,
+                      { class: EditorStyleHelper.suggestionTrigger },
+                      { inclusiveEnd: true }
+                    ),
+                  ])
+                : DecorationSet.empty,
+            };
+          }
+
+          if (
+            !tr.docChanged ||
+            pluginState.decorations === DecorationSet.empty
+          ) {
+            return pluginState;
+          }
+
+          const decorations = mapDecorations(pluginState.decorations, tr);
+          const [decoration] = decorations.find();
+          const { trigger } = extensionState;
+
+          // The trigger itself may have been edited away, for example by
+          // another user, leaving nothing to decorate.
+          if (
+            !trigger ||
+            !decoration ||
+            decoration.to - decoration.from < trigger.length ||
+            tr.doc.textBetween(
+              decoration.from,
+              decoration.from + trigger.length
+            ) !== trigger
+          ) {
+            return { decorations: DecorationSet.empty };
+          }
+
+          return { decorations };
+        },
+      },
+      // The menu state lives outside of the editor state, so ProseMirror is not
+      // otherwise aware that the decoration needs adding or removing.
       view: (view) => {
         const dispose = reaction(
           () => [
@@ -94,41 +160,33 @@ export class SuggestionsMenuPlugin extends Plugin {
           () => {
             // Avoid interrupting an in-progress IME composition, the decoration
             // will be added once the composition is committed.
-            if (!view.composing) {
-              view.dispatch(view.state.tr.setMeta("addToHistory", false));
+            if (view.composing) {
+              return;
             }
+
+            const setRange = (range: TriggerRange | null) =>
+              view.dispatch(
+                view.state.tr.setMeta(key, range).setMeta("addToHistory", false)
+              );
+
+            const { open, query, trigger, triggerPos } = extensionState;
+            if (!open || trigger === null || triggerPos === null) {
+              setRange(null);
+              return;
+            }
+
+            const to = triggerPos + trigger.length + query.length;
+            setRange(
+              to <= view.state.doc.content.size
+                ? { from: triggerPos, to }
+                : null
+            );
           }
         );
         return { destroy: dispose };
       },
       props: {
-        decorations: (state) => {
-          const { open, trigger, triggerPos } = extensionState;
-          const { selection } = state;
-          if (!open || trigger === null || triggerPos === null) {
-            return null;
-          }
-
-          const to = selection.from;
-
-          // The cursor may have moved away from the trigger, or the trigger may
-          // have been edited, while the menu is open.
-          if (
-            !selection.empty ||
-            to < triggerPos + trigger.length ||
-            triggerPos < selection.$from.start() ||
-            state.doc.textBetween(triggerPos, triggerPos + trigger.length) !==
-              trigger
-          ) {
-            return null;
-          }
-
-          return DecorationSet.create(state.doc, [
-            Decoration.inline(triggerPos, to, {
-              class: EditorStyleHelper.suggestionTrigger,
-            }),
-          ]);
-        },
+        decorations: (state) => key.getState(state)?.decorations,
         handleDOMEvents: {
           // IME composition (e.g. Korean, Japanese, Chinese) fires compositionupdate
           // as each character is being built up. ProseMirror's view.composing flag

--- a/shared/editor/styles/EditorStyleHelper.ts
+++ b/shared/editor/styles/EditorStyleHelper.ts
@@ -89,6 +89,11 @@ export class EditorStyleHelper {
   /** Notice block content area */
   static readonly noticeContent = "content";
 
+  // Suggestions
+
+  /** Trigger character and search term while a suggestion menu is open */
+  static readonly suggestionTrigger = "suggestion-trigger";
+
   // Checkbox Lists
 
   /** Checkbox list wrapper */


### PR DESCRIPTION
Adds a subtle inline decoration around the trigger character and search term while the block, emoji, or mention suggestion menu is open, making it clearer what will be replaced on selection.

- Stores the matched trigger alongside the query in the menu state, so the decoration range is derived without re-running the trigger regex
- Consolidates the four places that update menu state from a match into a single `applyMatch` helper
- Decoration is skipped when the menu was opened from the block menu button, or when the cursor moves away from the trigger