### PR TITLE
fix: Pasting a table from Google Sheets does not create a table

### DIFF
--- a/app/editor/extensions/PasteHandler.tsx
+++ b/app/editor/extensions/PasteHandler.tsx
@@ -274,7 +274,8 @@ export default class PasteHandler extends Extension {
             if (
               (isMarkdown(text) &&
                 !isDropboxPaper(html) &&
-                !isContainingImage(html)) ||
+                !isContainingImage(html) &&
+                !isContainingTable(html)) ||
               pasteCodeLanguage === "markdown" ||
               this.shiftKey ||
               !html
@@ -631,6 +632,17 @@ function isDropboxPaper(html: string): boolean {
  */
 function isContainingImage(html: string): boolean {
   return html?.includes("<img");
+}
+
+/**
+ * Checks if the HTML string contains a table. The plain text alternative on the
+ * clipboard cannot describe a table, so the HTML must be parsed instead.
+ *
+ * @param html The HTML string to check.
+ * @returns True if the HTML string contains a table.
+ */
+function isContainingTable(html: string): boolean {
+  return html?.includes("<table");
 }
 
 function sliceSingleNode(slice: Slice) {

--- a/shared/editor/lib/isMarkdown.test.ts
+++ b/shared/editor/lib/isMarkdown.test.ts
@@ -33,6 +33,15 @@ $1.00`)
   ).toBe(false);
 });
 
+it("returns false for currency amounts on a single line", () => {
+  expect(isMarkdown(`-$187.55\t-$91.93`)).toBe(false);
+  expect(
+    isMarkdown(`-$187.55\t-$91.93
+-$2,222.97\t-$4,109.98`)
+  ).toBe(false);
+  expect(isMarkdown(`It costs $10 or $20`)).toBe(false);
+});
+
 test("returns false for non-closed fence", () => {
   expect(
     isMarkdown(`\`\`\`

--- a/shared/editor/lib/isMarkdown.ts
+++ b/shared/editor/lib/isMarkdown.ts
@@ -9,8 +9,9 @@ export default function isMarkdown(text: string): boolean {
     signals += fences.length;
   }
 
-  // latex-ish
-  const latex = text.match(/\$(.+)\$/g);
+  // latex-ish, the delimiters must hug their content and the closing one must
+  // not be followed by a digit so that currency amounts are not counted.
+  const latex = text.match(/\$(?!\s)(.+?)(?<!\s)\$(?!\d)/g);
   if (latex && latex.length > 0) {
     signals += latex.length;
   }

--- a/shared/editor/lib/isMarkdown.ts
+++ b/shared/editor/lib/isMarkdown.ts
@@ -11,7 +11,7 @@ export default function isMarkdown(text: string): boolean {
 
   // latex-ish, the delimiters must hug their content and the closing one must
   // not be followed by a digit so that currency amounts are not counted.
-  const latex = text.match(/\$(?!\s)(.+?)(?<!\s)\$(?!\d)/g);
+  const latex = text.match(/\$[^\s](?:.*?[^\s])?\$(?!\d)/g);
   if (latex && latex.length > 0) {
     signals += latex.length;
   }


### PR DESCRIPTION
Google Sheets puts both a real HTML table and a tab-separated plain text version on the clipboard, and the paste handler was choosing the wrong one.

- Currency amounts in adjacent cells made `isMarkdown` read the tab-separated text as inline LaTeX, so the HTML table was discarded and the text reparsed as Markdown — flattening the table into a single paragraph.
- Tightened the LaTeX heuristic so the delimiters must hug their content and the closing delimiter cannot be followed by a digit.
- Clipboard HTML containing a table now always uses the HTML parser, since the plain text alternative can never describe a table.