### PR TITLE
fix: Correct open depths when unwrapping a single table cell on copy

### DIFF
--- a/shared/editor/nodes/TableCell.ts
+++ b/shared/editor/nodes/TableCell.ts
@@ -179,7 +179,10 @@ export default class TableCell extends Node {
                   row.childCount === 1
                 ) {
                   const cell = row.firstChild;
-                  if (cell?.type.spec.tableRole === "cell") {
+                  if (
+                    cell?.type.spec.tableRole === "cell" ||
+                    cell?.type.spec.tableRole === "header_cell"
+                  ) {
                     // The table, row, and cell levels are gone from the content,
                     // so the open depths must lose them too – a slice that is
                     // open deeper than its content is malformed and throws when

--- a/shared/editor/nodes/TableCell.ts
+++ b/shared/editor/nodes/TableCell.ts
@@ -180,10 +180,15 @@ export default class TableCell extends Node {
                 ) {
                   const cell = row.firstChild;
                   if (cell?.type.spec.tableRole === "cell") {
+                    // The table, row, and cell levels are gone from the content,
+                    // so the open depths must lose them too – a slice that is
+                    // open deeper than its content is malformed and throws when
+                    // ProseMirror walks into it.
+                    const unwrapped = 3;
                     return new Slice(
                       cell.content,
-                      slice.openStart,
-                      slice.openEnd
+                      Math.max(0, slice.openStart - unwrapped),
+                      Math.max(0, slice.openEnd - unwrapped)
                     );
                   }
                 }


### PR DESCRIPTION
The `transformCopied` prop that unwraps a single-cell table replaced the slice content with the cell's content, but kept the open depths that still counted the removed table, row, and cell levels.

- The slice claimed to be open deeper than its content, which is malformed
- Dragging any selection made inside a table cell threw in `dropPoint` on every pointer move, so the drop cursor never appeared
- Copying a cell also wrote incorrect slice depths to the clipboard

Fixes OUTLINE-CLOUD-99J