### PR TITLE
fix: Align pins.list response with document access

### DIFF
--- a/server/routes/api/pins/pins.test.ts
+++ b/server/routes/api/pins/pins.test.ts
@@ -362,6 +362,34 @@ describe("#pins.list", () => {
     expect(body.data.documents[0].id).toEqual(doc.id);
   });
 
+  it("should not return home pins for documents in a collection the user cannot read", async () => {
+    const admin = await buildAdmin({ teamId: user.teamId });
+    const privateCollection = await buildCollection({
+      teamId: admin.teamId,
+      createdById: admin.id,
+      permission: null,
+    });
+    const privateDocument = await buildDocument({
+      teamId: admin.teamId,
+      collectionId: privateCollection.id,
+    });
+    const privatePin = await buildPin({
+      createdById: admin.id,
+      documentId: privateDocument.id,
+      teamId: admin.teamId,
+    });
+
+    const res = await server.post("/api/pins.list", user);
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    const pinIds = body.data.pins.map((p: { id: string }) => p.id);
+    expect(pinIds).not.toContain(privatePin.id);
+    expect(
+      body.data.pins.map((p: { documentId: string }) => p.documentId)
+    ).not.toContain(privateDocument.id);
+    expect(body.data.pins).toHaveLength(2);
+  });
+
   it("should fail with status 403 forbidden when collection does not exist", async () => {
     const res = await server.post("/api/pins.list", user, {
       body: {

--- a/server/routes/api/pins/pins.ts
+++ b/server/routes/api/pins/pins.ts
@@ -135,12 +135,17 @@ router.post(
       },
     });
 
-    const policies = presentPolicies(user, [...documents, ...pins]);
+    // Pins are not scoped to document memberships, so only return those for
+    // documents the user can read.
+    const documentIds = new Set(documents.map((document) => document.id));
+    const visiblePins = pins.filter((pin) => documentIds.has(pin.documentId));
+
+    const policies = presentPolicies(user, [...documents, ...visiblePins]);
 
     ctx.body = {
       pagination: ctx.state.pagination,
       data: {
-        pins: pins.map(presentPin),
+        pins: visiblePins.map(presentPin),
         documents: await presentDocuments(ctx, documents),
       },
       policies,


### PR DESCRIPTION
- The home listing returned every team pin, while the accompanying documents were membership-scoped, so the two halves of the response could disagree.
- Pins are now filtered to documents the user can read, and policies are derived from the same set.
- No client-visible change — pins without a matching document already render nothing.