### PR TITLE
fix: Crash when a remote edit arrives during a table column resize

### DIFF
--- a/shared/editor/nodes/Table.ts
+++ b/shared/editor/nodes/Table.ts
@@ -43,6 +43,7 @@ import {
 } from "../commands/table";
 import type { MarkdownSerializerState } from "../lib/markdown/serializer";
 import { FixTablesPlugin } from "../plugins/FixTablesPlugin";
+import { TableColumnResizePlugin } from "../plugins/TableColumnResizePlugin";
 import { TableLayoutPlugin } from "../plugins/TableLayoutPlugin";
 import tablesRule from "../rules/tables";
 import { EditorStyleHelper } from "../styles/EditorStyleHelper";
@@ -168,6 +169,7 @@ export default class Table extends Node {
         defaultCellMinWidth: 25,
       }),
       tableEditing(),
+      new TableColumnResizePlugin(),
       new FixTablesPlugin(),
       new TableLayoutPlugin(),
     ];

--- a/shared/editor/plugins/TableColumnResizePlugin.test.ts
+++ b/shared/editor/plugins/TableColumnResizePlugin.test.ts
@@ -1,0 +1,66 @@
+import { Fragment, Slice } from "prosemirror-model";
+import type { EditorState } from "prosemirror-state";
+import { columnResizing, columnResizingPluginKey } from "prosemirror-tables";
+import {
+  createEditorState,
+  doc,
+  p,
+  schema,
+  table,
+  td,
+  tr,
+} from "@shared/test/editor";
+import { TableColumnResizePlugin } from "./TableColumnResizePlugin";
+
+/** Position of the first cell in a document that starts with a table. */
+const firstCellPos = 2;
+
+function startResizing(state: EditorState, handle: number) {
+  const withHandle = state.apply(
+    state.tr.setMeta(columnResizingPluginKey, { setHandle: handle })
+  );
+  return withHandle.apply(
+    withHandle.tr.setMeta(columnResizingPluginKey, {
+      setDragging: { startX: 0, startWidth: 100 },
+    })
+  );
+}
+
+describe("TableColumnResizePlugin", () => {
+  const createState = () =>
+    createEditorState(doc(table([tr([td("A"), td("B")])])), [
+      columnResizing(),
+      new TableColumnResizePlugin(),
+    ]);
+
+  it("should cancel dragging when the document is replaced under the handle", () => {
+    const state = startResizing(createState(), firstCellPos);
+    expect(columnResizingPluginKey.getState(state)?.dragging).toBeTruthy();
+
+    // Mimic the whole document replacement that y-prosemirror dispatches when a
+    // remote change arrives, which invalidates the drag handle.
+    const newState = state.apply(
+      state.tr.replace(
+        0,
+        state.doc.content.size,
+        new Slice(Fragment.from(p("Replaced")), 0, 0)
+      )
+    );
+
+    const resizeState = columnResizingPluginKey.getState(newState);
+    expect(resizeState?.activeHandle).toBe(-1);
+    expect(resizeState?.dragging).toBe(null);
+  });
+
+  it("should keep dragging when the handle survives the change", () => {
+    const state = startResizing(createState(), firstCellPos);
+
+    const newState = state.apply(
+      state.tr.insert(state.doc.content.size, schema.nodes.paragraph.create())
+    );
+
+    const resizeState = columnResizingPluginKey.getState(newState);
+    expect(resizeState?.activeHandle).toBe(firstCellPos);
+    expect(resizeState?.dragging).toBeTruthy();
+  });
+});

--- a/shared/editor/plugins/TableColumnResizePlugin.ts
+++ b/shared/editor/plugins/TableColumnResizePlugin.ts
@@ -1,0 +1,34 @@
+import type { Transaction, EditorState } from "prosemirror-state";
+import { Plugin } from "prosemirror-state";
+import { columnResizingPluginKey } from "prosemirror-tables";
+
+/**
+ * A ProseMirror plugin that cancels an in-progress column resize once the drag
+ * handle no longer points at a cell. The handle is invalidated whenever the
+ * document is replaced under the pointer, such as by a collaborative edit from
+ * another user, and resizing with an invalid handle throws.
+ */
+export class TableColumnResizePlugin extends Plugin {
+  constructor() {
+    super({
+      appendTransaction: (
+        transactions: readonly Transaction[],
+        _oldState: EditorState,
+        newState: EditorState
+      ) => {
+        if (!transactions.some((transaction) => transaction.docChanged)) {
+          return undefined;
+        }
+
+        const resizeState = columnResizingPluginKey.getState(newState);
+        if (!resizeState?.dragging || resizeState.activeHandle > -1) {
+          return undefined;
+        }
+
+        return newState.tr.setMeta(columnResizingPluginKey, {
+          setDragging: null,
+        });
+      },
+    });
+  }
+}


### PR DESCRIPTION
Remote changes are applied to the editor as a full document replacement, which invalidates the column resize handle while a drag is still in progress. Releasing the pointer then resolved position -1 and threw a `RangeError`, so a column resize crashed the editor whenever anyone else edited the document at the same time.

- Add a table plugin that cancels an in-progress resize once the handle no longer points at a cell
- The column falls back to its stored width instead of throwing

Fixes OUTLINE-CLOUD-B3R