### PR TITLE
fix: Apply all content transforms in `DocumentHelper.toJSON`

### DIFF
--- a/server/models/helpers/DocumentHelper.test.ts
+++ b/server/models/helpers/DocumentHelper.test.ts
@@ -86,6 +86,42 @@ describe("DocumentHelper", () => {
       const result = await DocumentHelper.toJSON(document);
       expect(result === document.content).toBe(true);
     });
+
+    it("should remove marks and replace internal urls together", async () => {
+      const document = await buildDocument({
+        text: "link",
+        content: {
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "text",
+                  text: "link",
+                  marks: [
+                    {
+                      type: "comment",
+                      attrs: { id: "comment-123", userId: "user-123" },
+                    },
+                    { type: "link", attrs: { href: "/doc/internal-123" } },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+      const result = await DocumentHelper.toJSON(document, {
+        removeMarks: ["comment"],
+        internalUrlBase: "/s/share-123",
+      });
+
+      const marks = result.content?.[0].content?.[0].marks;
+      expect(marks?.map((mark) => mark.type)).toEqual(["link"]);
+      expect(marks?.[0].attrs?.href).toBe("/s/share-123/doc/internal-123");
+    });
   });
 
   describe("toHTML", () => {

--- a/server/models/helpers/DocumentHelper.tsx
+++ b/server/models/helpers/DocumentHelper.tsx
@@ -13,6 +13,7 @@ import { EditorStyleHelper } from "@shared/editor/styles/EditorStyleHelper";
 import type { NavigationNode, ProsemirrorData } from "@shared/types";
 import { IconType, TextEditMode } from "@shared/types";
 import { determineIconType } from "@shared/utils/icon";
+import { ProsemirrorDataHelper } from "@shared/utils/ProsemirrorDataHelper";
 import { parser, serializer, schema } from "@server/editor";
 import { ValidationError } from "@server/errors";
 import { addTags } from "@server/logging/tracer";
@@ -142,7 +143,7 @@ export class DocumentHelper {
     }
   ): Promise<ProsemirrorData> {
     let doc: Node | null;
-    let data;
+    let data: ProsemirrorData;
 
     if ("content" in document && document.content) {
       // Optimized path for documents with content available and no transformation required.
@@ -171,7 +172,7 @@ export class DocumentHelper {
         options.signedUrls
       );
     } else {
-      data = doc?.toJSON() ?? {};
+      data = doc?.toJSON() ?? ProsemirrorDataHelper.getEmpty();
     }
 
     if (options?.internalUrlBase) {

--- a/server/models/helpers/ProsemirrorHelper.tsx
+++ b/server/models/helpers/ProsemirrorHelper.tsx
@@ -421,12 +421,16 @@ export class ProsemirrorHelper extends SharedProsemirrorHelper {
   /**
    * Prefixes internal document and collection links with the given base path.
    *
-   * @param doc The prosemirror document or JSON data
-   * @param basePath The base path to prefix internal links with, without a trailing slash
-   * @returns The document data with internal links rewritten
+   * @param doc The prosemirror document or JSON data.
+   * @param basePath The base path to prefix internal links with, without a
+   * trailing slash.
+   * @returns The document data with internal links rewritten.
    * @throws If the base path ends with a slash.
    */
-  static replaceInternalUrls(doc: Node | ProsemirrorData, basePath: string) {
+  static replaceInternalUrls(
+    doc: Node | ProsemirrorData,
+    basePath: string
+  ): ProsemirrorData {
     const json = "toJSON" in doc ? (doc.toJSON() as ProsemirrorData) : doc;
 
     if (basePath.endsWith("/")) {

--- a/server/models/helpers/ProsemirrorHelper.tsx
+++ b/server/models/helpers/ProsemirrorHelper.tsx
@@ -418,10 +418,15 @@ export class ProsemirrorHelper extends SharedProsemirrorHelper {
     return replaceDocumentReferencesInner(json);
   }
 
-  static async replaceInternalUrls(
-    doc: Node | ProsemirrorData,
-    basePath: string
-  ) {
+  /**
+   * Prefixes internal document and collection links with the given base path.
+   *
+   * @param doc The prosemirror document or JSON data
+   * @param basePath The base path to prefix internal links with, without a trailing slash
+   * @returns The document data with internal links rewritten
+   * @throws If the base path ends with a slash.
+   */
+  static replaceInternalUrls(doc: Node | ProsemirrorData, basePath: string) {
     const json = "toJSON" in doc ? (doc.toJSON() as ProsemirrorData) : doc;
 
     if (basePath.endsWith("/")) {


### PR DESCRIPTION
- `replaceInternalUrls` was declared async although it does no async work, so the promise it returned was passed into `removeMarks`, which returned it untouched rather than walking it — the transform was skipped whenever both options were given.
- Made the method synchronous and added its missing JSDoc.
- Typed the local in toJSON so the compiler reports a promise flowing through the transform chain, and used the existing empty-document helper for the fallback.