### PR TITLE
feat: Rank mention suggestions by familiarity

### DIFF
--- a/app/editor/components/MentionMenu.tsx
+++ b/app/editor/components/MentionMenu.tsx
@@ -29,6 +29,7 @@ import {
 import useRequest from "~/hooks/useRequest";
 import useStores from "~/hooks/useStores";
 import useUserLocale from "~/hooks/useUserLocale";
+import type Model from "~/models/base/Model";
 import { client } from "~/utils/ApiClient";
 import { useEditor } from "./EditorContext";
 import type { Props as SuggestionsMenuProps } from "./SuggestionsMenu";
@@ -42,6 +43,12 @@ type Props = Omit<
 
 function MentionMenu({ search = "", isActive, ...rest }: Props) {
   const [loaded, setLoaded] = useState(false);
+  // How familiar each suggested model is to the current user, keyed by model
+  // id. The score does not depend on the search term, so scores from earlier
+  // queries stay valid and are kept.
+  const [familiarity, setFamiliarity] = useState<ReadonlyMap<string, number>>(
+    new Map()
+  );
   const { t } = useTranslation();
   const { auth, documents, users, collections, groups } = useStores();
   const { props: editorProps } = useEditor();
@@ -127,7 +134,22 @@ function MentionMenu({ search = "", isActive, ...rest }: Props) {
         res.data.collections.map(collections.add);
         res.data.groups.map(groups.add);
       });
+
+      setFamiliarity(
+        (previous) =>
+          new Map([
+            ...previous,
+            ...Object.entries<number>(res.data.familiarity ?? {}),
+          ])
+      );
     }, [search, documents, users, collections, groups, maxResultsInSection])
+  );
+
+  // Suggestions that the current user is familiar with, for example a member of
+  // one of their groups, are ranked above equally relevant ones.
+  const weight = useCallback(
+    (model: Model) => familiarity.get(model.id) ?? 1,
+    [familiarity]
   );
 
   useEffect(() => {
@@ -147,21 +169,21 @@ function MentionMenu({ search = "", isActive, ...rest }: Props) {
   // runs outside the reactive context and triggered MobX warnings.
   const mentionItems: MentionMenuItem[] = actorId
     ? users
-        .findByQuery(search, { maxResults: maxResultsInSection })
+        .findByQuery(search, { maxResults: maxResultsInSection, weight })
         .map((user) => userMentionItem(t, user, actorId))
         .concat(
           groups
-            .findByQuery(search, { maxResults: maxResultsInSection })
+            .findByQuery(search, { maxResults: maxResultsInSection, weight })
             .map((group) => groupMentionItem(t, group, actorId))
         )
         .concat(
           documents
-            .findByQuery(search, { maxResults: maxResultsInSection })
+            .findByQuery(search, { maxResults: maxResultsInSection, weight })
             .map((doc) => documentMentionItem(doc, actorId))
         )
         .concat(
           collections
-            .findByQuery(search, { maxResults: maxResultsInSection })
+            .findByQuery(search, { maxResults: maxResultsInSection, weight })
             .map((collection) => collectionMentionItem(collection, actorId))
         )
         .concat(

--- a/app/stores/base/Store.ts
+++ b/app/stores/base/Store.ts
@@ -104,13 +104,29 @@ export default abstract class Store<T extends Model> {
     policies?.forEach((policy) => this.rootStore.policies.add(policy));
   };
 
-  findByQuery = (query: string, options?: { maxResults: number }): T[] => {
+  /**
+   * Finds the items that match the given query, ordered by relevance.
+   *
+   * @param query the search query, all items are returned when it is empty.
+   * @param options the maximum number of results, and a weight applied to the
+   * relevance score of each item, for example how familiar it is to the user.
+   * @returns the matching items.
+   */
+  findByQuery = (
+    query: string,
+    options?: { maxResults?: number; weight?: (item: T) => number }
+  ): T[] => {
     const normalized = deburr((query ?? "").trim().toLocaleLowerCase());
+    const weight = options?.weight;
 
     if (!normalized) {
-      return this.orderedData
-        .filter((item: T & Searchable) => !item.searchSuppressed)
-        .slice(0, options?.maxResults);
+      const items = this.orderedData.filter(
+        (item: T & Searchable) => !item.searchSuppressed
+      );
+
+      return (
+        weight ? items.sort((a, b) => weight(b) - weight(a)) : items
+      ).slice(0, options?.maxResults);
     }
 
     return this.orderedData
@@ -138,9 +154,11 @@ export default abstract class Store<T extends Model> {
 
         return {
           score:
-            seachables
+            (seachables
               .map((searchable) => commandScore(normalized, searchable))
-              .reduce((a, b) => a + b, 0) / seachables.length,
+              .reduce((a, b) => a + b, 0) /
+              seachables.length) *
+            (weight?.(item) ?? 1),
           item,
         };
       })

--- a/server/models/helpers/FamiliarityHelper.test.ts
+++ b/server/models/helpers/FamiliarityHelper.test.ts
@@ -1,0 +1,45 @@
+import { buildGroup, buildGroupUser, buildUser } from "@server/test/factories";
+import { FamiliarityHelper } from "./FamiliarityHelper";
+
+describe("FamiliarityHelper", () => {
+  describe("forUsers", () => {
+    const buildSharedGroups = async (count: number) => {
+      const actor = await buildUser();
+      const other = await buildUser({ teamId: actor.teamId });
+
+      const groupIds = [];
+      for (let i = 0; i < count; i++) {
+        const group = await buildGroup({ teamId: actor.teamId });
+        await buildGroupUser({
+          teamId: actor.teamId,
+          groupId: group.id,
+          userId: other.id,
+        });
+        groupIds.push(group.id);
+      }
+
+      return { other, groupIds };
+    };
+
+    it("should score a user for each group shared with the actor", async () => {
+      const { other, groupIds } = await buildSharedGroups(2);
+
+      const scores = await FamiliarityHelper.forUsers([other], groupIds);
+      expect(scores[other.id]).toEqual(2);
+    });
+
+    it("should not score a user that shares no group with the actor", async () => {
+      const { other } = await buildSharedGroups(1);
+
+      const scores = await FamiliarityHelper.forUsers([other], []);
+      expect(scores).toEqual({});
+    });
+
+    it("should cap the score of a user in many shared groups", async () => {
+      const { other, groupIds } = await buildSharedGroups(6);
+
+      const scores = await FamiliarityHelper.forUsers([other], groupIds);
+      expect(scores[other.id]).toEqual(3);
+    });
+  });
+});

--- a/server/models/helpers/FamiliarityHelper.ts
+++ b/server/models/helpers/FamiliarityHelper.ts
@@ -1,0 +1,82 @@
+import { type OrderItem, Sequelize } from "sequelize";
+import { GroupUser } from "@server/models";
+import type { User } from "@server/models";
+
+/**
+ * A multiplier per model id, applied by the client to the relevance score of a
+ * suggestion. Models without a score are equally familiar to everyone.
+ */
+export type FamiliarityScores = Record<string, number>;
+
+/**
+ * Scores how familiar a suggested model is to the user that is asking for it,
+ * so that the people and content they work with are suggested first.
+ */
+export class FamiliarityHelper {
+  /** The score of a model with no familiarity signal. */
+  public static defaultScore = 1;
+
+  /**
+   * Builds an order clause that ranks users familiar to the actor first. The
+   * query must pass the actor's group ids as a `groupIds` replacement.
+   *
+   * @param groupIds the identifiers of the groups the actor is a member of.
+   * @returns the order items, empty when the actor is in no group.
+   */
+  public static userOrder(groupIds: string[]): OrderItem[] {
+    if (!groupIds.length) {
+      return [];
+    }
+
+    return [
+      [
+        Sequelize.literal(
+          `(SELECT COUNT(*) FROM group_users WHERE group_users."userId" = "user"."id" AND group_users."groupId" IN (:groupIds))`
+        ),
+        "DESC",
+      ],
+    ];
+  }
+
+  /**
+   * Scores the given users by the number of groups they share with the actor.
+   *
+   * @param users the suggested users to score.
+   * @param groupIds the identifiers of the groups the actor is a member of.
+   * @returns the scores, keyed by user id.
+   */
+  public static async forUsers(
+    users: User[],
+    groupIds: string[]
+  ): Promise<FamiliarityScores> {
+    const scores: FamiliarityScores = {};
+
+    if (!users.length || !groupIds.length) {
+      return scores;
+    }
+
+    const groupUsers = await GroupUser.findAll({
+      attributes: ["userId"],
+      where: {
+        userId: users.map((user) => user.id),
+        groupId: groupIds,
+      },
+    });
+
+    for (const groupUser of groupUsers) {
+      scores[groupUser.userId] = Math.min(
+        (scores[groupUser.userId] ?? this.defaultScore) +
+          this.sharedGroupWeight,
+        this.maxScore
+      );
+    }
+
+    return scores;
+  }
+
+  /** The score added for each group shared with the actor. */
+  private static sharedGroupWeight = 0.5;
+
+  /** The highest score a model can reach, whatever the signals. */
+  private static maxScore = 3;
+}

--- a/server/routes/api/suggestions/suggestions.test.ts
+++ b/server/routes/api/suggestions/suggestions.test.ts
@@ -1,4 +1,9 @@
-import { buildGroup, buildGuestUser, buildUser } from "@server/test/factories";
+import {
+  buildGroup,
+  buildGroupUser,
+  buildGuestUser,
+  buildUser,
+} from "@server/test/factories";
 import { getTestServer } from "@server/test/support";
 
 const server = getTestServer();
@@ -19,6 +24,46 @@ describe("#suggestions.mention", () => {
     expect(body.data.groups.map((g: { id: string }) => g.id)).toContain(
       group.id
     );
+  });
+
+  it("should return users in the same group first", async () => {
+    const user = await buildUser();
+    const other = await buildUser({ teamId: user.teamId, name: "Anna" });
+    const teammate = await buildUser({ teamId: user.teamId, name: "Zoe" });
+    const group = await buildGroup({ teamId: user.teamId });
+
+    await buildGroupUser({
+      teamId: user.teamId,
+      groupId: group.id,
+      userId: user.id,
+    });
+    await buildGroupUser({
+      teamId: user.teamId,
+      groupId: group.id,
+      userId: teammate.id,
+    });
+
+    const res = await server.post("/api/suggestions.mention", user);
+    const body = await res.json();
+    const userIds = body.data.users.map((u: { id: string }) => u.id);
+
+    expect(res.status).toEqual(200);
+    expect(userIds.indexOf(teammate.id)).toBeLessThan(
+      userIds.indexOf(other.id)
+    );
+    expect(body.data.familiarity[teammate.id]).toBeGreaterThan(1);
+    expect(body.data.familiarity[other.id]).toBeUndefined();
+  });
+
+  it("should not return familiarity for a user in no group", async () => {
+    const user = await buildUser();
+    await buildUser({ teamId: user.teamId });
+
+    const res = await server.post("/api/suggestions.mention", user);
+    const body = await res.json();
+
+    expect(res.status).toEqual(200);
+    expect(body.data.familiarity).toEqual({});
   });
 
   it("should not return users or groups for a guest", async () => {

--- a/server/routes/api/suggestions/suggestions.ts
+++ b/server/routes/api/suggestions/suggestions.ts
@@ -5,6 +5,10 @@ import { StatusFilter } from "@shared/types";
 import auth from "@server/middlewares/authentication";
 import validate from "@server/middlewares/validate";
 import { Group, User } from "@server/models";
+import {
+  FamiliarityHelper,
+  type FamiliarityScores,
+} from "@server/models/helpers/FamiliarityHelper";
 import SearchProviderManager from "@server/utils/SearchProviderManager";
 import { QueryHelper } from "@server/storage/QueryHelper";
 import { can } from "@server/policies";
@@ -29,62 +33,81 @@ router.post(
     const { offset, limit } = ctx.state.pagination;
     const actor = ctx.state.auth.user;
 
-    const [documents, users, groups, collections] = await Promise.all([
-      SearchProviderManager.getProvider().searchTitlesForUser(actor, {
-        query,
-        offset,
-        limit,
-        statusFilter: [StatusFilter.Published],
-      }),
-      can(actor, "listUsers", actor.team)
-        ? User.findAll({
-            where: {
-              teamId: actor.teamId,
-              suspendedAt: {
-                [Op.eq]: null,
-              },
-              [Op.and]: query
-                ? {
-                    [Op.or]: [
-                      Sequelize.literal(
-                        `unaccent(LOWER(email)) like unaccent(LOWER(:query))`
-                      ),
-                      Sequelize.literal(
-                        `unaccent(LOWER(name)) like unaccent(LOWER(:query))`
-                      ),
-                    ],
-                  }
-                : {},
-            },
-            order: [["name", "ASC"]],
-            replacements: { query: QueryHelper.likeContains(query ?? "") },
-            offset,
-            limit,
-          })
-        : [],
-      can(actor, "listGroups", actor.team)
-        ? Group.findAll({
-            where: {
-              teamId: actor.teamId,
-              disableMentions: false,
-              [Op.and]: query
-                ? Sequelize.literal(
+    const suggestUsers = async (): Promise<{
+      users: User[];
+      familiarity: FamiliarityScores;
+    }> => {
+      if (!can(actor, "listUsers", actor.team)) {
+        return { users: [], familiarity: {} };
+      }
+
+      const groupIds = await actor.groupIds();
+      const users = await User.findAll({
+        where: {
+          teamId: actor.teamId,
+          suspendedAt: {
+            [Op.eq]: null,
+          },
+          [Op.and]: query
+            ? {
+                [Op.or]: [
+                  Sequelize.literal(
+                    `unaccent(LOWER(email)) like unaccent(LOWER(:query))`
+                  ),
+                  Sequelize.literal(
                     `unaccent(LOWER(name)) like unaccent(LOWER(:query))`
-                  )
-                : {},
-            },
-            order: [["name", "ASC"]],
-            replacements: { query: QueryHelper.likeContains(query ?? "") },
-            offset,
-            limit,
-          })
-        : [],
-      SearchProviderManager.getProvider().searchCollectionsForUser(actor, {
-        query,
+                  ),
+                ],
+              }
+            : {},
+        },
+        order: [...FamiliarityHelper.userOrder(groupIds), ["name", "ASC"]],
+        replacements: {
+          query: QueryHelper.likeContains(query ?? ""),
+          groupIds,
+        },
         offset,
         limit,
-      }),
-    ]);
+      });
+
+      return {
+        users,
+        familiarity: await FamiliarityHelper.forUsers(users, groupIds),
+      };
+    };
+
+    const [documents, { users, familiarity }, groups, collections] =
+      await Promise.all([
+        SearchProviderManager.getProvider().searchTitlesForUser(actor, {
+          query,
+          offset,
+          limit,
+          statusFilter: [StatusFilter.Published],
+        }),
+        suggestUsers(),
+        can(actor, "listGroups", actor.team)
+          ? Group.findAll({
+              where: {
+                teamId: actor.teamId,
+                disableMentions: false,
+                [Op.and]: query
+                  ? Sequelize.literal(
+                      `unaccent(LOWER(name)) like unaccent(LOWER(:query))`
+                    )
+                  : {},
+              },
+              order: [["name", "ASC"]],
+              replacements: { query: QueryHelper.likeContains(query ?? "") },
+              offset,
+              limit,
+            })
+          : [],
+        SearchProviderManager.getProvider().searchCollectionsForUser(actor, {
+          query,
+          offset,
+          limit,
+        }),
+      ]);
 
     ctx.body = {
       pagination: ctx.state.pagination,
@@ -98,6 +121,7 @@ router.post(
         ),
         groups: await Promise.all(groups.map((group) => presentGroup(group))),
         collections,
+        familiarity,
       },
     };
   }


### PR DESCRIPTION
- People that share a group with you are now suggested first in the mention menu, in place of a plain alphabetical order.
- The response carries a familiarity score per model id, which the client applies as a multiplier on the relevance of a suggestion and keeps across queries.
- The score is generic, so more signals and other model types can be added later without a change to the response shape.

Raised in #12744, where the request was to restrict mentions to a group — that hides people who can still read the document, so this reorders instead.