### PR TITLE
fix: Unhandled socket error during websocket upgrade crashes server

### DIFF
--- a/server/main.ts
+++ b/server/main.ts
@@ -14,6 +14,7 @@ import Redis from "@server/storage/redis";
 import Logger from "./logging/Logger";
 import { defaultRateLimiter } from "@server/middlewares/rateLimiter";
 import onerror from "./onerror";
+import onupgrade, { rejectUnhandledUpgrades } from "./onupgrade";
 import services from "./services";
 import { sequelize } from "./storage/database";
 import { getArg } from "./utils/args";
@@ -96,6 +97,10 @@ export async function start(id: number, disconnect: () => void) {
 
   app.use(router.routes());
 
+  // catch errors on sockets detached from the app by an upgrade request, this
+  // must happen before the services add upgrade handlers of their own
+  onupgrade(server);
+
   // loop through requested services at startup
   for (const name of env.SERVICES) {
     if (!Object.keys(services).includes(name)) {
@@ -106,6 +111,8 @@ export async function start(id: number, disconnect: () => void) {
     const { default: init } = await services[name as keyof typeof services]();
     await Promise.resolve(init(app, server as https.Server, env.SERVICES));
   }
+
+  rejectUnhandledUpgrades(server);
 
   server.on("error", (err) => {
     if ("code" in err && err.code === "EADDRINUSE") {

--- a/server/onupgrade.test.ts
+++ b/server/onupgrade.test.ts
@@ -1,3 +1,4 @@
+import { once } from "node:events";
 import http from "node:http";
 import { Socket } from "node:net";
 import { PassThrough } from "node:stream";
@@ -42,13 +43,14 @@ describe("onupgrade", () => {
 });
 
 describe("rejectUnhandledUpgrades", () => {
-  it("should close upgrade requests when no service handles them", () => {
+  it("should close upgrade requests when no service handles them", async () => {
     const server = http.createServer();
     const socket = new PassThrough();
     onupgrade(server);
     rejectUnhandledUpgrades(server);
 
     server.emit("upgrade", request(), socket);
+    await once(socket, "close");
 
     expect(socket.destroyed).toEqual(true);
   });
@@ -67,12 +69,13 @@ describe("rejectUnhandledUpgrades", () => {
 });
 
 describe("rejectUpgrade", () => {
-  it("should write a complete response and destroy the socket", () => {
+  it("should write a complete response and destroy the socket", async () => {
     const socket = new PassThrough();
     const chunks: Buffer[] = [];
     socket.on("data", (chunk: Buffer) => chunks.push(chunk));
 
     rejectUpgrade(socket);
+    await once(socket, "close");
 
     expect(Buffer.concat(chunks).toString()).toEqual(
       "HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: 0\r\n\r\n"

--- a/server/onupgrade.test.ts
+++ b/server/onupgrade.test.ts
@@ -1,0 +1,82 @@
+import http from "node:http";
+import { Socket } from "node:net";
+import { PassThrough } from "node:stream";
+import Logger from "@server/logging/Logger";
+import onupgrade, { rejectUnhandledUpgrades, rejectUpgrade } from "./onupgrade";
+
+const request = () => new http.IncomingMessage(new Socket());
+
+describe("onupgrade", () => {
+  it("should swallow expected disconnections without reporting them", () => {
+    const errorSpy = vi.spyOn(Logger, "error");
+    const server = http.createServer();
+    const socket = new PassThrough();
+    onupgrade(server);
+
+    server.emit("upgrade", request(), socket);
+
+    expect(() => {
+      socket.emit(
+        "error",
+        Object.assign(new Error("read ECONNRESET"), {
+          code: "ECONNRESET",
+        })
+      );
+    }).not.toThrow();
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("should report unexpected errors", () => {
+    const errorSpy = vi.spyOn(Logger, "error").mockImplementation(() => {});
+    const server = http.createServer();
+    const socket = new PassThrough();
+    onupgrade(server);
+
+    server.emit("upgrade", request(), socket);
+    socket.emit("error", new Error("something unexpected"));
+
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});
+
+describe("rejectUnhandledUpgrades", () => {
+  it("should close upgrade requests when no service handles them", () => {
+    const server = http.createServer();
+    const socket = new PassThrough();
+    onupgrade(server);
+    rejectUnhandledUpgrades(server);
+
+    server.emit("upgrade", request(), socket);
+
+    expect(socket.destroyed).toEqual(true);
+  });
+
+  it("should leave upgrade requests alone when a service handles them", () => {
+    const server = http.createServer();
+    const socket = new PassThrough();
+    onupgrade(server);
+    server.on("upgrade", () => undefined);
+    rejectUnhandledUpgrades(server);
+
+    server.emit("upgrade", request(), socket);
+
+    expect(socket.destroyed).toEqual(false);
+  });
+});
+
+describe("rejectUpgrade", () => {
+  it("should write a complete response and destroy the socket", () => {
+    const socket = new PassThrough();
+    const chunks: Buffer[] = [];
+    socket.on("data", (chunk: Buffer) => chunks.push(chunk));
+
+    rejectUpgrade(socket);
+
+    expect(Buffer.concat(chunks).toString()).toEqual(
+      "HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: 0\r\n\r\n"
+    );
+    expect(socket.destroyed).toEqual(true);
+  });
+});

--- a/server/onupgrade.ts
+++ b/server/onupgrade.ts
@@ -44,18 +44,21 @@ export function rejectUnhandledUpgrades(server: http.Server) {
 
 /**
  * Reject an upgrade request with a bad request response and close the socket.
- * The socket is destroyed rather than half-closed so that it cannot linger.
  *
  * @param socket the socket to respond on.
  */
 export function rejectUpgrade(socket: Duplex) {
-  if (socket.writable) {
-    socket.write(
-      `HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: 0\r\n\r\n`
-    );
+  if (!socket.writable) {
+    socket.destroy();
+    return;
   }
 
-  socket.destroy();
+  // Destroying only once the response has flushed avoids truncating it, and
+  // ensures the read side of the socket is not left half-open behind us.
+  socket.end(
+    `HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: 0\r\n\r\n`,
+    () => socket.destroy()
+  );
 }
 
 /**

--- a/server/onupgrade.ts
+++ b/server/onupgrade.ts
@@ -1,0 +1,65 @@
+import type http from "node:http";
+import type { IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
+import Logger from "@server/logging/Logger";
+
+/**
+ * Attach an error handler to every socket that is detached from the HTTP server
+ * by an upgrade request. Node removes its own handling before emitting the
+ * "upgrade" event, so without a listener a socket error is unhandled and will
+ * terminate the process.
+ *
+ * Must be called before any service adds an upgrade listener of its own.
+ *
+ * @param server the server to handle upgrade requests for.
+ */
+export default function onupgrade(server: http.Server) {
+  server.on("upgrade", (req: IncomingMessage, socket: Duplex) => {
+    socket.on("error", (error: NodeJS.ErrnoException) => {
+      if (error.code && expectedErrorCodes.includes(error.code)) {
+        return;
+      }
+
+      Logger.error("Socket error during websocket upgrade", error, {}, req);
+    });
+  });
+}
+
+/**
+ * Reject upgrade requests when no service has taken responsibility for them,
+ * they would otherwise be left open indefinitely – the error handler attached
+ * by `onupgrade` is itself a listener, which stops Node closing them for us.
+ *
+ * @param server the server, once all of its services have been started.
+ */
+export function rejectUnhandledUpgrades(server: http.Server) {
+  if (server.listenerCount("upgrade") > 1) {
+    return;
+  }
+
+  server.on("upgrade", (_req: IncomingMessage, socket: Duplex) =>
+    rejectUpgrade(socket)
+  );
+}
+
+/**
+ * Reject an upgrade request with a bad request response and close the socket.
+ * The socket is destroyed rather than half-closed so that it cannot linger.
+ *
+ * @param socket the socket to respond on.
+ */
+export function rejectUpgrade(socket: Duplex) {
+  if (socket.writable) {
+    socket.write(
+      `HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: 0\r\n\r\n`
+    );
+  }
+
+  socket.destroy();
+}
+
+/**
+ * Socket errors that are the result of a client, or an intermediary such as a
+ * reverse proxy, going away. They are expected and not worth reporting.
+ */
+const expectedErrorCodes = ["ECONNRESET", "ECONNABORTED", "EPIPE", "ETIMEDOUT"];

--- a/server/onupgrade.ts
+++ b/server/onupgrade.ts
@@ -53,8 +53,6 @@ export function rejectUpgrade(socket: Duplex) {
     return;
   }
 
-  // Destroying only once the response has flushed avoids truncating it, and
-  // ensures the read side of the socket is not left half-open behind us.
   socket.end(
     `HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: 0\r\n\r\n`,
     () => socket.destroy()

--- a/server/services/collaboration.ts
+++ b/server/services/collaboration.ts
@@ -13,6 +13,7 @@ import { ConnectionLimitExtension } from "@server/collaboration/ConnectionLimitE
 import { ViewsExtension } from "@server/collaboration/ViewsExtension";
 import env from "@server/env";
 import Logger from "@server/logging/Logger";
+import { rejectUpgrade } from "@server/onupgrade";
 import RedisAdapter from "@server/storage/redis";
 import ShutdownHelper, { ShutdownOrder } from "@server/utils/ShutdownHelper";
 import AuthenticationExtension from "../collaboration/AuthenticationExtension";
@@ -82,22 +83,6 @@ export default function init(
           .pop();
 
         if (documentId) {
-          // Handle socket errors that may occur during upgrade (e.g., maxPayload exceeded)
-          socket.on("error", (error: NodeJS.ErrnoException) => {
-            // ECONNRESET is common when clients disconnect abruptly, no need to log
-            if (error.code === "ECONNRESET") {
-              return;
-            }
-            Logger.error(
-              "Socket error during WebSocket upgrade",
-              error,
-              {
-                documentId,
-              },
-              req
-            );
-          });
-
           wss.handleUpgrade(req, socket, head, (client) => {
             // Handle websocket connection errors as soon as the client is upgraded
             client.on("error", (error) => {
@@ -133,7 +118,7 @@ export default function init(
       }
 
       // If the collaboration service is running it will close the connection
-      socket.end(`HTTP/1.1 400 Bad Request\r\n`);
+      rejectUpgrade(socket);
     }
   );
 

--- a/server/services/websockets.ts
+++ b/server/services/websockets.ts
@@ -13,6 +13,7 @@ import Metrics from "@server/logging/Metrics";
 import * as Tracing from "@server/logging/tracer";
 import { traceFunction } from "@server/logging/tracing";
 import type { User } from "@server/models";
+import { rejectUpgrade } from "@server/onupgrade";
 import Redis from "@server/storage/redis";
 import ShutdownHelper, { ShutdownOrder } from "@server/utils/ShutdownHelper";
 import { getUserForJWT } from "@server/utils/jwt";
@@ -69,7 +70,7 @@ export default function init(
           !env.isCloudHosted &&
           (!req.headers.origin || !env.URL.startsWith(req.headers.origin))
         ) {
-          socket.end(`HTTP/1.1 400 Bad Request\r\n`);
+          rejectUpgrade(socket);
           return;
         }
 
@@ -83,7 +84,7 @@ export default function init(
       }
 
       // If the collaboration service isn't running then we need to close the connection
-      socket.end(`HTTP/1.1 400 Bad Request\r\n`);
+      rejectUpgrade(socket);
     }
   );
 


### PR DESCRIPTION
Sockets are detached from the HTTP server the moment an upgrade request arrives, and Node removes its own error handling along with them – an abruptly reset connection can take down the entire process.

- Handle errors for every upgraded socket in one place, before the services register handlers of their own
- Rejected upgrades now send a well-formed response and destroy the socket, instead of leaving it half-open to be reset at any point in the future
- Close upgrade requests when no service is running to handle them

closes #13404