### PR TITLE
fix: Headings at the end of a document never highlight in the contents

### DIFF
--- a/app/scenes/Document/components/Contents.tsx
+++ b/app/scenes/Document/components/Contents.tsx
@@ -8,6 +8,7 @@ import breakpoint from "styled-components-breakpoint";
 import { EmojiText } from "@shared/components/EmojiText";
 import { EditorStyleHelper } from "@shared/editor/styles/EditorStyleHelper";
 import { depths, hideScrollbars, s } from "@shared/styles";
+import { supportsPassiveListener } from "@shared/utils/browser";
 import { useDocumentContext } from "~/components/DocumentContext";
 import useWindowScrollPosition from "~/hooks/useWindowScrollPosition";
 import { patchLocation } from "~/utils/history";
@@ -17,12 +18,21 @@ const HEADING_OFFSET = 20;
 
 function Contents() {
   const history = useHistory();
-  const [activeSlug, setActiveSlug] = useState<string>();
+  const [scrolledSlug, setScrolledSlug] = useState<string>();
+  const [selectedSlug, setSelectedSlug] = useState<string>();
   const scrollPosition = useWindowScrollPosition({
     throttle: 100,
   });
   const { headings } = useDocumentContext();
   const itemRefs = useRef<Record<string, HTMLLIElement | null>>({});
+
+  // A heading chosen from the contents stays highlighted until the reader
+  // scrolls themselves. Headings near the end of a document cannot reach the
+  // top of the viewport, so the scroll position alone would never select them.
+  const activeSlug =
+    selectedSlug && headings.some((heading) => heading.id === selectedSlug)
+      ? selectedSlug
+      : scrolledSlug;
 
   const handleClick = useCallback(
     (event: React.MouseEvent<HTMLAnchorElement>, id: string) => {
@@ -40,10 +50,30 @@ function Contents() {
       // Navigate via history so the location state (active sidebar context) is
       // retained rather than dropped by a native hash navigation.
       event.preventDefault();
+      setSelectedSlug(id);
       history.push(patchLocation(history.location, { hash: `#${id}` }));
     },
     [history]
   );
+
+  useEffect(() => {
+    if (!selectedSlug) {
+      return;
+    }
+
+    const handleUserScroll = () => setSelectedSlug(undefined);
+    const options = supportsPassiveListener ? { passive: true } : false;
+
+    window.addEventListener("wheel", handleUserScroll, options);
+    window.addEventListener("touchmove", handleUserScroll, options);
+    window.addEventListener("keydown", handleUserScroll);
+
+    return () => {
+      window.removeEventListener("wheel", handleUserScroll);
+      window.removeEventListener("touchmove", handleUserScroll);
+      window.removeEventListener("keydown", handleUserScroll);
+    };
+  }, [selectedSlug]);
 
   useEffect(() => {
     let activeId = headings.length > 0 ? headings[0].id : undefined;
@@ -63,10 +93,10 @@ function Contents() {
       }
     }
 
-    if (activeSlug !== activeId) {
-      setActiveSlug(activeId);
+    if (scrolledSlug !== activeId) {
+      setScrolledSlug(activeId);
     }
-  }, [scrollPosition, headings, activeSlug]);
+  }, [scrollPosition, headings, scrolledSlug]);
 
   useEffect(() => {
     const activeItem = activeSlug ? itemRefs.current[activeSlug] : undefined;

--- a/app/scenes/Document/components/Contents.tsx
+++ b/app/scenes/Document/components/Contents.tsx
@@ -61,18 +61,24 @@ function Contents() {
       return;
     }
 
-    const handleUserScroll = () => setSelectedSlug(undefined);
-    const options = supportsPassiveListener ? { passive: true } : false;
+    // Navigating to the heading scrolls the document during the same commit,
+    // so the position here is the one it came to rest at. Any movement away
+    // from it is the reader scrolling, whichever means they use.
+    const restingPosition = window.pageYOffset;
 
-    window.addEventListener("wheel", handleUserScroll, options);
-    window.addEventListener("touchmove", handleUserScroll, options);
-    window.addEventListener("keydown", handleUserScroll);
-
-    return () => {
-      window.removeEventListener("wheel", handleUserScroll);
-      window.removeEventListener("touchmove", handleUserScroll);
-      window.removeEventListener("keydown", handleUserScroll);
+    const handleScroll = () => {
+      if (window.pageYOffset !== restingPosition) {
+        setSelectedSlug(undefined);
+      }
     };
+
+    window.addEventListener(
+      "scroll",
+      handleScroll,
+      supportsPassiveListener ? { passive: true } : false
+    );
+
+    return () => window.removeEventListener("scroll", handleScroll);
   }, [selectedSlug]);
 
   useEffect(() => {


### PR DESCRIPTION
The highlight in the table of contents was derived only from the scroll position, so a heading in the final viewport of a document — one that can never reach the top of the screen — was never highlighted, even when clicked directly.

- Clicking a heading in the contents highlights it immediately
- The highlight is released as soon as the reader scrolls again, so the position in the document takes over as before
- The selection is ignored if the heading is removed or the document changes, so the contents cannot end up with nothing highlighted