### PR TITLE
fix: Tighten one-time credential handling in OAuth token exchange

### DIFF
--- a/server/models/base/Model.ts
+++ b/server/models/base/Model.ts
@@ -4,6 +4,7 @@ import type {
   Attributes,
   CreateOptions,
   CreationAttributes,
+  DestroyOptions,
   FindOptions,
   FindOrCreateOptions,
   ModelStatic,
@@ -185,6 +186,34 @@ class Model<
       }
       throw err;
     }
+  }
+
+  /**
+   * Destroys every row that matches the given options, publishing an event for
+   * each. Rows are matched when the destroy runs, so rows written after the
+   * options were prepared are destroyed too.
+   *
+   * @param ctx The API context.
+   * @param options The destroy options.
+   * @param eventOpts Optional event override options.
+   * @returns the number of destroyed rows.
+   */
+  public static destroyWithCtx<M extends Model>(
+    this: ModelStatic<M>,
+    ctx: APIContext,
+    options: DestroyOptions<Attributes<M>>,
+    eventOpts?: EventOverrideOptions
+  ) {
+    const hookContext = {
+      ...ctx.context,
+      ...options,
+      individualHooks: true,
+      event: {
+        ...eventOpts,
+        publish: true,
+      },
+    };
+    return this.destroy(hookContext);
   }
 
   /**

--- a/server/models/oauth/OAuthAuthentication.ts
+++ b/server/models/oauth/OAuthAuthentication.ts
@@ -241,6 +241,24 @@ class OAuthAuthentication extends ParanoidModel<
       ...options,
     });
   }
+
+  /**
+   * Revokes the OAuthAuthentication with the given refresh token. The update is
+   * atomic, so concurrent attempts to rotate one refresh token result in a
+   * single successful caller.
+   *
+   * @param input The refresh token to revoke
+   * @returns True if this call revoked the authentication
+   */
+  public static async revokeByRefreshToken(input: string) {
+    const count = await this.destroy({
+      where: {
+        refreshTokenHash: hash(input),
+      },
+    });
+
+    return count > 0;
+  }
 }
 
 export default OAuthAuthentication;

--- a/server/models/oauth/OAuthAuthorizationCode.test.ts
+++ b/server/models/oauth/OAuthAuthorizationCode.test.ts
@@ -1,0 +1,51 @@
+import crypto from "node:crypto";
+import { Scope } from "@shared/types";
+import { OAuthAuthorizationCode } from "@server/models";
+import { buildOAuthClient, buildUser } from "@server/test/factories";
+import { hash } from "@server/utils/crypto";
+
+const buildCode = async () => {
+  const user = await buildUser();
+  const client = await buildOAuthClient({ teamId: user.teamId });
+  const code = crypto.randomBytes(32).toString("hex");
+
+  await OAuthAuthorizationCode.create({
+    authorizationCodeHash: hash(code),
+    scope: [Scope.Read],
+    redirectUri: client.redirectUris[0],
+    oauthClientId: client.id,
+    userId: user.id,
+    expiresAt: new Date(Date.now() + 10000),
+    grantId: crypto.randomUUID(),
+  });
+
+  return code;
+};
+
+describe("OAuthAuthorizationCode", () => {
+  describe("consume", () => {
+    it("should consume the code once", async () => {
+      const code = await buildCode();
+
+      expect(await OAuthAuthorizationCode.consume(code)).toBe(true);
+      expect(await OAuthAuthorizationCode.consume(code)).toBe(false);
+      expect(await OAuthAuthorizationCode.findByCode(code)).toBeNull();
+    });
+
+    it("should succeed for a single caller when consumed concurrently", async () => {
+      const code = await buildCode();
+
+      const consumed = await Promise.all([
+        OAuthAuthorizationCode.consume(code),
+        OAuthAuthorizationCode.consume(code),
+        OAuthAuthorizationCode.consume(code),
+      ]);
+
+      expect(consumed.filter(Boolean).length).toBe(1);
+    });
+
+    it("should not consume an unknown code", async () => {
+      expect(await OAuthAuthorizationCode.consume("unknown")).toBe(false);
+    });
+  });
+});

--- a/server/models/oauth/OAuthAuthorizationCode.ts
+++ b/server/models/oauth/OAuthAuthorizationCode.ts
@@ -87,7 +87,8 @@ class OAuthAuthorizationCode extends IdModel<
   userId: string;
 
   /**
-   * Finds an OAuthAuthorizationCode by the given code.
+   * Finds an OAuthAuthorizationCode by the given code. Use `consume` to claim
+   * the code before a token is issued from it.
    *
    * @param input The code to search for
    * @returns The OAuthAuthentication if found
@@ -106,6 +107,24 @@ class OAuthAuthorizationCode extends IdModel<
         },
       ],
     });
+  }
+
+  /**
+   * Deletes the authorization code with the given code, so that it can only be
+   * exchanged once. The delete is atomic, so concurrent attempts to exchange one
+   * code result in a single successful caller.
+   *
+   * @param input The code to consume
+   * @returns True if this call consumed the code
+   */
+  public static async consume(input: string) {
+    const count = await this.destroy({
+      where: {
+        authorizationCodeHash: hash(input),
+      },
+    });
+
+    return count > 0;
   }
 }
 

--- a/server/routes/api/oauthAuthentications/oauthAuthentications.test.ts
+++ b/server/routes/api/oauthAuthentications/oauthAuthentications.test.ts
@@ -1,4 +1,4 @@
-import { OAuthClient, OAuthAuthentication } from "@server/models";
+import { Event, OAuthClient, OAuthAuthentication } from "@server/models";
 import {
   buildOAuthAuthentication,
   buildTeam,
@@ -192,5 +192,60 @@ describe("oauthAuthentications.delete", () => {
     // Verify other user's auth still exists
     const auth = await OAuthAuthentication.findByPk(otherAuth.id);
     expect(auth).not.toBeNull();
+  });
+
+  it("should delete authentications created while the request is in flight", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const oauthClient = await OAuthClient.create({
+      teamId: team.id,
+      createdById: user.id,
+      name: "Test Client",
+      redirectUris: ["https://example.com/callback"],
+    });
+
+    await buildOAuthAuthentication({
+      oauthClientId: oauthClient.id,
+      user,
+      scope: ["read"],
+    });
+
+    // Simulate a token refresh that writes a new authentication after the
+    // request has queried for the authentications to delete.
+    const findAll = OAuthAuthentication.findAll.bind(OAuthAuthentication);
+    vi.spyOn(OAuthAuthentication, "findAll").mockImplementationOnce(
+      async (options) => {
+        const found = await findAll(options);
+        await buildOAuthAuthentication({
+          oauthClientId: oauthClient.id,
+          user,
+          scope: ["read"],
+        });
+        return found;
+      }
+    );
+
+    const res = await server.post("/api/oauthAuthentications.delete", user, {
+      body: {
+        oauthClientId: oauthClient.id,
+      },
+    });
+    expect(res.status).toEqual(200);
+
+    const auths = await OAuthAuthentication.findAll({
+      where: {
+        userId: user.id,
+        oauthClientId: oauthClient.id,
+      },
+    });
+    expect(auths.length).toEqual(0);
+
+    const events = await Event.count({
+      where: {
+        name: "oauthAuthentications.delete",
+        userId: user.id,
+      },
+    });
+    expect(events).toEqual(2);
   });
 });

--- a/server/routes/api/oauthAuthentications/oauthAuthentications.ts
+++ b/server/routes/api/oauthAuthentications/oauthAuthentications.ts
@@ -67,19 +67,24 @@ router.post(
   async (ctx: APIContext<T.OAuthAuthenticationsDeleteReq>) => {
     const { user } = ctx.state.auth;
     const { oauthClientId, scope } = ctx.input.body;
+    const where = {
+      userId: user.id,
+      oauthClientId,
+      ...(scope ? { scope } : {}),
+    };
+
     const oauthAuthentications = await OAuthAuthentication.findAll({
-      where: {
-        userId: user.id,
-        oauthClientId,
-        ...(scope ? { scope } : {}),
-      },
+      where,
       transaction: ctx.state.transaction,
     });
 
     for (const oauthAuthentication of oauthAuthentications) {
       authorize(user, "delete", oauthAuthentication);
-      await oauthAuthentication.destroyWithCtx(ctx);
     }
+
+    // Destroy by predicate rather than by instance, so that an authentication
+    // created by a token refresh during this request is revoked too.
+    await OAuthAuthentication.destroyWithCtx(ctx, { where });
 
     ctx.body = {
       success: true,

--- a/server/routes/oauth/index.test.ts
+++ b/server/routes/oauth/index.test.ts
@@ -7,6 +7,7 @@ import {
   buildUser,
 } from "@server/test/factories";
 import { getTestServer, toFormData } from "@server/test/support";
+import { hash } from "@server/utils/crypto";
 
 const server = getTestServer();
 
@@ -416,6 +417,87 @@ describe("#oauth.token", () => {
       const foundAuth2 =
         await OAuthAuthentication.findByRefreshToken(auth2RefreshToken);
       expect(foundAuth2).not.toBeNull();
+    });
+  });
+
+  describe("authorization_code grant", () => {
+    const buildCodeGrant = async () => {
+      const user = await buildUser();
+      const client = await buildOAuthClient({
+        teamId: user.teamId,
+        clientType: "confidential",
+      });
+      const grantId = crypto.randomUUID();
+      const code = crypto.randomBytes(32).toString("hex");
+
+      await OAuthAuthorizationCode.create({
+        authorizationCodeHash: hash(code),
+        scope: [Scope.Read],
+        redirectUri: client.redirectUris[0],
+        oauthClientId: client.id,
+        userId: user.id,
+        expiresAt: new Date(Date.now() + 10000),
+        grantId,
+      });
+
+      const exchange = () =>
+        server.post("/oauth/token", {
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+          body: toFormData({
+            grant_type: "authorization_code",
+            code,
+            redirect_uri: client.redirectUris[0],
+            client_id: client.clientId,
+            client_secret: client.clientSecret,
+          }),
+        });
+
+      return { user, client, grantId, exchange };
+    };
+
+    it("should exchange an authorization code for a token", async () => {
+      const { exchange } = await buildCodeGrant();
+
+      const res = await exchange();
+      expect(res.status).toEqual(200);
+
+      const body = await res.json();
+      expect(body.access_token).toBeTruthy();
+      expect(body.refresh_token).toBeTruthy();
+    });
+
+    it("should issue a token to a single request when a code is exchanged concurrently", async () => {
+      const { grantId, exchange } = await buildCodeGrant();
+
+      const results = await Promise.all([exchange(), exchange()]);
+      const statuses = results.map((res) => res.status).sort((a, b) => a - b);
+      expect(statuses).toEqual([200, 400]);
+
+      const count = await OAuthAuthentication.count({
+        where: {
+          grantId,
+        },
+      });
+      expect(count).toEqual(1);
+    });
+
+    it("should reject a replayed authorization code", async () => {
+      const { grantId, exchange } = await buildCodeGrant();
+
+      const res1 = await exchange();
+      expect(res1.status).toEqual(200);
+
+      const res2 = await exchange();
+      expect(res2.status).toEqual(400);
+
+      const count = await OAuthAuthentication.count({
+        where: {
+          grantId,
+        },
+      });
+      expect(count).toEqual(1);
     });
   });
 });

--- a/server/utils/oauth/OAuthInterface.ts
+++ b/server/utils/oauth/OAuthInterface.ts
@@ -329,37 +329,25 @@ export const OAuthInterface: RefreshTokenModel &
   },
 
   /**
-   * Revokes a refresh token.
+   * Revokes a refresh token. The token is revoked atomically, so that only one
+   * of a set of concurrent requests can exchange it for new tokens.
    *
    * @param token The token object containing the refresh token to revoke.
    * @returns True if the token was revoked, false otherwise.
    */
   async revokeToken(token) {
-    const auth = await OAuthAuthentication.findByRefreshToken(
-      token.refreshToken
-    );
-    if (auth) {
-      await auth.destroy();
-      return true;
-    }
-    return false;
+    return OAuthAuthentication.revokeByRefreshToken(token.refreshToken);
   },
 
   /**
-   * Revokes an authorization code.
+   * Revokes an authorization code. The code is consumed atomically, so that only
+   * one of a set of concurrent requests can exchange it for a token.
    *
    * @param code The authorization code object to revoke.
    * @returns True if the code was revoked, false otherwise.
    */
   async revokeAuthorizationCode(code) {
-    const authCode = await OAuthAuthorizationCode.findByCode(
-      code.authorizationCode
-    );
-    if (authCode) {
-      await authCode.destroy();
-      return true;
-    }
-    return false;
+    return OAuthAuthorizationCode.consume(code.authorizationCode);
   },
 
   /**


### PR DESCRIPTION
Exchanging an authorization code, and rotating a refresh token, read the credential and then removed it in two separate steps.

- Claim each credential with a single conditional statement, so only one of a set of concurrent requests continues to token issuance
- Move the queries behind `consume` and `revokeByRefreshToken` model methods, keeping the raw where clauses out of the OAuth interface