### PR TITLE
fix: Pages fail to load on older browsers

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,5 +1,7 @@
 // oxlint-disable-next-line import/no-unresolved
 import "vite/modulepreload-polyfill";
+// Keep ahead of the other imports so polyfills apply before they evaluate.
+import "~/utils/polyfills";
 import { LazyMotion, domMax } from "framer-motion";
 import { KBarProvider } from "kbar";
 import { Provider } from "mobx-react";

--- a/app/utils/polyfills.ts
+++ b/app/utils/polyfills.ts
@@ -7,8 +7,12 @@ declare global {
 // Applied at module scope so dependencies that call it during evaluation, or on
 // first render, are covered. Unavailable before Chrome 93 and Safari 15.4.
 if (typeof Object.hasOwn !== "function") {
-  Object.hasOwn = (target: object, property: PropertyKey) =>
-    Object.prototype.hasOwnProperty.call(target, property);
+  Object.defineProperty(Object, "hasOwn", {
+    value: (target: object, property: PropertyKey) =>
+      Object.prototype.hasOwnProperty.call(target, property),
+    writable: true,
+    configurable: true,
+  });
 }
 
 /**

--- a/app/utils/polyfills.ts
+++ b/app/utils/polyfills.ts
@@ -1,3 +1,16 @@
+declare global {
+  interface ObjectConstructor {
+    hasOwn(target: object, property: PropertyKey): boolean;
+  }
+}
+
+// Applied at module scope so dependencies that call it during evaluation, or on
+// first render, are covered. Unavailable before Chrome 93 and Safari 15.4.
+if (typeof Object.hasOwn !== "function") {
+  Object.hasOwn = (target: object, property: PropertyKey) =>
+    Object.prototype.hasOwnProperty.call(target, property);
+}
+
 /**
  * Loads required polyfills.
  *


### PR DESCRIPTION
`Object.hasOwn` is unavailable before Chrome 93 and Safari 15.4, but es-toolkit calls it directly from `isEqualWith`, which useActionContext runs on every render — so the whole app throws on load.

- Polyfill it at module scope, ahead of the other imports, so dependency evaluation and first render are both covered
- Build targets don't help here: esbuild only downlevels syntax, and doesn't touch node_modules

Fixes OUTLINE-CLOUD-D0W