### PR TITLE
fix: Hide inapplicable options in the menu for deleted documents

### DIFF
--- a/app/actions/definitions/documents.tsx
+++ b/app/actions/definitions/documents.tsx
@@ -279,8 +279,12 @@ function findDocumentSiblingIndex(
  */
 function canCreateSiblingDocument(
   stores: ActionContext["stores"],
-  document: { collectionId?: string | null; parentDocumentId?: string }
+  document: Document
 ): boolean {
+  if (document.isDeleted) {
+    return false;
+  }
+
   return document.parentDocumentId
     ? stores.policies.abilities(document.parentDocumentId).createChildDocument
     : !!document.collectionId &&
@@ -418,6 +422,9 @@ export const createNewDocument = createActionWithChildren({
     if (!stores.policies.abilities(currentTeamId).createDocument) {
       return false;
     }
+    if (stores.documents.get(activeDocumentId)?.isDeleted) {
+      return false;
+    }
     return !isAlphabeticallySorted(stores, activeDocumentId);
   },
   children: [createDocumentBefore, createDocumentAfter, createNestedDocument],
@@ -466,6 +473,7 @@ export const starDocument = createAction({
       Document,
       (document) =>
         !document.isStarred &&
+        !document.isDeleted &&
         context.stores.policies.abilities(document.id).star
     ),
   perform: async (context) => {
@@ -1695,7 +1703,13 @@ export const toggleDocumentStats = createAction({
   icon: <HashtagIcon />,
   selected: ({ stores }) =>
     !!stores.auth.user?.getPreference(UserPreference.ShowDocumentStats),
-  visible: ({ activeDocumentId }) => !!activeDocumentId && !isMobile(),
+  visible: ({ activeDocumentId, stores }) => {
+    const document = activeDocumentId
+      ? stores.documents.get(activeDocumentId)
+      : undefined;
+
+    return !!activeDocumentId && !document?.isDeleted && !isMobile();
+  },
   perform: async ({ stores }) => {
     const { user } = stores.auth;
     if (!user) {

--- a/app/scenes/Document/components/Footer.tsx
+++ b/app/scenes/Document/components/Footer.tsx
@@ -21,7 +21,9 @@ type Props = {
 
 export const Footer = observer(({ document }: Props) => {
   const user = useCurrentUser({ rejectOnEmpty: false });
-  const showStats = !!user?.getPreference(UserPreference.ShowDocumentStats);
+  const showStats =
+    !!user?.getPreference(UserPreference.ShowDocumentStats) &&
+    !document.isDeleted;
   const context = useActionContext();
 
   const handleToggleStats = useCallback(

--- a/app/scenes/Document/components/Footer.tsx
+++ b/app/scenes/Document/components/Footer.tsx
@@ -28,6 +28,10 @@ export const Footer = observer(({ document }: Props) => {
 
   const handleToggleStats = useCallback(
     (event: KeyboardEvent) => {
+      if (document.isDeleted) {
+        return;
+      }
+
       // The command bar handles this shortcut everywhere else, it ignores
       // keystrokes while focus is in a text input.
       const target = event.target;
@@ -37,7 +41,7 @@ export const Footer = observer(({ document }: Props) => {
       event.preventDefault();
       void performAction(toggleDocumentStats, context);
     },
-    [context]
+    [context, document.isDeleted]
   );
 
   useKeyDown("g", handleToggleStats, { metaKey: true, shiftKey: true });


### PR DESCRIPTION
Documents in the trash showed menu items that cannot apply to them.

- Hides Star, "New document" (and its Before/After children), and "Show editing stats" for a deleted document
- Hides the editing stats display in the document footer for a deleted document