### PR TITLE
fix: Prevent removing document members with inherited access

### DIFF
--- a/app/components/Sharing/Document/DocumentMemberListItem.tsx
+++ b/app/components/Sharing/Document/DocumentMemberListItem.tsx
@@ -43,6 +43,9 @@ const DocumentMemberListItem = ({
     [onRemove, onUpdate]
   );
 
+  // Access inherited from a parent document cannot be removed here.
+  const canRemove = !membership?.sourceId;
+
   const permissions: Permission[] = [
     {
       label: t("View only"),
@@ -56,11 +59,15 @@ const DocumentMemberListItem = ({
       label: t("Manage"),
       value: DocumentPermission.Admin,
     },
-    {
-      divider: true,
-      label: t("Remove"),
-      value: EmptySelectValue,
-    },
+    ...(canRemove
+      ? ([
+          {
+            divider: true,
+            label: t("Remove"),
+            value: EmptySelectValue,
+          },
+        ] satisfies Permission[])
+      : []),
   ];
 
   const currentPermission = permissions.find(
@@ -105,10 +112,14 @@ const DocumentMemberListItem = ({
               onLeave
                 ? [
                     currentPermission,
-                    {
-                      label: `${t("Leave")}…`,
-                      value: EmptySelectValue,
-                    },
+                    ...(canRemove
+                      ? ([
+                          {
+                            label: `${t("Leave")}…`,
+                            value: EmptySelectValue,
+                          },
+                        ] satisfies Permission[])
+                      : []),
                   ]
                 : permissions
             }

--- a/server/routes/api/documents/documents.test.ts
+++ b/server/routes/api/documents/documents.test.ts
@@ -5529,6 +5529,55 @@ describe("#documents.remove_user", () => {
     expect(res.status).toEqual(200);
     expect(users.length).toEqual(0);
   });
+
+  it("should not remove user with access inherited from a parent", async () => {
+    const user = await buildUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      createdById: user.id,
+      permission: null,
+    });
+    const parentDocument = await buildDocument({
+      collectionId: collection.id,
+      createdById: user.id,
+      teamId: user.teamId,
+    });
+    const document = await buildDocument({
+      collectionId: collection.id,
+      parentDocumentId: parentDocument.id,
+      createdById: user.id,
+      teamId: user.teamId,
+    });
+    const member = await buildUser({
+      teamId: user.teamId,
+    });
+    const sourceMembership = await UserMembership.create({
+      createdById: user.id,
+      documentId: parentDocument.id,
+      userId: member.id,
+      permission: DocumentPermission.ReadWrite,
+    });
+    await UserMembership.create({
+      createdById: user.id,
+      documentId: document.id,
+      userId: member.id,
+      permission: DocumentPermission.ReadWrite,
+      sourceId: sourceMembership.id,
+    });
+
+    const res = await server.post("/api/documents.remove_user", user, {
+      body: {
+        id: document.id,
+        userId: member.id,
+      },
+    });
+    expect(res.status).toEqual(400);
+    expect(
+      await UserMembership.count({
+        where: { documentId: document.id, userId: member.id },
+      })
+    ).not.toEqual(0);
+  });
 });
 
 describe("#documents.add_group", () => {

--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -1873,6 +1873,12 @@ router.post(
       rejectOnEmpty: true,
     });
 
+    if (membership.sourceId) {
+      throw ValidationError(
+        "Cannot remove access that is inherited from a parent document"
+      );
+    }
+
     await membership.destroy(ctx.context);
 
     ctx.body = {


### PR DESCRIPTION
Memberships that originate from a parent document cannot be meaningfully removed from a nested document — they're owned by the parent.

- Server: `documents.remove_user` rejects memberships that have a source
- Client: the remove (and leave) option is hidden for those members