### PR TITLE
fix: Shift-click table grips to select a range of rows or columns

### DIFF
--- a/app/editor/components/InlineMenu.tsx
+++ b/app/editor/components/InlineMenu.tsx
@@ -5,6 +5,7 @@ import { RemoveScroll } from "react-remove-scroll";
 import styled from "styled-components";
 import EventBoundary from "@shared/components/EventBoundary";
 import { collapseSelection } from "@shared/editor/commands/collapseSelection";
+import { EditorStyleHelper } from "@shared/editor/styles/EditorStyleHelper";
 import type { MenuItem } from "@shared/editor/types";
 import { useTranslation } from "react-i18next";
 import Scrollable from "~/components/Scrollable";
@@ -28,6 +29,14 @@ type Props = {
   rtl: boolean;
 };
 
+type InteractOutsideEvent = Parameters<
+  NonNullable<
+    React.ComponentProps<
+      typeof DropdownMenuPrimitive.Content
+    >["onInteractOutside"]
+  >
+>[0];
+
 // The virtual anchor is an invisible zero-size element; the hook positions it
 // over the selection and Radix anchors the menu to it.
 const anchorStyle: React.CSSProperties = {
@@ -35,6 +44,15 @@ const anchorStyle: React.CSSProperties = {
   width: 0,
   height: 0,
 };
+
+// The affordances that select a table, row, or column.
+const gripSelector = [
+  EditorStyleHelper.tableGrip,
+  EditorStyleHelper.tableGripRow,
+  EditorStyleHelper.tableGripColumn,
+]
+  .map((className) => `.${className}`)
+  .join(", ");
 
 /**
  * Renders a selection-toolbar menu inline — a vertical menu anchored to the
@@ -72,6 +90,20 @@ const InlineMenu: React.FC<Props> = ({ items, rtl }) => {
     collapseSelection()(view.state, view.dispatch);
   }, [view]);
 
+  // Radix reports an outside interaction on pointerdown, before the editor
+  // handles the click. The table grips set the selection themselves — and read
+  // the current one to extend it — so leave it alone for them.
+  const handleInteractOutside = React.useCallback(
+    (event: InteractOutsideEvent) => {
+      const { target } = event.detail.originalEvent;
+      if (target instanceof HTMLElement && target.closest(gripSelector)) {
+        return;
+      }
+      handleDismiss();
+    },
+    [handleDismiss]
+  );
+
   if (isMobile) {
     return (
       <InlineMenuDrawer
@@ -100,7 +132,7 @@ const InlineMenu: React.FC<Props> = ({ items, rtl }) => {
             collisionPadding={6}
             aria-label={t("Options")}
             onCloseAutoFocus={preventFocus}
-            onInteractOutside={handleDismiss}
+            onInteractOutside={handleInteractOutside}
             onEscapeKeyDown={handleDismiss}
             asChild
           >

--- a/app/editor/menus/tableCol.tsx
+++ b/app/editor/menus/tableCol.tsx
@@ -84,6 +84,9 @@ export default function tableColMenuItems(ctx: SelectionContext): MenuItem[] {
   }
 
   const tableMap = selectedRect(state);
+  // Inserting and moving act on a single column, so they are ambiguous when
+  // the selection spans more than one.
+  const isMultipleColumns = selectedCols.length > 1;
   const colColors = getColumnColors(state, index);
   const hasBackground = colColors.size > 0;
   const activeColor =
@@ -222,26 +225,28 @@ export default function tableColMenuItems(ctx: SelectionContext): MenuItem[] {
       label: rtl ? t("Insert after") : t("Insert before"),
       icon: <InsertLeftIcon />,
       attrs: { index },
+      visible: !isMultipleColumns,
     },
     {
       name: rtl ? "addColumnBefore" : "addColumnAfter",
       label: rtl ? t("Insert before") : t("Insert after"),
       icon: <InsertRightIcon />,
       attrs: { index },
+      visible: !isMultipleColumns,
     },
     {
       name: "moveTableColumn",
       label: t("Move left"),
       icon: <ArrowLeftIcon />,
       attrs: { from: index, to: index - 1 },
-      visible: index > 0,
+      visible: !isMultipleColumns && index > 0,
     },
     {
       name: "moveTableColumn",
       label: t("Move right"),
       icon: <ArrowRightIcon />,
       attrs: { from: index, to: index + 1 },
-      visible: index < tableMap.map.width - 1,
+      visible: !isMultipleColumns && index < tableMap.map.width - 1,
     },
     {
       name: "separator",

--- a/app/editor/menus/tableRow.tsx
+++ b/app/editor/menus/tableRow.tsx
@@ -13,6 +13,7 @@ import {
 import type { EditorState } from "prosemirror-state";
 import { CellSelection, selectedRect } from "prosemirror-tables";
 import {
+  getAllSelectedRows,
   getCellsInRow,
   isMergedCellSelection,
   isMultipleCellSelection,
@@ -99,6 +100,9 @@ export default function tableRowMenuItems(ctx: SelectionContext): MenuItem[] {
   }
 
   const tableMap = selectedRect(state);
+  // Inserting and moving act on a single row, so they are ambiguous when the
+  // selection spans more than one.
+  const isMultipleRows = getAllSelectedRows(state).length > 1;
   const rowAlignments = getRowAlignments(state, index);
   const isAlignment = (alignment: string) =>
     rowAlignments.size === 1 && rowAlignments.has(alignment);
@@ -209,26 +213,28 @@ export default function tableRowMenuItems(ctx: SelectionContext): MenuItem[] {
       label: t("Insert before"),
       icon: <InsertAboveIcon />,
       attrs: { index },
+      visible: !isMultipleRows,
     },
     {
       name: "addRowAfter",
       label: t("Insert after"),
       icon: <InsertBelowIcon />,
       attrs: { index },
+      visible: !isMultipleRows,
     },
     {
       name: "moveTableRow",
       label: t("Move up"),
       icon: <ArrowUpIcon />,
       attrs: { from: index, to: index - 1 },
-      visible: index > 0,
+      visible: !isMultipleRows && index > 0,
     },
     {
       name: "moveTableRow",
       label: t("Move down"),
       icon: <ArrowDownIcon />,
       attrs: { from: index, to: index + 1 },
-      visible: index < tableMap.map.height - 1,
+      visible: !isMultipleRows && index < tableMap.map.height - 1,
     },
     {
       name: "separator",

--- a/shared/editor/commands/table.ts
+++ b/shared/editor/commands/table.ts
@@ -64,7 +64,7 @@ function restoreColumnSelection(
     const map = TableMap.get(table);
     const pos = map.positionAt(0, columnIndex, table);
     const $pos = tr.doc.resolve(tableStart + pos);
-    tr.setSelection(ColumnSelection.colSelection($pos));
+    tr.setSelection(ColumnSelection.colSelection($pos, $pos, columnIndex));
   }
 }
 
@@ -852,34 +852,98 @@ export function setTableAttr(attrs: { layout: TableLayout | null }): Command {
   };
 }
 
+/**
+ * Select a row in the table.
+ *
+ * @param index The index of the row to select.
+ * @param expand Whether to extend the existing selection to include every row
+ * between its anchor and the given row.
+ * @returns A command that selects the row.
+ */
 export function selectRow(index: number, expand = false): Command {
   return (state: EditorState, dispatch): boolean => {
     if (dispatch) {
       const rect = selectedRect(state);
       const pos = rect.map.positionAt(index, 0, rect.table);
       const $pos = state.doc.resolve(rect.tableStart + pos);
-      const rowSelection =
-        expand && state.selection instanceof CellSelection
-          ? RowSelection.rowSelection(state.selection.$anchorCell, $pos, index)
-          : RowSelection.rowSelection($pos, $pos, index);
-      dispatch(state.tr.setSelection(rowSelection));
+      const { selection } = state;
+      const expandFrom =
+        expand && selection instanceof CellSelection ? selection : undefined;
+
+      if (expandFrom) {
+        // Keep the anchor where the selection started so that the rows between
+        // it and the clicked row are all included.
+        const anchorIndex =
+          expandFrom instanceof RowSelection
+            ? expandFrom.anchorIndex
+            : rect.map.findCell(expandFrom.$anchorCell.pos - rect.tableStart)
+                .top;
+
+        dispatch(
+          state.tr.setSelection(
+            RowSelection.rowSelection(
+              expandFrom.$anchorCell,
+              $pos,
+              anchorIndex,
+              index
+            )
+          )
+        );
+        return true;
+      }
+
+      dispatch(
+        state.tr.setSelection(RowSelection.rowSelection($pos, $pos, index))
+      );
       return true;
     }
     return false;
   };
 }
 
+/**
+ * Select a column in the table.
+ *
+ * @param index The index of the column to select.
+ * @param expand Whether to extend the existing selection to include every
+ * column between its anchor and the given column.
+ * @returns A command that selects the column.
+ */
 export function selectColumn(index: number, expand = false): Command {
   return (state, dispatch): boolean => {
     if (dispatch) {
       const rect = selectedRect(state);
       const pos = rect.map.positionAt(0, index, rect.table);
       const $pos = state.doc.resolve(rect.tableStart + pos);
-      const colSelection =
-        expand && state.selection instanceof CellSelection
-          ? ColumnSelection.colSelection(state.selection.$anchorCell, $pos)
-          : ColumnSelection.colSelection($pos);
-      dispatch(state.tr.setSelection(colSelection));
+      const { selection } = state;
+      const expandFrom =
+        expand && selection instanceof CellSelection ? selection : undefined;
+
+      if (expandFrom) {
+        // Keep the anchor where the selection started so that the columns
+        // between it and the clicked column are all included.
+        const anchorIndex =
+          expandFrom instanceof ColumnSelection
+            ? expandFrom.anchorIndex
+            : rect.map.findCell(expandFrom.$anchorCell.pos - rect.tableStart)
+                .left;
+
+        dispatch(
+          state.tr.setSelection(
+            ColumnSelection.colSelection(
+              expandFrom.$anchorCell,
+              $pos,
+              anchorIndex,
+              index
+            )
+          )
+        );
+        return true;
+      }
+
+      dispatch(
+        state.tr.setSelection(ColumnSelection.colSelection($pos, $pos, index))
+      );
       return true;
     }
     return false;

--- a/shared/editor/queries/table.ts
+++ b/shared/editor/queries/table.ts
@@ -214,14 +214,11 @@ export function getCellsInRow(index: number) {
  * @returns Boolean indicating if the column is selected
  */
 export function isColumnSelected(index: number) {
-  return (state: EditorState): boolean => {
-    if (isColSelection(state)) {
-      const rect = selectedRect(state);
-      return rect.left <= index && rect.right > index;
-    }
-
-    return false;
-  };
+  return (state: EditorState): boolean =>
+    state.selection instanceof ColumnSelection &&
+    state.selection.isColSelection()
+      ? state.selection.containsColumn(index)
+      : false;
 }
 
 /**
@@ -265,7 +262,7 @@ export function isHeaderEnabled(
 export function isRowSelected(index: number) {
   return (state: EditorState): boolean =>
     state.selection instanceof RowSelection && state.selection.isRowSelection()
-      ? state.selection.$index === index
+      ? state.selection.containsRow(index)
       : false;
 }
 

--- a/shared/editor/queries/table.ts
+++ b/shared/editor/queries/table.ts
@@ -368,7 +368,33 @@ export function tableHasRowspan(state: EditorState): boolean {
   return false;
 }
 
+/**
+ * Get the indices between two bounds, in ascending order and inclusive of both.
+ */
+function indexRange(from: number, to: number): number[] {
+  const indices: number[] = [];
+  for (let index = Math.min(from, to); index <= Math.max(from, to); index++) {
+    indices.push(index);
+  }
+
+  return indices;
+}
+
+/**
+ * Get the indices of all currently selected columns.
+ *
+ * @param state The editor state
+ * @returns Array of selected column indices
+ */
 export function getAllSelectedColumns(state: EditorState): number[] {
+  const { selection } = state;
+
+  // A cell that spans columns widens the rect beyond the selected columns, so
+  // take the range from the selection itself where it is known.
+  if (selection instanceof ColumnSelection && selection.isColSelection()) {
+    return indexRange(selection.anchorIndex, selection.headIndex);
+  }
+
   const rect = selectedRect(state);
 
   const selectedColumns: number[] = [];
@@ -386,6 +412,14 @@ export function getAllSelectedColumns(state: EditorState): number[] {
  * @returns Array of selected row indices
  */
 export function getAllSelectedRows(state: EditorState): number[] {
+  const { selection } = state;
+
+  // A cell that spans rows deepens the rect beyond the selected rows, so take
+  // the range from the selection itself where it is known.
+  if (selection instanceof RowSelection && selection.isRowSelection()) {
+    return indexRange(selection.anchorIndex, selection.headIndex);
+  }
+
   const rect = selectedRect(state);
 
   const selectedRows: number[] = [];

--- a/shared/editor/selection/ColumnSelection.ts
+++ b/shared/editor/selection/ColumnSelection.ts
@@ -5,13 +5,42 @@ import { CellSelection, inSameTable, TableMap } from "prosemirror-tables";
 import type { Mappable } from "prosemirror-transform";
 
 export class ColumnSelection extends CellSelection {
+  constructor(
+    public $anchorCell: ResolvedPos,
+    public $headCell: ResolvedPos,
+    public anchorIndex: number = 0,
+    public headIndex: number = anchorIndex
+  ) {
+    super($anchorCell, $headCell);
+  }
+
+  /**
+   * Check whether a column is part of the selection.
+   *
+   * @param index the visual index of the column.
+   * @returns true if the column is within the selected range.
+   */
+  containsColumn(index: number): boolean {
+    return (
+      index >= Math.min(this.anchorIndex, this.headIndex) &&
+      index <= Math.max(this.anchorIndex, this.headIndex)
+    );
+  }
+
   getBookmark(): ColumnBookmark {
-    return new ColumnBookmark(this.$anchorCell.pos, this.$headCell.pos);
+    return new ColumnBookmark(
+      this.$anchorCell.pos,
+      this.$headCell.pos,
+      this.anchorIndex,
+      this.headIndex
+    );
   }
 
   public static colSelection(
     $anchorCell: ResolvedPos,
-    $headCell: ResolvedPos = $anchorCell
+    $headCell: ResolvedPos = $anchorCell,
+    anchorIndex: number = 0,
+    headIndex: number = anchorIndex
   ): CellSelection {
     const table = $anchorCell.node(-1);
     const map = TableMap.get(table);
@@ -42,18 +71,25 @@ export class ColumnSelection extends CellSelection {
         );
       }
     }
-    return new ColumnSelection($anchorCell, $headCell);
+    return new ColumnSelection($anchorCell, $headCell, anchorIndex, headIndex);
   }
 }
 
 export class ColumnBookmark {
   constructor(
     public anchor: number,
-    public head: number
+    public head: number,
+    public anchorIndex: number = 0,
+    public headIndex: number = anchorIndex
   ) {}
 
   map(mapping: Mappable): ColumnBookmark {
-    return new ColumnBookmark(mapping.map(this.anchor), mapping.map(this.head));
+    return new ColumnBookmark(
+      mapping.map(this.anchor),
+      mapping.map(this.head),
+      this.anchorIndex,
+      this.headIndex
+    );
   }
 
   resolve(doc: Node): CellSelection | Selection {
@@ -66,7 +102,12 @@ export class ColumnBookmark {
       $headCell.index() < $headCell.parent.childCount &&
       inSameTable($anchorCell, $headCell)
     ) {
-      return new ColumnSelection($anchorCell, $headCell);
+      return new ColumnSelection(
+        $anchorCell,
+        $headCell,
+        this.anchorIndex,
+        this.headIndex
+      );
     } else {
       return Selection.near($headCell, 1);
     }

--- a/shared/editor/selection/RowSelection.ts
+++ b/shared/editor/selection/RowSelection.ts
@@ -8,23 +8,39 @@ export class RowSelection extends CellSelection {
   constructor(
     public $anchorCell: ResolvedPos,
     public $headCell: ResolvedPos,
-    public $index: number = 0
+    public anchorIndex: number = 0,
+    public headIndex: number = anchorIndex
   ) {
     super($anchorCell, $headCell);
+  }
+
+  /**
+   * Check whether a row is part of the selection.
+   *
+   * @param index the visual index of the row.
+   * @returns true if the row is within the selected range.
+   */
+  containsRow(index: number): boolean {
+    return (
+      index >= Math.min(this.anchorIndex, this.headIndex) &&
+      index <= Math.max(this.anchorIndex, this.headIndex)
+    );
   }
 
   getBookmark(): RowBookmark {
     return new RowBookmark(
       this.$anchorCell.pos,
       this.$headCell.pos,
-      this.$index
+      this.anchorIndex,
+      this.headIndex
     );
   }
 
   public static rowSelection(
     $anchorCell: ResolvedPos,
     $headCell: ResolvedPos = $anchorCell,
-    $index: number = 0
+    anchorIndex: number = 0,
+    headIndex: number = anchorIndex
   ): CellSelection {
     const table = $anchorCell.node(-1);
     const map = TableMap.get(table);
@@ -55,7 +71,7 @@ export class RowSelection extends CellSelection {
         );
       }
     }
-    return new RowSelection($anchorCell, $headCell, $index);
+    return new RowSelection($anchorCell, $headCell, anchorIndex, headIndex);
   }
 }
 
@@ -63,14 +79,16 @@ export class RowBookmark {
   constructor(
     public anchor: number,
     public head: number,
-    public index: number = 0
+    public anchorIndex: number = 0,
+    public headIndex: number = anchorIndex
   ) {}
 
   map(mapping: Mappable): RowBookmark {
     return new RowBookmark(
       mapping.map(this.anchor),
       mapping.map(this.head),
-      this.index
+      this.anchorIndex,
+      this.headIndex
     );
   }
 
@@ -84,7 +102,12 @@ export class RowBookmark {
       $headCell.index() < $headCell.parent.childCount &&
       inSameTable($anchorCell, $headCell)
     ) {
-      return new RowSelection($anchorCell, $headCell);
+      return new RowSelection(
+        $anchorCell,
+        $headCell,
+        this.anchorIndex,
+        this.headIndex
+      );
     } else {
       return Selection.near($headCell, 1);
     }


### PR DESCRIPTION
- Shift or cmd clicking a second row or column grip now extends the selection to cover every row or column in between.
- Row and column selections track their anchor and head index, so all grips in the range highlight and a cell that spans rows or columns no longer pulls its neighbours in.
- The insert and move items are hidden in the row and column menus when the selection covers more than one row or column, as they act on a single one.