### PR TITLE
fix: Stabilize signed attachment urls so browser caches can be reused

### DIFF
--- a/server/routes/app.ts
+++ b/server/routes/app.ts
@@ -11,6 +11,7 @@ import {
   type NavigationNode,
 } from "@shared/types";
 import { unicodeCLDRtoISO639 } from "@shared/utils/date";
+import { Hour } from "@shared/utils/time";
 import env from "@server/env";
 import { allowScriptSrc } from "@server/middlewares/csp";
 import { Integration } from "@server/models";
@@ -309,7 +310,7 @@ export const renderShare = async (ctx: Context, next: Next) => {
           includeStyles: false,
           includeHead: false,
           includeTitle: true,
-          signedUrls: true,
+          signedUrls: Hour.seconds,
         })
       : undefined;
 

--- a/server/storage/files/BaseStorage.test.ts
+++ b/server/storage/files/BaseStorage.test.ts
@@ -1,3 +1,4 @@
+import { Hour, Minute, Week } from "@shared/utils/time";
 import BaseStorage from "./BaseStorage";
 import env from "@server/env";
 
@@ -63,9 +64,41 @@ class MockStorage extends BaseStorage {
   async moveFile() {}
 
   async deleteFile() {}
+
+  static signingDateFor(expiresIn: number) {
+    return MockStorage.getSigningDate(expiresIn);
+  }
 }
 
 describe("BaseStorage", () => {
+  describe("getSigningDate", () => {
+    it("should return the same date for calls within a window", () => {
+      const first = MockStorage.signingDateFor(Hour.seconds);
+      const second = MockStorage.signingDateFor(Hour.seconds);
+      expect(second.getTime()).toBe(first.getTime());
+    });
+
+    it("should align to a window no longer than half the lifetime", () => {
+      const expiresIn = 10 * Minute.seconds;
+      const signingDate = MockStorage.signingDateFor(expiresIn);
+      const elapsed = Date.now() - signingDate.getTime();
+      expect(elapsed).toBeGreaterThanOrEqual(0);
+      expect(elapsed).toBeLessThanOrEqual((expiresIn / 2) * 1000);
+    });
+
+    it("should cap the window so long lifetimes stay predictable", () => {
+      const signingDate = MockStorage.signingDateFor(Week.seconds);
+      const elapsed = Date.now() - signingDate.getTime();
+      expect(elapsed).toBeLessThanOrEqual(BaseStorage.maxSigningWindow * 1000);
+    });
+
+    it("should not align a lifetime too short to divide", () => {
+      const before = Date.now();
+      const signingDate = MockStorage.signingDateFor(1);
+      expect(signingDate.getTime()).toBeGreaterThanOrEqual(before);
+    });
+  });
+
   describe("getPresignedPut", () => {
     it("should return undefined from default implementation", async () => {
       const storage = new MockStorage();

--- a/server/storage/files/BaseStorage.test.ts
+++ b/server/storage/files/BaseStorage.test.ts
@@ -72,30 +72,60 @@ class MockStorage extends BaseStorage {
 
 describe("BaseStorage", () => {
   describe("getSigningDate", () => {
+    // A time deliberately offset from a window boundary, so that rounding is
+    // exercised and two calls cannot straddle a boundary.
+    const now = new Date("2026-04-16T12:07:31.500Z");
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(now);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     it("should return the same date for calls within a window", () => {
       const first = MockStorage.signingDateFor(Hour.seconds);
+      vi.setSystemTime(new Date("2026-04-16T12:08:01.500Z"));
       const second = MockStorage.signingDateFor(Hour.seconds);
       expect(second.getTime()).toBe(first.getTime());
     });
 
+    it("should round down to the start of the window", () => {
+      // The window is capped at 15 minutes, so 12:07:31.500 rounds to 12:00.
+      const signingDate = MockStorage.signingDateFor(Hour.seconds);
+      expect(signingDate.toISOString()).toBe("2026-04-16T12:00:00.000Z");
+    });
+
+    it("should move to the next window once the boundary passes", () => {
+      const first = MockStorage.signingDateFor(Hour.seconds);
+      vi.setSystemTime(new Date("2026-04-16T12:22:31.500Z"));
+      const second = MockStorage.signingDateFor(Hour.seconds);
+      expect(second.getTime()).toBeGreaterThan(first.getTime());
+    });
+
     it("should align to a window no longer than half the lifetime", () => {
+      // The lifetime is shorter than the cap, so the window halves to 5
+      // minutes and 12:07:31.500 rounds to 12:05.
       const expiresIn = 10 * Minute.seconds;
       const signingDate = MockStorage.signingDateFor(expiresIn);
-      const elapsed = Date.now() - signingDate.getTime();
+      const elapsed = now.getTime() - signingDate.getTime();
+
+      expect(signingDate.toISOString()).toBe("2026-04-16T12:05:00.000Z");
       expect(elapsed).toBeGreaterThanOrEqual(0);
       expect(elapsed).toBeLessThanOrEqual((expiresIn / 2) * 1000);
     });
 
     it("should cap the window so long lifetimes stay predictable", () => {
       const signingDate = MockStorage.signingDateFor(Week.seconds);
-      const elapsed = Date.now() - signingDate.getTime();
+      const elapsed = now.getTime() - signingDate.getTime();
       expect(elapsed).toBeLessThanOrEqual(BaseStorage.maxSigningWindow * 1000);
     });
 
     it("should not align a lifetime too short to divide", () => {
-      const before = Date.now();
       const signingDate = MockStorage.signingDateFor(1);
-      expect(signingDate.getTime()).toBeGreaterThanOrEqual(before);
+      expect(signingDate.getTime()).toBe(now.getTime());
     });
   });
 

--- a/server/storage/files/BaseStorage.ts
+++ b/server/storage/files/BaseStorage.ts
@@ -7,7 +7,7 @@ import { omit } from "es-toolkit/compat";
 import { toError, errToString } from "@shared/utils/error";
 import FileHelper from "@shared/editor/lib/FileHelper";
 import { isBase64Url, isInternalUrl } from "@shared/utils/urls";
-import { Week } from "@shared/utils/time";
+import { Minute, Week } from "@shared/utils/time";
 import env from "@server/env";
 import Logger from "@server/logging/Logger";
 import type { RequestInit } from "@server/utils/fetch";
@@ -23,6 +23,40 @@ export default abstract class BaseStorage {
    * AWS S3 Signature V4 presigned URLs must have an expiration date less than one week in the future.
    */
   public static maxSignedUrlExpires = Week.seconds;
+
+  /**
+   * The longest period over which the signing timestamp is held constant. See
+   * `getSigningDate` for why this matters.
+   */
+  public static maxSigningWindow = 15 * Minute.seconds;
+
+  /**
+   * Rounds the current time down to a fixed window so that repeated signatures
+   * of the same file produce an identical URL. Without this every signature is
+   * unique and caches can never be reused, which means the same file is
+   * downloaded again for each URL.
+   *
+   * The window never exceeds half of the requested lifetime, so a returned URL
+   * is always valid for at least half of `expiresIn`. Because the window only
+   * moves the signing time backwards, a URL never outlives the lifetime it
+   * would have had without it.
+   *
+   * @param expiresIn The number of seconds until the signed URL expires.
+   * @returns The timestamp to sign with.
+   */
+  protected static getSigningDate(expiresIn: number): Date {
+    const window = Math.min(
+      BaseStorage.maxSigningWindow,
+      Math.floor(expiresIn / 2)
+    );
+
+    if (window < 1) {
+      return new Date();
+    }
+
+    const windowMs = window * 1000;
+    return new Date(Math.floor(Date.now() / windowMs) * windowMs);
+  }
 
   /**
    * Returns a presigned post for uploading files to the storage provider.

--- a/server/storage/files/LocalStorage.test.ts
+++ b/server/storage/files/LocalStorage.test.ts
@@ -1,0 +1,45 @@
+import JWT from "jsonwebtoken";
+import { Hour } from "@shared/utils/time";
+import env from "@server/env";
+import LocalStorage from "./LocalStorage";
+
+describe("LocalStorage", () => {
+  describe("getSignedUrl", () => {
+    it("should return an identical url for repeated calls", async () => {
+      const storage = new LocalStorage();
+      const first = await storage.getSignedUrl(
+        "uploads/test.png",
+        Hour.seconds
+      );
+      const second = await storage.getSignedUrl(
+        "uploads/test.png",
+        Hour.seconds
+      );
+
+      expect(second).toBe(first);
+    });
+
+    it("should return a different url for a different key", async () => {
+      const storage = new LocalStorage();
+      const first = await storage.getSignedUrl("uploads/one.png", Hour.seconds);
+      const second = await storage.getSignedUrl(
+        "uploads/two.png",
+        Hour.seconds
+      );
+
+      expect(second).not.toBe(first);
+    });
+
+    it("should remain valid for at least half of the requested lifetime", async () => {
+      const storage = new LocalStorage();
+      const url = await storage.getSignedUrl("uploads/test.png", Hour.seconds);
+      const sig = new URL(url).searchParams.get("sig");
+
+      const payload = JWT.verify(sig!, env.SECRET_KEY) as { exp: number };
+      const remaining = payload.exp - Math.floor(Date.now() / 1000);
+
+      expect(remaining).toBeGreaterThanOrEqual(Hour.seconds / 2);
+      expect(remaining).toBeLessThanOrEqual(Hour.seconds);
+    });
+  });
+});

--- a/server/storage/files/LocalStorage.test.ts
+++ b/server/storage/files/LocalStorage.test.ts
@@ -5,12 +5,27 @@ import LocalStorage from "./LocalStorage";
 
 describe("LocalStorage", () => {
   describe("getSignedUrl", () => {
+    // A time deliberately offset from a window boundary, so that rounding is
+    // exercised and two calls cannot straddle a boundary.
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-04-16T12:07:31.500Z"));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     it("should return an identical url for repeated calls", async () => {
       const storage = new LocalStorage();
       const first = await storage.getSignedUrl(
         "uploads/test.png",
         Hour.seconds
       );
+
+      // Move on within the same window, which is what separates the server
+      // rendered page from the API request that follows it.
+      vi.setSystemTime(new Date("2026-04-16T12:08:01.500Z"));
       const second = await storage.getSignedUrl(
         "uploads/test.png",
         Hour.seconds
@@ -24,6 +39,22 @@ describe("LocalStorage", () => {
       const first = await storage.getSignedUrl("uploads/one.png", Hour.seconds);
       const second = await storage.getSignedUrl(
         "uploads/two.png",
+        Hour.seconds
+      );
+
+      expect(second).not.toBe(first);
+    });
+
+    it("should return a different url once the window has passed", async () => {
+      const storage = new LocalStorage();
+      const first = await storage.getSignedUrl(
+        "uploads/test.png",
+        Hour.seconds
+      );
+
+      vi.setSystemTime(new Date("2026-04-16T12:22:31.500Z"));
+      const second = await storage.getSignedUrl(
+        "uploads/test.png",
         Hour.seconds
       );
 

--- a/server/storage/files/LocalStorage.ts
+++ b/server/storage/files/LocalStorage.ts
@@ -117,6 +117,9 @@ export default class LocalStorage extends BaseStorage {
       {
         key,
         type: "attachment",
+        iat: Math.floor(
+          LocalStorage.getSigningDate(expiresIn).getTime() / 1000
+        ),
       },
       env.SECRET_KEY,
       {

--- a/server/storage/files/S3Storage.ts
+++ b/server/storage/files/S3Storage.ts
@@ -220,7 +220,9 @@ export default class S3Storage extends BaseStorage {
           url: cfUrl,
           keyPairId: env.AWS_CLOUDFRONT_KEY_PAIR_ID,
           privateKey,
-          dateLessThan: new Date(Date.now() + expiresIn * 1000).toISOString(),
+          dateLessThan: new Date(
+            S3Storage.getSigningDate(expiresIn).getTime() + expiresIn * 1000
+          ).toISOString(),
         });
       } catch (err) {
         Logger.error(
@@ -425,6 +427,7 @@ export default class S3Storage extends BaseStorage {
     const command = new sdk.GetObjectCommand(params);
     const url = await getSignedUrl(client, command, {
       expiresIn: clampedExpiresIn,
+      signingDate: S3Storage.getSigningDate(clampedExpiresIn),
     });
 
     if (env.AWS_S3_ACCELERATE_URL) {


### PR DESCRIPTION
Every call to `getSignedUrl` produced a unique signature, so the same attachment was downloaded again for every URL. On a public share the first image was fetched twice at full size — once by the preload scanner from the server-rendered HTML, then again when the client rendered the document from the API response.

- Round the signing timestamp down to a window so repeated signatures of the same key are identical
- The window is capped at half the requested lifetime, so a URL stays valid for at least half of `expiresIn` and never outlives the lifetime it had before
- Applied to the S3 presigner, CloudFront, and the JWT used by local storage
- Sign the share page HTML with the same lifetime the API presenter uses, so the two agree