### PR TITLE
fix: Do no report expired wss auth to error tracker

### DIFF
--- a/app/components/WebsocketProvider.tsx
+++ b/app/components/WebsocketProvider.tsx
@@ -13,7 +13,7 @@ import {
   FileOperationType,
   ImportState,
 } from "@shared/types";
-import { toError } from "@shared/utils/error";
+import { errToId, toError } from "@shared/utils/error";
 import type RootStore from "~/stores/RootStore";
 import type Collection from "~/models/Collection";
 import type Comment from "~/models/Comment";
@@ -46,6 +46,12 @@ import { getVisibilityListener, getPageVisible } from "~/utils/pageVisibility";
 type SocketWithAuthentication = Socket & {
   authenticated?: boolean;
 };
+
+/** Identifiers of socket authentication errors that are expected in normal use. */
+const unreportableErrorIds = [
+  "authentication_required",
+  "invalid_authentication",
+];
 
 export const WebsocketContext = createContext<SocketWithAuthentication | null>(
   null
@@ -138,7 +144,10 @@ function useConnectionHandlers() {
 
       toast.error(message);
 
-      if (message === "No access token") {
+      // Authentication failures are an expected result of an expired or
+      // otherwise unusable token, there is nothing to report.
+      const errorId = errToId(err);
+      if (errorId && unreportableErrorIds.includes(errorId)) {
         return;
       }
 

--- a/server/services/websockets.ts
+++ b/server/services/websockets.ts
@@ -5,7 +5,7 @@ import cookie from "cookie";
 import type Koa from "koa";
 import IO from "socket.io";
 import { createAdapter } from "socket.io-redis";
-import { errToString, toError } from "@shared/utils/error";
+import { errToId, errToString, toError } from "@shared/utils/error";
 import env from "@server/env";
 import { AuthenticationError } from "@server/errors";
 import Logger from "@server/logging/Logger";
@@ -156,7 +156,7 @@ export default function init(
       Logger.debug("websockets", `Authentication error socket ${socket.id}`, {
         error: message,
       });
-      socket.emit("unauthorized", { message }, function () {
+      socket.emit("unauthorized", { message, id: errToId(err) }, function () {
         socket.disconnect();
       });
     }


### PR DESCRIPTION
Fixes spurious errors occasionally appearing in Sentry when auth is expired and user is kicked out via wss rather than API request.