### PR TITLE
fix: Editor fails to load on iOS Safari 15

### DIFF
--- a/shared/editor/rules/tables.test.ts
+++ b/shared/editor/rules/tables.test.ts
@@ -35,6 +35,26 @@ function tableWith(cell: Record<string, unknown>) {
   });
 }
 
+/**
+ * Parses markdown and collects the hard breaks and text of the result, so cell
+ * break handling can be asserted without depending on the surrounding nodes.
+ */
+function parseBreaks(markdown: string) {
+  const texts: string[] = [];
+  let breakCount = 0;
+
+  parser.parse(markdown)?.descendants((node) => {
+    if (node.type.name === "br") {
+      breakCount++;
+    }
+    if (node.isText) {
+      texts.push(node.text ?? "");
+    }
+  });
+
+  return { breakCount, texts };
+}
+
 it("round-trips a notice inside a table cell", () => {
   const doc = tableWith({
     type: "container_notice",
@@ -95,6 +115,25 @@ it("round-trips a math block inside a table cell", () => {
 
   const markdown = serializer.serialize(doc, { commonMark: true });
   expect(parser.parse(markdown)!.toJSON()).toEqual(doc.toJSON());
+});
+
+it("splits a table cell on an unescaped newline escape", () => {
+  const { breakCount, texts } = parseBreaks(
+    "| Header |\n|--------|\n| Line one\\nLine two |"
+  );
+
+  expect(breakCount).toBe(1);
+  expect(texts).toContain("Line one");
+  expect(texts).toContain("Line two");
+});
+
+it("keeps an escaped backslash in a table cell as text", () => {
+  const { breakCount, texts } = parseBreaks(
+    "| Header |\n|--------|\n| C:\\\\name |"
+  );
+
+  expect(breakCount).toBe(0);
+  expect(texts).toContain("C:\\name");
 });
 
 it("keeps a multi-line paragraph cell as hard breaks, not a fenced block", () => {

--- a/shared/editor/rules/tables.ts
+++ b/shared/editor/rules/tables.ts
@@ -1,14 +1,69 @@
 import type MarkdownIt from "markdown-it";
 import { unescapeRawTableCell } from "../lib/markdown/tableCell";
 
-const BREAK_REGEX = /(?<=^|[^\\])\\n/;
 const BR_TAG_REGEX = /<br\s*\/?>/gi;
+
 // Matches checkbox syntax with optional list prefix: "- [x] Task" or "[x] Task"
 // Stops at <br> or newline to handle multiple checkboxes in a cell
 const CHECKBOX_REGEX = /^(?:-\s*)?\[(X|\s|_|-)\]\s([^<\n]*)?/i;
+
 // Matches the opening of a notice (:::style), toggle (+++), code (```) or math
 // ($$) fence
 const FENCE_OPEN_REGEX = /^(?::::\S|\+{3,}|```|\$\$)/;
+
+/**
+ * Find the offset of the first "\n" escape at or after the given offset that is
+ * not itself escaped by a preceding backslash.
+ *
+ * A lookbehind assertion would say this in one regex, but Safari below 16.4
+ * throws on lookbehind, so the preceding character is examined by hand.
+ *
+ * @param content - the text to scan.
+ * @param from - the offset to start scanning at.
+ * @returns the offset of the break, or -1 if there is none.
+ */
+function findBreak(content: string, from: number): number {
+  let index = content.indexOf("\\n", from);
+  while (index !== -1) {
+    if (index === 0 || content[index - 1] !== "\\") {
+      return index;
+    }
+    index = content.indexOf("\\n", index + 2);
+  }
+  return -1;
+}
+
+/**
+ * Check whether the text holds a "\n" escape that is not itself escaped.
+ *
+ * @param content - the text to scan.
+ * @returns true if the text holds an unescaped break.
+ */
+function hasBreak(content: string): boolean {
+  return findBreak(content, 0) !== -1;
+}
+
+/**
+ * Split the text on each "\n" escape that is not itself escaped, leaving
+ * escaped ones in place.
+ *
+ * @param content - the text to split.
+ * @returns the parts between the breaks.
+ */
+function splitOnBreaks(content: string): string[] {
+  const parts: string[] = [];
+  let start = 0;
+  let index = findBreak(content, start);
+
+  while (index !== -1) {
+    parts.push(content.slice(start, index));
+    start = index + 2;
+    index = findBreak(content, start);
+  }
+
+  parts.push(content.slice(start));
+  return parts;
+}
 
 /**
  * Block content (notice, toggle, code & math fences) is serialized onto a
@@ -66,8 +121,7 @@ export default function markdownTables(md: MarkdownIt): void {
       // convert unescaped \n and <br> tags in the text into real br tokens
       if (
         tokens[i].type === "inline" &&
-        (tokens[i].content.match(BREAK_REGEX) ||
-          tokens[i].content.match(BR_TAG_REGEX))
+        (hasBreak(tokens[i].content) || tokens[i].content.match(BR_TAG_REGEX))
       ) {
         const existing = tokens[i].children || [];
         tokens[i].children = [];
@@ -86,7 +140,7 @@ export default function markdownTables(md: MarkdownIt): void {
             content = content.replace(BR_TAG_REGEX, "\\n");
           }
 
-          const breakParts = content.split(BREAK_REGEX);
+          const breakParts = splitOnBreaks(content);
 
           // a schema agnostic way to know if a node is inline code would be
           // great, for now we are stuck checking the node type.


### PR DESCRIPTION
The table markdown rule built a regex with a lookbehind assertion at module scope. Safari below 16.4 has no lookbehind, so the constructor threw during module evaluation and took out the editor on every device we still claim to support.

- Replace the lookbehind with a manual scan of the preceding character
- Behaviour is unchanged — escaped breaks stay literal, unescaped ones still split
- No other lookbehind remains in client-reachable code

closes #13446