### PR TITLE
fix: Crash when pasting a single block of content into document title

### DIFF
--- a/app/scenes/Document/components/DocumentTitle.tsx
+++ b/app/scenes/Document/components/DocumentTitle.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import { Slice } from "prosemirror-model";
+import type { Slice } from "prosemirror-model";
 import { Selection } from "prosemirror-state";
 import { __parseFromClipboard } from "prosemirror-view";
 import * as React from "react";
@@ -9,6 +9,7 @@ import breakpoint from "styled-components-breakpoint";
 import Icon, { IconTitleWrapper } from "@shared/components/Icon";
 import isMarkdown from "@shared/editor/lib/isMarkdown";
 import normalizePastedMarkdown from "@shared/editor/lib/markdown/normalize";
+import { sliceWithoutFirstNode } from "@shared/editor/lib/sliceWithoutFirstNode";
 import { extraArea, s } from "@shared/styles";
 import { light } from "@shared/styles/theme";
 import {
@@ -179,7 +180,7 @@ const DocumentTitle = React.forwardRef(function DocumentTitle_(
 
       if (editor && content) {
         const { view, pasteParser } = editor;
-        let slice;
+        let slice: Slice | undefined;
 
         if (isMarkdown(text)) {
           const paste = pasteParser.parse(normalizePastedMarkdown(content));
@@ -195,16 +196,10 @@ const DocumentTitle = React.forwardRef(function DocumentTitle_(
             view.state.selection.$from
           );
 
-          // remove first node from slice
-          slice = defaultSlice.content.firstChild
-            ? new Slice(
-                defaultSlice.content.cut(
-                  defaultSlice.content.firstChild.nodeSize
-                ),
-                defaultSlice.openStart,
-                defaultSlice.openEnd
-              )
-            : defaultSlice;
+          // remove first node from slice, it was inserted into the title
+          slice = defaultSlice
+            ? sliceWithoutFirstNode(defaultSlice)
+            : undefined;
         }
 
         if (slice) {

--- a/app/typings/prosemirror-view.d.ts
+++ b/app/typings/prosemirror-view.d.ts
@@ -1,7 +1,7 @@
 import "prosemirror-view";
 
 declare module "prosemirror-view" {
-  import { ResolvedPos } from "prosemirror-model";
+  import { ResolvedPos, Slice } from "prosemirror-model";
   import { EditorView } from "prosemirror-view";
 
   export function __parseFromClipboard(
@@ -10,5 +10,5 @@ declare module "prosemirror-view" {
     html: string | null,
     plainText: boolean,
     $context: ResolvedPos
-  );
+  ): Slice | null;
 }

--- a/shared/editor/lib/sliceWithoutFirstNode.test.ts
+++ b/shared/editor/lib/sliceWithoutFirstNode.test.ts
@@ -1,0 +1,70 @@
+import { Fragment, Schema, Slice } from "prosemirror-model";
+import { EditorState, Selection } from "prosemirror-state";
+import { sliceWithoutFirstNode } from "./sliceWithoutFirstNode";
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    paragraph: { content: "inline*", group: "block" },
+    horizontal_rule: { group: "block" },
+    text: { group: "inline" },
+  },
+});
+
+const paragraph = (text: string) =>
+  schema.nodes.paragraph.create(null, text ? schema.text(text) : null);
+
+describe("sliceWithoutFirstNode", () => {
+  it("returns undefined for an empty slice", () => {
+    expect(sliceWithoutFirstNode(Slice.empty)).toBeUndefined();
+  });
+
+  it("returns undefined when the slice holds a single node", () => {
+    const slice = new Slice(Fragment.from(paragraph("one")), 1, 1);
+    expect(sliceWithoutFirstNode(slice)).toBeUndefined();
+  });
+
+  it("removes the first node and keeps the open depths", () => {
+    const slice = new Slice(
+      Fragment.fromArray([paragraph("one"), paragraph("two")]),
+      1,
+      1
+    );
+    const result = sliceWithoutFirstNode(slice);
+
+    expect(result?.content.childCount).toBe(1);
+    expect(result?.content.firstChild?.textContent).toBe("two");
+    expect(result?.openStart).toBe(1);
+    expect(result?.openEnd).toBe(1);
+  });
+
+  it("clamps the open depths to leaf nodes", () => {
+    const slice = new Slice(
+      Fragment.fromArray([
+        paragraph("one"),
+        schema.nodes.horizontal_rule.create(),
+      ]),
+      1,
+      1
+    );
+    const result = sliceWithoutFirstNode(slice);
+
+    expect(result?.content.childCount).toBe(1);
+    expect(result?.openStart).toBe(0);
+    expect(result?.openEnd).toBe(0);
+  });
+
+  it("returns a slice that can replace a selection", () => {
+    const slice = new Slice(
+      Fragment.fromArray([paragraph("one"), paragraph("two")]),
+      1,
+      1
+    );
+    const state = EditorState.create({ schema });
+    const tr = state.tr
+      .setSelection(Selection.atStart(state.doc))
+      .replaceSelection(sliceWithoutFirstNode(slice) ?? Slice.empty);
+
+    expect(tr.doc.textContent).toBe("two");
+  });
+});

--- a/shared/editor/lib/sliceWithoutFirstNode.ts
+++ b/shared/editor/lib/sliceWithoutFirstNode.ts
@@ -1,0 +1,28 @@
+import { Slice } from "prosemirror-model";
+
+/**
+ * Removes the first top-level node from a slice. The open depths are clamped to
+ * the remaining content, as the removed node may have been the one that they
+ * referred to.
+ *
+ * @param slice the slice to remove the first node from.
+ * @returns a new slice, or undefined if no content remains.
+ */
+export function sliceWithoutFirstNode(slice: Slice): Slice | undefined {
+  const { firstChild } = slice.content;
+  if (!firstChild) {
+    return undefined;
+  }
+
+  const content = slice.content.cut(firstChild.nodeSize);
+  if (content.childCount === 0) {
+    return undefined;
+  }
+
+  const maxOpen = Slice.maxOpen(content);
+  return new Slice(
+    content,
+    Math.min(slice.openStart, maxOpen.openStart),
+    Math.min(slice.openEnd, maxOpen.openEnd)
+  );
+}


### PR DESCRIPTION
Pasting multi-line content into a document title puts the first line in the title and the remainder into the editor. Removing the first node from the pasted slice kept the original open depths, which no longer describe the remaining content — when the clipboard held a single top-level node (eg. one paragraph containing a line break) the content became empty while `openEnd` stayed above zero, and ProseMirror walked into a null child.

- Clamp the open depths to the remaining content, and skip the insert entirely when nothing remains
- Also guards a rarer case where the new first node is a leaf, such as a horizontal rule
- Type the return of the private clipboard parser so its nullable result is handled

Fixes OUTLINE-CLOUD-51V