### PR TITLE
feat: Optional `lastRevision` parameter on `documents.update`

### DIFF
--- a/server/commands/documentCollaborativeUpdater.ts
+++ b/server/commands/documentCollaborativeUpdater.ts
@@ -106,6 +106,9 @@ export default async function documentCollaborativeUpdater({
         lastModifiedById,
         collaboratorIds,
         editorVersion,
+        // Hooks are disabled below, so the revision increment that normally
+        // happens in BeforeUpdate must be applied manually.
+        revisionCount: document.revisionCount + 1,
       },
       {
         transaction,

--- a/server/commands/documentUpdater.ts
+++ b/server/commands/documentUpdater.ts
@@ -1,4 +1,5 @@
 import type { TextEditMode } from "@shared/types";
+import { DocumentConflictError } from "@server/errors";
 import { Event, Document } from "@server/models";
 import { DocumentHelper } from "@server/models/helpers/DocumentHelper";
 import { TextHelper } from "@server/models/helpers/TextHelper";
@@ -27,6 +28,8 @@ type Props = {
   insightsEnabled?: boolean;
   /** The edit mode: "replace", "append", "prepend", or "patch" */
   editMode?: TextEditMode;
+  /** The document revision the changes are based on, the update is rejected if it no longer matches */
+  lastRevision?: number;
   /** The markdown text to find when using "patch" edit mode */
   findText?: string;
   /** Whether the document should be published to the collection */
@@ -56,6 +59,7 @@ export default async function documentUpdater(
     insightsEnabled,
     editMode,
     findText,
+    lastRevision,
     publish,
     collectionId,
     done,
@@ -99,15 +103,23 @@ export default async function documentUpdater(
 
   // Serialize concurrent updates to the same document by taking a row-level
   // lock before writing. The wait is already bounded by the transaction's
-  // statement_timeout.
+  // statement_timeout. When lastRevision is provided it becomes part of the
+  // predicate, so a document modified since that revision matches no row.
   if (transaction) {
-    await Document.unscoped().findOne({
+    const locked = await Document.unscoped().findOne({
       attributes: ["id"],
-      where: { id: document.id },
+      where: {
+        id: document.id,
+        ...(lastRevision !== undefined && { revisionCount: lastRevision }),
+      },
       transaction,
       lock: transaction.LOCK.UPDATE,
       paranoid: false,
     });
+
+    if (!locked && lastRevision !== undefined) {
+      throw DocumentConflictError();
+    }
   }
 
   const changed = document.changed();

--- a/server/errors.ts
+++ b/server/errors.ts
@@ -118,6 +118,15 @@ export function NotFoundError(message = "Resource not found") {
   });
 }
 
+export function DocumentConflictError(
+  message = "Document has been modified since the provided revision"
+) {
+  return httpErrors(409, message, {
+    id: "document_conflict",
+    isReportable: false,
+  });
+}
+
 export function ParamRequiredError(message = "Required parameter missing") {
   return httpErrors(400, message, {
     id: "param_required",

--- a/server/routes/api/documents/documents.test.ts
+++ b/server/routes/api/documents/documents.test.ts
@@ -4013,6 +4013,47 @@ describe("#documents.update", () => {
     expect(events.length).toEqual(1);
   });
 
+  it("should update document when lastRevision matches", async () => {
+    const user = await buildUser();
+    const document = await buildDocument({
+      userId: user.id,
+      teamId: user.teamId,
+    });
+    const res = await server.post("/api/documents.update", user, {
+      body: {
+        id: document.id,
+        text: "Updated text",
+        lastRevision: document.revisionCount,
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.data.text).toBe("Updated text");
+    expect(body.data.revision).toBe(document.revisionCount + 1);
+  });
+
+  it("should return conflict when lastRevision does not match", async () => {
+    const user = await buildUser();
+    const document = await buildDocument({
+      userId: user.id,
+      teamId: user.teamId,
+    });
+    const res = await server.post("/api/documents.update", user, {
+      body: {
+        id: document.id,
+        text: "Updated text",
+        lastRevision: document.revisionCount - 1,
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(409);
+    expect(body.error).toBe("document_conflict");
+
+    const previousRevision = document.revisionCount;
+    await document.reload();
+    expect(document.revisionCount).toBe(previousRevision);
+  });
+
   it("should not update a document with text over the maximum length", async () => {
     const user = await buildUser();
     const document = await buildDocument({

--- a/server/routes/api/documents/schema.ts
+++ b/server/routes/api/documents/schema.ts
@@ -291,6 +291,9 @@ export const DocumentsUpdateSchema = BaseSchema.extend({
     /** Doc collection Id */
     collectionId: z.uuid().nullish(),
 
+    /** If set, the update is rejected when the doc revision does not match */
+    lastRevision: z.number().int().nonnegative().optional(),
+
     /** @deprecated Use editMode instead */
     append: z.boolean().optional(),
 


### PR DESCRIPTION
An API client writing a full document body has no way to signal which state it based that body on, so a stale write silently overwrites edits made in a collaborative session since.

- Adds an optional `lastRevision` parameter to `documents.update` — when provided and the document's revision no longer matches, the request is rejected with a 409 (`document_conflict`). Omitting it preserves existing behavior.
- Collaborative persists now increment the revision counter (previously skipped because hooks are disabled on that path), making the check reliable and fixing the stale `revision` field returned for collaboratively-edited documents.

closes #13405