### PR TITLE
fix: Optically center letter avatars in Facepile

### DIFF
--- a/app/components/Avatar/Initials.tsx
+++ b/app/components/Avatar/Initials.tsx
@@ -15,6 +15,12 @@ const Initials = styled(Flex)<{
   justify-content: center;
   width: 100%;
   height: 100%;
+
+  // Allows a parent to nudge the initials away from an edge that is masked off,
+  // so they remain optically centered in the visible area.
+  padding-right: var(--initials-inset, 0px);
+  transition: padding-right 100ms;
+
   color: ${(props) =>
     getLuminance(props.color ?? props.theme.textTertiary) > 0.5
       ? s("black50")

--- a/app/components/Facepile.tsx
+++ b/app/components/Facepile.tsx
@@ -52,7 +52,7 @@ function Facepile({
   }
 
   return (
-    <Avatars {...rest}>
+    <Avatars $size={size} {...rest}>
       {filtered.map((model, index) => {
         const lastChild = index === 0;
         return (
@@ -108,14 +108,22 @@ const SVG = styled.svg`
   left: 0;
 `;
 
-const Avatars = styled(Flex)`
+const Avatars = styled(Flex)<{ $size: number }>`
   align-items: center;
   flex-direction: row-reverse;
   cursor: var(--pointer);
 
+  // Every avatar but the first in the DOM order is clipped on its right edge,
+  // move the initials left by half of what is removed so they stay centered on
+  // the part that remains visible.
+  > *:not(:first-child) {
+    --initials-inset: ${(props) => props.$size / 10}px;
+  }
+
   *:hover {
     clip-path: none !important;
     box-shadow: 0 0 0 2px ${s("background")};
+    --initials-inset: 0;
   }
 `;
 


### PR DESCRIPTION
Avatars in a facepile are clipped on their right edge, so initials centered on the full box drift into the part that is cut away.

- Move the initials left by half of the removed area, scaled to the avatar size
- Restore true centering on hover, where the clip is lifted

ref https://x.com/flornkm/status/2088296589282705508