### PR TITLE
fix: RangeError when restoring editor selection after focus

### DIFF
--- a/shared/editor/lib/ExtensionManager.ts
+++ b/shared/editor/lib/ExtensionManager.ts
@@ -276,10 +276,11 @@ export default class ExtensionManager {
             // Focusing a blurred editor (e.g. when the command is run from a
             // menu that holds focus) can collapse a non-text selection such as
             // a table cell selection. Restore it so selection-based commands
-            // operate on the intended selection.
-            const { selection } = view.state;
+            // operate on the intended selection, unless focus also flushed
+            // document changes that make the previous selection invalid.
+            const { doc, selection } = view.state;
             view.focus();
-            if (!view.state.selection.eq(selection)) {
+            if (view.state.doc === doc && !view.state.selection.eq(selection)) {
               view.dispatch(
                 view.state.tr
                   .setSelection(selection)


### PR DESCRIPTION
Running a command that focuses the editor first could throw `Selection passed to setSelection must point at the current document`.

- Focusing the editor can flush pending DOM changes, so the selection captured beforehand may point at a stale document
- Only restore the previous selection when the document is unchanged, otherwise the command runs against the current selection

Fixes OUTLINE-CLOUD-CP6