### PR TITLE
fix: Make code fence markdown serialization round-trip stable

### DIFF
--- a/shared/editor/lib/markdown/serializer.test.ts
+++ b/shared/editor/lib/markdown/serializer.test.ts
@@ -1,0 +1,56 @@
+import { Node } from "prosemirror-model";
+import { parser, schema, serializer } from "../../../test/editor";
+
+describe("code fences", () => {
+  it("serializes code blocks containing backtick runs with a longer fence", () => {
+    const doc = Node.fromJSON(schema, {
+      type: "doc",
+      content: [
+        {
+          type: "code_block",
+          content: [
+            { type: "text", text: "one\n``` not a closing fence\nthree" },
+          ],
+        },
+      ],
+    });
+    const output = serializer.serialize(doc);
+
+    expect(output.startsWith("````")).toBe(true);
+    expect(parser.parse(output)?.toJSON()).toEqual(doc.toJSON());
+  });
+
+  it("round trips a code block followed by other content", () => {
+    const markdown =
+      "````\ntext with a\n``` fenced line\n````\n\nA paragraph after";
+    const doc = parser.parse(markdown);
+    const output = serializer.serialize(doc);
+
+    expect(parser.parse(output)?.toJSON()).toEqual(doc?.toJSON());
+  });
+
+  it("parses only the first token of the fence info string as language", () => {
+    const doc = parser.parse("``` • a whole sentence here\ncontent\n```");
+
+    expect(doc?.firstChild?.type.name).toBe("code_block");
+    expect(doc?.firstChild?.attrs.language).toBe("•");
+  });
+
+  it("serializes an unsafe language attribute as a single safe token", () => {
+    const doc = Node.fromJSON(schema, {
+      type: "doc",
+      content: [
+        {
+          type: "code_block",
+          attrs: { language: " ` not a ` language" },
+          content: [{ type: "text", text: "content" }],
+        },
+      ],
+    });
+    const output = serializer.serialize(doc);
+    const infoLine = output.split("\n")[0];
+
+    expect(infoLine).toBe("```not");
+    expect(parser.parse(output)?.firstChild?.type.name).toBe("code_block");
+  });
+});

--- a/shared/editor/nodes/CodeFence.ts
+++ b/shared/editor/nodes/CodeFence.ts
@@ -64,6 +64,20 @@ const COLLAPSE_HEIGHT_RATIO = 0.5;
 /** Approximate rendered line height of a code block, in pixels. */
 const CODE_LINE_HEIGHT = 20;
 
+/**
+ * Reduce a language attribute or fence info string to a single safe token, so
+ * it cannot break the fence line when written back to markdown.
+ *
+ * @param language - the language attribute or fence info string.
+ * @returns the first whitespace-separated token with backticks removed.
+ */
+function sanitizeLanguage(language: string | null | undefined): string {
+  return String(language ?? "")
+    .replace(/`/g, "")
+    .trim()
+    .split(/\s/)[0];
+}
+
 interface CollapseState {
   /** Positions of code blocks taller than COLLAPSE_HEIGHT_RATIO of the viewport. */
   tallBlocks: Set<number>;
@@ -717,10 +731,17 @@ export default class CodeFence extends Node<CodeFenceOptions> {
       ? escapeRawTableCell(node.textContent)
       : node.textContent;
 
-    state.write("```" + (node.attrs.language || "") + "\n");
+    // The fence must be longer than any backtick run in the content, or the
+    // content could terminate the fence early when the markdown is parsed.
+    const backticks = content.match(/`{3,}/g);
+    const fence = "`".repeat(
+      backticks ? Math.max(...backticks.map((run) => run.length)) + 1 : 3
+    );
+
+    state.write(fence + sanitizeLanguage(node.attrs.language) + "\n");
     state.text(content, false);
     state.ensureNewLine();
-    state.write("```");
+    state.write(fence);
     state.closeBlock(node);
   }
 
@@ -731,7 +752,7 @@ export default class CodeFence extends Node<CodeFenceOptions> {
   parseMarkdown() {
     return {
       block: "code_block",
-      getAttrs: (tok: Token) => ({ language: tok.info }),
+      getAttrs: (tok: Token) => ({ language: sanitizeLanguage(tok.info) }),
       noCloseToken: true,
     };
   }

--- a/shared/editor/nodes/Image.test.ts
+++ b/shared/editor/nodes/Image.test.ts
@@ -1,11 +1,5 @@
-import { extensionManager, findNodes, schema } from "../../test/editor";
+import { findNodes, parser, serializer } from "../../test/editor";
 import { ImageSource } from "../lib/FileHelper";
-
-const serializer = extensionManager.serializer();
-const parser = extensionManager.parser({
-  schema,
-  plugins: extensionManager.rulePlugins,
-});
 
 const findImageNode = (doc: ReturnType<typeof parser.parse>) => {
   const imageNode = findNodes(doc?.toJSON(), "image")[0];

--- a/shared/editor/rules/checkboxes.test.ts
+++ b/shared/editor/rules/checkboxes.test.ts
@@ -1,10 +1,4 @@
-import { extensionManager, findNodes, schema } from "../../test/editor";
-
-const serializer = extensionManager.serializer();
-const parser = extensionManager.parser({
-  schema,
-  plugins: extensionManager.rulePlugins,
-});
+import { findNodes, parser, serializer } from "../../test/editor";
 
 it("preserves mixed checkbox and regular items in a list", () => {
   const markdown = `- [x] Checked item

--- a/shared/editor/rules/hardbreaks.test.ts
+++ b/shared/editor/rules/hardbreaks.test.ts
@@ -1,10 +1,4 @@
-import { extensionManager, schema } from "../../test/editor";
-
-const serializer = extensionManager.serializer();
-const parser = extensionManager.parser({
-  schema,
-  plugins: extensionManager.rulePlugins,
-});
+import { parser, schema, serializer } from "../../test/editor";
 
 const docWithHardBreak = schema.nodeFromJSON({
   type: "doc",

--- a/shared/editor/rules/math.test.ts
+++ b/shared/editor/rules/math.test.ts
@@ -1,10 +1,5 @@
 import type { JSONNode } from "../../test/editor";
-import { extensionManager, findNodes, schema } from "../../test/editor";
-
-const parser = extensionManager.parser({
-  schema,
-  plugins: extensionManager.rulePlugins,
-});
+import { findNodes, parser } from "../../test/editor";
 
 const parseToJSON = (markdown: string): JSONNode | undefined =>
   parser.parse(markdown)?.toJSON();

--- a/shared/editor/rules/tables.test.ts
+++ b/shared/editor/rules/tables.test.ts
@@ -1,10 +1,4 @@
-import { extensionManager, schema } from "../../test/editor";
-
-const serializer = extensionManager.serializer();
-const parser = extensionManager.parser({
-  schema,
-  plugins: extensionManager.rulePlugins,
-});
+import { parser, schema, serializer } from "../../test/editor";
 
 /**
  * Wraps a block node in a single-cell table so cell serialization/parsing can

--- a/shared/test/editor.ts
+++ b/shared/test/editor.ts
@@ -19,6 +19,19 @@ export const schema = new Schema({
 });
 
 /**
+ * Markdown parser using the rich extensions and their rule plugins.
+ */
+export const parser = extensionManager.parser({
+  schema,
+  plugins: extensionManager.rulePlugins,
+});
+
+/**
+ * Markdown serializer using the rich extensions.
+ */
+export const serializer = extensionManager.serializer();
+
+/**
  * Creates an editor state with the given document and plugins.
  *
  * @param doc - the document node.


### PR DESCRIPTION
- Code fences now serialize with more backticks than the longest backtick run in their content, so a content line can no longer terminate the fence early when the markdown is parsed again
- The fence info string and `language` attribute are reduced to a single safe token on both parse and serialize, instead of storing arbitrary text verbatim
- Previously an affected document changed block structure on every export → import round trip, which could collapse most of a document into a single code block and made revision diffs extremely expensive
- Adds shared `parser`/`serializer` exports to the editor test helper and removes the duplicated construction from existing tests