### PR TITLE
fix: Code block with a null language makes the document impossible to open

### DIFF
--- a/app/editor/extensions/PasteHandler.tsx
+++ b/app/editor/extensions/PasteHandler.tsx
@@ -241,7 +241,7 @@ export default class PasteHandler extends Extension {
                             vscodeMeta.mode
                           )
                             ? vscodeMeta.mode
-                            : null,
+                            : "none",
                         })
                       )
                       .insertText(text)

--- a/app/editor/menus/code.tsx
+++ b/app/editor/menus/code.tsx
@@ -108,7 +108,7 @@ const langToMenuItem = ({
 }): MenuItem => ({
   name: "code_block",
   label,
-  active: () => node.attrs.language === value,
+  active: () => (node.attrs.language ?? "none") === value,
   attrs: {
     language: value,
   },

--- a/shared/editor/nodes/CodeFence.ts
+++ b/shared/editor/nodes/CodeFence.ts
@@ -199,7 +199,9 @@ export default class CodeFence extends Node<CodeFenceOptions> {
       attrs: {
         language: {
           default: DEFAULT_LANGUAGE,
-          validate: "string",
+          // Null is permitted as existing documents can contain code blocks
+          // written before a language was always recorded.
+          validate: "string|null",
         },
         wrap: {
           default: false,


### PR DESCRIPTION
Pasting code from VS Code with an unrecognised language stored `language: null` on the code block. Node creation does not validate attributes, but loading the saved document does — so the editor threw on open and the document could no longer be edited.

- Allow a null language in the code block schema, so existing documents open again
- Store the plain text language identifier instead of null when pasting an unrecognised language
- Show "Plain text" as the selected item in the language menu for a null language

Fixes OUTLINE-CLOUD-C80