### PR TITLE
fix: Attachment downloads lose original file extension

### DIFF
--- a/plugins/storage/server/api/files.ts
+++ b/plugins/storage/server/api/files.ts
@@ -150,7 +150,7 @@ router.get(
       contentDisposition(fileName, {
         type: forceDownload
           ? "attachment"
-          : FileStorage.getContentDisposition(contentType),
+          : FileStorage.getContentDispositionType(contentType),
       })
     );
 

--- a/server/storage/files/BaseStorage.test.ts
+++ b/server/storage/files/BaseStorage.test.ts
@@ -198,4 +198,50 @@ describe("BaseStorage", () => {
       });
     });
   });
+
+  describe("getContentDisposition", () => {
+    const storage = new MockStorage();
+
+    it("should include the file name so browsers keep the extension", () => {
+      expect(storage.getContentDisposition("text/plain", "config.yaml")).toBe(
+        'attachment; filename="config.yaml"'
+      );
+    });
+
+    it("should return inline for safe content types", () => {
+      expect(storage.getContentDisposition("image/png", "photo.png")).toBe(
+        'inline; filename="photo.png"'
+      );
+    });
+
+    it("should omit the file name when not provided", () => {
+      expect(storage.getContentDisposition("text/plain")).toBe("attachment");
+      expect(storage.getContentDisposition("image/png")).toBe("inline");
+    });
+  });
+
+  describe("getContentDispositionType", () => {
+    const storage = new MockStorage();
+
+    it("should return attachment when content type is missing", () => {
+      expect(storage.getContentDispositionType()).toBe("attachment");
+    });
+
+    it("should return inline for audio, video, and safe types", () => {
+      expect(storage.getContentDispositionType("audio/mpeg")).toBe("inline");
+      expect(storage.getContentDispositionType("video/mp4")).toBe("inline");
+      expect(storage.getContentDispositionType("application/pdf")).toBe(
+        "inline"
+      );
+    });
+
+    it("should return attachment for other content types", () => {
+      expect(storage.getContentDispositionType("image/svg+xml")).toBe(
+        "attachment"
+      );
+      expect(storage.getContentDispositionType("text/plain")).toBe(
+        "attachment"
+      );
+    });
+  });
 });

--- a/server/storage/files/BaseStorage.ts
+++ b/server/storage/files/BaseStorage.ts
@@ -2,6 +2,7 @@ import type { Blob } from "node:buffer";
 import type { Readable } from "node:stream";
 import { buffer } from "node:stream/consumers";
 import type { PresignedPost } from "@aws-sdk/s3-presigned-post";
+import contentDisposition from "content-disposition";
 import { omit } from "es-toolkit/compat";
 import { toError, errToString } from "@shared/utils/error";
 import FileHelper from "@shared/editor/lib/FileHelper";
@@ -282,12 +283,29 @@ export default abstract class BaseStorage {
   public abstract deleteFile(key: string): Promise<void>;
 
   /**
-   * Returns the content disposition for a given content type.
+   * Returns the Content-Disposition header value for a given content type and
+   * file name. Including the file name ensures browsers keep the original
+   * extension when downloading, rather than deriving one from the content type.
    *
    * @param contentType The content type
-   * @returns The content disposition
+   * @param fileName The name of the file, if known
+   * @returns The Content-Disposition header value
    */
-  public getContentDisposition(contentType?: string) {
+  public getContentDisposition(contentType?: string, fileName?: string) {
+    return contentDisposition(fileName, {
+      type: this.getContentDispositionType(contentType),
+    });
+  }
+
+  /**
+   * Returns the content disposition type for a given content type.
+   *
+   * @param contentType The content type
+   * @returns The content disposition type
+   */
+  public getContentDispositionType(
+    contentType?: string
+  ): "inline" | "attachment" {
     if (!contentType) {
       return "attachment";
     }

--- a/server/storage/files/S3Storage.ts
+++ b/server/storage/files/S3Storage.ts
@@ -11,6 +11,7 @@ import { compact } from "es-toolkit/compat";
 import { toError } from "@shared/utils/error";
 import env from "@server/env";
 import Logger from "@server/logging/Logger";
+import AttachmentHelper from "@server/models/helpers/AttachmentHelper";
 import BaseStorage from "./BaseStorage";
 import type { AppContext } from "@server/types";
 
@@ -37,7 +38,10 @@ export default class S3Storage extends BaseStorage {
         ["starts-with", "$Cache-Control", ""],
       ]),
       Fields: {
-        "Content-Disposition": this.getContentDisposition(contentType),
+        "Content-Disposition": this.getContentDisposition(
+          contentType,
+          AttachmentHelper.parseKey(key).fileName
+        ),
         key,
         ...(env.AWS_S3_ACL && { ACL: env.AWS_S3_ACL as ObjectCannedACL }),
       },
@@ -65,7 +69,10 @@ export default class S3Storage extends BaseStorage {
     contentLength: number,
     contentType: string
   ): Promise<{ url: string; headers: Record<string, string> }> {
-    const contentDisposition = this.getContentDisposition(contentType);
+    const contentDisposition = this.getContentDisposition(
+      contentType,
+      AttachmentHelper.parseKey(key).fileName
+    );
     const cacheControl = "max-age=31557600";
 
     const { sdk, client } = await this.getS3();
@@ -167,7 +174,10 @@ export default class S3Storage extends BaseStorage {
         ContentType: contentType,
         // See bug, if used causes large files to hang: https://github.com/aws/aws-sdk-js-v3/issues/3915
         // ContentLength: contentLength,
-        ContentDisposition: this.getContentDisposition(contentType),
+        ContentDisposition: this.getContentDisposition(
+          contentType,
+          AttachmentHelper.parseKey(key).fileName
+        ),
         Body: body,
       },
     });


### PR DESCRIPTION
When an attachment's stored content type does not match its extension (e.g. a `.yaml` file uploaded as text/plain), browsers rename the download — a YAML file comes back as `file.txt`.

- Include the file name in the Content-Disposition header baked into S3 objects at upload (presigned POST, presigned PUT, and server-side store), so browsers keep the original extension instead of deriving one from the content type
- Split the inline/attachment decision into `getContentDispositionType` and align the local storage route with it