### PR TITLE
fix: Uploads fail when the file name contains an accented character

### DIFF
--- a/server/storage/files/BaseStorage.test.ts
+++ b/server/storage/files/BaseStorage.test.ts
@@ -281,6 +281,34 @@ describe("BaseStorage", () => {
       expect(storage.getContentDisposition("text/plain")).toBe("attachment");
       expect(storage.getContentDisposition("image/png")).toBe("inline");
     });
+
+    it("should encode a latin-1 file name rather than send it raw", () => {
+      expect(
+        storage.getContentDisposition("application/zip", "Café-export.zip")
+      ).toBe(
+        "attachment; filename=\"Caf?-export.zip\"; filename*=UTF-8''Caf%C3%A9-export.zip"
+      );
+    });
+
+    it("should encode a file name outside latin-1", () => {
+      expect(storage.getContentDisposition("image/png", "日本語.png")).toBe(
+        "inline; filename=\"???.png\"; filename*=UTF-8''%E6%97%A5%E6%9C%AC%E8%AA%9E.png"
+      );
+    });
+
+    it("should only produce US-ASCII, whatever the file name", () => {
+      const names = [
+        "Zürich Team-export.markdown.zip",
+        "naïve.pdf",
+        "Ünicode ✨ 日本語.png",
+        "plain.txt",
+      ];
+
+      for (const name of names) {
+        const value = storage.getContentDisposition("application/zip", name);
+        expect(value).toMatch(/^[\x20-\x7e]*$/);
+      }
+    });
   });
 
   describe("getContentDispositionType", () => {

--- a/server/storage/files/BaseStorage.ts
+++ b/server/storage/files/BaseStorage.ts
@@ -321,6 +321,11 @@ export default abstract class BaseStorage {
    * file name. Including the file name ensures browsers keep the original
    * extension when downloading, rather than deriving one from the content type.
    *
+   * The value is always US-ASCII, a name outside that range being carried in the
+   * RFC 5987 `filename*` parameter. Request signing hashes header values as
+   * UTF-8 while Node writes them as Latin-1, so a raw high byte here makes the
+   * storage provider calculate a different signature and reject the upload.
+   *
    * @param contentType The content type
    * @param fileName The name of the file, if known
    * @returns The Content-Disposition header value
@@ -328,6 +333,7 @@ export default abstract class BaseStorage {
   public getContentDisposition(contentType?: string, fileName?: string) {
     return contentDisposition(fileName, {
       type: this.getContentDispositionType(contentType),
+      fallback: fileName?.replace(/[^\x20-\x7e]/g, "?"),
     });
   }
 


### PR DESCRIPTION
- The file name added to `Content-Disposition` in #13423 was left unencoded whenever it fell inside Latin-1, so a name such as "Café" reached the header as raw high bytes.
- Request signing hashes header values as UTF-8 while Node writes them as Latin-1, so the storage provider calculated a different signature and rejected the request.
- This broke every server-side upload for a file, collection or workspace with an accent in its name — export archives, import attachments and attachment uploads all failed.
- Passing an ASCII-only fallback carries such names in the RFC 5987 `filename*` parameter instead; browsers still read the original name from there, so the extension fix is preserved.