### PR TITLE
feat: Sticky first column in tables with a header column

### DIFF
--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -2469,6 +2469,41 @@ table {
   }
 }
 
+.${EditorStyleHelper.tableStickyColumn} {
+  // The padding of the scroll container also holds the column back, so the
+  // column stops at the same place it sits when the table is not scrolled.
+  > .${EditorStyleHelper.tableScrollable} > table > tbody > tr > th[data-first-column] {
+    position: sticky;
+    left: 0;
+    z-index: 1;
+  }
+
+  // The first cell is part of both the sticky row and column, so it goes above both.
+  &.${EditorStyleHelper.tableStickyHeader} > .${EditorStyleHelper.tableScrollable} > table > tbody > tr:first-child > th[data-first-column] {
+    z-index: 3;
+  }
+
+  // Move the scroll shadow from the edge of the table to the edge of the column.
+  &.${EditorStyleHelper.tableShadowLeft} {
+    &::before {
+      box-shadow: none;
+    }
+
+    > .${EditorStyleHelper.tableScrollable} > table > tbody > tr > th[data-first-column]::after {
+      content: "";
+      position: absolute;
+      top: -1px;
+      bottom: -1px;
+      right: -${EditorStyleHelper.padding}px;
+      width: ${EditorStyleHelper.padding}px;
+      pointer-events: none;
+      box-shadow: 16px 0 16px -16px inset rgba(0, 0, 0, ${
+        props.theme.isDark ? 1 : 0.25
+      });
+    }
+  }
+}
+
 .${EditorStyleHelper.tableScrollable} {
   position: relative;
   margin: -1em ${-EditorStyleHelper.padding}px -0.5em;

--- a/shared/editor/nodes/TableView.ts
+++ b/shared/editor/nodes/TableView.ts
@@ -1,5 +1,8 @@
 import type { Node } from "prosemirror-model";
-import { TableView as ProsemirrorTableView } from "prosemirror-tables";
+import {
+  TableMap,
+  TableView as ProsemirrorTableView,
+} from "prosemirror-tables";
 import { EditorStyleHelper } from "../styles/EditorStyleHelper";
 import { TableLayout } from "../types";
 import { HEADER_HEIGHT } from "../../constants";
@@ -81,6 +84,11 @@ export class TableView extends ProsemirrorTableView {
       node.attrs.layout === TableLayout.fullWidth
     );
 
+    this.dom.classList.toggle(
+      EditorStyleHelper.tableStickyColumn,
+      this.hasHeaderColumn(node)
+    );
+
     const shadowLeft = !!(this.scrollable && this.scrollable.scrollLeft > 0);
     const shadowRight = !!(
       this.scrollable &&
@@ -105,6 +113,23 @@ export class TableView extends ProsemirrorTableView {
       this.dom.style.removeProperty("--table-height");
       this.dom.style.removeProperty("--table-width");
     }
+  }
+
+  /**
+   * Whether every cell in the first column of the table is a header cell.
+   *
+   * @param node the table node.
+   * @returns true if the first column is a header column.
+   */
+  private hasHeaderColumn(node: Node) {
+    const map = TableMap.get(node);
+    if (!map.width || !map.height) {
+      return false;
+    }
+
+    return map
+      .cellsInRect({ left: 0, top: 0, right: 1, bottom: map.height })
+      .every((pos) => node.nodeAt(pos)?.type.spec.tableRole === "header_cell");
   }
 
   private scrollable: HTMLDivElement | null = null;

--- a/shared/editor/nodes/TableView.ts
+++ b/shared/editor/nodes/TableView.ts
@@ -116,21 +116,33 @@ export class TableView extends ProsemirrorTableView {
   }
 
   /**
-   * Whether every cell in the first column of the table is a header cell.
+   * Whether every cell in the first column of the table is a header cell. Nodes
+   * are immutable, so the answer is cached until the node itself changes.
    *
    * @param node the table node.
    * @returns true if the first column is a header column.
    */
   private hasHeaderColumn(node: Node) {
-    const map = TableMap.get(node);
-    if (!map.width || !map.height) {
-      return false;
+    if (node !== this.headerColumnNode) {
+      const map = TableMap.get(node);
+
+      this.headerColumnNode = node;
+      this.headerColumn =
+        map.width > 0 &&
+        map.height > 0 &&
+        map
+          .cellsInRect({ left: 0, top: 0, right: 1, bottom: map.height })
+          .every(
+            (pos) => node.nodeAt(pos)?.type.spec.tableRole === "header_cell"
+          );
     }
 
-    return map
-      .cellsInRect({ left: 0, top: 0, right: 1, bottom: map.height })
-      .every((pos) => node.nodeAt(pos)?.type.spec.tableRole === "header_cell");
+    return this.headerColumn;
   }
+
+  private headerColumnNode: Node | null = null;
+
+  private headerColumn = false;
 
   private scrollable: HTMLDivElement | null = null;
 

--- a/shared/editor/styles/EditorStyleHelper.ts
+++ b/shared/editor/styles/EditorStyleHelper.ts
@@ -140,6 +140,9 @@ export class EditorStyleHelper {
   /** Sticky header state */
   static readonly tableStickyHeader = "table-sticky-header";
 
+  /** Sticky first column state */
+  static readonly tableStickyColumn = "table-sticky-column";
+
   /** Drop indicator for table drag and drop */
   static readonly tableDragDropIndicator = "table-drag-drop-indicator";
 


### PR DESCRIPTION
Tables that are wider than the available space now keep their first column in place while scrolling horizontally, in the same way the header row sticks when scrolling past the top of the screen.

- Applies only when every cell in the first column is a header cell
- The cell shared by the sticky row and column is drawn above both
- The left scroll shadow moves from the edge of the table to the edge of the sticky column
- Also works when there is both a header row and column