### PR TITLE
Add "New doc" item to child documents list

### DIFF
--- a/app/scenes/Document/components/ReferenceListItem.tsx
+++ b/app/scenes/Document/components/ReferenceListItem.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import { DocumentIcon } from "outline-icons";
+import { DocumentIcon, PlusIcon } from "outline-icons";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import styled, { css } from "styled-components";
@@ -19,7 +19,7 @@ import type { SidebarContextType } from "~/components/Sidebar/components/Sidebar
 import { ActionContextProvider } from "~/hooks/useActionContext";
 import { useDocumentMenuAction } from "~/hooks/useDocumentMenuAction";
 import DocumentMenu from "~/menus/DocumentMenu";
-import { sharedModelPath } from "~/utils/routeHelpers";
+import { newNestedDocumentPath, sharedModelPath } from "~/utils/routeHelpers";
 import useBoolean from "~/hooks/useBoolean";
 import useClickIntent from "~/hooks/useClickIntent";
 import useStores from "~/hooks/useStores";
@@ -32,6 +32,44 @@ type Props = {
   showCollection?: boolean;
   sidebarContext?: SidebarContextType;
 };
+
+type NewChildProps = {
+  parentDocumentId: string;
+  sidebarContext?: SidebarContextType;
+};
+
+/**
+ * A list item that starts the creation of a new document nested under the given
+ * parent document.
+ *
+ * @param parentDocumentId - the identifier of the parent document.
+ * @param sidebarContext - the sidebar context to keep after navigation.
+ * @returns a list item linking to the new document screen.
+ */
+export function NewChildReferenceListItem({
+  parentDocumentId,
+  sidebarContext,
+}: NewChildProps) {
+  const { t } = useTranslation();
+  const [pathname, search] = newNestedDocumentPath(parentDocumentId).split("?");
+
+  return (
+    <li>
+      <DocumentLink
+        to={{
+          pathname,
+          search,
+          state: { sidebarContext },
+        }}
+      >
+        <Content gap={4} dir="auto">
+          <PlusIcon />
+          <SecondaryTitle>{t("New doc")}</SecondaryTitle>
+        </Content>
+      </DocumentLink>
+    </li>
+  );
+}
 
 const Actions = styled(EventBoundary)`
   display: none;
@@ -103,6 +141,10 @@ const Title = styled.div`
   padding-top: 3px;
   color: ${s("text")};
   font-family: ${s("fontFamily")};
+`;
+
+const SecondaryTitle = styled(Title)`
+  color: ${s("textSecondary")};
 `;
 
 function ReferenceListItem({

--- a/app/scenes/Document/components/References.tsx
+++ b/app/scenes/Document/components/References.tsx
@@ -9,7 +9,10 @@ import { Tab, Tabs } from "~/components/Tabs";
 import useCurrentUser from "~/hooks/useCurrentUser";
 import { useLocationSidebarContext } from "~/hooks/useLocationSidebarContext";
 import useStores from "~/hooks/useStores";
-import ReferenceListItem from "./ReferenceListItem";
+import usePolicy from "~/hooks/usePolicy";
+import ReferenceListItem, {
+  NewChildReferenceListItem,
+} from "./ReferenceListItem";
 import useShare from "@shared/hooks/useShare";
 import type { NavigationNode } from "@shared/types";
 import { flattenTree } from "@shared/utils/tree";
@@ -40,11 +43,18 @@ function References({ document }: Props) {
 
   const children = useChildren(document, sharedTree);
   const backlinks = useBacklinks(document, sharedTree);
+  const can = usePolicy(document);
   const showBacklinks = !!backlinks.length;
   const showChildDocuments = !!children.length;
+  const showNewChildDocument =
+    showChildDocuments && !isShare && !!can.createChildDocument;
   const shouldFade = useRef(!showBacklinks && !showChildDocuments);
   const isBacklinksTab = activeTab === "backlinks" || !showChildDocuments;
-  const height = Math.max(backlinks.length, children.length) * 40;
+  const height =
+    Math.max(
+      backlinks.length,
+      children.length + (showNewChildDocument ? 1 : 0)
+    ) * 40;
   const Component = shouldFade.current ? Fade : Fragment;
 
   return showBacklinks || showChildDocuments ? (
@@ -111,6 +121,12 @@ function References({ document }: Props) {
                 />
               );
             })}
+            {showNewChildDocument && (
+              <NewChildReferenceListItem
+                parentDocumentId={document.id}
+                sidebarContext={locationSidebarContext}
+              />
+            )}
           </List>
         )}
       </Content>


### PR DESCRIPTION
Adds a quick way to create a nested document from the references section at the bottom of a document.

- A "New doc" row now appears as the last item of the child documents list, styled to match the sibling rows
- Only shown when the list is already visible, the user is not viewing a share, and they have permission to create a child document
- Links into the existing new nested document flow, preserving sidebar context