### PR TITLE
fix: Omit last activity info from share unfurl response

### DIFF
--- a/server/routes/api/urls/urls.test.ts
+++ b/server/routes/api/urls/urls.test.ts
@@ -351,6 +351,30 @@ Install instructions here.`
     expect(body.id).toEqual(document.id);
   });
 
+  it("should not include last activity for a share url the user can read", async () => {
+    const author = await buildUser({ teamId: user.teamId });
+    const document = await buildDocument({
+      teamId: user.teamId,
+      userId: author.id,
+    });
+    const share = await buildShare({
+      teamId: user.teamId,
+      userId: author.id,
+      documentId: document.id,
+      published: true,
+    });
+
+    const res = await server.post("/api/urls.unfurl", user, {
+      body: {
+        url: `${env.URL}/s/${share.id}/doc/${document.urlId}`,
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.id).toEqual(document.id);
+    expect(body.lastActivityByViewer).toBeUndefined();
+  });
+
   it("should return share-scoped url in unfurl response", async () => {
     const document = await buildDocument({
       teamId: user.teamId,

--- a/server/routes/api/urls/urls.ts
+++ b/server/routes/api/urls/urls.ts
@@ -79,7 +79,6 @@ router.post(
         ctx.body = await presentUnfurl({
           type: UnfurlResourceType.Document,
           document,
-          viewer: actor,
           anchor: urlObj.hash,
           url: `${share.canonicalUrl}/doc/${document.url.replace("/doc/", "")}${urlObj.hash}`,
         });


### PR DESCRIPTION
- The unfurl response for a share link included the name of the document author or last editor, along with a relative timestamp.
- That information is deliberately excluded from the share document presenter, so it is now left out of the unfurl response for shares as well.
- Unfurls of a regular document URL are unaffected and still include last activity for readers of the document.