### PR TITLE
perf: Skip revision diff when too expensive to compute

### DIFF
--- a/server/models/helpers/DocumentHelper.tsx
+++ b/server/models/helpers/DocumentHelper.tsx
@@ -452,7 +452,8 @@ export class DocumentHelper {
    * @param after The after document
    * @param options Options passed to HTML generation
    * @returns The diff as an HTML string, an empty string when there is no
-   * before document, or undefined when the documents contain no changes.
+   * before document, or undefined when the documents contain no changes or
+   * the changeset was too expensive to compute.
    */
   static async toEmailDiff(
     before: Document | Revision | null,
@@ -463,7 +464,26 @@ export class DocumentHelper {
       return "";
     }
 
-    const html = await DocumentHelper.diff(before, after, options);
+    addTags({
+      beforeId: before.id,
+      documentId: after.documentId,
+      options,
+    });
+
+    const beforeJSON = await DocumentHelper.toJSON(before);
+    const afterJSON = await DocumentHelper.toJSON(after);
+    const changeset = ChangesetHelper.getChangeset(afterJSON, beforeJSON);
+
+    // Without a changeset no diff elements can render, so skip the expensive
+    // HTML generation and clipping entirely.
+    if (!changeset?.changes.length) {
+      return undefined;
+    }
+
+    const html = await DocumentHelper.toHTML(after, {
+      ...options,
+      changes: changeset.changes,
+    });
     // Loaded lazily to keep jsdom off the startup path — only HTML export needs it.
     const { JSDOM } = await import("jsdom");
     const dom = new JSDOM(html);

--- a/shared/editor/lib/ChangesetHelper.test.ts
+++ b/shared/editor/lib/ChangesetHelper.test.ts
@@ -234,4 +234,25 @@ describe("ChangesetHelper.getChangeset", () => {
     expect(changes).toHaveLength(1);
     expect(changes[0].inserted).toHaveLength(1);
   });
+
+  describe("complexity guard", () => {
+    const texts = Array.from(
+      { length: 500 },
+      (_, i) => `paragraph ${i} ${"lorem ipsum dolor sit amet ".repeat(12)}`
+    );
+
+    it("returns null when the changeset is too expensive to compute", () => {
+      const before = paras(...texts);
+      const after = paras(...texts.map((text) => `${text} rewritten`));
+
+      expect(ChangesetHelper.getChangeset(after, before)).toBeNull();
+    });
+
+    it("still computes a changeset for a small change to a large document", () => {
+      const before = paras(...texts);
+      const after = paras(...texts.slice(0, -1), "a different final paragraph");
+
+      expect(ChangesetHelper.getChangeset(after, before)).not.toBeNull();
+    });
+  });
 });

--- a/shared/editor/lib/ChangesetHelper.ts
+++ b/shared/editor/lib/ChangesetHelper.ts
@@ -158,6 +158,15 @@ function mergeInterleavedChanges<T extends { step: Step; slice: Slice | null }>(
 }
 
 /**
+ * The maximum estimated cost of computing a changeset, as the number of patch
+ * operations multiplied by the document node size. Step recreation copies and
+ * validates the full document once per operation, so its runtime grows with
+ * this product; above the bound the changeset is skipped instead of blocking
+ * the process for seconds or minutes.
+ */
+const MAX_CHANGESET_COMPLEXITY = 50_000_000;
+
+/**
  * Marks that carry no document content and should not be surfaced as changes.
  */
 const IGNORED_MARKS = ["comment"];
@@ -272,7 +281,9 @@ export class ChangesetHelper {
    *
    * @param revision - The current revision data.
    * @param previousRevision - The previous revision data to compare against.
-   * @returns An object containing the simplified changes and the new document.
+   * @returns An object containing the simplified changes and the new document,
+   * or null when there is nothing to compare against or the changeset is too
+   * expensive to compute.
    */
   public static getChangeset(
     revision?: ProsemirrorData | null,
@@ -304,11 +315,13 @@ export class ChangesetHelper {
       );
       const docNew = removeIgnoredMarks(original);
 
-      // Calculate the transform and changeset
+      // Calculate the transform and changeset. Throws, and so returns null,
+      // when the diff is too expensive to compute.
       const tr = recreateTransform(docOld, docNew, {
         complexSteps: false,
         wordDiffs: true,
         simplifyDiff: true,
+        maxComplexity: MAX_CHANGESET_COMPLEXITY,
       });
 
       // Map steps to capture the actual content being replaced from the document

--- a/shared/editor/lib/prosemirror-recreate-transform/recreateTransform.ts
+++ b/shared/editor/lib/prosemirror-recreate-transform/recreateTransform.ts
@@ -72,17 +72,7 @@ export class RecreateTransform {
       this.finalJSON = this.toDoc.toJSON();
     }
 
-    this.ops = createPatch(this.currentJSON, this.finalJSON);
-
-    if (this.maxComplexity !== undefined) {
-      const size = Math.max(this.fromDoc.nodeSize, this.toDoc.nodeSize);
-      if (this.ops.length * size > this.maxComplexity) {
-        throw new Error(
-          `Diff exceeds maxComplexity: ${this.ops.length} operations on document of size ${size}`
-        );
-      }
-    }
-
+    this.recalculateOps();
     this.recreateChangeContentSteps();
 
     if (this.complexSteps) {
@@ -94,6 +84,20 @@ export class RecreateTransform {
     }
 
     return this.tr;
+  }
+
+  /** compute json-diff ops from the current to the final document, enforcing maxComplexity */
+  recalculateOps() {
+    this.ops = createPatch(this.currentJSON, this.finalJSON);
+
+    if (this.maxComplexity !== undefined) {
+      const size = Math.max(this.fromDoc.nodeSize, this.toDoc.nodeSize);
+      if (this.ops.length * size > this.maxComplexity) {
+        throw new Error(
+          `Diff exceeds maxComplexity: ${this.ops.length} operations on document of size ${size}`
+        );
+      }
+    }
   }
 
   /** convert json-diff to prosemirror steps */
@@ -182,7 +186,7 @@ export class RecreateTransform {
       }
       this.currentJSON = removeMarks(this.tr.doc).toJSON();
       // setting the node markup may have invalidated the following ops, so we calculate them again.
-      this.ops = createPatch(this.currentJSON, this.finalJSON);
+      this.recalculateOps();
       return true;
     }
     return false;

--- a/shared/editor/lib/prosemirror-recreate-transform/recreateTransform.ts
+++ b/shared/editor/lib/prosemirror-recreate-transform/recreateTransform.ts
@@ -15,6 +15,12 @@ export interface Options {
   complexSteps?: boolean;
   wordDiffs?: boolean;
   simplifyDiff?: boolean;
+  /**
+   * Maximum allowed product of patch operation count and document node size.
+   * Recreating steps copies and validates the full document once per
+   * operation, so cost grows with this product. When exceeded, init throws.
+   */
+  maxComplexity?: number;
 }
 
 export class RecreateTransform {
@@ -23,6 +29,7 @@ export class RecreateTransform {
   complexSteps: boolean;
   wordDiffs: boolean;
   simplifyDiff: boolean;
+  maxComplexity?: number;
   schema: Schema;
   tr: Transform;
   /* current working document data, may get updated while recalculating node steps */
@@ -44,6 +51,7 @@ export class RecreateTransform {
     this.complexSteps = o.complexSteps; // Whether to return steps other than ReplaceSteps
     this.wordDiffs = o.wordDiffs; // Whether to make text diffs cover entire words
     this.simplifyDiff = o.simplifyDiff;
+    this.maxComplexity = o.maxComplexity;
     this.schema = fromDoc.type.schema;
     this.tr = new Transform(fromDoc);
     this.currentJSON = {};
@@ -58,15 +66,27 @@ export class RecreateTransform {
       // any mapping changes anyway.
       this.currentJSON = removeMarks(this.fromDoc).toJSON();
       this.finalJSON = removeMarks(this.toDoc).toJSON();
-      this.ops = createPatch(this.currentJSON, this.finalJSON);
-      this.recreateChangeContentSteps();
-      this.recreateChangeMarkSteps();
     } else {
       // We don't differentiate between mark changes and other changes.
       this.currentJSON = this.fromDoc.toJSON();
       this.finalJSON = this.toDoc.toJSON();
-      this.ops = createPatch(this.currentJSON, this.finalJSON);
-      this.recreateChangeContentSteps();
+    }
+
+    this.ops = createPatch(this.currentJSON, this.finalJSON);
+
+    if (this.maxComplexity !== undefined) {
+      const size = Math.max(this.fromDoc.nodeSize, this.toDoc.nodeSize);
+      if (this.ops.length * size > this.maxComplexity) {
+        throw new Error(
+          `Diff exceeds maxComplexity: ${this.ops.length} operations on document of size ${size}`
+        );
+      }
+    }
+
+    this.recreateChangeContentSteps();
+
+    if (this.complexSteps) {
+      this.recreateChangeMarkSteps();
     }
 
     if (this.simplifyDiff) {


### PR DESCRIPTION
Recreating steps from a JSON patch copies and validates the full document once per operation, so a structure collapse on a very large document could block the worker event loop for a long time.

Skip the changeset when the product of operation count and document size exceeds a bound, and fallback to sending notification emails without the inline preview in that case.