### PR TITLE
fix: Serialize external mentions as links in exported markdown

### DIFF
--- a/server/models/helpers/DocumentHelper.tsx
+++ b/server/models/helpers/DocumentHelper.tsx
@@ -296,6 +296,12 @@ export class DocumentHelper {
       signedUrls?: number;
       /** The team context */
       teamId?: string;
+      /**
+       * Whether the Markdown is leaving Outline, in which case portable
+       * CommonMark is written in place of Outline's internal representation
+       * (default: false)
+       */
+      commonMark?: boolean;
     }
   ) {
     let node = DocumentHelper.toProsemirror(document);
@@ -310,7 +316,7 @@ export class DocumentHelper {
     }
 
     const text = serializer
-      .serialize(node)
+      .serialize(node, { commonMark: options?.commonMark })
       .replace(/(^|\n)\\(\n|$)/g, "\n\n")
       .trim();
 

--- a/server/queues/tasks/ExportDocumentTreeTask.ts
+++ b/server/queues/tasks/ExportDocumentTreeTask.ts
@@ -68,7 +68,7 @@ export default abstract class ExportDocumentTreeTask extends ExportTask {
     let text =
       format === FileOperationFormat.HTMLZip
         ? await DocumentHelper.toHTML(document, { centered: true })
-        : await DocumentHelper.toMarkdown(document);
+        : await DocumentHelper.toMarkdown(document, { commonMark: true });
 
     const isTextBundle = format === FileOperationFormat.TextBundleZip;
 

--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -996,6 +996,7 @@ router.post(
       DocumentHelper.toMarkdown(document, {
         signedUrls,
         teamId: user.teamId,
+        commonMark: true,
       });
 
     // A TextBundle is a directory of files, so unlike the other formats it has

--- a/server/routes/api/revisions/revisions.ts
+++ b/server/routes/api/revisions/revisions.ts
@@ -170,10 +170,12 @@ router.post(
       );
     } else if (isTextBundle || accept?.includes("text/markdown")) {
       contentType = "text/markdown";
-      content = await DocumentHelper.toMarkdown(revision);
+      content = await DocumentHelper.toMarkdown(revision, {
+        commonMark: true,
+      });
     } else {
       ctx.body = {
-        data: await DocumentHelper.toMarkdown(revision),
+        data: await DocumentHelper.toMarkdown(revision, { commonMark: true }),
       };
       return;
     }

--- a/server/routes/app.ts
+++ b/server/routes/app.ts
@@ -263,6 +263,7 @@ export const renderShare = async (ctx: Context, next: Next) => {
       includeTitle: true,
       signedUrls: 86400, // 24 hours
       teamId: team?.id,
+      commonMark: true,
     });
 
     // Append child documents list if the share includes them

--- a/shared/editor/nodes/Mention.test.ts
+++ b/shared/editor/nodes/Mention.test.ts
@@ -1,0 +1,151 @@
+import { MentionType } from "../../types";
+import { schema, serializer } from "../../test/editor";
+
+const id = "0c440212-8b40-49fa-8a64-2548d6b60d59";
+const modelId = "c85a0d80-3a89-4b25-a0cd-e7fc83f0d226";
+
+const serializeMention = (
+  attrs: Record<string, unknown>,
+  options?: { commonMark?: boolean }
+) => {
+  const doc = schema.nodeFromJSON({
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [{ type: "mention", attrs: { id, modelId, ...attrs } }],
+      },
+    ],
+  });
+  return serializer.serialize(doc, options).trim();
+};
+
+describe("Mention serialization", () => {
+  describe("markdown leaving Outline", () => {
+    it("serializes an issue mention as a link to the external url", () => {
+      expect(
+        serializeMention(
+          {
+            type: MentionType.Issue,
+            label: "Epic 1: Control plane Helm chart",
+            href: "https://github.com/acme/infra/issues/2",
+          },
+          { commonMark: true }
+        )
+      ).toBe(
+        "[Epic 1: Control plane Helm chart](https://github.com/acme/infra/issues/2)"
+      );
+    });
+
+    it("serializes a pull request mention as a link to the external url", () => {
+      expect(
+        serializeMention(
+          {
+            type: MentionType.PullRequest,
+            label: "Add Helm chart",
+            href: "https://github.com/acme/infra/pull/42",
+          },
+          { commonMark: true }
+        )
+      ).toBe("[Add Helm chart](https://github.com/acme/infra/pull/42)");
+    });
+
+    it("serializes a project mention as a link to the external url", () => {
+      expect(
+        serializeMention(
+          {
+            type: MentionType.Project,
+            label: "Q3 Roadmap",
+            href: "https://github.com/orgs/acme/projects/7",
+          },
+          { commonMark: true }
+        )
+      ).toBe("[Q3 Roadmap](https://github.com/orgs/acme/projects/7)");
+    });
+
+    it("sanitizes an unsafe url", () => {
+      const markdown = serializeMention(
+        {
+          type: MentionType.Issue,
+          label: "Epic 1",
+          // oxlint-disable-next-line no-script-url
+          href: "javascript:alert(1)",
+        },
+        { commonMark: true }
+      );
+      expect(markdown).not.toContain("(javascript:");
+    });
+
+    it("keeps the mention:// format when there is no url to link to", () => {
+      expect(
+        serializeMention(
+          { type: MentionType.Issue, label: "Epic 1" },
+          { commonMark: true }
+        )
+      ).toBe(`@[Epic 1](mention://${id}/issue/${modelId})`);
+    });
+
+    it("keeps the mention:// format for internal mentions", () => {
+      expect(
+        serializeMention(
+          { type: MentionType.User, label: "John Doe" },
+          { commonMark: true }
+        )
+      ).toBe(`@[John Doe](mention://${id}/user/${modelId})`);
+    });
+  });
+
+  describe("markdown staying within Outline", () => {
+    it("keeps the mention:// format for an issue mention", () => {
+      expect(
+        serializeMention({
+          type: MentionType.Issue,
+          label: "Epic 1: Control plane Helm chart",
+          href: "https://github.com/acme/infra/issues/2",
+        })
+      ).toBe(
+        `@[Epic 1: Control plane Helm chart](mention://${id}/issue/${modelId})`
+      );
+    });
+
+    it("keeps the mention:// format for a pull request mention", () => {
+      expect(
+        serializeMention({
+          type: MentionType.PullRequest,
+          label: "Add Helm chart",
+          href: "https://github.com/acme/infra/pull/42",
+        })
+      ).toBe(`@[Add Helm chart](mention://${id}/pull_request/${modelId})`);
+    });
+
+    it("keeps the mention:// format for a project mention", () => {
+      expect(
+        serializeMention({
+          type: MentionType.Project,
+          label: "Q3 Roadmap",
+          href: "https://github.com/orgs/acme/projects/7",
+        })
+      ).toBe(`@[Q3 Roadmap](mention://${id}/project/${modelId})`);
+    });
+  });
+
+  describe("document and collection mentions", () => {
+    it("serializes a document mention as an internal link", () => {
+      expect(
+        serializeMention(
+          { type: MentionType.Document, label: "Onboarding" },
+          { commonMark: true }
+        )
+      ).toBe(`[Onboarding](/doc/${modelId})`);
+    });
+
+    it("serializes a collection mention as an internal link", () => {
+      expect(
+        serializeMention(
+          { type: MentionType.Collection, label: "Engineering" },
+          { commonMark: true }
+        )
+      ).toBe(`[Engineering](/collection/${modelId})`);
+    });
+  });
+});

--- a/shared/editor/nodes/Mention.tsx
+++ b/shared/editor/nodes/Mention.tsx
@@ -277,10 +277,10 @@ export default class Mention extends Node {
         ) {
           const mentionType = selection.node.attrs.type;
 
-          let link: string;
+          let link: string | undefined;
 
           if (isExternalMention(mentionType)) {
-            link = selection.node.attrs.href;
+            link = sanitizeUrl(selection.node.attrs.href);
           } else {
             const { modelId } = selection.node.attrs;
 
@@ -296,7 +296,9 @@ export default class Mention extends Node {
             }`;
           }
 
-          this.editor.props.onClickLink?.(link);
+          if (link) {
+            this.editor.props.onClickLink?.(link);
+          }
           return true;
         }
         return false;

--- a/shared/editor/nodes/Mention.tsx
+++ b/shared/editor/nodes/Mention.tsx
@@ -49,6 +49,22 @@ function dateMentionLabel(node: ProsemirrorNode): string {
     : node.attrs.label;
 }
 
+/**
+ * Whether a mention points at a resource outside of Outline, in which case the
+ * real URL is stored in `attrs.href` rather than addressed with a `mention://`
+ * reference.
+ *
+ * @param type the mention type.
+ * @returns true if the mention links to an external URL.
+ */
+function isExternalMention(type: MentionType): boolean {
+  return (
+    type === MentionType.Issue ||
+    type === MentionType.PullRequest ||
+    type === MentionType.Project
+  );
+}
+
 export default class Mention extends Node {
   get name() {
     return "mention";
@@ -148,12 +164,9 @@ export default class Mention extends Node {
           "data-id": node.attrs.modelId,
           "data-actorid": node.attrs.actorId,
           "data-anchor-id": node.attrs.anchorId,
-          "data-url":
-            node.attrs.type === MentionType.PullRequest ||
-            node.attrs.type === MentionType.Issue ||
-            node.attrs.type === MentionType.Project
-              ? sanitizeUrl(node.attrs.href)
-              : `mention://${node.attrs.id}/${node.attrs.type}/${node.attrs.modelId}`,
+          "data-url": isExternalMention(node.attrs.type)
+            ? sanitizeUrl(node.attrs.href)
+            : `mention://${node.attrs.id}/${node.attrs.type}/${node.attrs.modelId}`,
           "data-unfurl": JSON.stringify(node.attrs.unfurl),
         },
         toPlainText(node),
@@ -266,11 +279,7 @@ export default class Mention extends Node {
 
           let link: string;
 
-          if (
-            mentionType === MentionType.Issue ||
-            mentionType === MentionType.PullRequest ||
-            mentionType === MentionType.Project
-          ) {
+          if (isExternalMention(mentionType)) {
             link = selection.node.attrs.href;
           } else {
             const { modelId } = selection.node.attrs;
@@ -376,8 +385,17 @@ export default class Mention extends Node {
       );
     } else if (mType === MentionType.Collection) {
       state.write(`[${label}](/collection/${mId})`);
+    } else if (
+      state.options.commonMark &&
+      isExternalMention(mType) &&
+      node.attrs.href
+    ) {
+      // Markdown that leaves Outline cannot resolve a mention:// reference, so
+      // external mentions fall back to the URL they already carry.
+      state.write(`[${label}](${sanitizeUrl(node.attrs.href)})`);
     } else {
-      // Keep the existing mention:// format for other types (user, group, issue, pull_request, url)
+      // Keep the mention:// format for everything else, it round-trips back
+      // into a live mention through Outline's own parser.
       state.write(`@[${label}](mention://${id}/${mType}/${mId})`);
     }
   }


### PR DESCRIPTION
Issues, pull requests, and project mentions carry the real URL, but always serialized to a `mention://` reference that nothing outside of Outline can resolve.

- Write a plain markdown link for these mentions when the `commonMark` serializer option is set, falling back to the existing reference when there is no url
- Set that option on the paths where markdown leaves the platform – document and revision export, zip exports, and the public share markdown response
- Internal paths keep the existing format, so MCP reads, the API text field and stored document text are unchanged

Closes #13053
Supersedes #13054