### PR TITLE
feat: Filter DSL for `groups.list`

### DIFF
--- a/app/scenes/Settings/Groups.tsx
+++ b/app/scenes/Settings/Groups.tsx
@@ -7,6 +7,7 @@ import { useState, useMemo, useCallback, useEffect } from "react";
 import { useTranslation, Trans } from "react-i18next";
 import { useHistory, useLocation } from "react-router-dom";
 import { toast } from "sonner";
+import type { Filter } from "@shared/helpers/FilterHelper";
 import type Group from "~/models/Group";
 import { Action } from "~/components/Actions";
 import Button from "~/components/Button";
@@ -26,6 +27,12 @@ import { CreateGroupDialog } from "./components/GroupDialogs";
 import GroupSourceFilter from "./components/GroupSourceFilter";
 import { GroupsTable } from "./components/GroupsTable";
 import { StickyFilters } from "./components/StickyFilters";
+
+function getGroupFilters(source?: string): Filter[] | undefined {
+  return source
+    ? [{ field: "source", operator: "eq", value: source }]
+    : undefined;
+}
 
 function getFilteredGroups(groups: Group[], query?: string, source?: string) {
   let filtered = groups;
@@ -58,16 +65,18 @@ function Groups() {
   const params = useQuery();
   const [query, setQuery] = useState("");
 
+  const source = params.get("source") || undefined;
+
   const reqParams = useMemo(
     () => ({
       query: params.get("query") || undefined,
-      source: params.get("source") || undefined,
+      filters: getGroupFilters(source),
       sort: params.get("sort") || "name",
       direction: (params.get("direction") || "asc").toUpperCase() as
         | "ASC"
         | "DESC",
     }),
-    [params]
+    [params, source]
   );
 
   const sort: ColumnSort = useMemo(
@@ -79,11 +88,7 @@ function Groups() {
   );
 
   const { data, error, loading, next } = useTableRequest({
-    data: getFilteredGroups(
-      groups.orderedData,
-      reqParams.query,
-      reqParams.source
-    ),
+    data: getFilteredGroups(groups.orderedData, reqParams.query, source),
     sort,
     reqFn: groups.fetchPage,
     reqParams,
@@ -177,7 +182,7 @@ function Groups() {
               onChange={handleSearch}
             />
             <LargeGroupSourceFilter
-              activeKey={reqParams.source ?? ""}
+              activeKey={source ?? ""}
               onSelect={handleSourceFilter}
             />
           </StickyFilters>

--- a/app/stores/GroupsStore.ts
+++ b/app/stores/GroupsStore.ts
@@ -3,12 +3,10 @@ import { filter } from "es-toolkit/compat";
 import { action, runInAction, computed } from "mobx";
 import naturalSort from "@shared/utils/naturalSort";
 import Group from "~/models/Group";
-import type { PaginationParams } from "~/types";
 import { client } from "~/utils/ApiClient";
 import type RootStore from "./RootStore";
+import type { FetchPageParams } from "./base/Store";
 import Store from "./base/Store";
-
-type FetchPageParams = PaginationParams & { query?: string };
 
 export default class GroupsStore extends Store<Group> {
   constructor(rootStore: RootStore) {

--- a/server/models/helpers/Filters.test.ts
+++ b/server/models/helpers/Filters.test.ts
@@ -10,8 +10,10 @@ import {
   expandDocumentIdInFilter,
   extractTopLevelEqValue,
   hasFieldInFilter,
+  legacyGroupParamsToFilter,
   legacyParamsToFilter,
   mapFilterFields,
+  replaceFieldInFilter,
 } from "./Filters";
 
 describe("Filters", () => {
@@ -689,6 +691,124 @@ describe("Filters", () => {
           { field: "archivedAt", operator: "isNotNull" },
         ],
       });
+    });
+  });
+
+  describe("legacyGroupParamsToFilter", () => {
+    it("returns undefined when no legacy params are set", () => {
+      expect(legacyGroupParamsToFilter({})).toBeUndefined();
+    });
+
+    it("returns a single leaf when only one legacy param is set", () => {
+      expect(legacyGroupParamsToFilter({ name: "Engineering" })).toEqual({
+        field: "name",
+        operator: "eq",
+        value: "Engineering",
+      });
+    });
+
+    it("converts userId to an eq leaf", () => {
+      expect(legacyGroupParamsToFilter({ userId: "u1" })).toEqual({
+        field: "userId",
+        operator: "eq",
+        value: "u1",
+      });
+    });
+
+    it("converts source to an eq leaf", () => {
+      expect(legacyGroupParamsToFilter({ source: "manual" })).toEqual({
+        field: "source",
+        operator: "eq",
+        value: "manual",
+      });
+    });
+
+    it("ANDs every legacy leaf when multiple are supplied", () => {
+      expect(
+        legacyGroupParamsToFilter({
+          userId: "u1",
+          externalId: "ext-1",
+          name: "Engineering",
+          source: "slack",
+        })
+      ).toEqual({
+        operator: "AND",
+        filters: [
+          { field: "userId", operator: "eq", value: "u1" },
+          { field: "externalId", operator: "eq", value: "ext-1" },
+          { field: "name", operator: "eq", value: "Engineering" },
+          { field: "source", operator: "eq", value: "slack" },
+        ],
+      });
+    });
+  });
+
+  describe("replaceFieldInFilter", () => {
+    it("replaces a top-level eq leaf", () => {
+      expect(
+        replaceFieldInFilter(
+          { field: "userId", operator: "eq", value: "u1" },
+          "userId",
+          (values) => ({ field: "id", operator: "in", value: values })
+        )
+      ).toEqual({ field: "id", operator: "in", value: ["u1"] });
+    });
+
+    it("passes every value of an in leaf to the replacement", () => {
+      expect(
+        replaceFieldInFilter(
+          { field: "userId", operator: "in", value: ["u1", "u2"] },
+          "userId",
+          (values) => ({ field: "id", operator: "in", value: values })
+        )
+      ).toEqual({ field: "id", operator: "in", value: ["u1", "u2"] });
+    });
+
+    it("replaces leaves nested inside groups, preserving structure", () => {
+      expect(
+        replaceFieldInFilter(
+          {
+            operator: "OR",
+            filters: [
+              { field: "name", operator: "eq", value: "x" },
+              { field: "userId", operator: "eq", value: "u1" },
+            ],
+          },
+          "userId",
+          () => ({ field: "id", operator: "in", value: ["g1"] })
+        )
+      ).toEqual({
+        operator: "OR",
+        filters: [
+          { field: "name", operator: "eq", value: "x" },
+          { field: "id", operator: "in", value: ["g1"] },
+        ],
+      });
+    });
+
+    it("leaves other fields untouched", () => {
+      const filter = {
+        field: "name" as const,
+        operator: "eq" as const,
+        value: "x",
+      };
+      expect(replaceFieldInFilter(filter, "userId", () => filter)).toEqual(
+        filter
+      );
+    });
+
+    it("leaves the leaf untouched when no values can be resolved", () => {
+      const filter = {
+        field: "userId" as const,
+        operator: "isNull" as const,
+      };
+      expect(
+        replaceFieldInFilter(filter, "userId", () => ({
+          field: "id",
+          operator: "in",
+          value: ["g1"],
+        }))
+      ).toEqual(filter);
     });
   });
 

--- a/server/models/helpers/Filters.ts
+++ b/server/models/helpers/Filters.ts
@@ -401,6 +401,91 @@ export function legacyParamsToFilter(legacy: LegacyParams): Filter | undefined {
   return combineFilters(leaves);
 }
 
+interface LegacyGroupParams {
+  userId?: string;
+  externalId?: string;
+  name?: string;
+  source?: string;
+}
+
+/**
+ * Translate the deprecated top-level params of groups.list into an equivalent
+ * filter expression, ANDing each one together.
+ *
+ * @param legacy the deprecated top-level params.
+ * @returns the equivalent filter, or undefined if none were set.
+ */
+export function legacyGroupParamsToFilter(
+  legacy: LegacyGroupParams
+): Filter | undefined {
+  const leaves: Filter[] = [];
+
+  if (legacy.userId) {
+    leaves.push({ field: "userId", operator: "eq", value: legacy.userId });
+  }
+  if (legacy.externalId) {
+    leaves.push({
+      field: "externalId",
+      operator: "eq",
+      value: legacy.externalId,
+    });
+  }
+  if (legacy.name) {
+    leaves.push({ field: "name", operator: "eq", value: legacy.name });
+  }
+  if (legacy.source) {
+    leaves.push({ field: "source", operator: "eq", value: legacy.source });
+  }
+
+  return combineFilters(leaves);
+}
+
+/** The values a single `eq` or `in` leaf refers to, if it is one of those. */
+function leafValues(condition: FilterCondition): string[] | undefined {
+  if (condition.operator === "eq" && condition.value !== undefined) {
+    return [String(condition.value)];
+  }
+  if (condition.operator === "in" && Array.isArray(condition.value)) {
+    return condition.value.map(String);
+  }
+  return undefined;
+}
+
+/**
+ * Replace every leaf referencing a field with a filter of the caller's
+ * choosing, preserving the surrounding structure.
+ *
+ * Used for fields that name something outside the model's own columns (e.g. a
+ * document subtree, a group membership) and so have to be resolved to real
+ * columns by the route handler before the query is built. Leaves the leaf
+ * untouched when its operator is neither `eq` nor `in`, as no set of values
+ * can be resolved from it.
+ *
+ * @param filter the filter to transform.
+ * @param field the field name to replace.
+ * @param replace called with the leaf's values, returning its replacement.
+ * @returns a new filter with the substitution applied.
+ */
+export function replaceFieldInFilter(
+  filter: Filter,
+  field: string,
+  replace: (values: string[]) => Filter
+): Filter {
+  if (isGroup(filter)) {
+    return {
+      operator: filter.operator,
+      filters: filter.filters.map((f) =>
+        replaceFieldInFilter(f, field, replace)
+      ),
+    };
+  }
+  if (filter.field !== field) {
+    return filter;
+  }
+  const values = leafValues(filter);
+  return values ? replace(values) : filter;
+}
+
 /**
  * Replace `documentId` leaves in a filter with `id in [...]` leaves using ids
  * pre-resolved by the route handler (typically each document plus its
@@ -416,35 +501,15 @@ export function expandDocumentIdInFilter(
   filter: Filter,
   expandedIds: Map<string, string[]>
 ): Filter {
-  if (isGroup(filter)) {
-    return {
-      operator: filter.operator,
-      filters: filter.filters.map((f) =>
-        expandDocumentIdInFilter(f, expandedIds)
-      ),
-    };
-  }
-  if (filter.field !== "documentId") {
-    return filter;
-  }
   // `eq` is the single-id case of `in`; both map to the deduped union of each
   // document's pre-resolved expansion (falling back to the raw id).
-  let ids: string[] | undefined;
-  if (filter.operator === "eq" && filter.value !== undefined) {
-    ids = [String(filter.value)];
-  } else if (filter.operator === "in" && Array.isArray(filter.value)) {
-    ids = filter.value.map(String);
-  }
-  if (!ids) {
-    return filter;
-  }
-  return {
+  return replaceFieldInFilter(filter, "documentId", (ids) => ({
     field: "id",
     operator: "in",
     value: Array.from(
       new Set(ids.flatMap((id) => expandedIds.get(id) ?? [id]))
     ),
-  };
+  }));
 }
 
 /**

--- a/server/routes/api/groups/groups.test.ts
+++ b/server/routes/api/groups/groups.test.ts
@@ -402,6 +402,327 @@ describe("#groups.list", () => {
   });
 });
 
+describe("#groups.list filters", () => {
+  it("should filter by name", async () => {
+    const user = await buildUser();
+    const group = await buildGroup({ teamId: user.teamId });
+    await buildGroup({ teamId: user.teamId });
+
+    const res = await server.post("/api/groups.list", user, {
+      body: {
+        filters: [{ field: "name", operator: "eq", value: group.name }],
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.pagination.total).toEqual(1);
+    expect(body.data.groups[0].id).toEqual(group.id);
+  });
+
+  it("should filter by a partial name", async () => {
+    const user = await buildUser();
+    const group = await buildGroup({ teamId: user.teamId, name: "Engineers" });
+    await buildGroup({ teamId: user.teamId, name: "Designers" });
+
+    const res = await server.post("/api/groups.list", user, {
+      body: {
+        filters: [{ field: "name", operator: "contains", value: "engine" }],
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.data.groups.length).toEqual(1);
+    expect(body.data.groups[0].id).toEqual(group.id);
+  });
+
+  it("should filter by externalId", async () => {
+    const user = await buildUser();
+    const group = await buildGroup({ teamId: user.teamId, externalId: "123" });
+    await buildGroup({ teamId: user.teamId });
+
+    const res = await server.post("/api/groups.list", user, {
+      body: {
+        filters: [{ field: "externalId", operator: "eq", value: "123" }],
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.pagination.total).toEqual(1);
+    expect(body.data.groups[0].id).toEqual(group.id);
+  });
+
+  it("should filter by id", async () => {
+    const user = await buildUser();
+    const group = await buildGroup({ teamId: user.teamId });
+    await buildGroup({ teamId: user.teamId });
+
+    const res = await server.post("/api/groups.list", user, {
+      body: {
+        filters: [{ field: "id", operator: "in", value: [group.id] }],
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.pagination.total).toEqual(1);
+    expect(body.data.groups[0].id).toEqual(group.id);
+  });
+
+  it("should filter to the groups a user is a member of", async () => {
+    const user = await buildUser();
+    const group = await buildGroup({ teamId: user.teamId });
+    await buildGroup({ teamId: user.teamId });
+    await buildGroupUser({
+      teamId: user.teamId,
+      groupId: group.id,
+      userId: user.id,
+      createdById: user.id,
+    });
+
+    const res = await server.post("/api/groups.list", user, {
+      body: {
+        filters: [{ field: "userId", operator: "eq", value: user.id }],
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.pagination.total).toEqual(1);
+    expect(body.data.groups[0].id).toEqual(group.id);
+  });
+
+  it("should filter to the groups any of several users are members of", async () => {
+    const user = await buildUser();
+    const other = await buildUser({ teamId: user.teamId });
+    const group = await buildGroup({ teamId: user.teamId });
+    const otherGroup = await buildGroup({ teamId: user.teamId });
+    await buildGroup({ teamId: user.teamId });
+    await buildGroupUser({
+      teamId: user.teamId,
+      groupId: group.id,
+      userId: user.id,
+      createdById: user.id,
+    });
+    await buildGroupUser({
+      teamId: user.teamId,
+      groupId: otherGroup.id,
+      userId: other.id,
+      createdById: user.id,
+    });
+
+    const res = await server.post("/api/groups.list", user, {
+      body: {
+        filters: [
+          { field: "userId", operator: "in", value: [user.id, other.id] },
+        ],
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(
+      body.data.groups.map((group: { id: string }) => group.id).sort()
+    ).toEqual([group.id, otherGroup.id].sort());
+  });
+
+  it("should combine a membership filter with a source filter", async () => {
+    const user = await buildUser();
+    const group = await buildGroup({ teamId: user.teamId });
+    const syncedGroup = await buildGroup({ teamId: user.teamId });
+    await buildGroupUser({
+      teamId: user.teamId,
+      groupId: group.id,
+      userId: user.id,
+      createdById: user.id,
+    });
+    await buildGroupUser({
+      teamId: user.teamId,
+      groupId: syncedGroup.id,
+      userId: user.id,
+      createdById: user.id,
+    });
+
+    const authProvider = (await AuthenticationProvider.findOne({
+      where: { teamId: user.teamId },
+    }))!;
+    await ExternalGroup.create({
+      externalId: "ext-1",
+      name: "Synced Group",
+      groupId: syncedGroup.id,
+      authenticationProviderId: authProvider.id,
+      teamId: user.teamId,
+    });
+
+    const res = await server.post("/api/groups.list", user, {
+      body: {
+        filters: [
+          { field: "userId", operator: "eq", value: user.id },
+          { field: "source", operator: "eq", value: authProvider.name },
+        ],
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.pagination.total).toEqual(1);
+    expect(body.data.groups[0].id).toEqual(syncedGroup.id);
+  });
+
+  it("should filter to manually created groups", async () => {
+    const user = await buildUser();
+    const group = await buildGroup({ teamId: user.teamId });
+    const syncedGroup = await buildGroup({ teamId: user.teamId });
+
+    const authProvider = (await AuthenticationProvider.findOne({
+      where: { teamId: user.teamId },
+    }))!;
+    await ExternalGroup.create({
+      externalId: "ext-1",
+      name: "Synced Group",
+      groupId: syncedGroup.id,
+      authenticationProviderId: authProvider.id,
+      teamId: user.teamId,
+    });
+
+    const res = await server.post("/api/groups.list", user, {
+      body: {
+        filters: [{ field: "source", operator: "eq", value: "manual" }],
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.pagination.total).toEqual(1);
+    expect(body.data.groups[0].id).toEqual(group.id);
+  });
+
+  it("should return every group as manual when none are synced", async () => {
+    const user = await buildUser();
+    await buildGroup({ teamId: user.teamId });
+    await buildGroup({ teamId: user.teamId });
+
+    const res = await server.post("/api/groups.list", user, {
+      body: {
+        filters: [{ field: "source", operator: "eq", value: "manual" }],
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.pagination.total).toEqual(2);
+  });
+
+  it("should support groups of conditions", async () => {
+    const user = await buildUser();
+    const group = await buildGroup({ teamId: user.teamId, name: "Engineers" });
+    const otherGroup = await buildGroup({
+      teamId: user.teamId,
+      name: "Designers",
+    });
+    await buildGroup({ teamId: user.teamId, name: "Marketing" });
+
+    const res = await server.post("/api/groups.list", user, {
+      body: {
+        filters: [
+          {
+            operator: "OR",
+            filters: [
+              { field: "name", operator: "eq", value: "Engineers" },
+              { field: "name", operator: "eq", value: "Designers" },
+            ],
+          },
+        ],
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(
+      body.data.groups.map((item: { id: string }) => item.id).sort()
+    ).toEqual([group.id, otherGroup.id].sort());
+  });
+
+  it("should filter by date", async () => {
+    const user = await buildUser();
+    await buildGroup({
+      teamId: user.teamId,
+      createdAt: new Date("2010-01-01T00:00:00.000Z"),
+    });
+    const group = await buildGroup({ teamId: user.teamId });
+
+    const res = await server.post("/api/groups.list", user, {
+      body: {
+        filters: [{ field: "createdAt", operator: "gte", value: "2018-01-01" }],
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.pagination.total).toEqual(1);
+    expect(body.data.groups[0].id).toEqual(group.id);
+  });
+
+  it("should allow filters combined with query", async () => {
+    const user = await buildUser();
+    const group = await buildGroup({ teamId: user.teamId, name: "Engineers" });
+    await buildGroup({ teamId: user.teamId, name: "Engineering managers" });
+
+    const res = await server.post("/api/groups.list", user, {
+      body: {
+        query: "engineer",
+        filters: [{ field: "name", operator: "eq", value: group.name }],
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.pagination.total).toEqual(1);
+    expect(body.data.groups[0].id).toEqual(group.id);
+  });
+
+  it("should not return groups from another team", async () => {
+    const user = await buildUser();
+    const group = await buildGroup({ teamId: user.teamId, name: "Engineers" });
+    const other = await buildUser();
+    await buildGroup({ teamId: other.teamId, name: "Engineers" });
+
+    const res = await server.post("/api/groups.list", user, {
+      body: {
+        filters: [{ field: "name", operator: "eq", value: "Engineers" }],
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.pagination.total).toEqual(1);
+    expect(body.data.groups[0].id).toEqual(group.id);
+  });
+
+  it("should reject a field that is not filterable", async () => {
+    const user = await buildUser();
+
+    const res = await server.post("/api/groups.list", user, {
+      body: {
+        filters: [{ field: "teamId", operator: "isNotNull" }],
+      },
+    });
+    expect(res.status).toEqual(400);
+  });
+
+  it("should reject an operator the field does not support", async () => {
+    const user = await buildUser();
+
+    const res = await server.post("/api/groups.list", user, {
+      body: {
+        filters: [{ field: "userId", operator: "isNull" }],
+      },
+    });
+    expect(res.status).toEqual(400);
+  });
+
+  it("should reject filters combined with deprecated parameters", async () => {
+    const user = await buildUser();
+
+    const res = await server.post("/api/groups.list", user, {
+      body: {
+        source: "manual",
+        filters: [{ field: "name", operator: "eq", value: "Engineers" }],
+      },
+    });
+    expect(res.status).toEqual(400);
+  });
+});
+
 describe("#groups.info", () => {
   it("should return group if admin", async () => {
     const user = await buildAdmin();

--- a/server/routes/api/groups/groups.ts
+++ b/server/routes/api/groups/groups.ts
@@ -1,7 +1,9 @@
 import Router from "koa-router";
+import { uniq } from "es-toolkit/compat";
 import type { WhereOptions } from "sequelize";
 import { Op } from "sequelize";
 import { MAX_AVATAR_DISPLAY } from "@shared/constants";
+import type { Filter } from "@shared/helpers/FilterHelper";
 import { GroupPermission, UserRole } from "@shared/types";
 import auth from "@server/middlewares/authentication";
 import { rateLimiter } from "@server/middlewares/rateLimiter";
@@ -14,6 +16,13 @@ import {
   ExternalGroup,
   AuthenticationProvider,
 } from "@server/models";
+import {
+  buildWhere,
+  collectEqValues,
+  combineFilters,
+  legacyGroupParamsToFilter,
+  replaceFieldInFilter,
+} from "@server/models/helpers/Filters";
 import { authorize } from "@server/policies";
 import { ValidationError } from "@server/errors";
 import {
@@ -29,6 +38,106 @@ import pagination from "../middlewares/pagination";
 import * as T from "./schema";
 
 const router = new Router();
+
+/** Value of the `source` filter field matching groups with no external link. */
+const MANUAL_SOURCE = "manual";
+
+/**
+ * Resolve the filter fields that do not map to a column of Group — `userId`
+ * and `source` — into `id` leaves the query layer can execute.
+ *
+ * @param filter the filter to resolve.
+ * @param teamId the team the request is scoped to.
+ * @returns the filter with both fields replaced.
+ */
+async function resolveGroupFilter(
+  filter: Filter,
+  teamId: string
+): Promise<Filter> {
+  let resolved = filter;
+
+  const userIds = uniq(collectEqValues(resolved, "userId"));
+  if (userIds.length) {
+    const groupUsers = await GroupUser.findAll({
+      attributes: ["groupId", "userId"],
+      where: { userId: userIds },
+    });
+
+    resolved = replaceFieldInFilter(resolved, "userId", (values) => ({
+      field: "id",
+      operator: "in",
+      value: uniq(
+        groupUsers
+          .filter((groupUser) => values.includes(groupUser.userId))
+          .map((groupUser) => groupUser.groupId)
+      ),
+    }));
+  }
+
+  const sources = uniq(collectEqValues(resolved, "source"));
+  if (sources.length) {
+    const externalGroups = await ExternalGroup.findAll({
+      attributes: ["groupId"],
+      where: {
+        teamId,
+        groupId: { [Op.ne]: null },
+      },
+      include: [
+        {
+          model: AuthenticationProvider,
+          as: "authenticationProvider",
+          attributes: ["name"],
+        },
+      ],
+    });
+
+    const syncedIds = uniq(
+      externalGroups
+        .map((externalGroup) => externalGroup.groupId)
+        .filter((id): id is string => id !== null)
+    );
+    const idsByProvider = new Map<string, string[]>();
+    for (const externalGroup of externalGroups) {
+      const provider = externalGroup.authenticationProvider?.name;
+      if (!provider || !externalGroup.groupId) {
+        continue;
+      }
+      idsByProvider.set(provider, [
+        ...(idsByProvider.get(provider) ?? []),
+        externalGroup.groupId,
+      ]);
+    }
+
+    resolved = replaceFieldInFilter(resolved, "source", (values) => {
+      const providerIds = uniq(
+        values
+          .filter((value) => value !== MANUAL_SOURCE)
+          .flatMap((value) => idsByProvider.get(value) ?? [])
+      );
+      const synced: Filter = {
+        field: "id",
+        operator: "in",
+        value: providerIds,
+      };
+
+      if (!values.includes(MANUAL_SOURCE)) {
+        return synced;
+      }
+
+      // With nothing synced every group is manual, which `notIn []` cannot
+      // express – every group has an id, so match on that instead.
+      const manual: Filter = syncedIds.length
+        ? { field: "id", operator: "notIn", value: syncedIds }
+        : { field: "id", operator: "isNotNull" };
+
+      return providerIds.length
+        ? { operator: "OR", filters: [manual, synced] }
+        : manual;
+    });
+  }
+
+  return resolved;
+}
 
 /** Standard include for loading ExternalGroup with its AuthenticationProvider. */
 const externalGroupInclude = {
@@ -50,81 +159,42 @@ router.post(
   pagination(),
   validate(T.GroupsListSchema),
   async (ctx: APIContext<T.GroupsListReq>) => {
-    const { sort, direction, query, userId, externalId, name, source } =
-      ctx.input.body;
+    const {
+      sort,
+      direction,
+      query,
+      userId,
+      externalId,
+      name,
+      source,
+      filters: rawFilters,
+    } = ctx.input.body;
     const { user } = ctx.state.auth;
     authorize(user, "listGroups", user.team);
 
-    let where: WhereOptions<Group> = {
+    const where: WhereOptions<Group> & {
+      [Op.and]: WhereOptions<Group>[];
+    } = {
       teamId: user.teamId,
+      [Op.and]: [],
     };
 
-    if (name) {
-      where = {
-        ...where,
-        name: {
-          [Op.eq]: name,
-        },
-      };
-    } else if (query) {
-      where = {
-        ...where,
-        name: { [Op.iLike]: QueryHelper.likeContains(query) },
-      };
-    }
+    // The schema rejects callers that combine `filters` with the deprecated
+    // top-level params, so exactly one of these is set.
+    const filter =
+      combineFilters(rawFilters) ??
+      legacyGroupParamsToFilter({ userId, externalId, name, source });
 
-    if (externalId) {
-      where = {
-        ...where,
-        externalId,
-      };
-    }
-
-    if (userId) {
-      const groupIds = await Group.filterByMember(userId)
-        .findAll({
-          attributes: ["id"],
-        })
-        .then((groups) => groups.map((g) => g.id));
-
-      where = {
-        ...where,
-        id: {
-          [Op.in]: groupIds,
-        },
-      };
-    }
-
-    if (source) {
-      const externalGroupWhere: WhereOptions<ExternalGroup> = {
-        teamId: user.teamId,
-        groupId: { [Op.ne]: null },
-      };
-
-      const sourceGroupIds = await ExternalGroup.findAll({
-        attributes: ["groupId"],
-        where: externalGroupWhere,
-        ...(source !== "manual" && {
-          include: [
-            {
-              model: AuthenticationProvider,
-              as: "authenticationProvider",
-              attributes: [],
-              where: { name: source },
-            },
-          ],
-        }),
-      }).then((egs) =>
-        egs.map((eg) => eg.groupId).filter((id): id is string => id !== null)
+    if (filter) {
+      where[Op.and].push(
+        buildWhere<Group>(await resolveGroupFilter(filter, user.teamId))
       );
+    }
 
-      where = {
-        ...where,
-        id: {
-          ...(where.id as object),
-          [source === "manual" ? Op.notIn : Op.in]: sourceGroupIds,
-        },
-      };
+    if (query) {
+      where[Op.and].push({
+        name: { [Op.iLike]: QueryHelper.likeContains(query) },
+      });
     }
 
     const [groups, total] = await Promise.all([

--- a/server/routes/api/groups/schema.ts
+++ b/server/routes/api/groups/schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { createFilterSchema } from "@shared/helpers/FilterHelper";
 import { GroupPermission } from "@shared/types";
 import { GroupValidation } from "@shared/validations";
 import { Group } from "@server/models";
@@ -8,36 +9,92 @@ const BaseIdSchema = z.object({
   id: z.uuid(),
 });
 
-export const GroupsListSchema = z.object({
-  body: z.object({
-    /** Groups sorting direction */
-    direction: z
-      .string()
-      .optional()
-      .transform((val) => (val !== "ASC" ? "DESC" : val)),
-    /** Groups sorting column */
-    sort: z
-      .string()
-      .refine(
-        (val) =>
-          Object.keys(Group.getAttributes()).includes(val) || val === "source",
-        {
-          error: "Invalid sort parameter",
-        }
-      )
-      .prefault("updatedAt"),
-    /** Only list groups where this user is a member */
-    userId: z.uuid().optional(),
-    /** Find group matching externalId */
-    externalId: z.string().optional(),
-    /** @deprecated Find group with matching name */
-    name: z.string().optional(),
-    /** Filter groups by source: "manual" for non-synced, or a provider name */
-    source: z.string().optional(),
-    /** Find group matching query */
-    query: z.string().optional(),
-  }),
-});
+const groupFilterFields = {
+  id: { kind: "uuid", operators: ["eq", "neq", "in", "notIn"] },
+  name: "string",
+  description: "string",
+  externalId: "string",
+  createdAt: "date",
+  updatedAt: "date",
+  // `userId` scopes results to the groups that user is a member of, and
+  // `source` to the provider a group is synced from. Neither is a column, so
+  // both are resolved to group ids by the route handler, which only supports
+  // `eq` and `in`.
+  userId: { kind: "uuid", operators: ["eq", "in"] },
+  source: { kind: "string", operators: ["eq", "in"] },
+} as const;
+
+const groupListFilter = createFilterSchema(groupFilterFields);
+
+export const GroupsListSchema = z
+  .object({
+    body: z.object({
+      /** Groups sorting direction */
+      direction: z
+        .string()
+        .optional()
+        .transform((val) => (val !== "ASC" ? "DESC" : val)),
+      /** Groups sorting column */
+      sort: z
+        .string()
+        .refine(
+          (val) =>
+            Object.keys(Group.getAttributes()).includes(val) ||
+            val === "source",
+          {
+            error: "Invalid sort parameter",
+          }
+        )
+        .prefault("updatedAt"),
+
+      /**
+       * Only list groups where this user is a member.
+       * @deprecated use `filters` with field `userId` instead.
+       */
+      userId: z.uuid().optional(),
+
+      /**
+       * Find group matching externalId.
+       * @deprecated use `filters` with field `externalId` instead.
+       */
+      externalId: z.string().optional(),
+
+      /**
+       * Find group with matching name.
+       * @deprecated use `filters` with field `name` instead.
+       */
+      name: z.string().optional(),
+
+      /**
+       * Filter groups by source: "manual" for non-synced, or a provider name.
+       * @deprecated use `filters` with field `source` instead.
+       */
+      source: z.string().optional(),
+
+      /** Search term matched against group name */
+      query: z.string().optional(),
+
+      /**
+       * List of filter expressions. Implicit AND between top-level entries.
+       *
+       * The `source` field accepts a provider name, or "manual" for groups
+       * that are not synced from any provider.
+       */
+      filters: groupListFilter.FilterListSchema.optional(),
+    }),
+  })
+  .refine(
+    (req) =>
+      req.body.filters === undefined ||
+      (req.body.userId === undefined &&
+        req.body.externalId === undefined &&
+        req.body.name === undefined &&
+        req.body.source === undefined),
+    {
+      message:
+        "filters cannot be combined with deprecated parameters userId, externalId, name, or source",
+    }
+  );
 
 export type GroupsListReq = z.infer<typeof GroupsListSchema>;
 


### PR DESCRIPTION
Extends the filter expression language already used by documents.list and users.list to `groups.list`.

- Adds `filters` over an allowlist of id, name, description, externalId, createdAt, updatedAt, userId and source
- Deprecates the userId, externalId, name and source parameters — they now translate into the DSL, so a single path builds the query, and combining them with the new parameter is rejected
- The userId and source fields are resolved to group ids by the route, sharing the leaf replacement helper with documentId expansion
- Fixes a membership filter being overwritten when combined with a source filter, and source "manual" matching nothing when no groups are synced
- The Groups settings screen sends the new parameter

Follow up to https://github.com/outline/outline/pull/13456