### PR TITLE
feat: Support OIDC back-channel logout

### DIFF
--- a/plugins/oidc/server/JWKSCache.ts
+++ b/plugins/oidc/server/JWKSCache.ts
@@ -1,0 +1,129 @@
+import crypto, { type JsonWebKey } from "node:crypto";
+import { InternalError } from "@server/errors";
+import fetch from "@server/utils/fetch";
+import { Minute, Second } from "@shared/utils/time";
+
+interface JSONWebKey extends JsonWebKey {
+  kid?: string;
+  use?: string;
+  alg?: string;
+}
+
+/** How long a fetched key set is used before it is fetched again. */
+const DEFAULT_TTL_MS = Minute.ms * 10;
+
+/** The shortest interval between two fetches, limiting load on the provider. */
+const MIN_REFRESH_INTERVAL_MS = Minute.ms;
+
+/**
+ * Fetches and caches an authentication provider's JSON Web Key Set, resolving
+ * the individual public keys that verify tokens signed by the provider.
+ *
+ * The key set is cached for a short period, and fetched again on demand when a
+ * token references an unknown key. Providers can therefore rotate their signing
+ * keys without a restart.
+ */
+export class JWKSCache {
+  /**
+   * @param uri The provider's `jwks_uri` endpoint.
+   * @param ttl How long a fetched key set is cached, in milliseconds.
+   */
+  constructor(
+    private uri: string,
+    private ttl: number = DEFAULT_TTL_MS
+  ) {}
+
+  /**
+   * Resolves the public key with the given identifier.
+   *
+   * @param kid The key identifier from the token header. When omitted the key
+   * set must contain exactly one signing key.
+   * @returns the public key, in PEM form.
+   * @throws {InternalError} if the key set cannot be loaded, or contains no
+   * matching key.
+   */
+  public async getSigningKey(kid?: string): Promise<string | Buffer> {
+    if (this.expiresAt <= Date.now()) {
+      await this.refresh();
+    }
+
+    let jwk = this.find(kid);
+
+    // A miss usually means the provider rotated its keys, so try once more with
+    // a freshly fetched set before giving up.
+    if (!jwk && this.refreshableAt <= Date.now()) {
+      await this.refresh();
+      jwk = this.find(kid);
+    }
+
+    if (!jwk) {
+      throw InternalError(
+        `The key set at ${this.uri} contains no signing key matching "${kid ?? "any"}"`
+      );
+    }
+
+    return crypto
+      .createPublicKey({ key: jwk, format: "jwk" })
+      .export({ type: "spki", format: "pem" });
+  }
+
+  private keys: JSONWebKey[] = [];
+
+  private expiresAt = 0;
+
+  private refreshableAt = 0;
+
+  private inflight: Promise<void> | undefined;
+
+  private find(kid?: string): JSONWebKey | undefined {
+    const signing = this.keys.filter((key) => key.use !== "enc");
+
+    if (!kid) {
+      return signing.length === 1 ? signing[0] : undefined;
+    }
+
+    return signing.find((key) => key.kid === kid);
+  }
+
+  /** Fetches the key set, sharing a single request between concurrent callers. */
+  private async refresh(): Promise<void> {
+    if (this.inflight) {
+      return this.inflight;
+    }
+
+    this.inflight = this.load();
+
+    try {
+      await this.inflight;
+    } finally {
+      this.inflight = undefined;
+    }
+  }
+
+  private async load(): Promise<void> {
+    const response = await fetch(this.uri, {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+      },
+      timeout: Second.ms * 10,
+      allowPrivateIPAddress: true,
+    });
+
+    if (!response.ok) {
+      throw InternalError(
+        `Failed to fetch key set from ${this.uri}: ${response.status} ${response.statusText}`
+      );
+    }
+
+    const body = await response.json();
+
+    if (!body || !Array.isArray(body.keys)) {
+      throw InternalError(`The key set at ${this.uri} is malformed`);
+    }
+
+    this.keys = body.keys;
+    this.expiresAt = Date.now() + this.ttl;
+    this.refreshableAt = Date.now() + MIN_REFRESH_INTERVAL_MS;
+  }
+}

--- a/plugins/oidc/server/auth/backchannelLogout.test.ts
+++ b/plugins/oidc/server/auth/backchannelLogout.test.ts
@@ -1,0 +1,227 @@
+import crypto from "node:crypto";
+import JWT from "jsonwebtoken";
+import Koa from "koa";
+import bodyParser from "koa-body";
+import Router from "koa-router";
+import { http, HttpResponse } from "msw";
+import { verifyCSRFToken } from "@server/middlewares/csrf";
+import { UserAuthentication } from "@server/models";
+import onerror from "@server/onerror";
+import type { AppContext, AppState } from "@server/types";
+import { buildTeam, buildUser } from "@server/test/factories";
+import { server as mockServer } from "@server/test/msw";
+import TestServer from "@server/test/TestServer";
+import { JWKSCache } from "../JWKSCache";
+import { backchannelLogout } from "./backchannelLogout";
+
+const Issuer = "http://example.com";
+const Audience = "client-id";
+const JWKSUri = `${Issuer}/jwks`;
+const LogoutEvent = "http://schemas.openid.net/event/backchannel-logout";
+const Path = "/auth/oidc.backchannel_logout";
+
+const { publicKey, privateKey } = crypto.generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+});
+const jwk = {
+  ...publicKey.export({ format: "jwk" }),
+  kid: "test-key",
+  use: "sig",
+  alg: "RS256",
+};
+
+// Mirrors how the endpoint is mounted in the auth router, so that body parsing
+// and CSRF verification apply as they do in production.
+const app = new Koa<AppState, AppContext>();
+const router = new Router<AppState, AppContext>();
+router.post(
+  Path,
+  backchannelLogout({
+    jwks: new JWKSCache(JWKSUri),
+    audience: Audience,
+    issuer: Issuer,
+  })
+);
+app.use(bodyParser());
+app.use(verifyCSRFToken());
+app.use(router.routes());
+onerror(app);
+
+const server = new TestServer(app);
+
+afterAll(() => server.close());
+
+let counter = 0;
+
+function signLogoutToken(
+  claims: Record<string, unknown> = {},
+  key: crypto.KeyObject = privateKey
+) {
+  return JWT.sign(
+    {
+      iss: Issuer,
+      aud: Audience,
+      jti: `jti-${++counter}`,
+      events: { [LogoutEvent]: {} },
+      ...claims,
+    },
+    key.export({ type: "pkcs8", format: "pem" }),
+    { algorithm: "RS256", keyid: jwk.kid }
+  );
+}
+
+function postLogoutToken(token: string) {
+  return server.post(Path, {
+    body: new URLSearchParams({ logout_token: token }).toString(),
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  });
+}
+
+/** Builds a user that authenticated with OIDC under the given subject. */
+async function buildOIDCUser(sub: string) {
+  const team = await buildTeam({
+    authenticationProviders: [{ name: "oidc", providerId: "example.com" }],
+  });
+  const user = await buildUser({ teamId: team.id });
+  await UserAuthentication.update(
+    { providerId: sub },
+    { where: { userId: user.id } }
+  );
+  return user;
+}
+
+describe("backchannelLogout", () => {
+  beforeEach(() => {
+    mockServer.use(http.get(JWKSUri, () => HttpResponse.json({ keys: [jwk] })));
+  });
+
+  it("should revoke the sessions of the user named in the token", async () => {
+    const user = await buildOIDCUser("subject-revoked");
+    const { jwtSecret } = user;
+
+    const res = await postLogoutToken(
+      signLogoutToken({ sub: "subject-revoked" })
+    );
+
+    expect(res.status).toEqual(200);
+    expect(res.headers.get("cache-control")).toEqual("no-cache, no-store");
+
+    await user.reload();
+    expect(user.jwtSecret).not.toEqual(jwtSecret);
+  });
+
+  it("should not require a CSRF token", async () => {
+    const res = await postLogoutToken(signLogoutToken({ sub: "unknown" }));
+    expect(res.status).toEqual(200);
+  });
+
+  it("should leave other users signed in", async () => {
+    const user = await buildOIDCUser("subject-untouched");
+    const { jwtSecret } = user;
+
+    const res = await postLogoutToken(signLogoutToken({ sub: "other" }));
+
+    expect(res.status).toEqual(200);
+    await user.reload();
+    expect(user.jwtSecret).toEqual(jwtSecret);
+  });
+
+  it("should reject a request without a token", async () => {
+    const res = await server.post(Path, {
+      body: "",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    });
+
+    expect(res.status).toEqual(400);
+    expect((await res.json()).error).toEqual("invalid_request");
+  });
+
+  it("should reject a token signed by an unknown key", async () => {
+    const { privateKey: otherKey } = crypto.generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+    });
+
+    const res = await postLogoutToken(
+      signLogoutToken({ sub: "subject" }, otherKey)
+    );
+    expect(res.status).toEqual(400);
+  });
+
+  it("should reject an unsigned token", async () => {
+    const token = JWT.sign(
+      {
+        iss: Issuer,
+        aud: Audience,
+        jti: `jti-${++counter}`,
+        sub: "subject",
+        events: { [LogoutEvent]: {} },
+      },
+      "",
+      { algorithm: "none" }
+    );
+
+    const res = await postLogoutToken(token);
+    expect(res.status).toEqual(400);
+  });
+
+  it("should reject a token from another issuer", async () => {
+    const res = await postLogoutToken(
+      signLogoutToken({ sub: "subject", iss: "http://attacker.example.com" })
+    );
+    expect(res.status).toEqual(400);
+  });
+
+  it("should reject a token issued for another audience", async () => {
+    const res = await postLogoutToken(
+      signLogoutToken({ sub: "subject", aud: "another-client" })
+    );
+    expect(res.status).toEqual(400);
+  });
+
+  it("should reject a token without the logout event claim", async () => {
+    const res = await postLogoutToken(
+      signLogoutToken({ sub: "subject", events: {} })
+    );
+    expect(res.status).toEqual(400);
+  });
+
+  it("should reject an id_token presented as a logout token", async () => {
+    const res = await postLogoutToken(
+      signLogoutToken({ sub: "subject", nonce: "abc" })
+    );
+    expect(res.status).toEqual(400);
+  });
+
+  it("should reject a token that is no longer fresh", async () => {
+    const res = await postLogoutToken(
+      signLogoutToken({
+        sub: "subject",
+        iat: Math.floor(Date.now() / 1000) - 60 * 60,
+      })
+    );
+    expect(res.status).toEqual(400);
+  });
+
+  it("should reject a token without a jti claim", async () => {
+    const res = await postLogoutToken(
+      signLogoutToken({ sub: "subject", jti: undefined })
+    );
+    expect(res.status).toEqual(400);
+  });
+
+  it("should reject a replayed token", async () => {
+    const token = signLogoutToken({ sub: "subject-replayed" });
+
+    expect((await postLogoutToken(token)).status).toEqual(200);
+    expect((await postLogoutToken(token)).status).toEqual(400);
+  });
+
+  it("should reject a token scoped to a provider session alone", async () => {
+    const res = await postLogoutToken(
+      signLogoutToken({ sid: "session-id", sub: undefined })
+    );
+
+    expect(res.status).toEqual(400);
+    expect((await res.json()).error_description).toContain("sub claim");
+  });
+});

--- a/plugins/oidc/server/auth/backchannelLogout.test.ts
+++ b/plugins/oidc/server/auth/backchannelLogout.test.ts
@@ -185,6 +185,26 @@ describe("backchannelLogout", () => {
     expect(res.status).toEqual(400);
   });
 
+  it.each([
+    ["null", null],
+    ["an array", []],
+    ["a string", "logout"],
+  ])("should reject a logout event claim that is %s", async (_name, value) => {
+    const res = await postLogoutToken(
+      signLogoutToken({ sub: "subject", events: { [LogoutEvent]: value } })
+    );
+
+    expect(res.status).toEqual(400);
+    expect((await res.json()).error_description).toContain(LogoutEvent);
+  });
+
+  it("should reject an events claim that is not an object", async () => {
+    const res = await postLogoutToken(
+      signLogoutToken({ sub: "subject", events: null })
+    );
+    expect(res.status).toEqual(400);
+  });
+
   it("should reject an id_token presented as a logout token", async () => {
     const res = await postLogoutToken(
       signLogoutToken({ sub: "subject", nonce: "abc" })

--- a/plugins/oidc/server/auth/backchannelLogout.test.ts
+++ b/plugins/oidc/server/auth/backchannelLogout.test.ts
@@ -4,8 +4,9 @@ import Koa from "koa";
 import bodyParser from "koa-body";
 import Router from "koa-router";
 import { http, HttpResponse } from "msw";
+import { vi } from "vitest";
 import { verifyCSRFToken } from "@server/middlewares/csrf";
-import { UserAuthentication } from "@server/models";
+import { User, UserAuthentication } from "@server/models";
 import onerror from "@server/onerror";
 import type { AppContext, AppState } from "@server/types";
 import { buildTeam, buildUser } from "@server/test/factories";
@@ -19,6 +20,11 @@ const Audience = "client-id";
 const JWKSUri = `${Issuer}/jwks`;
 const LogoutEvent = "http://schemas.openid.net/event/backchannel-logout";
 const Path = "/auth/oidc.backchannel_logout";
+
+// A second endpoint whose key set is never reachable, used to prove that a
+// failure to resolve the signing key rejects the token rather than erroring.
+const UnreachableJWKSUri = `${Issuer}/unreachable-jwks`;
+const UnreachablePath = "/auth/oidc.backchannel_logout_unreachable";
 
 const { publicKey, privateKey } = crypto.generateKeyPairSync("rsa", {
   modulusLength: 2048,
@@ -42,6 +48,14 @@ router.post(
     issuer: Issuer,
   })
 );
+router.post(
+  UnreachablePath,
+  backchannelLogout({
+    jwks: new JWKSCache(UnreachableJWKSUri),
+    audience: Audience,
+    issuer: Issuer,
+  })
+);
 app.use(bodyParser());
 app.use(verifyCSRFToken());
 app.use(router.routes());
@@ -55,18 +69,28 @@ let counter = 0;
 
 function signLogoutToken(
   claims: Record<string, unknown> = {},
-  key: crypto.KeyObject = privateKey
+  {
+    key = privateKey,
+    ...options
+  }: JWT.SignOptions & { key?: crypto.KeyObject } = {}
 ) {
+  const payload = {
+    iss: Issuer,
+    aud: Audience,
+    jti: `jti-${++counter}`,
+    exp: Math.floor(Date.now() / 1000) + 300,
+    events: { [LogoutEvent]: {} },
+    ...claims,
+  };
+
   return JWT.sign(
-    {
-      iss: Issuer,
-      aud: Audience,
-      jti: `jti-${++counter}`,
-      events: { [LogoutEvent]: {} },
-      ...claims,
-    },
+    // A claim set to undefined is dropped, so that a test can describe a token
+    // that omits it.
+    Object.fromEntries(
+      Object.entries(payload).filter(([, value]) => value !== undefined)
+    ),
     key.export({ type: "pkcs8", format: "pem" }),
-    { algorithm: "RS256", keyid: jwk.kid }
+    { algorithm: "RS256", keyid: jwk.kid, ...options }
   );
 }
 
@@ -142,8 +166,36 @@ describe("backchannelLogout", () => {
     });
 
     const res = await postLogoutToken(
-      signLogoutToken({ sub: "subject" }, otherKey)
+      signLogoutToken({ sub: "subject" }, { key: otherKey })
     );
+    expect(res.status).toEqual(400);
+  });
+
+  it("should reject a token naming a key that is not in the key set", async () => {
+    const res = await postLogoutToken(
+      signLogoutToken({ sub: "subject" }, { keyid: "unknown-key" })
+    );
+
+    // A rejected token, not a fault of our own.
+    expect(res.status).toEqual(400);
+    expect((await res.json()).error).toEqual("invalid_request");
+  });
+
+  it("should reject a token when the key set cannot be reached", async () => {
+    mockServer.use(
+      http.get(
+        UnreachableJWKSUri,
+        () => new HttpResponse(null, { status: 503 })
+      )
+    );
+
+    const res = await server.post(UnreachablePath, {
+      body: new URLSearchParams({
+        logout_token: signLogoutToken({ sub: "subject" }),
+      }).toString(),
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    });
+
     expect(res.status).toEqual(400);
   });
 
@@ -222,9 +274,42 @@ describe("backchannelLogout", () => {
     expect(res.status).toEqual(400);
   });
 
-  it("should reject a token without a jti claim", async () => {
+  it.each(["jti", "iat", "exp"])(
+    "should reject a token without a %s claim",
+    async (claim) => {
+      const res = await postLogoutToken(
+        signLogoutToken(
+          { sub: "subject", [claim]: undefined },
+          claim === "iat" ? { noTimestamp: true } : {}
+        )
+      );
+      expect(res.status).toEqual(400);
+    }
+  );
+
+  it("should reject a token issued to more than one audience", async () => {
     const res = await postLogoutToken(
-      signLogoutToken({ sub: "subject", jti: undefined })
+      signLogoutToken({ sub: "subject", aud: [Audience, "another-client"] })
+    );
+
+    expect(res.status).toEqual(400);
+    expect((await res.json()).error_description).toContain("azp");
+  });
+
+  it("should accept more than one audience when azp names this client", async () => {
+    const res = await postLogoutToken(
+      signLogoutToken({
+        sub: "subject",
+        aud: [Audience, "another-client"],
+        azp: Audience,
+      })
+    );
+    expect(res.status).toEqual(200);
+  });
+
+  it("should reject a token whose azp claim names another party", async () => {
+    const res = await postLogoutToken(
+      signLogoutToken({ sub: "subject", azp: "another-client" })
     );
     expect(res.status).toEqual(400);
   });
@@ -234,6 +319,23 @@ describe("backchannelLogout", () => {
 
     expect((await postLogoutToken(token)).status).toEqual(200);
     expect((await postLogoutToken(token)).status).toEqual(400);
+  });
+
+  it("should accept the same token again when the logout failed", async () => {
+    const user = await buildOIDCUser("subject-retried");
+    const { jwtSecret } = user;
+    const token = signLogoutToken({ sub: "subject-retried" });
+
+    vi.spyOn(User, "findAll").mockRejectedValueOnce(new Error("database gone"));
+    expect((await postLogoutToken(token)).status).toEqual(500);
+
+    // The record was released, so the provider's retry is not refused as a
+    // replay and the logout completes.
+    vi.restoreAllMocks();
+    expect((await postLogoutToken(token)).status).toEqual(200);
+
+    await user.reload();
+    expect(user.jwtSecret).not.toEqual(jwtSecret);
   });
 
   it("should reject a token scoped to a provider session alone", async () => {

--- a/plugins/oidc/server/auth/backchannelLogout.ts
+++ b/plugins/oidc/server/auth/backchannelLogout.ts
@@ -73,6 +73,10 @@ const ReplayWindowSeconds = Minute.seconds * 10;
 const LogoutTokenSchema = z
   .object({
     jti: z.string(),
+    iat: z.number(),
+    exp: z.number(),
+    aud: z.union([z.string(), z.array(z.string())]),
+    azp: z.string().optional(),
     sub: z.string().optional(),
     sid: z.string().optional(),
     nonce: z.undefined().optional(),
@@ -111,10 +115,13 @@ export async function validateLogoutToken(
     );
   }
 
-  const key = await options.jwks.getSigningKey(decoded.header.kid);
-
   let payload;
   try {
+    // Resolving the key is part of validation – an unknown key identifier, or
+    // a key set that cannot be reached, must be reported as a rejected token
+    // rather than as a fault of our own.
+    const key = await options.jwks.getSigningKey(decoded.header.kid);
+
     payload = JWT.verify(token, key, {
       algorithms: Algorithms,
       audience: options.audience,
@@ -140,7 +147,22 @@ export async function validateLogoutToken(
     );
   }
 
-  const { jti, sub, sid } = result.data;
+  const { jti, sub, sid, aud, azp } = result.data;
+
+  // Verification proved this client is one of the audiences. Any further
+  // audience belongs to a party we do not trust, so the token is only accepted
+  // when it names this client as the authorized party.
+  // https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation
+  if (Array.isArray(aud) && aud.length > 1 && azp !== options.audience) {
+    throw new LogoutTokenError(
+      "Logout token has more than one audience and does not name this client in the azp claim"
+    );
+  }
+  if (azp !== undefined && azp !== options.audience) {
+    throw new LogoutTokenError(
+      "Logout token names another authorized party in the azp claim"
+    );
+  }
 
   // Recorded only once the token is otherwise trusted, so that an unverified
   // request cannot fill the store.
@@ -203,13 +225,37 @@ export function backchannelLogout(options: BackchannelLogoutOptions) {
       );
     }
 
-    await revokeSessions(claims.sub);
+    try {
+      await revokeSessions(claims.sub);
+    } catch (err) {
+      // The logout did not complete, so give up the replay record. Holding it
+      // would refuse the provider's retry of the very same token.
+      await releaseLogoutToken(claims.jti);
+      throw err;
+    }
 
     // The specification requires 200 on success, providers may treat any other
     // status as a failed logout.
     ctx.status = 200;
     ctx.body = "";
   };
+}
+
+/**
+ * Discards the replay record of a token, so that a provider can present it
+ * again after a logout that could not be completed. Best-effort – never throws.
+ */
+async function releaseLogoutToken(tokenId: string) {
+  try {
+    await Redis.defaultClient.del(
+      RedisPrefixHelper.getLogoutTokenReplayKey(config.id, tokenId)
+    );
+  } catch (err) {
+    Logger.warn("Failed to release an OIDC logout token record", {
+      tokenId,
+      error: toError(err).message,
+    });
+  }
 }
 
 /**

--- a/plugins/oidc/server/auth/backchannelLogout.ts
+++ b/plugins/oidc/server/auth/backchannelLogout.ts
@@ -1,0 +1,259 @@
+import JWT, { type Algorithm } from "jsonwebtoken";
+import { uniq } from "es-toolkit";
+import { toError } from "@shared/utils/error";
+import { Minute } from "@shared/utils/time";
+import Logger from "@server/logging/Logger";
+import {
+  AuthenticationProvider,
+  User,
+  UserAuthentication,
+} from "@server/models";
+import Redis from "@server/storage/redis";
+import type { AppContext } from "@server/types";
+import { RedisPrefixHelper } from "@server/utils/RedisPrefixHelper";
+import config from "../../plugin.json";
+import type { JWKSCache } from "../JWKSCache";
+
+export interface BackchannelLogoutOptions {
+  /** The provider key set, used to verify the token signature. */
+  jwks: JWKSCache;
+  /** The client identifier that must appear in the token audience. */
+  audience: string;
+  /** The identifier the token issuer must name itself with. */
+  issuer: string;
+}
+
+export interface LogoutTokenClaims {
+  /** The unique identifier of the token. */
+  jti: string;
+  /** The subject the logout applies to, as known to the provider. */
+  sub?: string;
+  /** The provider session the logout applies to. */
+  sid?: string;
+}
+
+/** Raised when a logout token is missing, malformed, or cannot be trusted. */
+export class LogoutTokenError extends Error {}
+
+/**
+ * The event identifier that distinguishes a logout token from an ID token.
+ * https://openid.net/specs/openid-connect-backchannel-1_0.html#LogoutToken
+ */
+const LogoutEvent = "http://schemas.openid.net/event/backchannel-logout";
+
+/** The signature algorithms a logout token may be signed with. */
+const Algorithms: Algorithm[] = [
+  "RS256",
+  "RS384",
+  "RS512",
+  "PS256",
+  "PS384",
+  "PS512",
+  "ES256",
+  "ES384",
+  "ES512",
+];
+
+/** How long a token remains acceptable after it was issued. */
+const MaxTokenAge = "5m";
+
+/** Permitted difference between the provider's clock and our own, in seconds. */
+const ClockTolerance = Minute.seconds;
+
+/** How long a consumed token identifier is retained to reject replays. */
+const ReplayWindowSeconds = Minute.seconds * 10;
+
+/**
+ * Validates a back-channel logout token against the OpenID Connect
+ * specification and records it so that it cannot be presented a second time.
+ *
+ * @param token The encoded logout token.
+ * @param options The provider key set and expected token claims.
+ * @returns the validated claims.
+ * @throws {LogoutTokenError} if the token cannot be trusted.
+ */
+export async function validateLogoutToken(
+  token: string,
+  options: BackchannelLogoutOptions
+): Promise<LogoutTokenClaims> {
+  const decoded = JWT.decode(token, { complete: true });
+
+  if (!decoded || typeof decoded.payload === "string") {
+    throw new LogoutTokenError("Logout token is not a valid JWT");
+  }
+
+  // Pinning the algorithm before and during verification rejects both
+  // unsigned tokens and tokens signed with a symmetric key of our own.
+  if (!Algorithms.some((algorithm) => algorithm === decoded.header.alg)) {
+    throw new LogoutTokenError(
+      `Logout token signature algorithm "${decoded.header.alg}" is not supported`
+    );
+  }
+
+  const key = await options.jwks.getSigningKey(decoded.header.kid);
+
+  let payload;
+  try {
+    payload = JWT.verify(token, key, {
+      algorithms: Algorithms,
+      audience: options.audience,
+      issuer: options.issuer,
+      maxAge: MaxTokenAge,
+      clockTolerance: ClockTolerance,
+    });
+  } catch (err) {
+    throw new LogoutTokenError(toError(err).message);
+  }
+
+  if (typeof payload === "string") {
+    throw new LogoutTokenError("Logout token has no claims");
+  }
+
+  const events = payload.events;
+  if (
+    !events ||
+    typeof events !== "object" ||
+    typeof events[LogoutEvent] !== "object"
+  ) {
+    throw new LogoutTokenError(
+      "Logout token is missing the back-channel logout event claim"
+    );
+  }
+
+  // A nonce identifies an ID token. Its presence means the provider, or an
+  // attacker, supplied a token that was issued for a different purpose.
+  if ("nonce" in payload) {
+    throw new LogoutTokenError("Logout token must not contain a nonce claim");
+  }
+
+  const { jti, sub, sid } = payload;
+
+  if (typeof jti !== "string") {
+    throw new LogoutTokenError("Logout token is missing a jti claim");
+  }
+  if (typeof sub !== "string" && typeof sid !== "string") {
+    throw new LogoutTokenError("Logout token is missing a sub or sid claim");
+  }
+
+  // Recorded only once the token is otherwise trusted, so that an unverified
+  // request cannot fill the store.
+  const stored = await Redis.defaultClient.set(
+    RedisPrefixHelper.getLogoutTokenReplayKey(config.id, jti),
+    "1",
+    "EX",
+    ReplayWindowSeconds,
+    "NX"
+  );
+
+  if (stored !== "OK") {
+    throw new LogoutTokenError("Logout token has already been used");
+  }
+
+  return { jti, sub, sid };
+}
+
+/**
+ * Creates a route handler that accepts provider-initiated logout notifications
+ * and ends the Outline sessions of the identified user.
+ *
+ * @param options The provider key set and expected token claims.
+ * @returns the route handler.
+ */
+export function backchannelLogout(options: BackchannelLogoutOptions) {
+  return async function backchannelLogoutHandler(ctx: AppContext) {
+    // The response carries the outcome of a state change and must never be
+    // stored by an intermediary.
+    ctx.set("Cache-Control", "no-cache, no-store");
+
+    const token = ctx.request.body?.logout_token;
+    if (typeof token !== "string" || !token) {
+      return respondWithError(ctx, "A logout_token parameter is required");
+    }
+
+    let claims;
+    try {
+      claims = await validateLogoutToken(token, options);
+    } catch (err) {
+      if (err instanceof LogoutTokenError) {
+        Logger.warn("Rejected an OIDC back-channel logout token", {
+          error: err.message,
+        });
+        return respondWithError(ctx, err.message);
+      }
+      throw err;
+    }
+
+    // Outline cannot revoke an individual session, so a logout scoped to a
+    // provider session alone cannot be honored.
+    if (!claims.sub) {
+      return respondWithError(
+        ctx,
+        "Logout token must contain a sub claim, session-scoped logout is not supported"
+      );
+    }
+
+    await revokeSessions(claims.sub);
+
+    ctx.status = 200;
+    ctx.body = "";
+  };
+}
+
+/**
+ * Ends every Outline session belonging to the users that authenticated with
+ * the given provider subject.
+ */
+async function revokeSessions(profileId: string) {
+  const providers = await AuthenticationProvider.findAll({
+    attributes: ["id"],
+    where: { name: config.id, enabled: true },
+  });
+
+  if (providers.length === 0) {
+    return;
+  }
+
+  const authentications = await UserAuthentication.findAll({
+    attributes: ["userId"],
+    where: {
+      providerId: profileId,
+      authenticationProviderId: providers.map((provider) => provider.id),
+    },
+  });
+
+  const userIds = uniq(
+    authentications.map((authentication) => authentication.userId)
+  );
+
+  if (userIds.length === 0) {
+    // Not an error – the subject may belong to another application entirely.
+    Logger.info(
+      "authentication",
+      "No user matched an OIDC back-channel logout request"
+    );
+    return;
+  }
+
+  const users = await User.findAll({ where: { id: userIds } });
+
+  // Rotating the secret invalidates every token issued to the user, signing
+  // them out of all of their devices.
+  await Promise.all(users.map((user) => user.rotateJwtSecret({})));
+
+  Logger.info(
+    "authentication",
+    `Revoked sessions for ${users.length} user(s) after OIDC back-channel logout`
+  );
+}
+
+/**
+ * Responds with the error shape the specification defines for a logout request
+ * that could not be handled.
+ */
+function respondWithError(ctx: AppContext, description: string) {
+  ctx.status = 400;
+  ctx.body = {
+    error: "invalid_request",
+    error_description: description,
+  };
+}

--- a/plugins/oidc/server/auth/backchannelLogout.ts
+++ b/plugins/oidc/server/auth/backchannelLogout.ts
@@ -1,8 +1,9 @@
 import JWT, { type Algorithm } from "jsonwebtoken";
 import { z } from "zod";
 import { uniq } from "es-toolkit";
-import { toError } from "@shared/utils/error";
+import { errToId, toError } from "@shared/utils/error";
 import { Minute } from "@shared/utils/time";
+import { OIDCLogoutTokenError } from "@server/errors";
 import Logger from "@server/logging/Logger";
 import {
   AuthenticationProvider,
@@ -32,9 +33,6 @@ export interface LogoutTokenClaims {
   /** The provider session the logout applies to. */
   sid?: string;
 }
-
-/** Raised when a logout token is missing, malformed, or cannot be trusted. */
-export class LogoutTokenError extends Error {}
 
 /**
  * The event identifier that distinguishes a logout token from an ID token.
@@ -95,7 +93,7 @@ const LogoutTokenSchema = z
  * @param token The encoded logout token.
  * @param options The provider key set and expected token claims.
  * @returns the validated claims.
- * @throws {LogoutTokenError} if the token cannot be trusted.
+ * @throws {OIDCLogoutTokenError} if the token cannot be trusted.
  */
 export async function validateLogoutToken(
   token: string,
@@ -104,13 +102,13 @@ export async function validateLogoutToken(
   const decoded = JWT.decode(token, { complete: true });
 
   if (!decoded || typeof decoded.payload === "string") {
-    throw new LogoutTokenError("Logout token is not a valid JWT");
+    throw OIDCLogoutTokenError("Logout token is not a valid JWT");
   }
 
   // Pinning the algorithm before and during verification rejects both
   // unsigned tokens and tokens signed with a symmetric key of our own.
   if (!Algorithms.some((algorithm) => algorithm === decoded.header.alg)) {
-    throw new LogoutTokenError(
+    throw OIDCLogoutTokenError(
       `Logout token signature algorithm "${decoded.header.alg}" is not supported`
     );
   }
@@ -130,17 +128,17 @@ export async function validateLogoutToken(
       clockTolerance: ClockTolerance,
     });
   } catch (err) {
-    throw new LogoutTokenError(toError(err).message);
+    throw OIDCLogoutTokenError(toError(err).message);
   }
 
   if (typeof payload === "string") {
-    throw new LogoutTokenError("Logout token has no claims");
+    throw OIDCLogoutTokenError("Logout token has no claims");
   }
 
   const result = LogoutTokenSchema.safeParse(payload);
 
   if (!result.success) {
-    throw new LogoutTokenError(
+    throw OIDCLogoutTokenError(
       `Logout token claims are invalid – ${result.error.issues
         .map((issue) => `${issue.path.join(".") || "claims"}: ${issue.message}`)
         .join(", ")}`
@@ -154,12 +152,12 @@ export async function validateLogoutToken(
   // when it names this client as the authorized party.
   // https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation
   if (Array.isArray(aud) && aud.length > 1 && azp !== options.audience) {
-    throw new LogoutTokenError(
+    throw OIDCLogoutTokenError(
       "Logout token has more than one audience and does not name this client in the azp claim"
     );
   }
   if (azp !== undefined && azp !== options.audience) {
-    throw new LogoutTokenError(
+    throw OIDCLogoutTokenError(
       "Logout token names another authorized party in the azp claim"
     );
   }
@@ -175,7 +173,7 @@ export async function validateLogoutToken(
   );
 
   if (stored !== "OK") {
-    throw new LogoutTokenError("Logout token has already been used");
+    throw OIDCLogoutTokenError("Logout token has already been used");
   }
 
   return { jti, sub, sid };
@@ -203,17 +201,19 @@ export function backchannelLogout(options: BackchannelLogoutOptions) {
     try {
       claims = await validateLogoutToken(token, options);
     } catch (err) {
-      if (err instanceof LogoutTokenError) {
-        Logger.warn("Rejected an OIDC back-channel logout token", {
-          error: err.message,
-          expectedIssuer: options.issuer,
-          expectedAudience: options.audience,
-          ip: ctx.ip,
-          ...describeToken(token),
-        });
-        return respondWithError(ctx, err.message);
+      if (errToId(err) !== "invalid_logout_token") {
+        throw err;
       }
-      throw err;
+
+      const { message } = toError(err);
+      Logger.warn("Rejected an OIDC back-channel logout token", {
+        error: message,
+        expectedIssuer: options.issuer,
+        expectedAudience: options.audience,
+        ip: ctx.ip,
+        ...describeToken(token),
+      });
+      return respondWithError(ctx, message);
     }
 
     // Outline cannot revoke an individual session, so a logout scoped to a

--- a/plugins/oidc/server/auth/backchannelLogout.ts
+++ b/plugins/oidc/server/auth/backchannelLogout.ts
@@ -1,4 +1,5 @@
 import JWT, { type Algorithm } from "jsonwebtoken";
+import { z } from "zod";
 import { uniq } from "es-toolkit";
 import { toError } from "@shared/utils/error";
 import { Minute } from "@shared/utils/time";
@@ -64,6 +65,26 @@ const ClockTolerance = Minute.seconds;
 const ReplayWindowSeconds = Minute.seconds * 10;
 
 /**
+ * The claims a logout token must carry. The logout event must hold a JSON
+ * object rather than any other JSON type, and a nonce is refused because it
+ * identifies an ID token, which must not be accepted in place of a logout
+ * token.
+ */
+const LogoutTokenSchema = z
+  .object({
+    jti: z.string(),
+    sub: z.string().optional(),
+    sid: z.string().optional(),
+    nonce: z.undefined().optional(),
+    events: z.object({
+      [LogoutEvent]: z.looseObject({}),
+    }),
+  })
+  .refine((claims) => !!claims.sub || !!claims.sid, {
+    error: "a sub or sid claim is required",
+  });
+
+/**
  * Validates a back-channel logout token against the OpenID Connect
  * specification and records it so that it cannot be presented a second time.
  *
@@ -109,31 +130,17 @@ export async function validateLogoutToken(
     throw new LogoutTokenError("Logout token has no claims");
   }
 
-  const events = payload.events;
-  if (
-    !events ||
-    typeof events !== "object" ||
-    typeof events[LogoutEvent] !== "object"
-  ) {
+  const result = LogoutTokenSchema.safeParse(payload);
+
+  if (!result.success) {
     throw new LogoutTokenError(
-      "Logout token is missing the back-channel logout event claim"
+      `Logout token claims are invalid – ${result.error.issues
+        .map((issue) => `${issue.path.join(".") || "claims"}: ${issue.message}`)
+        .join(", ")}`
     );
   }
 
-  // A nonce identifies an ID token. Its presence means the provider, or an
-  // attacker, supplied a token that was issued for a different purpose.
-  if ("nonce" in payload) {
-    throw new LogoutTokenError("Logout token must not contain a nonce claim");
-  }
-
-  const { jti, sub, sid } = payload;
-
-  if (typeof jti !== "string") {
-    throw new LogoutTokenError("Logout token is missing a jti claim");
-  }
-  if (typeof sub !== "string" && typeof sid !== "string") {
-    throw new LogoutTokenError("Logout token is missing a sub or sid claim");
-  }
+  const { jti, sub, sid } = result.data;
 
   // Recorded only once the token is otherwise trusted, so that an unverified
   // request cannot fill the store.

--- a/plugins/oidc/server/auth/backchannelLogout.ts
+++ b/plugins/oidc/server/auth/backchannelLogout.ts
@@ -184,6 +184,10 @@ export function backchannelLogout(options: BackchannelLogoutOptions) {
       if (err instanceof LogoutTokenError) {
         Logger.warn("Rejected an OIDC back-channel logout token", {
           error: err.message,
+          expectedIssuer: options.issuer,
+          expectedAudience: options.audience,
+          ip: ctx.ip,
+          ...describeToken(token),
         });
         return respondWithError(ctx, err.message);
       }
@@ -201,8 +205,36 @@ export function backchannelLogout(options: BackchannelLogoutOptions) {
 
     await revokeSessions(claims.sub);
 
+    // The specification requires 200 on success, providers may treat any other
+    // status as a failed logout.
     ctx.status = 200;
     ctx.body = "";
+  };
+}
+
+/**
+ * Describes a rejected token for the log. The token did not pass validation,
+ * so every value here is unverified and is only a record of what was received.
+ */
+function describeToken(token: string) {
+  const decoded = JWT.decode(token, { complete: true });
+
+  if (!decoded || typeof decoded.payload === "string") {
+    return { tokenLength: token.length };
+  }
+
+  const { iss, aud, sub, sid, jti, iat, exp } = decoded.payload;
+
+  return {
+    algorithm: decoded.header.alg,
+    keyId: decoded.header.kid,
+    issuer: iss,
+    audience: aud,
+    subject: sub,
+    sessionId: sid,
+    tokenId: jti,
+    issuedAt: iat ? new Date(iat * 1000).toISOString() : undefined,
+    expiresAt: exp ? new Date(exp * 1000).toISOString() : undefined,
   };
 }
 

--- a/plugins/oidc/server/auth/oidc.ts
+++ b/plugins/oidc/server/auth/oidc.ts
@@ -52,6 +52,8 @@ if (hasManualConfig) {
         tokenURL: oidcConfig.token_endpoint,
         userInfoURL: oidcConfig.userinfo_endpoint,
         logoutURL: oidcConfig.end_session_endpoint,
+        jwksURI: oidcConfig.jwks_uri,
+        issuer: oidcConfig.issuer,
         pkce: oidcConfig.code_challenge_methods_supported?.includes("S256"),
       });
 

--- a/plugins/oidc/server/auth/oidcRouter.ts
+++ b/plugins/oidc/server/auth/oidcRouter.ts
@@ -7,6 +7,7 @@ import { toError } from "@shared/utils/error";
 import { slugifyDomain } from "@shared/utils/domains";
 import { parseEmail } from "@shared/utils/email";
 import { isBase64Url } from "@shared/utils/urls";
+import { Minute } from "@shared/utils/time";
 import accountProvisioner from "@server/commands/accountProvisioner";
 import {
   OIDCMalformedUserInfoError,
@@ -14,6 +15,7 @@ import {
 } from "@server/errors";
 import Logger from "@server/logging/Logger";
 import passportMiddleware from "@server/middlewares/passport";
+import { rateLimiter } from "@server/middlewares/rateLimiter";
 import type { User } from "@server/models";
 import { AuthenticationProvider } from "@server/models";
 import type { AuthenticationResult } from "@server/types";
@@ -29,14 +31,29 @@ import {
 } from "@server/utils/passport";
 import config from "../../plugin.json";
 import env from "../env";
+import { JWKSCache } from "../JWKSCache";
+import { backchannelLogout } from "./backchannelLogout";
 import { OIDCStrategy } from "./OIDCStrategy";
 import { createContext } from "@server/context";
 
+/**
+ * The provider endpoints the OIDC routes are built from, either configured
+ * manually or discovered from the provider's well-known configuration.
+ */
 export interface OIDCEndpoints {
+  /** The endpoint the user is sent to in order to authenticate. */
   authorizationURL: string;
+  /** The endpoint an authorization code is exchanged for tokens at. */
   tokenURL: string;
+  /** The endpoint the authenticated user's profile is loaded from. */
   userInfoURL: string;
+  /** The endpoint that ends the provider session, if the provider has one. */
   logoutURL?: string;
+  /** The endpoint the provider publishes its public signing keys at. */
+  jwksURI?: string;
+  /** The identifier the provider names itself with in the tokens it signs. */
+  issuer?: string;
+  /** Whether to protect the authorization request with PKCE. */
   pkce?: boolean;
 }
 
@@ -291,4 +308,21 @@ export function createOIDCRouter(
       return ctx.redirect("/");
     }
   });
+
+  // Accepts a logout initiated by the provider and signs the identified user
+  // out of Outline. The endpoint is unauthenticated – the logout token itself
+  // is the credential – so it is only mounted when discovery has supplied both
+  // the key set that verifies the token signature and the expected issuer.
+  // https://openid.net/specs/openid-connect-backchannel-1_0.html
+  if (endpoints.jwksURI && endpoints.issuer) {
+    router.post(
+      `${config.id}.backchannel_logout`,
+      rateLimiter({ duration: Minute.seconds, requests: 200 }),
+      backchannelLogout({
+        jwks: new JWKSCache(endpoints.jwksURI),
+        audience: env.OIDC_CLIENT_ID!,
+        issuer: endpoints.issuer,
+      })
+    );
+  }
 }

--- a/server/errors.ts
+++ b/server/errors.ts
@@ -231,6 +231,13 @@ export function OIDCMalformedUserInfoError(
   });
 }
 
+export function OIDCLogoutTokenError(message = "Logout token rejected") {
+  return httpErrors(400, message, {
+    id: "invalid_logout_token",
+    isReportable: false,
+  });
+}
+
 export function AuthenticationProviderDisabledError(
   message = "Authentication method has been disabled by an admin",
   redirectPath = "/"

--- a/server/utils/RedisPrefixHelper.ts
+++ b/server/utils/RedisPrefixHelper.ts
@@ -91,4 +91,16 @@ export class RedisPrefixHelper {
   public static getLogoutTokenKey(provider: string, sessionId: string) {
     return `auth:logout:${provider}:${sessionId}`;
   }
+
+  /**
+   * Gets key for recording a consumed provider logout token, used to reject a
+   * token that is presented more than once.
+   *
+   * @param provider The auth provider id (e.g. "oidc").
+   * @param tokenId The unique token identifier to generate a key for.
+   * @returns the cache key string.
+   */
+  public static getLogoutTokenReplayKey(provider: string, tokenId: string) {
+    return `auth:logout:${provider}:replay:${tokenId}`;
+  }
 }


### PR DESCRIPTION
Adds `/auth/oidc.backchannel_logout`, which accepts a provider-initiated logout notification and ends the Outline sessions of the identified user.

- Mounted only when discovery supplies the key set and issuer, so there is no new configuration – the URL just needs registering with the provider.
- Logout tokens are validated against the spec: signature from the cached provider keys, issuer, audience, freshness, the logout event claim, absence of a nonce, and single use by `jti`.
- Provider signing keys are cached and refetched on an unknown key id, so key rotation needs no restart.
- Revocation rotates the user's JWT secret, so the sign-out covers all of their devices. A token scoped to a provider session alone is rejected, as individual sessions cannot be revoked.