### PR TITLE
fix: Rendering of PDF previews in server-side document HTML

### DIFF
--- a/server/models/helpers/ProseMirrorHelper.test.ts
+++ b/server/models/helpers/ProseMirrorHelper.test.ts
@@ -53,6 +53,31 @@ describe("ProsemirrorHelper", () => {
       expect(html).not.toContain('contenteditable="true"');
     });
 
+    it("should render a pdf attachment preview", async () => {
+      const doc = Node.fromJSON(schema, {
+        type: "doc",
+        content: [
+          {
+            type: "attachment",
+            attrs: {
+              id: "8f0e2a1c-1f2b-4c3d-9e4f-5a6b7c8d9e0f",
+              href: "https://example.com/file.pdf",
+              title: "file.pdf",
+              size: 1024,
+              preview: true,
+              contentType: "application/pdf",
+            },
+          },
+        ],
+      });
+      const html = await ProsemirrorHelper.toHTML(doc, {
+        includeStyles: false,
+        includeHead: false,
+      });
+      expect(html).toContain("<embed");
+      expect(html).toContain("https://example.com/file.pdf");
+    });
+
     it("should include styles of rendered components", async () => {
       const doc = Node.fromJSON(schema, {
         type: "doc",

--- a/server/models/helpers/ProsemirrorHelper.tsx
+++ b/server/models/helpers/ProsemirrorHelper.tsx
@@ -88,6 +88,20 @@ export type MentionAttrs = {
 
 const pluginsWithSafeDecorations = new WeakSet<Plugin>();
 
+// jsdom does not implement ResizeObserver, and the exported document never
+// resizes, so components that observe their element on mount get a no-op.
+class NoopResizeObserver implements ResizeObserver {
+  public observe() {
+    // noop
+  }
+  public unobserve() {
+    // noop
+  }
+  public disconnect() {
+    // noop
+  }
+}
+
 // KaTeX renders math server-side during HTML export, but relies on this
 // stylesheet (loaded dynamically in the app) to position glyphs correctly.
 const katexStylesheetUrl =
@@ -1123,6 +1137,7 @@ export class ProsemirrorHelper extends SharedProsemirrorHelper {
       HTMLElement: g.HTMLElement,
       Node: g.Node,
       MutationObserver: g.MutationObserver,
+      ResizeObserver: g.ResizeObserver,
     };
 
     const patch = (key: string, value: unknown) => {
@@ -1142,6 +1157,7 @@ export class ProsemirrorHelper extends SharedProsemirrorHelper {
     patch("HTMLElement", domWindow.HTMLElement);
     patch("Node", domWindow.Node);
     patch("MutationObserver", domWindow.MutationObserver);
+    patch("ResizeObserver", NoopResizeObserver);
 
     return () => {
       Object.entries(globalParams).forEach(([key, value]) => {


### PR DESCRIPTION
- jsdom has no `ResizeObserver`, so the PDF attachment preview component threw from a React effect whenever a document containing one was rendered to HTML on the server — most visibly on public share pages.
- Adds a no-op ResizeObserver to the globals patched for that render, alongside the existing stubs for getSelection and requestAnimationFrame.
- The exported HTML is static and never resizes, so a no-op is the correct behaviour, and it also covers any future component that observes an element on mount.