### PR TITLE
Tighten how editor node and mark attributes are rendered

### DIFF
--- a/shared/editor/components/Frame.tsx
+++ b/shared/editor/components/Frame.tsx
@@ -97,7 +97,11 @@ const Frame = ({
         <Bar>
           {icon} <Title>{title}</Title>
           {canonicalUrl && (
-            <Open href={canonicalUrl} target="_blank" rel="noopener noreferrer">
+            <Open
+              href={sanitizeUrl(canonicalUrl)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               <OpenIcon size={18} /> Open
             </Open>
           )}

--- a/shared/editor/components/Mentions.tsx
+++ b/shared/editor/components/Mentions.tsx
@@ -33,7 +33,7 @@ import {
 } from "../../types";
 import { cn } from "../styles/utils";
 import type { ComponentProps } from "../types";
-import { toDisplayUrl, cdnPath } from "../../utils/urls";
+import { toDisplayUrl, cdnPath, sanitizeImageSrc } from "../../utils/urls";
 import Squircle from "../../components/Squircle";
 
 type Attrs = {
@@ -273,7 +273,9 @@ export const MentionURL = (props: IssueUrlProps) => {
       rel="noopener noreferrer nofollow"
     >
       <Flex align="center" gap={6}>
-        {unfurl.faviconUrl ? <Logo src={unfurl.faviconUrl} alt="" /> : null}
+        {unfurl.faviconUrl ? (
+          <Logo src={sanitizeImageSrc(unfurl.faviconUrl)} alt="" />
+        ) : null}
         <Text>
           <Backticks content={unfurl.title} />
         </Text>
@@ -426,7 +428,7 @@ export const MentionProject = observer((props: ProjectProps) => {
     >
       <Flex align="center" gap={6}>
         {project.avatarUrl ? (
-          <ProjectAvatar src={project.avatarUrl} alt="" />
+          <ProjectAvatar src={sanitizeImageSrc(project.avatarUrl)} alt="" />
         ) : (
           <Squircle color={project.color} size={12} />
         )}

--- a/shared/editor/embeds/index.tsx
+++ b/shared/editor/embeds/index.tsx
@@ -113,14 +113,13 @@ export class EmbedDescriptor {
   }
 
   matcher(url: string): false | RegExpMatchArray {
-    const regexes = this.regexMatch ?? [];
     const settingsDomainRegex = this.settings?.url
       ? urlRegex(this.settings?.url)
       : undefined;
 
-    if (settingsDomainRegex) {
-      regexes.unshift(settingsDomainRegex);
-    }
+    const regexes = settingsDomainRegex
+      ? [settingsDomainRegex, ...(this.regexMatch ?? [])]
+      : (this.regexMatch ?? []);
 
     for (const regex of regexes) {
       const result = url.match(regex);
@@ -161,7 +160,7 @@ const embeds: EmbedDescriptor[] = [
     keywords: "video",
     defaultHidden: true,
     regexMatch: [
-      /(?:https?:\/\/)?(www\.bilibili\.com)\/video\/([\w\d]+)?(\?\S+)?/i,
+      /^(?:https?:\/\/)?(www\.bilibili\.com)\/video\/([\w\d]+)?(\?\S+)?/i,
     ],
     transformMatch: (matches: RegExpMatchArray) =>
       `https://player.bilibili.com/player.html?bvid=${matches[2]}&page=1&high_quality=1&autoplay=0`,
@@ -328,7 +327,7 @@ const embeds: EmbedDescriptor[] = [
     id: "gliffy",
     title: "Gliffy",
     keywords: "diagram",
-    regexMatch: [new RegExp("https?://go\\.gliffy\\.com/go/share/(.*)$")],
+    regexMatch: [new RegExp("^https?://go\\.gliffy\\.com/go/share/(.*)$")],
     transformMatch: (matches: RegExpMatchArray) => matches[0],
     icon: <Img src="/images/gliffy.png" alt="Gliffy" />,
   }),

--- a/shared/editor/marks/Highlight.ts
+++ b/shared/editor/marks/Highlight.ts
@@ -118,16 +118,24 @@ export default class Highlight extends Mark {
           },
         },
       ],
-      toDOM: (node) => [
-        "mark",
-        {
-          "data-color": node.attrs.color,
-          style: `background-color: ${rgba(
-            node.attrs.color || Highlight.presetColors[0].hex,
-            Highlight.opacity
-          )}`,
-        },
-      ],
+      toDOM: (node) => {
+        // rgba() throws for a color it cannot parse, which would stop the
+        // document rendering.
+        const color = validateColorHex(node.attrs.color ?? "")
+          ? node.attrs.color
+          : null;
+
+        return [
+          "mark",
+          {
+            "data-color": color,
+            style: `background-color: ${rgba(
+              color || Highlight.presetColors[0].hex,
+              Highlight.opacity
+            )}`,
+          },
+        ];
+      },
     };
   }
 

--- a/shared/editor/nodes/Heading.ts
+++ b/shared/editor/nodes/Heading.ts
@@ -27,6 +27,28 @@ export enum HeadingLevel {
   Four,
 }
 
+/** Levels the editor offers. */
+const editorLevels = [
+  HeadingLevel.One,
+  HeadingLevel.Two,
+  HeadingLevel.Three,
+  HeadingLevel.Four,
+];
+
+/** Levels a document may hold – Markdown can also import an h5 or an h6. */
+const documentLevels = [...editorLevels, 5, 6];
+
+/**
+ * Restricts a heading level to one that can be rendered as a tag.
+ *
+ * @param value the level to restrict.
+ * @returns a level a document may hold.
+ */
+const toLevel = (value: unknown): number =>
+  documentLevels.includes(value as HeadingLevel)
+    ? (value as number)
+    : HeadingLevel.One;
+
 /**
  * Options for the Heading node.
  */
@@ -44,7 +66,7 @@ export default class Heading extends Node<HeadingOptions> {
 
   get defaultOptions(): Partial<HeadingOptions> {
     return {
-      levels: [1, 2, 3, 4],
+      levels: editorLevels,
     };
   }
 
@@ -68,7 +90,9 @@ export default class Heading extends Node<HeadingOptions> {
         attrs: { level },
       })),
       toDOM: (node) => [
-        `h${node.attrs.level + (this.options.offset || 0)}`,
+        // A level outside of the range produces an invalid tag name, which
+        // would stop the document rendering.
+        `h${toLevel(node.attrs.level) + (this.options.offset || 0)}`,
         {
           dir: "auto",
           class: "heading-content",
@@ -79,7 +103,7 @@ export default class Heading extends Node<HeadingOptions> {
   }
 
   toMarkdown(state: MarkdownSerializerState, node: ProsemirrorNode) {
-    state.write(state.repeat("#", node.attrs.level) + " ");
+    state.write(state.repeat("#", toLevel(node.attrs.level)) + " ");
     state.renderInline(node);
     state.closeBlock(node);
   }

--- a/shared/editor/nodes/OrderedList.ts
+++ b/shared/editor/nodes/OrderedList.ts
@@ -12,6 +12,8 @@ import { listWrappingInputRule } from "../lib/listInputRule";
 import alphaListsRule from "../rules/alphaLists";
 import Node from "./Node";
 
+const LIST_STYLES = ["number", "lower-alpha", "upper-alpha"];
+
 export default class OrderedList extends Node {
   get name() {
     return "ordered_list";
@@ -30,8 +32,7 @@ export default class OrderedList extends Node {
         },
         listStyle: {
           default: "number",
-          validate: (style: string) =>
-            ["number", "lower-alpha", "upper-alpha"].includes(style),
+          validate: (style: string) => LIST_STYLES.includes(style),
         },
       },
       content: "list_item+",
@@ -54,7 +55,12 @@ export default class OrderedList extends Node {
           attrs.start = node.attrs.order;
         }
 
-        if (node.attrs.listStyle !== "number") {
+        // The style is written into a declaration, so only a style the editor
+        // renders is emitted.
+        if (
+          node.attrs.listStyle !== "number" &&
+          LIST_STYLES.includes(node.attrs.listStyle)
+        ) {
           attrs.style = `list-style-type: ${node.attrs.listStyle}`;
         }
 

--- a/shared/utils/urls.test.ts
+++ b/shared/utils/urls.test.ts
@@ -384,7 +384,7 @@ describe("#urlRegex", () => {
 
   it("should return corresponding regex otherwise", () => {
     const regex = urlRegex("https://docs.google.com");
-    expect(regex?.source).toBe(/https:\/\/docs\.google\.com/.source);
+    expect(regex?.source).toBe(/^https:\/\/docs\.google\.com/.source);
     expect(regex?.test("https://docs.google.com")).toBe(true);
     expect(regex?.test("https://docs.google.com/")).toBe(true);
     expect(regex?.test("https://docs.google.com/d/123")).toBe(true);
@@ -392,6 +392,9 @@ describe("#urlRegex", () => {
     expect(regex?.test("http://docs.google.com")).toBe(false);
     expect(regex?.test("http://docs.google.com/")).toBe(false);
     expect(regex?.test("http://docs.google.com/d/123")).toBe(false);
+    expect(regex?.test("javascript:alert(1)//https://docs.google.com")).toBe(
+      false
+    );
   });
 });
 

--- a/shared/utils/urls.ts
+++ b/shared/utils/urls.ts
@@ -246,10 +246,10 @@ export function sanitizeImageSrc(src: string | null | undefined) {
 }
 
 /**
- * Returns a regex to match the given url.
+ * Returns a regex to match urls that begin with the given url's origin.
  *
  * @param url The url to create a regex for.
- * @returns A regex to match the url.
+ * @returns A regex anchored to the origin, a path and query may follow.
  */
 export function urlRegex(url: string | null | undefined): RegExp | undefined {
   if (!url || !isUrl(url)) {
@@ -258,7 +258,7 @@ export function urlRegex(url: string | null | undefined): RegExp | undefined {
 
   const urlObj = new URL(sanitizeUrl(url) as string);
 
-  return new RegExp(escapeRegExp(`${urlObj.protocol}//${urlObj.host}`));
+  return new RegExp(`^${escapeRegExp(`${urlObj.protocol}//${urlObj.host}`)}`);
 }
 
 /**


### PR DESCRIPTION
A robustness pass over how node and mark attributes are turned into DOM in the editor.

- Route the embed toolbar link and mention unfurl images through the existing url helpers before they reach the DOM
- Anchor the embed url matchers, and `urlRegex`, so a match must begin at the start of the url
- Fall back to a renderable heading level and highlight color, rather than letting an unexpected stored value interrupt rendering of the whole document
- Only emit a list style that the editor actually renders