### PR TITLE
fix: Sticky hash prevents re-scroll to TOC heading

### DIFF
--- a/app/editor/index.tsx
+++ b/app/editor/index.tsx
@@ -582,6 +582,13 @@ export class Editor extends React.PureComponent<
     return view;
   }
 
+  /**
+   * Scroll the document to the element matching the given selector, waiting for
+   * it to be added to the DOM if it is not rendered yet.
+   *
+   * @param hash the selector to scroll to, typically a heading id prefixed
+   * with #.
+   */
   public async scrollToAnchor(hash: string) {
     if (!hash) {
       return;

--- a/app/scenes/Document/components/Contents.tsx
+++ b/app/scenes/Document/components/Contents.tsx
@@ -23,7 +23,8 @@ function Contents() {
   const scrollPosition = useWindowScrollPosition({
     throttle: 100,
   });
-  const { headings } = useDocumentContext();
+  const documentContext = useDocumentContext();
+  const { headings } = documentContext;
   const itemRefs = useRef<Record<string, HTMLLIElement | null>>({});
 
   // A heading chosen from the contents stays highlighted until the reader
@@ -52,8 +53,12 @@ function Contents() {
       event.preventDefault();
       setSelectedSlug(id);
       history.push(patchLocation(history.location, { hash: `#${id}` }));
+
+      // Scroll from here rather than relying on the hash changing, so that
+      // clicking the same heading again still moves the reader to it.
+      void documentContext.editor?.scrollToAnchor(`#${id}`);
     },
-    [history]
+    [history, documentContext]
   );
 
   useEffect(() => {

--- a/app/scenes/Document/components/Editor.tsx
+++ b/app/scenes/Document/components/Editor.tsx
@@ -2,7 +2,7 @@ import { observer } from "mobx-react";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { mergeRefs } from "react-merge-refs";
-import { useRouteMatch } from "react-router-dom";
+import { useLocation, useRouteMatch } from "react-router-dom";
 import styled from "styled-components";
 import Text from "@shared/components/Text";
 import type { CommentAnchor } from "@shared/editor/commands/comment";
@@ -70,6 +70,7 @@ function DocumentEditor(props: Props, ref: React.ForwardedRef<SharedEditor>) {
   const titleRef = React.useRef<RefHandle>(null);
   const { t } = useTranslation();
   const match = useRouteMatch();
+  const location = useLocation();
   const { setFocusedCommentId } = useDocumentContext();
   const focusedComment = useFocusedComment();
   const { ui, comments } = useStores();
@@ -258,7 +259,7 @@ function DocumentEditor(props: Props, ref: React.ForwardedRef<SharedEditor>) {
         lang={getLangFor(document.language)}
         autoFocus={!!document.title && !props.defaultValue}
         placeholder={t("Type '/' to insert, or start writing…")}
-        scrollTo={decodeURIComponentSafe(window.location.hash)}
+        scrollTo={decodeURIComponentSafe(location.hash)}
         readOnly={readOnly}
         userId={user?.id}
         focusedCommentId={focusedComment?.id}


### PR DESCRIPTION
closes #13428