### PR TITLE
fix: API updates published to wrong Redis when collaboration Redis is separate

### DIFF
--- a/server/collaboration/APIUpdateExtension.ts
+++ b/server/collaboration/APIUpdateExtension.ts
@@ -200,7 +200,7 @@ export class APIUpdateExtension implements Extension {
       timestamp: Date.now(),
     });
 
-    await RedisAdapter.defaultClient.publish(channel, message);
+    await RedisAdapter.collaborationClient.publish(channel, message);
 
     Logger.debug("multiplayer", `Published API update notification`, {
       documentId,


### PR DESCRIPTION
`APIUpdateExtension` creates its subscriber against `REDIS_COLLABORATION_URL || REDIS_URL`, but `notifyUpdate` published on `RedisAdapter.defaultClient`, which is always bound to `REDIS_URL`.

When a deployment configures a separate collaboration Redis instance, the `collaboration:api-update:*` notification went to the main instance while every collaboration process listened on the collaboration instance. The message never arrived, so clients with the document open in the editor did not see API edits (e.g. `documents.update`) until they reloaded.

Publishing now goes through `RedisAdapter.collaborationClient`, which returns the default client when `REDIS_COLLABORATION_URL` is unset — so single-Redis installations are unchanged.

Note that Redis pub/sub is instance-wide rather than per-database, so this only affected deployments pointing the collaboration URL at a genuinely separate instance.