### PR TITLE
fix: re-scroll when the same table of contents entry is clicked again

### DIFF
--- a/app/editor/index.tsx
+++ b/app/editor/index.tsx
@@ -106,6 +106,12 @@ export type Props = {
   maxLength?: number;
   /** Heading id to scroll to when the editor has loaded */
   scrollTo?: string;
+  /**
+   * Monotonic value that changes on each navigation to the same `scrollTo`
+   * target, so repeated clicks re-trigger scrolling even when the hash is
+   * unchanged.
+   */
+  scrollToNonce?: number;
   /** Callback for handling uploaded images, should return the url of uploaded file */
   uploadFile?: (
     file: File | string,
@@ -309,7 +315,11 @@ export class Editor extends React.PureComponent<
       );
     }
 
-    if (this.props.scrollTo && this.props.scrollTo !== prevProps.scrollTo) {
+    if (
+      this.props.scrollTo &&
+      (this.props.scrollTo !== prevProps.scrollTo ||
+        this.props.scrollToNonce !== prevProps.scrollToNonce)
+    ) {
       void this.scrollToAnchor(this.props.scrollTo);
     }
 

--- a/app/scenes/Document/components/Contents.tsx
+++ b/app/scenes/Document/components/Contents.tsx
@@ -38,9 +38,20 @@ function Contents() {
         return;
       }
       // Navigate via history so the location state (active sidebar context) is
-      // retained rather than dropped by a native hash navigation.
+      // retained rather than dropped by a native hash navigation. The nonce
+      // forces a re-scroll when the same heading is clicked again after the
+      // hash is already set — the editor otherwise skips scrolling when the
+      // target is unchanged.
       event.preventDefault();
-      history.push(patchLocation(history.location, { hash: `#${id}` }));
+      const previousState =
+        typeof history.location.state === "object" &&
+        history.location.state !== null
+          ? history.location.state
+          : {};
+      history.push({
+        ...patchLocation(history.location, { hash: `#${id}` }),
+        state: { ...previousState, tocScrollNonce: Date.now() },
+      });
     },
     [history]
   );

--- a/app/scenes/Document/components/Editor.tsx
+++ b/app/scenes/Document/components/Editor.tsx
@@ -2,7 +2,7 @@ import { observer } from "mobx-react";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { mergeRefs } from "react-merge-refs";
-import { useRouteMatch } from "react-router-dom";
+import { useLocation, useRouteMatch } from "react-router-dom";
 import styled from "styled-components";
 import Text from "@shared/components/Text";
 import type { CommentAnchor } from "@shared/editor/commands/comment";
@@ -70,6 +70,11 @@ function DocumentEditor(props: Props, ref: React.ForwardedRef<SharedEditor>) {
   const titleRef = React.useRef<RefHandle>(null);
   const { t } = useTranslation();
   const match = useRouteMatch();
+  const location = useLocation();
+  const locationState = location.state as
+    | { tocScrollNonce?: number }
+    | null
+    | undefined;
   const { setFocusedCommentId } = useDocumentContext();
   const focusedComment = useFocusedComment();
   const { ui, comments } = useStores();
@@ -258,7 +263,8 @@ function DocumentEditor(props: Props, ref: React.ForwardedRef<SharedEditor>) {
         lang={getLangFor(document.language)}
         autoFocus={!!document.title && !props.defaultValue}
         placeholder={t("Type '/' to insert, or start writing…")}
-        scrollTo={decodeURIComponentSafe(window.location.hash)}
+        scrollTo={decodeURIComponentSafe(location.hash)}
+        scrollToNonce={locationState?.tocScrollNonce}
         readOnly={readOnly}
         userId={user?.id}
         focusedCommentId={focusedComment?.id}

--- a/app/scenes/Document/components/MultiplayerEditor.tsx
+++ b/app/scenes/Document/components/MultiplayerEditor.tsx
@@ -342,6 +342,7 @@ function MultiplayerEditor(
           defaultValue={props.defaultValue}
           extensions={props.extensions}
           scrollTo={props.scrollTo}
+          scrollToNonce={props.scrollToNonce}
           cacheOnly
           readOnly
           ref={ref}


### PR DESCRIPTION
Fixes #13428

### Problem

Clicking a TOC entry pushes a location with only the hash changed. The editor receives `scrollTo` derived from the current hash and only re-runs `scrollToAnchor` when that prop value changes — so once the hash points at a heading, clicking that same TOC entry again is a no-op (verified with a jsdom simulation replicating the exact component chain: the scene does re-render, but the guard in `componentDidUpdate` blocks the call).

### Solution

Include a monotonically changing `tocScrollNonce` in the pushed location's state, thread it through as a `scrollToNonce` prop alongside `scrollTo`, and re-run `scrollToAnchor` when either value changes:

- `Contents.tsx` — include `tocScrollNonce: Date.now()` in the pushed location state.
- `Editor.tsx` — read the hash via `useLocation` and pass `scrollToNonce` from the location state.
- `editor/index.tsx` — new optional `scrollToNonce` prop; the update guard now also fires when the nonce changes.
- `MultiplayerEditor.tsx` — pass `scrollToNonce` through to the cache editor.

Unrelated re-renders still never re-scroll (the hash and nonce are both unchanged for them); only explicit repeated clicks do.
