### PR TITLE
fix: Uncaught error handling messages from the diagram editor

### DIFF
--- a/shared/editor/lib/DiagramsNetClient.ts
+++ b/shared/editor/lib/DiagramsNetClient.ts
@@ -133,11 +133,19 @@ export class DiagramsNetClient {
    * @param event - the message event.
    */
   private handleMessage = (event: MessageEvent) => {
-    if (!event.data.length || event.source !== this.window) {
+    if (
+      !this.window ||
+      event.source !== this.window ||
+      typeof event.data !== "string" ||
+      !event.data.length
+    ) {
       return;
     }
 
-    const message = JSON.parse(event.data) as DiagramsNetMessage;
+    const message = this.parseMessage(event.data);
+    if (!message) {
+      return;
+    }
 
     switch (message.event) {
       case DiagramsNetEvent.Init:
@@ -159,6 +167,25 @@ export class DiagramsNetClient {
         break;
     }
   };
+
+  /**
+   * Parses a message received from the editor window. The editor also emits
+   * plain text messages, such as "ready", which are not part of the JSON
+   * protocol and are ignored.
+   *
+   * @param data - the raw message data.
+   * @returns the parsed message, or null if the data is not a JSON object.
+   */
+  private parseMessage(data: string): DiagramsNetMessage | null {
+    try {
+      const parsed: unknown = JSON.parse(data);
+      return parsed && typeof parsed === "object"
+        ? (parsed as DiagramsNetMessage)
+        : null;
+    } catch (_err) {
+      return null;
+    }
+  }
 }
 
 /**

--- a/shared/editor/lib/DiagramsNetClient.ts
+++ b/shared/editor/lib/DiagramsNetClient.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 /**
  * Events sent by diagrams.net to the parent window.
  */
@@ -23,22 +25,25 @@ export enum DiagramsNetAction {
 }
 
 /**
- * Message format for communication with diagrams.net.
+ * Message format for communication with diagrams.net. Unknown properties are
+ * stripped, so only the ones below are read from incoming messages.
  */
-export interface DiagramsNetMessage {
+export const DiagramsNetMessageSchema = z.object({
   /** Event type from diagrams.net. */
-  event?: string;
+  event: z.string().optional(),
   /** Action to perform in diagrams.net. */
-  action?: string;
+  action: z.string().optional(),
   /** Export format (e.g., "xmlsvg", "xmlpng"). */
-  format?: string;
+  format: z.string().optional(),
   /** Base64 encoded data for export responses. */
-  data?: string;
+  data: z.string().optional(),
   /** Data URI or base64 encoded image with embedded XML for loading. */
-  xml?: string;
+  xml: z.string().optional(),
   /** Loading spinner key. */
-  spinKey?: string;
-}
+  spinKey: z.string().optional(),
+});
+
+export type DiagramsNetMessage = z.infer<typeof DiagramsNetMessageSchema>;
 
 /**
  * Handles communication with the diagrams.net editor window.
@@ -174,14 +179,13 @@ export class DiagramsNetClient {
    * protocol and are ignored.
    *
    * @param data - the raw message data.
-   * @returns the parsed message, or null if the data is not a JSON object.
+   * @returns the parsed message, or null if the data does not match the
+   * message format.
    */
   private parseMessage(data: string): DiagramsNetMessage | null {
     try {
-      const parsed: unknown = JSON.parse(data);
-      return parsed && typeof parsed === "object"
-        ? (parsed as DiagramsNetMessage)
-        : null;
+      const result = DiagramsNetMessageSchema.safeParse(JSON.parse(data));
+      return result.success ? result.data : null;
     } catch (_err) {
       return null;
     }


### PR DESCRIPTION
The diagram editor also posts plain text messages, such as "ready", which were passed straight to `JSON.parse` and threw from the window listener.

- Ignore any message that is not a JSON object.
- Ignore messages when the editor window is not open — a blocked popup left the window null, which matched the null source of unrelated messages.

Fixes OUTLINE-CLOUD-D1B