### PR TITLE
Re-authorize collaboration connections when access changes

### DIFF
--- a/server/collaboration/APIUpdateExtension.ts
+++ b/server/collaboration/APIUpdateExtension.ts
@@ -7,7 +7,6 @@ import type {
 } from "@hocuspocus/server";
 import type { Document as HocuspocusDocument } from "@hocuspocus/server";
 import * as Y from "yjs";
-import env from "@server/env";
 import Logger from "@server/logging/Logger";
 import { trace } from "@server/logging/tracing";
 import Document from "@server/models/Document";
@@ -51,19 +50,7 @@ export class APIUpdateExtension implements Extension {
     this.configured = true;
 
     try {
-      // Create a dedicated subscriber for API update notifications
-      this.subscriber = new RedisAdapter(
-        env.REDIS_COLLABORATION_URL || env.REDIS_URL,
-        {
-          connectionNameSuffix: "collab-api-updates",
-          maxRetriesPerRequest: null,
-        }
-      );
-
-      // Handle Redis connection errors
-      this.subscriber.on("error", (err) => {
-        Logger.error("Redis subscriber error in APIUpdateExtension", err);
-      });
+      this.subscriber = RedisAdapter.collaborationSubscriber;
 
       // Subscribe to the API update channel pattern
       await this.subscriber.psubscribe(`${CHANNEL_PREFIX}:*`, (err) => {
@@ -99,8 +86,8 @@ export class APIUpdateExtension implements Extension {
 
   async onDestroy(_data: onDestroyPayload): Promise<void> {
     if (this.subscriber) {
+      this.subscriber.off("pmessage", this.handleMessage);
       await this.subscriber.punsubscribe(`${CHANNEL_PREFIX}:*`);
-      await this.subscriber.quit();
       this.subscriber = null;
     }
     this.documents.clear();

--- a/server/collaboration/AuthenticationExtension.test.ts
+++ b/server/collaboration/AuthenticationExtension.test.ts
@@ -1,0 +1,198 @@
+import type {
+  Hocuspocus,
+  onConfigurePayload,
+  onDestroyPayload,
+} from "@hocuspocus/server";
+import { AuthorizationChanged } from "@shared/collaboration/CloseEvents";
+import { CollectionPermission } from "@shared/types";
+import { sleep } from "@shared/utils/timers";
+import { UserMembership } from "@server/models";
+import type User from "@server/models/User";
+import RedisAdapter from "@server/storage/redis";
+import {
+  buildAdmin,
+  buildCollection,
+  buildDocument,
+  buildGroup,
+  buildGroupUser,
+  buildTeam,
+  buildUser,
+} from "@server/test/factories";
+import { APIUpdateExtension } from "./APIUpdateExtension";
+import AuthenticationExtension from "./AuthenticationExtension";
+
+const buildConnection = (user: User) => ({
+  context: { user },
+  readOnly: false,
+  close: vi.fn(),
+});
+
+type Connections = Record<string, ReturnType<typeof buildConnection>[]>;
+
+describe("AuthenticationExtension", () => {
+  let extension: AuthenticationExtension;
+
+  const configure = (connections: Connections) => {
+    const instance = {
+      documents: new Map(
+        Object.entries(connections).map(([documentId, forDocument]) => [
+          `document.${documentId}`,
+          { getConnections: () => forDocument },
+        ])
+      ),
+    } as unknown as Hocuspocus;
+
+    return extension.onConfigure({ instance } as onConfigurePayload);
+  };
+
+  /** Build a private collection that a member has been given access to. */
+  const buildPrivateCollection = async () => {
+    const team = await buildTeam();
+    const admin = await buildAdmin({ teamId: team.id });
+    const user = await buildUser({ teamId: team.id });
+    const collection = await buildCollection({
+      teamId: team.id,
+      userId: admin.id,
+      permission: null,
+    });
+    const document = await buildDocument({
+      teamId: team.id,
+      userId: admin.id,
+      collectionId: collection.id,
+    });
+    const membership = await UserMembership.create({
+      collectionId: collection.id,
+      userId: user.id,
+      createdById: admin.id,
+      permission: CollectionPermission.ReadWrite,
+    });
+
+    return { admin, collection, document, membership, team, user };
+  };
+
+  beforeEach(() => {
+    extension = new AuthenticationExtension();
+  });
+
+  afterEach(() => extension.onDestroy({} as onDestroyPayload));
+
+  it("should disconnect when an invalidation is published", async () => {
+    const { document, user } = await buildPrivateCollection();
+    const connection = buildConnection(user);
+    await configure({ [document.id]: [connection] });
+
+    await AuthenticationExtension.invalidate({ userIds: [user.id] });
+    await sleep(100);
+
+    expect(connection.close).toHaveBeenCalledWith(AuthorizationChanged);
+  });
+
+  it("should ignore messages for other collaboration channels", async () => {
+    const { document, user } = await buildPrivateCollection();
+    const apiUpdates = new APIUpdateExtension();
+    await apiUpdates.onConfigure({} as onConfigurePayload);
+
+    const connection = buildConnection(user);
+    await configure({ [document.id]: [connection] });
+
+    // Both extensions share a single subscriber, so a message for one must not
+    // be handled by the other.
+    await RedisAdapter.collaborationClient.publish(
+      `collaboration:api-update:${document.id}`,
+      JSON.stringify({ actorId: user.id })
+    );
+    await sleep(100);
+
+    expect(connection.close).not.toHaveBeenCalled();
+
+    await AuthenticationExtension.invalidate({ userIds: [user.id] });
+    await sleep(100);
+
+    expect(connection.close).toHaveBeenCalledWith(AuthorizationChanged);
+    await apiUpdates.onDestroy({} as onDestroyPayload);
+  });
+
+  it("should disconnect connections for documents in the collection", async () => {
+    const { collection, document, user } = await buildPrivateCollection();
+    const connection = buildConnection(user);
+    await configure({ [document.id]: [connection] });
+
+    await extension.disconnect({
+      userIds: [user.id],
+      collectionId: collection.id,
+    });
+
+    expect(connection.close).toHaveBeenCalledWith(AuthorizationChanged);
+  });
+
+  it("should disconnect connections for members of the group", async () => {
+    const { document, team, user } = await buildPrivateCollection();
+    const group = await buildGroup({ teamId: team.id });
+    await buildGroupUser({
+      teamId: team.id,
+      groupId: group.id,
+      userId: user.id,
+    });
+    const connection = buildConnection(user);
+    await configure({ [document.id]: [connection] });
+
+    await extension.disconnect({ groupId: group.id });
+
+    expect(connection.close).toHaveBeenCalledWith(AuthorizationChanged);
+  });
+
+  it("should not disconnect connections belonging to another user", async () => {
+    const { collection, document, team, user } = await buildPrivateCollection();
+    const other = await buildUser({ teamId: team.id });
+    const connection = buildConnection(user);
+    await configure({ [document.id]: [connection] });
+
+    await extension.disconnect({
+      userIds: [other.id],
+      collectionId: collection.id,
+    });
+
+    expect(connection.close).not.toHaveBeenCalled();
+  });
+
+  it("should not disconnect connections for documents in another collection", async () => {
+    const { document, team, user } = await buildPrivateCollection();
+    const other = await buildCollection({ teamId: team.id });
+    const connection = buildConnection(user);
+    await configure({ [document.id]: [connection] });
+
+    await extension.disconnect({ collectionId: other.id });
+
+    expect(connection.close).not.toHaveBeenCalled();
+  });
+
+  it("should not disconnect connections for users outside the group", async () => {
+    const { document, team, user } = await buildPrivateCollection();
+    const group = await buildGroup({ teamId: team.id });
+    const connection = buildConnection(user);
+    await configure({ [document.id]: [connection] });
+
+    await extension.disconnect({ groupId: group.id });
+
+    expect(connection.close).not.toHaveBeenCalled();
+  });
+
+  it("should refuse to publish an empty scope", async () => {
+    await expect(AuthenticationExtension.invalidate({})).rejects.toThrow(
+      "must not be empty"
+    );
+    await expect(
+      AuthenticationExtension.invalidate({ userIds: undefined })
+    ).rejects.toThrow("must not be empty");
+  });
+
+  it("should not disconnect connections for other documents", async () => {
+    const { document, user } = await buildPrivateCollection();
+    const connection = buildConnection(user);
+    await configure({ [document.id]: [connection] });
+
+    await extension.disconnect({ documentIds: ["other-document-id"] });
+
+    expect(connection.close).not.toHaveBeenCalled();
+  });
+});

--- a/server/collaboration/AuthenticationExtension.ts
+++ b/server/collaboration/AuthenticationExtension.ts
@@ -198,13 +198,19 @@ export default class AuthenticationExtension implements Extension {
       affected = affected.filter((item) => documentIds.has(item.documentId));
     }
 
-    for (const { documentId, userId, connection } of affected) {
-      Logger.info(
-        "multiplayer",
-        `Closing connection to "${documentId}" to authorize it again`,
-        { userId }
-      );
+    if (!affected.length) {
+      return;
+    }
 
+    // Each closed connection is logged again by LoggerExtension, so record the
+    // reason once rather than per connection.
+    Logger.info(
+      "multiplayer",
+      `Closing ${affected.length} connections to authorize them again`,
+      scope
+    );
+
+    for (const { connection } of affected) {
       connection.close(AuthorizationChanged);
     }
   }

--- a/server/collaboration/AuthenticationExtension.ts
+++ b/server/collaboration/AuthenticationExtension.ts
@@ -1,12 +1,77 @@
-import type { onAuthenticatePayload, Extension } from "@hocuspocus/server";
+import type {
+  Connection,
+  Extension,
+  Hocuspocus,
+  onAuthenticatePayload,
+  onConfigurePayload,
+  onDestroyPayload,
+} from "@hocuspocus/server";
+import { uniq } from "es-toolkit";
+import { AuthorizationChanged } from "@shared/collaboration/CloseEvents";
+import { toError } from "@shared/utils/error";
+import Logger from "@server/logging/Logger";
 import { trace } from "@server/logging/tracing";
 import Document from "@server/models/Document";
+import GroupUser from "@server/models/GroupUser";
+import type User from "@server/models/User";
 import { can } from "@server/policies";
+import RedisAdapter from "@server/storage/redis";
 import { getUserForJWT } from "@server/utils/jwt";
-import { AuthenticationError } from "../errors";
+import { AuthenticationError, InternalError } from "../errors";
 
+/**
+ * Redis channel that carries access changes to collaboration servers.
+ */
+const CHANNEL = "collaboration:authorization";
+
+/**
+ * Describes which connections are affected by an access change. A connection is
+ * closed only when it matches every property provided, so an empty scope
+ * matches all of them.
+ */
+export interface AuthorizationScope {
+  /** Restrict to connections belonging to one of these users. */
+  userIds?: string[];
+  /** Restrict to connections belonging to members of this group. */
+  groupId?: string;
+  /** Restrict to connections for documents in this collection. */
+  collectionId?: string;
+  /** Restrict to connections for these documents. */
+  documentIds?: string[];
+}
+
+/**
+ * Authorizes connections to a document when they are established, and closes
+ * them again whenever the access a user was granted may have changed. Clients
+ * reconnect on their own, so authorization is only ever decided in one place.
+ */
 @trace()
 export default class AuthenticationExtension implements Extension {
+  /**
+   * Publish an access change so that every collaboration server closes the
+   * connections it holds within the given scope. Access itself is not
+   * evaluated here, the scope only has to cover the connections that may be
+   * affected.
+   *
+   * @param scope The connections that may be affected by the change.
+   * @returns A promise that resolves once the change has been published.
+   * @throws {Error} If the scope is empty, which would match every connection.
+   */
+  static async invalidate(scope: AuthorizationScope): Promise<void> {
+    // An absent property matches all connections, so a scope in which every
+    // property is absent would disconnect the entire cluster.
+    if (!Object.values(scope).some((value) => value !== undefined)) {
+      throw InternalError("An authorization scope must not be empty");
+    }
+
+    await RedisAdapter.collaborationClient.publish(
+      CHANNEL,
+      JSON.stringify(scope)
+    );
+
+    Logger.debug("multiplayer", "Published access change", scope);
+  }
+
   async onAuthenticate({
     connection,
     token,
@@ -38,4 +103,126 @@ export default class AuthenticationExtension implements Extension {
       user,
     };
   }
+
+  async onConfigure({ instance }: onConfigurePayload) {
+    this.instance = instance;
+
+    if (this.subscribed) {
+      return;
+    }
+    this.subscribed = true;
+
+    try {
+      const subscriber = RedisAdapter.collaborationSubscriber;
+      await subscriber.subscribe(CHANNEL);
+      subscriber.on("message", this.handleMessage);
+
+      Logger.debug("multiplayer", `Subscribed to ${CHANNEL}`);
+    } catch (error) {
+      Logger.error("Failed to subscribe to access changes", toError(error));
+      this.subscribed = false;
+    }
+  }
+
+  async onDestroy(_data: onDestroyPayload) {
+    if (this.subscribed) {
+      const subscriber = RedisAdapter.collaborationSubscriber;
+      subscriber.off("message", this.handleMessage);
+      await subscriber.unsubscribe(CHANNEL);
+      this.subscribed = false;
+    }
+
+    this.instance = undefined;
+  }
+
+  /**
+   * Close every locally held connection within the scope of an access change.
+   * A client that has kept its access reconnects with only a brief
+   * interruption, one that has not is refused by `onAuthenticate`.
+   *
+   * @param scope The connections that may be affected by the change.
+   * @returns A promise that resolves once the connections have been closed.
+   */
+  async disconnect(scope: AuthorizationScope) {
+    if (!this.instance) {
+      return;
+    }
+
+    let affected: {
+      documentId: string;
+      userId: string;
+      connection: Connection;
+    }[] = [];
+
+    for (const [documentName, document] of this.instance.documents) {
+      const [, documentId] = documentName.split(".");
+
+      if (scope.documentIds && !scope.documentIds.includes(documentId)) {
+        continue;
+      }
+
+      for (const connection of document.getConnections()) {
+        const context: { user?: User } = connection.context;
+        const userId = context.user?.id;
+
+        if (!userId || (scope.userIds && !scope.userIds.includes(userId))) {
+          continue;
+        }
+
+        affected.push({ documentId, userId, connection });
+      }
+    }
+
+    if (scope.groupId && affected.length) {
+      const groupUsers = await GroupUser.findAll({
+        attributes: ["userId"],
+        where: {
+          groupId: scope.groupId,
+          userId: uniq(affected.map((item) => item.userId)),
+        },
+      });
+      const userIds = new Set(groupUsers.map((groupUser) => groupUser.userId));
+      affected = affected.filter((item) => userIds.has(item.userId));
+    }
+
+    if (scope.collectionId && affected.length) {
+      const documents = await Document.unscoped().findAll({
+        attributes: ["id"],
+        where: {
+          id: uniq(affected.map((item) => item.documentId)),
+          collectionId: scope.collectionId,
+        },
+        paranoid: false,
+      });
+      const documentIds = new Set(documents.map((document) => document.id));
+      affected = affected.filter((item) => documentIds.has(item.documentId));
+    }
+
+    for (const { documentId, userId, connection } of affected) {
+      Logger.info(
+        "multiplayer",
+        `Closing connection to "${documentId}" to authorize it again`,
+        { userId }
+      );
+
+      connection.close(AuthorizationChanged);
+    }
+  }
+
+  private instance?: Hocuspocus;
+
+  private subscribed = false;
+
+  private handleMessage = async (channel: string, message: string) => {
+    if (channel !== CHANNEL) {
+      return;
+    }
+
+    try {
+      const scope: AuthorizationScope = JSON.parse(message);
+      await this.disconnect(scope);
+    } catch (error) {
+      Logger.error("Failed to handle access change", toError(error));
+    }
+  };
 }

--- a/server/queues/processors/CollaborationAuthorizationProcessor.test.ts
+++ b/server/queues/processors/CollaborationAuthorizationProcessor.test.ts
@@ -1,0 +1,116 @@
+import { CollectionPermission } from "@shared/types";
+import AuthenticationExtension from "@server/collaboration/AuthenticationExtension";
+import type { CollectionUserEvent } from "@server/types";
+import CollaborationAuthorizationProcessor from "./CollaborationAuthorizationProcessor";
+
+describe("CollaborationAuthorizationProcessor", () => {
+  const processor = new CollaborationAuthorizationProcessor();
+
+  const buildAddUserEvent = (
+    overrides: Partial<CollectionUserEvent> = {}
+  ): CollectionUserEvent => ({
+    name: "collections.add_user",
+    teamId: "team-id",
+    actorId: "actor-id",
+    ip: null,
+    userId: "user-id",
+    modelId: "membership-id",
+    collectionId: "collection-id",
+    data: { isNew: true },
+    ...overrides,
+  });
+
+  const invalidate = () =>
+    vi.spyOn(AuthenticationExtension, "invalidate").mockResolvedValue();
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("should invalidate when a membership is created", async () => {
+    const spy = invalidate();
+
+    await processor.perform(buildAddUserEvent());
+
+    expect(spy).toHaveBeenCalledWith({
+      userIds: ["user-id"],
+      collectionId: "collection-id",
+    });
+  });
+
+  it("should invalidate when a membership permission changed", async () => {
+    const spy = invalidate();
+
+    await processor.perform(
+      buildAddUserEvent({
+        data: { isNew: false },
+        changes: {
+          attributes: { permission: CollectionPermission.Read },
+          previous: { permission: CollectionPermission.ReadWrite },
+        },
+      })
+    );
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("should not invalidate when a membership index changed", async () => {
+    const spy = invalidate();
+
+    await processor.perform(
+      buildAddUserEvent({
+        data: { isNew: false },
+        changes: {
+          attributes: { index: "P" },
+          previous: { index: "O" },
+        },
+      })
+    );
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("should invalidate when a membership is removed", async () => {
+    const spy = invalidate();
+
+    // Removal events carry no data at all.
+    await processor.perform(
+      buildAddUserEvent({ name: "collections.remove_user", data: undefined })
+    );
+
+    expect(spy).toHaveBeenCalledWith({
+      userIds: ["user-id"],
+      collectionId: "collection-id",
+    });
+  });
+
+  it("should not scope a document membership to the document, as it is inherited", async () => {
+    const spy = invalidate();
+
+    await processor.perform({
+      name: "documents.remove_user",
+      teamId: "team-id",
+      actorId: "actor-id",
+      ip: null,
+      userId: "user-id",
+      modelId: "membership-id",
+      documentId: "document-id",
+    });
+
+    expect(spy).toHaveBeenCalledWith({ userIds: ["user-id"] });
+  });
+
+  it("should not scope a document group membership to the document", async () => {
+    const spy = invalidate();
+
+    await processor.perform({
+      name: "documents.remove_group",
+      teamId: "team-id",
+      actorId: "actor-id",
+      ip: null,
+      modelId: "group-id",
+      documentId: "document-id",
+      data: { membershipId: "membership-id" },
+    });
+
+    expect(spy).toHaveBeenCalledWith({ groupId: "group-id" });
+  });
+});

--- a/server/queues/processors/CollaborationAuthorizationProcessor.ts
+++ b/server/queues/processors/CollaborationAuthorizationProcessor.ts
@@ -1,0 +1,139 @@
+import AuthenticationExtension from "@server/collaboration/AuthenticationExtension";
+import type {
+  CollectionUserEvent,
+  DocumentUserEvent,
+  Event as TEvent,
+} from "@server/types";
+import BaseProcessor from "./BaseProcessor";
+
+/**
+ * Collaboration connections are authorized once, when the websocket is first
+ * established. This processor notifies collaboration servers whenever the
+ * access a user was granted may have changed.
+ */
+export default class CollaborationAuthorizationProcessor extends BaseProcessor {
+  static applicableEvents: TEvent["name"][] = [
+    "collections.add_user",
+    "collections.remove_user",
+    "collections.add_group",
+    "collections.remove_group",
+    "collections.permission_changed",
+    "collections.archive",
+    "collections.delete",
+    "documents.add_user",
+    "documents.remove_user",
+    "documents.add_group",
+    "documents.remove_group",
+    "documents.move",
+    "documents.unpublish",
+    "groups.add_user",
+    "groups.remove_user",
+    "groups.delete",
+    "users.demote",
+    "users.suspend",
+    "users.delete",
+  ];
+
+  async perform(event: TEvent) {
+    switch (event.name) {
+      // A membership was created, removed, or had its permission changed.
+      case "collections.add_user":
+      case "collections.remove_user":
+        if (!this.affectsAccess(event)) {
+          return;
+        }
+        return AuthenticationExtension.invalidate({
+          userIds: [event.userId],
+          collectionId: event.collectionId,
+        });
+
+      // A membership on a document is inherited by its published descendants,
+      // which emit no events of their own, so the document is left out of the
+      // scope rather than resolving the tree it applies to.
+      case "documents.add_user":
+      case "documents.remove_user":
+        if (!this.affectsAccess(event)) {
+          return;
+        }
+        return AuthenticationExtension.invalidate({
+          userIds: [event.userId],
+        });
+
+      case "collections.add_group":
+      case "collections.remove_group":
+        return AuthenticationExtension.invalidate({
+          groupId: event.modelId,
+          collectionId: event.collectionId,
+        });
+
+      case "documents.add_group":
+      case "documents.remove_group":
+        return AuthenticationExtension.invalidate({
+          groupId: event.modelId,
+        });
+
+      // Every membership derived from the group is gone, the users that were
+      // members are resolved by the collaboration server.
+      case "groups.delete":
+        return AuthenticationExtension.invalidate({
+          groupId: event.modelId,
+        });
+
+      case "groups.add_user":
+      case "groups.remove_user":
+        return AuthenticationExtension.invalidate({
+          userIds: [event.userId],
+        });
+
+      // The collection a document inherits access from changed, which applies
+      // to the moved document and all of its children.
+      case "documents.move":
+        return AuthenticationExtension.invalidate({
+          documentIds: event.data.documentIds,
+        });
+
+      // A published document became a draft, visible only to its author.
+      case "documents.unpublish":
+        return AuthenticationExtension.invalidate({
+          documentIds: [event.documentId],
+        });
+
+      // Access to every document in the collection may have changed.
+      case "collections.permission_changed":
+      case "collections.archive":
+      case "collections.delete":
+        return AuthenticationExtension.invalidate({
+          collectionId: event.collectionId,
+        });
+
+      // The user's role or status changed, which applies to every document.
+      case "users.demote":
+      case "users.suspend":
+      case "users.delete":
+        return AuthenticationExtension.invalidate({
+          userIds: [event.userId],
+        });
+
+      default:
+        return;
+    }
+  }
+
+  /**
+   * User membership events are also emitted for changes that grant no access,
+   * such as the index that orders a document in the sidebar.
+   *
+   * @param event The membership event to check.
+   * @returns true if the event may have changed the user's access.
+   */
+  private affectsAccess(event: CollectionUserEvent | DocumentUserEvent) {
+    // An existing membership only matters when the permission itself changed,
+    // anything else is either a new or a removed membership. Removals carry no
+    // data at all.
+    if (event.data?.isNew === false) {
+      return !!event.changes && "permission" in event.changes.attributes;
+    }
+
+    return true;
+  }
+}

--- a/server/queues/processors/NotificationsProcessor.ts
+++ b/server/queues/processors/NotificationsProcessor.ts
@@ -77,7 +77,7 @@ export default class NotificationsProcessor extends BaseProcessor {
   }
 
   async documentAddUser(event: DocumentUserEvent) {
-    if (!event.data.isNew || event.userId === event.actorId) {
+    if (!event.data?.isNew || event.userId === event.actorId) {
       return;
     }
     await new DocumentAddUserNotificationsTask().schedule(event);
@@ -112,7 +112,7 @@ export default class NotificationsProcessor extends BaseProcessor {
   }
 
   async collectionAddUser(event: CollectionUserEvent) {
-    if (!event.data.isNew || event.userId === event.actorId) {
+    if (!event.data?.isNew || event.userId === event.actorId) {
       return;
     }
 

--- a/server/storage/redis.ts
+++ b/server/storage/redis.ts
@@ -126,6 +126,7 @@ export default class RedisAdapter extends Redis {
   private static client: RedisAdapter;
   private static subscriber: RedisAdapter;
   private static collabClient: RedisAdapter;
+  private static collabSubscriber: RedisAdapter;
 
   public static get defaultClient(): RedisAdapter {
     return (
@@ -159,6 +160,22 @@ export default class RedisAdapter extends Redis {
       (this.collabClient = new this(env.REDIS_COLLABORATION_URL, {
         connectionNameSuffix: "collab",
       }))
+    );
+  }
+
+  /**
+   * A Redis adapter for subscriptions to collaboration channels.
+   */
+  public static get collaborationSubscriber(): RedisAdapter {
+    return (
+      this.collabSubscriber ||
+      (this.collabSubscriber = new this(
+        env.REDIS_COLLABORATION_URL || env.REDIS_URL,
+        {
+          maxRetriesPerRequest: null,
+          connectionNameSuffix: "collab-subscriber",
+        }
+      ))
     );
   }
 }

--- a/server/types.ts
+++ b/server/types.ts
@@ -287,7 +287,8 @@ export type CollectionUserEvent = BaseEvent<UserMembership> & {
   userId: string;
   modelId: string;
   collectionId: string;
-  data: {
+  /** Only present when the membership was created or updated. */
+  data?: {
     isNew?: boolean;
   };
 };
@@ -304,7 +305,8 @@ export type DocumentUserEvent = BaseEvent<UserMembership> & {
   userId: string;
   modelId: string;
   documentId: string;
-  data: {
+  /** Only present when the membership was created or updated. */
+  data?: {
     isNew?: boolean;
   };
 };

--- a/shared/collaboration/CloseEvents.ts
+++ b/shared/collaboration/CloseEvents.ts
@@ -27,6 +27,16 @@ export const AuthorizationFailed = {
 };
 
 /**
+ * The access the user was granted may have changed and must be established
+ * again. The client is expected to reconnect, at which point it is either
+ * authorized as normal or refused with `AuthorizationFailed`.
+ */
+export const AuthorizationChanged = {
+  code: 4205,
+  reason: "Authorization Changed",
+};
+
+/**
  * The server is refusing to process the request because there are too many connections
  * to the given document.
  */


### PR DESCRIPTION
Collaboration connections are authorized once, when the websocket is first established, so a connection could outlive changes to the access it was granted. **Important note**: The _client side_ disconnects realtime connections already, so this is hardening to also have the _server side_ disconnect.

- Adds a processor that publishes access changes to the collaboration servers over Redis
- Each server closes the connections it holds within the scope of the change, and clients reconnect and are authorized as normal — so authorization is still decided in one place
- Membership changes are scoped by user rather than by document, as a membership on a document is inherited by descendants that emit no events of their own
- An empty scope is refused rather than published, since it would match every connection
- The API update subscriber now shares a single Redis connection instead of opening its own