### PR TITLE
fix: Match base domain on a label boundary when parsing hosts

### DIFF
--- a/server/routes/api/urls/urls.ts
+++ b/server/routes/api/urls/urls.ts
@@ -3,7 +3,7 @@ import Router from "koa-router";
 import { traceFunction } from "@server/logging/tracing";
 import isUUID from "validator/lib/isUUID";
 import { MentionType, UnfurlResourceType } from "@shared/types";
-import { getBaseDomain } from "@shared/utils/domains";
+import { parseDomain } from "@shared/utils/domains";
 import parseDocumentSlug from "@shared/utils/parseDocumentSlug";
 import parseMentionUrl from "@shared/utils/parseMentionUrl";
 import { isInternalUrl, parseShareIdFromUrl } from "@shared/utils/urls";
@@ -292,14 +292,13 @@ router.post(
       throw ValidationError("Invalid domain");
     }
 
-    if (addresses.length === 0) {
+    const address = addresses[0];
+    if (!address) {
       throw ValidationError("No CNAME record found");
     }
 
-    const address = addresses[0];
-    const likelyValid = address.endsWith(getBaseDomain());
-
-    if (!likelyValid) {
+    // the record must point at the base domain, or a subdomain of it
+    if (parseDomain(address).custom) {
       throw ValidationError("CNAME is not configured correctly");
     }
 

--- a/shared/utils/domains.test.ts
+++ b/shared/utils/domains.test.ts
@@ -133,6 +133,32 @@ describe("#parseDomain", () => {
     });
   });
 
+  it("should normalize the case of the host", () => {
+    expect(parseDomain("MyTeam.Example.Com")).toMatchObject({
+      teamSubdomain: "myteam",
+      host: "myteam.example.com",
+      custom: false,
+    });
+    expect(parseDomain("HTTPS://WWW.EXAMPLE.COM")).toMatchObject({
+      teamSubdomain: "",
+      host: "www.example.com",
+      custom: false,
+    });
+  });
+
+  it("should remove a trailing root label", () => {
+    expect(parseDomain("myteam.example.com.")).toMatchObject({
+      teamSubdomain: "myteam",
+      host: "myteam.example.com",
+      custom: false,
+    });
+    expect(parseDomain("example.com.")).toMatchObject({
+      teamSubdomain: "",
+      host: "example.com",
+      custom: false,
+    });
+  });
+
   it("should recognize include private domains like blogspot.com as custom", () => {
     expect(parseDomain("foo.blogspot.com")).toMatchObject({
       teamSubdomain: "",

--- a/shared/utils/domains.test.ts
+++ b/shared/utils/domains.test.ts
@@ -115,6 +115,24 @@ describe("#parseDomain", () => {
     });
   });
 
+  it("should treat a host that only contains the base domain as custom", () => {
+    expect(parseDomain("myteam.example.com.evil.com")).toMatchObject({
+      teamSubdomain: "",
+      host: "myteam.example.com.evil.com",
+      custom: true,
+    });
+    expect(parseDomain("https://example.com.evil.com/path")).toMatchObject({
+      teamSubdomain: "",
+      host: "example.com.evil.com",
+      custom: true,
+    });
+    expect(parseDomain("notexample.com")).toMatchObject({
+      teamSubdomain: "",
+      host: "notexample.com",
+      custom: true,
+    });
+  });
+
   it("should recognize include private domains like blogspot.com as custom", () => {
     expect(parseDomain("foo.blogspot.com")).toMatchObject({
       teamSubdomain: "",

--- a/shared/utils/domains.ts
+++ b/shared/utils/domains.ts
@@ -62,16 +62,17 @@ export function parseDomain(url: string): Domain {
 
   const host = normalizeUrl(url);
   const baseDomain = getBaseDomain();
+  const suffix = `.${baseDomain}`;
 
-  // if the url doesn't include the base url, then it must be a custom domain
-  const baseUrlStart = host === baseDomain ? 0 : host.indexOf(`.${baseDomain}`);
-
-  if (baseUrlStart === -1) {
+  // the host must be the base domain, or end with it on a label boundary,
+  // otherwise it is a custom domain
+  if (host !== baseDomain && !host.endsWith(suffix)) {
     return { teamSubdomain: "", host, port: undefined, custom: true };
   }
 
   // we consider anything in front of the baseUrl to be the subdomain
-  const subdomain = host.substring(0, baseUrlStart);
+  const subdomain =
+    host === baseDomain ? "" : host.substring(0, host.length - suffix.length);
   const isReservedSubdomain = RESERVED_SUBDOMAINS.includes(subdomain);
 
   return {

--- a/shared/utils/domains.ts
+++ b/shared/utils/domains.ts
@@ -21,14 +21,16 @@ export function slugifyDomain(domain: string) {
 // strips protocol, userinfo, port, path, query, and whitespace from input
 // to extract a clean hostname
 function normalizeUrl(url: string) {
-  const stripped = trim(url.replace(/(https?:)?\/\//, ""));
+  const stripped = trim(url.replace(/(https?:)?\/\//i, ""));
   // Extract authority (everything before the first slash)
   const authority = stripped.split("/")[0];
   // Strip userinfo if present (e.g. "user:pass@host" → "host")
   const atIndex = authority.lastIndexOf("@");
   const hostWithPort =
     atIndex !== -1 ? authority.substring(atIndex + 1) : authority;
-  return hostWithPort.split(/[:?]/)[0];
+  const host = hostWithPort.split(/[:?]/)[0];
+  // Hostnames are case-insensitive and may carry a trailing root label
+  return host.toLowerCase().replace(/\.$/, "");
 }
 
 // The base domain is where root cookies are set in hosted mode


### PR DESCRIPTION
- Host parsing looked for the base domain anywhere in the string, so a host that merely contained the install's domain was classified as one of its subdomains rather than as a custom domain.
- The base domain is now matched against the end of the host, on a label boundary.
- The custom domain CNAME check reuses `parseDomain` instead of keeping its own comparison.