### PR TITLE
fix: Align mention unfurl with document insights settings

### DIFF
--- a/server/presenters/unfurl.ts
+++ b/server/presenters/unfurl.ts
@@ -11,10 +11,14 @@ import { opts } from "@server/utils/i18n";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- heterogeneous payload from internal callers and third-party unfurl plugins.
 type UnfurlData = Record<string, any>;
 
-async function presentUnfurl(
-  data: UnfurlData,
-  options?: { includeEmail: boolean }
-) {
+interface UnfurlOptions {
+  /** Whether the mentioned user's email may be included in the response. */
+  includeEmail: boolean;
+  /** Whether the mentioned user's viewing activity may be included in the response. */
+  includeLastViewed: boolean;
+}
+
+async function presentUnfurl(data: UnfurlData, options?: UnfurlOptions) {
   switch (data.type) {
     case UnfurlResourceType.Mention:
       return presentMention(data, options);
@@ -49,13 +53,16 @@ const presentURL = (
 
 const presentMention = async (
   data: UnfurlData,
-  options?: { includeEmail: boolean }
+  options?: UnfurlOptions
 ): Promise<UnfurlResponse[UnfurlResourceType.Mention]> => {
   const user: User = data.user;
   const document: Document = data.document;
 
   const lastOnlineInfo = presentLastOnlineInfoFor(user);
-  const lastViewedInfo = await presentLastViewedInfoFor(user, document);
+  const lastViewedInfo =
+    options && options.includeLastViewed
+      ? await presentLastViewedInfoFor(user, document)
+      : undefined;
 
   return {
     type: UnfurlResourceType.Mention,
@@ -63,7 +70,9 @@ const presentMention = async (
     email: options && options.includeEmail ? user.email : null,
     avatarUrl: user.avatarUrl,
     color: user.color,
-    lastActive: `${lastOnlineInfo} • ${lastViewedInfo}`,
+    lastActive: lastViewedInfo
+      ? `${lastOnlineInfo} • ${lastViewedInfo}`
+      : lastOnlineInfo,
   };
 };
 

--- a/server/routes/api/urls/urls.test.ts
+++ b/server/routes/api/urls/urls.test.ts
@@ -1,8 +1,10 @@
 import type { Mock } from "vitest";
 import { randomString } from "@shared/random";
 import { UnfurlResourceType } from "@shared/types";
+import { createContext } from "@server/context";
 import env from "@server/env";
 import type { User } from "@server/models";
+import { View } from "@server/models";
 import {
   buildCollection,
   buildDocument,
@@ -153,6 +155,51 @@ describe("#urls.unfurl", () => {
     expect(res.status).toEqual(200);
     expect(body.type).toEqual(UnfurlResourceType.Mention);
     expect(body.name).toEqual(mentionedUser.name);
+  });
+
+  it("should include the mentioned user's viewing activity when insights are enabled", async () => {
+    const mentionedUser = await buildUser({ teamId: user.teamId });
+    const document = await buildDocument({
+      teamId: user.teamId,
+      insightsEnabled: true,
+    });
+    await View.incrementOrCreate(createContext({ user: mentionedUser }), {
+      documentId: document.id,
+      userId: mentionedUser.id,
+    });
+
+    const res = await server.post("/api/urls.unfurl", user, {
+      body: {
+        url: `mention://2767ba0e-ac5c-4533-b9cf-4f5fc456600e/user/${mentionedUser.id}`,
+        documentId: document.id,
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.lastActive).toContain("Viewed");
+  });
+
+  it("should not include the mentioned user's viewing activity when insights are disabled", async () => {
+    const mentionedUser = await buildUser({ teamId: user.teamId });
+    const document = await buildDocument({
+      teamId: user.teamId,
+      insightsEnabled: false,
+    });
+    await View.incrementOrCreate(createContext({ user: mentionedUser }), {
+      documentId: document.id,
+      userId: mentionedUser.id,
+    });
+
+    const res = await server.post("/api/urls.unfurl", user, {
+      body: {
+        url: `mention://2767ba0e-ac5c-4533-b9cf-4f5fc456600e/user/${mentionedUser.id}`,
+        documentId: document.id,
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.lastActive).not.toContain("Viewed");
+    expect(body.lastActive).not.toContain("Never viewed");
   });
 
   it("should return 204 when internal document url points to non-existent document", async () => {

--- a/server/routes/api/urls/urls.ts
+++ b/server/routes/api/urls/urls.ts
@@ -122,7 +122,11 @@ router.post(
             user,
             document,
           },
-          { includeEmail: !!can(actor, "readEmail", user) }
+          {
+            includeEmail: !!can(actor, "readEmail", user),
+            includeLastViewed:
+              document.insightsEnabled && !!can(actor, "listViews", document),
+          }
         );
       } else if (mentionType === MentionType.Group) {
         const [group, document] = await Promise.all([


### PR DESCRIPTION
- The viewing activity shown in a mention preview now respects the document's insights setting.
- It is also subject to the same ability check used by the other endpoints that expose this data, which differs from plain read access for guests.
- When either does not pass, the preview shows online status alone.