### PR TITLE
fix: Align credential transport handling in authentication middleware

### DIFF
--- a/plugins/figma/server/api/figma.test.ts
+++ b/plugins/figma/server/api/figma.test.ts
@@ -11,9 +11,8 @@ describe("#figma.callback", () => {
       nonce: "attacker-nonce",
     });
     const res = await server.get(
-      `/api/figma.callback?state=${encodeURIComponent(
-        state
-      )}&code=123&token=${user.getSessionToken()}`,
+      `/api/figma.callback?state=${encodeURIComponent(state)}&code=123`,
+      user,
       { redirect: "manual" }
     );
     const body = await res.json();
@@ -25,9 +24,8 @@ describe("#figma.callback", () => {
     const user = await buildUser();
     const state = JSON.stringify({ teamId: user.teamId });
     const res = await server.get(
-      `/api/figma.callback?state=${encodeURIComponent(
-        state
-      )}&code=123&token=${user.getSessionToken()}`,
+      `/api/figma.callback?state=${encodeURIComponent(state)}&code=123`,
+      user,
       { redirect: "manual" }
     );
     expect(res.status).toEqual(400);
@@ -36,7 +34,8 @@ describe("#figma.callback", () => {
   it("should fail when state is not valid JSON", async () => {
     const user = await buildUser();
     const res = await server.get(
-      `/api/figma.callback?state=bad&code=123&token=${user.getSessionToken()}`,
+      `/api/figma.callback?state=bad&code=123`,
+      user,
       { redirect: "manual" }
     );
     expect(res.status).toEqual(400);

--- a/plugins/github/server/api/github.test.ts
+++ b/plugins/github/server/api/github.test.ts
@@ -14,7 +14,8 @@ describe("#github.callback", () => {
     const res = await server.get(
       `/api/github.callback?state=${encodeURIComponent(
         state
-      )}&code=123&setup_action=${SetupAction.install}&installation_id=1&token=${user.getSessionToken()}`,
+      )}&code=123&setup_action=${SetupAction.install}&installation_id=1`,
+      user,
       { redirect: "manual" }
     );
     const body = await res.json();
@@ -28,7 +29,8 @@ describe("#github.callback", () => {
     const res = await server.get(
       `/api/github.callback?state=${encodeURIComponent(
         state
-      )}&code=123&setup_action=${SetupAction.install}&installation_id=1&token=${user.getSessionToken()}`,
+      )}&code=123&setup_action=${SetupAction.install}&installation_id=1`,
+      user,
       { redirect: "manual" }
     );
     expect(res.status).toEqual(400);
@@ -37,7 +39,8 @@ describe("#github.callback", () => {
   it("should fail when state is not valid JSON", async () => {
     const user = await buildUser();
     const res = await server.get(
-      `/api/github.callback?state=bad&code=123&setup_action=${SetupAction.install}&installation_id=1&token=${user.getSessionToken()}`,
+      `/api/github.callback?state=bad&code=123&setup_action=${SetupAction.install}&installation_id=1`,
+      user,
       { redirect: "manual" }
     );
     expect(res.status).toEqual(400);

--- a/plugins/gitlab/server/api/gitlab.test.ts
+++ b/plugins/gitlab/server/api/gitlab.test.ts
@@ -11,9 +11,8 @@ describe("#gitlab.callback", () => {
       nonce: "attacker-nonce",
     });
     const res = await server.get(
-      `/api/gitlab.callback?state=${encodeURIComponent(
-        state
-      )}&code=123&token=${user.getSessionToken()}`,
+      `/api/gitlab.callback?state=${encodeURIComponent(state)}&code=123`,
+      user,
       { redirect: "manual" }
     );
     const body = await res.json();
@@ -25,9 +24,8 @@ describe("#gitlab.callback", () => {
     const user = await buildUser();
     const state = JSON.stringify({ teamId: user.teamId });
     const res = await server.get(
-      `/api/gitlab.callback?state=${encodeURIComponent(
-        state
-      )}&code=123&token=${user.getSessionToken()}`,
+      `/api/gitlab.callback?state=${encodeURIComponent(state)}&code=123`,
+      user,
       { redirect: "manual" }
     );
     expect(res.status).toEqual(400);
@@ -36,7 +34,8 @@ describe("#gitlab.callback", () => {
   it("should fail when state is not valid JSON", async () => {
     const user = await buildUser();
     const res = await server.get(
-      `/api/gitlab.callback?state=bad&code=123&token=${user.getSessionToken()}`,
+      `/api/gitlab.callback?state=bad&code=123`,
+      user,
       { redirect: "manual" }
     );
     expect(res.status).toEqual(400);

--- a/plugins/linear/server/api/linear.test.ts
+++ b/plugins/linear/server/api/linear.test.ts
@@ -11,9 +11,8 @@ describe("#linear.callback", () => {
       nonce: "attacker-nonce",
     });
     const res = await server.get(
-      `/api/linear.callback?state=${encodeURIComponent(
-        state
-      )}&code=123&token=${user.getSessionToken()}`,
+      `/api/linear.callback?state=${encodeURIComponent(state)}&code=123`,
+      user,
       { redirect: "manual" }
     );
     const body = await res.json();
@@ -25,9 +24,8 @@ describe("#linear.callback", () => {
     const user = await buildUser();
     const state = JSON.stringify({ teamId: user.teamId });
     const res = await server.get(
-      `/api/linear.callback?state=${encodeURIComponent(
-        state
-      )}&code=123&token=${user.getSessionToken()}`,
+      `/api/linear.callback?state=${encodeURIComponent(state)}&code=123`,
+      user,
       { redirect: "manual" }
     );
     expect(res.status).toEqual(400);
@@ -36,7 +34,8 @@ describe("#linear.callback", () => {
   it("should fail when state is not valid JSON", async () => {
     const user = await buildUser();
     const res = await server.get(
-      `/api/linear.callback?state=bad&code=123&token=${user.getSessionToken()}`,
+      `/api/linear.callback?state=bad&code=123`,
+      user,
       { redirect: "manual" }
     );
     expect(res.status).toEqual(400);

--- a/plugins/notion/server/api/notion.test.ts
+++ b/plugins/notion/server/api/notion.test.ts
@@ -11,9 +11,8 @@ describe("#notion.callback", () => {
       nonce: "attacker-nonce",
     });
     const res = await server.get(
-      `/api/notion.callback?state=${encodeURIComponent(
-        state
-      )}&code=123&token=${user.getSessionToken()}`,
+      `/api/notion.callback?state=${encodeURIComponent(state)}&code=123`,
+      user,
       { redirect: "manual" }
     );
     const body = await res.json();
@@ -25,9 +24,8 @@ describe("#notion.callback", () => {
     const user = await buildUser();
     const state = JSON.stringify({ teamId: user.teamId });
     const res = await server.get(
-      `/api/notion.callback?state=${encodeURIComponent(
-        state
-      )}&code=123&token=${user.getSessionToken()}`,
+      `/api/notion.callback?state=${encodeURIComponent(state)}&code=123`,
+      user,
       { redirect: "manual" }
     );
     expect(res.status).toEqual(400);
@@ -36,7 +34,8 @@ describe("#notion.callback", () => {
   it("should fail when state is not valid JSON", async () => {
     const user = await buildUser();
     const res = await server.get(
-      `/api/notion.callback?state=bad&code=123&token=${user.getSessionToken()}`,
+      `/api/notion.callback?state=bad&code=123`,
+      user,
       { redirect: "manual" }
     );
     expect(res.status).toEqual(400);

--- a/plugins/slack/server/auth/slack.test.ts
+++ b/plugins/slack/server/auth/slack.test.ts
@@ -9,18 +9,15 @@ describe("#slack.post", () => {
   it("should fail with status 400 bad request if query param state is not valid", async () => {
     const user = await buildUser();
     const res = await server.get(
-      `/auth/slack.post?state=${JSON.stringify(
-        {}
-      )}&code=123&token=${user.getSessionToken()}`
+      `/auth/slack.post?state=${JSON.stringify({})}&code=123`,
+      user
     );
     expect(res.status).toEqual(400);
   });
 
   it("should fail with status 400 bad request if query param state is not JSON", async () => {
     const user = await buildUser();
-    const res = await server.get(
-      `/auth/slack.post?state=bad&code=123&token=${user.getSessionToken()}`
-    );
+    const res = await server.get(`/auth/slack.post?state=bad&code=123`, user);
     expect(res.status).toEqual(400);
   });
 
@@ -41,9 +38,8 @@ describe("#slack.post", () => {
       nonce: "attacker-nonce",
     });
     const res = await server.get(
-      `/auth/slack.post?state=${encodeURIComponent(
-        state
-      )}&code=123&token=${user.getSessionToken()}`,
+      `/auth/slack.post?state=${encodeURIComponent(state)}&code=123`,
+      user,
       { redirect: "manual" }
     );
     const body = await res.json();
@@ -58,9 +54,8 @@ describe("#slack.post", () => {
       teamId: user.teamId,
     });
     const res = await server.get(
-      `/auth/slack.post?state=${encodeURIComponent(
-        state
-      )}&code=123&token=${user.getSessionToken()}`,
+      `/auth/slack.post?state=${encodeURIComponent(state)}&code=123`,
+      user,
       { redirect: "manual" }
     );
     expect(res.status).toEqual(400);

--- a/plugins/storage/server/api/files.test.ts
+++ b/plugins/storage/server/api/files.test.ts
@@ -52,9 +52,7 @@ describe("#files.create", () => {
     const form = new FormData();
     form.append("key", attachment.key);
     form.append("file", content, fileName);
-    form.append("token", user.getSessionToken());
-
-    const res = await server.post(`/api/files.create`, {
+    const res = await server.post(`/api/files.create`, user, {
       headers: form.getHeaders(),
       body: form,
     });
@@ -89,9 +87,7 @@ describe("#files.create", () => {
     const form = new FormData();
     form.append("key", attachment.key);
     form.append("file", content, fileName);
-    form.append("token", user.getSessionToken());
-
-    const res = await server.post(`/api/files.create`, {
+    const res = await server.post(`/api/files.create`, user, {
       headers: form.getHeaders(),
       body: form,
     });
@@ -118,9 +114,7 @@ describe("#files.create", () => {
     const form = new FormData();
     form.append("key", attachment.key);
     form.append("file", content, fileName);
-    form.append("token", user.getSessionToken());
-
-    const res = await server.post(`/api/files.create`, {
+    const res = await server.post(`/api/files.create`, user, {
       headers: form.getHeaders(),
       body: form,
     });
@@ -150,9 +144,7 @@ describe("#files.create", () => {
     const form = new FormData();
     form.append("key", attachment.key);
     form.append("file", content, fileName);
-    form.append("token", user.getSessionToken());
-
-    const res = await server.post(`/api/files.create`, {
+    const res = await server.post(`/api/files.create`, user, {
       headers: form.getHeaders(),
       body: form,
     });
@@ -181,9 +173,7 @@ describe("#files.create", () => {
     const form = new FormData();
     form.append("key", attachment.key);
     form.append("file", content, fileName);
-    form.append("token", user.getSessionToken());
-
-    const res = await server.post(`/api/files.create`, {
+    const res = await server.post(`/api/files.create`, user, {
       headers: form.getHeaders(),
       body: form,
     });
@@ -366,9 +356,7 @@ describe("#files.get", () => {
     const form = new FormData();
     form.append("key", attachment.key);
     form.append("file", content, fileName);
-    form.append("token", user.getSessionToken());
-
-    await server.post(`/api/files.create`, {
+    await server.post(`/api/files.create`, user, {
       headers: form.getHeaders(),
       body: form,
     });
@@ -402,9 +390,7 @@ describe("#files.get", () => {
     const form = new FormData();
     form.append("key", attachment.key);
     form.append("file", content, fileName);
-    form.append("token", user.getSessionToken());
-
-    await server.post(`/api/files.create`, {
+    await server.post(`/api/files.create`, user, {
       headers: form.getHeaders(),
       body: form,
     });

--- a/server/middlewares/authentication.test.ts
+++ b/server/middlewares/authentication.test.ts
@@ -290,7 +290,7 @@ describe("Authentication middleware", () => {
     }
   });
 
-  it("should allow passing auth token as a GET param", async () => {
+  it("should allow passing session token in a cookie", async () => {
     const state = {} as DefaultState;
     const user = await buildUser();
     const authMiddleware = auth();
@@ -299,9 +299,10 @@ describe("Authentication middleware", () => {
         request: {
           // @ts-expect-error mock request
           get: vi.fn(() => null),
-          query: {
-            token: user.getSessionToken(),
-          },
+        },
+        // @ts-expect-error mock cookies
+        cookies: {
+          get: vi.fn(() => user.getSessionToken()),
         },
         state,
         cache: {},
@@ -311,7 +312,57 @@ describe("Authentication middleware", () => {
     expect(state.auth.user.id).toEqual(user.id);
   });
 
-  it("should allow passing auth token in body params", async () => {
+  it("should return error with session token as a GET param", async () => {
+    const state = {} as DefaultState;
+    const user = await buildUser();
+    const authMiddleware = auth();
+
+    await expect(
+      authMiddleware(
+        {
+          request: {
+            // @ts-expect-error mock request
+            get: vi.fn(() => null),
+            query: {
+              token: user.getSessionToken(),
+            },
+          },
+          state,
+          cache: {},
+        },
+        vi.fn()
+      )
+    ).rejects.toThrow(
+      "Session token must be passed in the cookie or Authorization header"
+    );
+  });
+
+  it("should return error with session token in body params", async () => {
+    const state = {} as DefaultState;
+    const user = await buildUser();
+    const authMiddleware = auth();
+
+    await expect(
+      authMiddleware(
+        {
+          request: {
+            // @ts-expect-error mock request
+            get: vi.fn(() => null),
+            body: {
+              token: user.getSessionToken(),
+            },
+          },
+          state,
+          cache: {},
+        },
+        vi.fn()
+      )
+    ).rejects.toThrow(
+      "Session token must be passed in the cookie or Authorization header"
+    );
+  });
+
+  it("should allow passing transfer token as a GET param", async () => {
     const state = {} as DefaultState;
     const user = await buildUser();
     const authMiddleware = auth();
@@ -320,8 +371,8 @@ describe("Authentication middleware", () => {
         request: {
           // @ts-expect-error mock request
           get: vi.fn(() => null),
-          body: {
-            token: user.getSessionToken(),
+          query: {
+            token: user.getTransferToken(),
           },
         },
         state,

--- a/server/middlewares/authentication.ts
+++ b/server/middlewares/authentication.ts
@@ -10,7 +10,7 @@ import tracer, {
 import { User, Team, ApiKey, OAuthAuthentication } from "@server/models";
 import type { AppContext } from "@server/types";
 import { AuthenticationType } from "@server/types";
-import { getUserForJWT } from "@server/utils/jwt";
+import { getJWTPayload, getUserForJWT } from "@server/utils/jwt";
 import {
   AuthenticationError,
   AuthorizationError,
@@ -243,6 +243,19 @@ async function validateAuthentication(
     scope = apiKey.scope ?? ["*"];
     await apiKey.updateActiveAt();
   } else {
+    // Session tokens are long-lived, so keep them out of transports that end up
+    // in browser history, referrers, and request logs. Short-lived single-use
+    // tokens such as transfer are still accepted from anywhere.
+    if (transport !== "cookie" && transport !== "header") {
+      const payload = getJWTPayload(token);
+
+      if (payload.type === "session") {
+        throw AuthenticationError(
+          "Session token must be passed in the cookie or Authorization header"
+        );
+      }
+    }
+
     type = AuthenticationType.APP;
     const result = await getUserForJWT(token);
     user = result.user;

--- a/server/routes/api/batch/batch.test.ts
+++ b/server/routes/api/batch/batch.test.ts
@@ -339,23 +339,20 @@ describe("#batch", () => {
       const otherKey = await buildApiKey({ userId: other.id, scope: ["*"] });
       const title = otherDocument.title;
 
-      const res = await server.post(
-        `/api/batch?token=${encodeURIComponent(user.getSessionToken())}`,
-        {
-          body: {
-            requests: [
-              {
-                method: "documents.update",
-                body: {
-                  id: otherDocument.id,
-                  title: "smuggled",
-                  token: otherKey.value,
-                },
+      const res = await server.post(`/api/batch`, user, {
+        body: {
+          requests: [
+            {
+              method: "documents.update",
+              body: {
+                id: otherDocument.id,
+                title: "smuggled",
+                token: otherKey.value,
               },
-            ],
-          },
-        }
-      );
+            },
+          ],
+        },
+      });
       const body = await res.json();
 
       expect(res.status).toEqual(200);

--- a/server/routes/api/documents/documents.test.ts
+++ b/server/routes/api/documents/documents.test.ts
@@ -3471,10 +3471,9 @@ describe("#documents.import", () => {
     );
     const form = new FormData();
     form.append("file", content, "markdown.md");
-    form.append("token", user.getSessionToken());
     form.append("collectionId", collection.id);
 
-    const res = await server.post("/api/documents.import", {
+    const res = await server.post("/api/documents.import", user, {
       headers: form.getHeaders(),
       body: form,
     });
@@ -3534,11 +3533,10 @@ describe("#documents.import", () => {
     );
     const form = new FormData();
     form.append("file", content, "markdown.md");
-    form.append("token", user.getSessionToken());
     form.append("collectionId", collection.id);
     form.append("parentDocumentId", parentDocument.id);
 
-    const res = await server.post("/api/documents.import", {
+    const res = await server.post("/api/documents.import", user, {
       headers: form.getHeaders(),
       body: form,
     });
@@ -3599,12 +3597,11 @@ describe("#documents.import", () => {
     );
     const form = new FormData();
     form.append("file", content, "markdown.md");
-    form.append("token", user.getSessionToken());
     form.append("collectionId", privateCollection.id);
     form.append("parentDocumentId", parentDocument.id);
     form.append("publish", "true");
 
-    const res = await server.post("/api/documents.import", {
+    const res = await server.post("/api/documents.import", user, {
       headers: form.getHeaders(),
       body: form,
     });

--- a/server/routes/api/users/users.test.ts
+++ b/server/routes/api/users/users.test.ts
@@ -793,9 +793,10 @@ describe("#users.updateEmail", () => {
       const user = await buildUser();
       const email = faker.internet.email();
       await server.get(
-        `/api/users.updateEmail?token=${user.getSessionToken()}&code=${user.getEmailUpdateToken(
+        `/api/users.updateEmail?code=${user.getEmailUpdateToken(
           email
-        )}&follow=true`
+        )}&follow=true`,
+        user
       );
 
       await user.reload();


### PR DESCRIPTION
The authentication middleware applies different transport rules to each credential type it parses. This brings session tokens into line with the others. TLDR we allowed session tokens to theoretically be passed in query string, though this was only ever used for tests.

- Session tokens are read only from the cookie or the `Authorization` header
- Short-lived single-use transfer tokens are unchanged, so the subdomain and desktop sign-in hand-offs are unaffected
- No client passes session tokens any other way today, so there is no user-facing change