### PR TITLE
fix: Tighten credential handling in OAuth client and batch endpoints

### DIFF
--- a/server/presenters/oauthClient.ts
+++ b/server/presenters/oauthClient.ts
@@ -51,10 +51,11 @@ export function presentDCRClient(
  * Presents the OAuth client to the user.
  * This should ONLY be used for admin users who need to manage the OAuth client.
  *
- * @param oauthClient The OAuth client to present
+ * @param oauthClient The OAuth client to present.
  * @param options.includeSecret whether to include the client secret. Because the
  *   secret is a durable credential it is omitted unless the request is
  *   explicitly known to be permitted to manage the client.
+ * @returns the presented OAuth client.
  */
 export default function presentOAuthClient(
   oauthClient: OAuthClient,

--- a/server/presenters/oauthClient.ts
+++ b/server/presenters/oauthClient.ts
@@ -48,12 +48,18 @@ export function presentDCRClient(
 }
 
 /**
- * Presents the OAuth client to the user, including the client secret.
+ * Presents the OAuth client to the user.
  * This should ONLY be used for admin users who need to manage the OAuth client.
  *
  * @param oauthClient The OAuth client to present
+ * @param options.includeSecret whether to include the client secret. Because the
+ *   secret is a durable credential it is omitted unless the request is
+ *   explicitly known to be permitted to manage the client.
  */
-export default function presentOAuthClient(oauthClient: OAuthClient) {
+export default function presentOAuthClient(
+  oauthClient: OAuthClient,
+  { includeSecret = false }: { includeSecret?: boolean } = {}
+) {
   return {
     id: oauthClient.id,
     name: oauthClient.name,
@@ -62,7 +68,7 @@ export default function presentOAuthClient(oauthClient: OAuthClient) {
     developerUrl: oauthClient.developerUrl,
     avatarUrl: oauthClient.avatarUrl,
     clientId: oauthClient.clientId,
-    clientSecret: oauthClient.clientSecret,
+    ...(includeSecret && { clientSecret: oauthClient.clientSecret }),
     clientType: oauthClient.clientType,
     redirectUris: oauthClient.redirectUris,
     published: oauthClient.published,

--- a/server/routes/api/batch/batch.test.ts
+++ b/server/routes/api/batch/batch.test.ts
@@ -310,7 +310,7 @@ describe("#batch", () => {
     });
   });
   describe("credentials", () => {
-    it("should reject an API key, which cannot carry a per-method scope", async () => {
+    it("should reject an API key, as dispatching requires a session", async () => {
       const apiKey = await buildApiKey({ userId: user.id, scope: ["write"] });
 
       const res = await server.post("/api/batch", {

--- a/server/routes/api/batch/batch.test.ts
+++ b/server/routes/api/batch/batch.test.ts
@@ -3,6 +3,7 @@ import env from "@server/env";
 import type { Document, User } from "@server/models";
 import {
   buildAdmin,
+  buildApiKey,
   buildCollection,
   buildDocument,
   buildUser,
@@ -306,6 +307,63 @@ describe("#batch", () => {
       expect(res.status).toEqual(200);
       expect(body.data[0].ok).toBe(false);
       expect(body.data[0].status).toEqual(429);
+    });
+  });
+  describe("credentials", () => {
+    it("should reject an API key, which cannot carry a per-method scope", async () => {
+      const apiKey = await buildApiKey({ userId: user.id, scope: ["write"] });
+
+      const res = await server.post("/api/batch", {
+        headers: { authorization: `Bearer ${apiKey.value}` },
+        body: {
+          requests: [
+            {
+              method: "documents.update",
+              body: { id: documentOne.id, title: "x" },
+            },
+          ],
+        },
+      });
+
+      expect(res.status).toEqual(403);
+    });
+
+    it("should ignore a token in a sub-request body", async () => {
+      // A credential for an unrelated workspace, which the parent request has
+      // no access to. The sub-request must run as the parent's credential.
+      const other = await buildUser();
+      const otherDocument = await buildDocument({
+        userId: other.id,
+        teamId: other.teamId,
+      });
+      const otherKey = await buildApiKey({ userId: other.id, scope: ["*"] });
+      const title = otherDocument.title;
+
+      const res = await server.post(
+        `/api/batch?token=${encodeURIComponent(user.getSessionToken())}`,
+        {
+          body: {
+            requests: [
+              {
+                method: "documents.update",
+                body: {
+                  id: otherDocument.id,
+                  title: "smuggled",
+                  token: otherKey.value,
+                },
+              },
+            ],
+          },
+        }
+      );
+      const body = await res.json();
+
+      expect(res.status).toEqual(200);
+      expect(body.data[0].ok).toBe(false);
+      expect(body.data[0].status).toEqual(403);
+
+      await otherDocument.reload();
+      expect(otherDocument.title).toEqual(title);
     });
   });
 });

--- a/server/routes/api/batch/batch.ts
+++ b/server/routes/api/batch/batch.ts
@@ -1,4 +1,4 @@
-import { chunk, snakeCase } from "es-toolkit/compat";
+import { chunk, omit, snakeCase } from "es-toolkit/compat";
 import type { Middleware } from "koa";
 import compose from "koa-compose";
 import Router from "koa-router";
@@ -110,12 +110,20 @@ function createSubContext(
   // concurrent sub-requests or back to the parent.
   sub.state = { ...ctx.state };
   sub.request = Object.create(ctx.request);
-  sub.request.body = body;
+  // The parent's credential is the actor for every sub-request, so a token in
+  // the sub-request body must not re-authenticate it as a different one.
+  sub.request.body = omit(body, ["token"]);
   // Present the sub-request's own path so per-method rate limiting keys on the
   // dispatched method rather than the shared /batch path.
   Object.defineProperty(sub, "path", {
     configurable: true,
     get: () => `/${method}`,
+  });
+  // Credential scope is enforced against originalUrl, so it must also name the
+  // dispatched method rather than the parent /api/batch path.
+  Object.defineProperty(sub, "originalUrl", {
+    configurable: true,
+    get: () => `/api/${method}`,
   });
 
   const captured: { body?: RouteResponse; status: number } = { status: 404 };

--- a/server/routes/api/oauthClients/oauthClients.test.ts
+++ b/server/routes/api/oauthClients/oauthClients.test.ts
@@ -1,5 +1,10 @@
 import { OAuthClient } from "@server/models";
-import { buildTeam, buildUser, buildAdmin } from "@server/test/factories";
+import {
+  buildApiKey,
+  buildTeam,
+  buildUser,
+  buildAdmin,
+} from "@server/test/factories";
 import { getTestServer } from "@server/test/support";
 
 const server = getTestServer();
@@ -87,6 +92,55 @@ describe("oauthClients.info", () => {
     expect(body.data.published).toBeFalsy();
     expect(body.data.clientSecret).toBeDefined();
     expect(body.data.redirectUris).toEqual(["https://example.com/callback"]);
+  });
+
+  it("should not return the client secret to a read-only credential", async () => {
+    const team = await buildTeam();
+    const user = await buildAdmin({ teamId: team.id });
+    const apiKey = await buildApiKey({ userId: user.id, scope: ["read"] });
+
+    const client = await OAuthClient.create({
+      teamId: team.id,
+      createdById: user.id,
+      name: "Test Client",
+      redirectUris: ["https://example.com/callback"],
+    });
+
+    const res = await server.post("/api/oauthClients.info", {
+      headers: { authorization: `Bearer ${apiKey.value}` },
+      body: {
+        id: client.id,
+      },
+    });
+
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.data.name).toEqual("Test Client");
+    expect(body.data.clientSecret).toBeUndefined();
+  });
+
+  it("should return the client secret to a write credential", async () => {
+    const team = await buildTeam();
+    const user = await buildAdmin({ teamId: team.id });
+    const apiKey = await buildApiKey({ userId: user.id, scope: ["write"] });
+
+    const client = await OAuthClient.create({
+      teamId: team.id,
+      createdById: user.id,
+      name: "Test Client",
+      redirectUris: ["https://example.com/callback"],
+    });
+
+    const res = await server.post("/api/oauthClients.info", {
+      headers: { authorization: `Bearer ${apiKey.value}` },
+      body: {
+        id: client.id,
+      },
+    });
+
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.data.clientSecret).toEqual(client.clientSecret);
   });
 
   it("should return basic information about an OAuth client when member", async () => {

--- a/server/routes/api/oauthClients/oauthClients.ts
+++ b/server/routes/api/oauthClients/oauthClients.ts
@@ -1,5 +1,6 @@
 import Router from "koa-router";
 import { Op } from "sequelize";
+import AuthenticationHelper from "@shared/helpers/AuthenticationHelper";
 import { UserRole } from "@shared/types";
 import { ValidationError } from "@server/errors";
 import auth from "@server/middlewares/authentication";
@@ -19,6 +20,21 @@ import pagination from "../middlewares/pagination";
 import * as T from "./schema";
 
 const router = new Router();
+
+/**
+ * Whether the presented credential is scoped to manage OAuth clients. The
+ * user's ability is not sufficient on its own to receive a client secret, as a
+ * restricted credential must not be able to trade itself for a durable one.
+ *
+ * @param ctx The request context.
+ * @returns true if the credential's scope covers managing clients.
+ */
+function hasManageScope(ctx: APIContext) {
+  return AuthenticationHelper.canAccess(
+    "/api/oauthClients.update",
+    ctx.state.auth.scope ?? ["*"]
+  );
+}
 
 router.post(
   "oauthClients.list",
@@ -49,7 +65,9 @@ router.post(
       pagination: { ...ctx.state.pagination, total },
       data: oauthClients.map((oauthClient) =>
         can(user, "update", oauthClient)
-          ? presentOAuthClient(oauthClient)
+          ? presentOAuthClient(oauthClient, {
+              includeSecret: hasManageScope(ctx),
+            })
           : presentPublishedOAuthClient(oauthClient)
       ),
       policies: presentPolicies(user, oauthClients),
@@ -79,7 +97,9 @@ router.post(
 
     ctx.body = {
       data: canUpdate
-        ? presentOAuthClient(oauthClient)
+        ? presentOAuthClient(oauthClient, {
+            includeSecret: hasManageScope(ctx),
+          })
         : presentPublishedOAuthClient(oauthClient),
       policies: isInternalApp ? presentPolicies(user, [oauthClient]) : [],
     };
@@ -105,7 +125,7 @@ router.post(
     });
 
     ctx.body = {
-      data: presentOAuthClient(oauthClient),
+      data: presentOAuthClient(oauthClient, { includeSecret: true }),
       policies: presentPolicies(user, [oauthClient]),
     };
   }
@@ -131,7 +151,7 @@ router.post(
     await oauthClient.updateWithCtx(ctx, input);
 
     ctx.body = {
-      data: presentOAuthClient(oauthClient),
+      data: presentOAuthClient(oauthClient, { includeSecret: true }),
       policies: presentPolicies(user, [oauthClient]),
     };
   }
@@ -159,7 +179,7 @@ router.post(
     await oauthClient.saveWithCtx(ctx);
 
     ctx.body = {
-      data: presentOAuthClient(oauthClient),
+      data: presentOAuthClient(oauthClient, { includeSecret: true }),
       policies: presentPolicies(user, [oauthClient]),
     };
   }

--- a/server/routes/oauth/index.ts
+++ b/server/routes/oauth/index.ts
@@ -15,6 +15,7 @@ import OAuthAuthentication from "@server/models/oauth/OAuthAuthentication";
 import { authorize } from "@server/policies";
 import { presentDCRClient } from "@server/presenters/oauthClient";
 import type { APIContext } from "@server/types";
+import { AuthenticationType } from "@server/types";
 import { RateLimiterStrategy } from "@server/utils/RateLimiter";
 import { TeamPreference } from "@shared/types";
 import { OAuthInterface } from "@server/utils/oauth/OAuthInterface";
@@ -41,7 +42,9 @@ const oauth = new OAuth2Server({
 router.post(
   "/authorize",
   rateLimiter(RateLimiterStrategy.OneHundredPerHour),
-  auth(),
+  // Consent is given interactively, so only a session may authorize a client.
+  // An API key or access token must never mint credentials for another client.
+  auth({ type: AuthenticationType.APP }),
   async (ctx) => {
     const { user } = ctx.state.auth;
     const clientId = ctx.request.body.client_id;

--- a/server/routes/oauth/oauth.test.ts
+++ b/server/routes/oauth/oauth.test.ts
@@ -3,7 +3,12 @@ import sharedEnv from "@shared/env";
 import { TeamPreference } from "@shared/types";
 import env from "@server/env";
 import { OAuthClient } from "@server/models";
-import { buildTeam } from "@server/test/factories";
+import {
+  buildApiKey,
+  buildOAuthClient,
+  buildTeam,
+  buildUser,
+} from "@server/test/factories";
 import { getTestServer } from "@server/test/support";
 
 const server = getTestServer();
@@ -517,5 +522,47 @@ describe("GET /.well-known/oauth-protected-resource", () => {
     } finally {
       env.URL = sharedEnv.URL = originalUrl;
     }
+  });
+});
+
+describe("POST /oauth/authorize", () => {
+  it("should not accept an API key in place of a session", async () => {
+    const user = await buildUser();
+    const client = await buildOAuthClient({ teamId: user.teamId });
+    const apiKey = await buildApiKey({ userId: user.id, scope: ["write"] });
+
+    const res = await server.post("/oauth/authorize", {
+      redirect: "manual",
+      headers: { authorization: `Bearer ${apiKey.value}` },
+      body: {
+        client_id: client.clientId,
+        response_type: "code",
+        redirect_uri: client.redirectUris[0],
+        state: "state",
+        scope: "read write",
+      },
+    });
+
+    expect(res.status).toEqual(403);
+    expect(res.headers.get("location")).toBeNull();
+  });
+
+  it("should issue an authorization code for a session", async () => {
+    const user = await buildUser();
+    const client = await buildOAuthClient({ teamId: user.teamId });
+
+    const res = await server.post("/oauth/authorize", user, {
+      redirect: "manual",
+      body: {
+        client_id: client.clientId,
+        response_type: "code",
+        redirect_uri: client.redirectUris[0],
+        state: "state",
+        scope: "read",
+      },
+    });
+
+    expect(res.status).toEqual(302);
+    expect(res.headers.get("location")).toContain("code=");
   });
 });


### PR DESCRIPTION
- Include an OAuth client secret in a response only when the presented credential is itself scoped to manage clients, rather than deciding from the user's abilities alone.
- Require an interactive session at the authorization endpoint, matching `/api/batch`, so the consent step cannot be answered programmatically.
- Resolve a batched sub-request's scope against the dispatched method rather than the parent path, and always run sub-requests as the parent's credential.