### PR TITLE
fix: Recover from mismatched chunks after a deploy

### DIFF
--- a/app/components/ErrorBoundary.tsx
+++ b/app/components/ErrorBoundary.tsx
@@ -14,6 +14,7 @@ import Text from "~/components/Text";
 import env from "~/env";
 import Logger from "~/utils/Logger";
 import isCloudHosted from "~/utils/isCloudHosted";
+import { isStaleChunkError } from "~/utils/lazyWithRetry";
 import Storage from "@shared/utils/Storage";
 import { deleteAllDatabases } from "~/utils/developer";
 import Flex from "./Flex";
@@ -57,8 +58,7 @@ class ErrorBoundaryClass extends React.Component<Props> {
 
     if (
       this.props.reloadOnChunkMissing &&
-      error.message &&
-      error.message.match(/dynamically imported module/) &&
+      isStaleChunkError(error) &&
       !this.isRepeatedError
     ) {
       // If the editor bundle fails to load then reload the entire window. This
@@ -133,12 +133,7 @@ class ErrorBoundaryClass extends React.Component<Props> {
     if (this.error) {
       const error = this.error;
       const isReported = !!env.SENTRY_DSN && isCloudHosted;
-      const isChunkError = [
-        "module script failed",
-        "dynamically imported module",
-      ].some((msg) => this.error?.message?.includes(msg));
-
-      if (isChunkError) {
+      if (isStaleChunkError(error)) {
         return (
           <Component>
             {showTitle && (

--- a/app/utils/lazyWithRetry.test.ts
+++ b/app/utils/lazyWithRetry.test.ts
@@ -1,0 +1,38 @@
+import { isStaleChunkError } from "./lazyWithRetry";
+
+describe("isStaleChunkError", () => {
+  it("matches a chunk that could not be fetched", () => {
+    expect(
+      isStaleChunkError(
+        new TypeError(
+          "Failed to fetch dynamically imported module: https://example.com/Editor.abc123.js"
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("matches a module script that failed to import", () => {
+    expect(
+      isStaleChunkError(new TypeError("Importing a module script failed."))
+    ).toBe(true);
+  });
+
+  it("matches a chunk with a missing export", () => {
+    expect(
+      isStaleChunkError(
+        new SyntaxError(
+          "The requested module './PluginIcon.BGMce7FN.js' does not provide an export named 't'"
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("matches a non-error value", () => {
+    expect(isStaleChunkError("Importing a module script failed.")).toBe(true);
+  });
+
+  it("does not match an unrelated error", () => {
+    expect(isStaleChunkError(new Error("Something went wrong"))).toBe(false);
+    expect(isStaleChunkError(undefined)).toBe(false);
+  });
+});

--- a/app/utils/lazyWithRetry.ts
+++ b/app/utils/lazyWithRetry.ts
@@ -6,6 +6,25 @@ type ComponentPromise<T extends React.ComponentType<any>> = Promise<{
 }>;
 
 /**
+ * Matches errors thrown when a JavaScript chunk is missing, or when chunks from
+ * different builds are mixed together – both usually the result of a deploy
+ * happening while the tab was open.
+ */
+export const staleChunkErrorPattern =
+  /dynamically imported module|module script failed|does not provide an export named/i;
+
+/**
+ * Whether an error was caused by loading a stale or missing JavaScript chunk.
+ *
+ * @param error the error to check.
+ * @returns true if the error is a chunk loading failure.
+ */
+export function isStaleChunkError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return staleChunkErrorPattern.test(message);
+}
+
+/**
  * Lazy load a component with automatic retry on failure.
  *
  * @param component A function that returns a promise of a component.
@@ -50,20 +69,15 @@ const reloadSessionKey = "chunkReload";
 
 /**
  * Reloads the page when a dynamic import fails because the chunk no longer
- * exists, typically after a deploy left an open tab referencing stale URLs.
- * Guarded so it only reloads once per session to avoid reload loops.
+ * exists, or does not match the chunks already loaded – typically after a
+ * deploy left an open tab referencing stale URLs. Guarded so it only reloads
+ * once per session to avoid reload loops.
  *
  * @param error The error thrown by the failed dynamic import.
  * @returns Whether a reload was triggered.
  */
 function reloadIfStaleChunk(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  const isChunkError =
-    /Failed to fetch dynamically imported module|Importing a module script failed/i.test(
-      message
-    );
-
-  if (!isChunkError) {
+  if (!isStaleChunkError(error)) {
     return false;
   }
 

--- a/app/utils/sentry.ts
+++ b/app/utils/sentry.ts
@@ -13,6 +13,7 @@ import {
   ServiceUnavailableError,
   UpdateRequiredError,
 } from "./errors";
+import { staleChunkErrorPattern } from "./lazyWithRetry";
 
 /**
  * Initializes the Sentry error tracking client for the browser.
@@ -50,8 +51,7 @@ export function initSentry(history: History) {
     ],
     tracesSampleRate: env.ENVIRONMENT === "production" ? 0.05 : 1,
     ignoreErrors: [
-      "Failed to fetch dynamically imported module",
-      "Importing a module script failed",
+      staleChunkErrorPattern,
       "ResizeObserver loop completed with undelivered notifications",
       "ResizeObserver loop limit exceeded",
       "Object Not Found Matching Id",


### PR DESCRIPTION
A dynamic import can resolve to a chunk built from a different revision, throwing `does not provide an export named` rather than one of the two messages we already recognized. The result was no retry, no reload, the generic crash screen, and Sentry noise.

- Share one stale chunk matcher between the lazy import retry, the error boundary, and Sentry
- Add the export mismatch message to it, so all three now treat it as recoverable

Fixes OUTLINE-CLOUD-D1M