### PR TITLE
Animate drafts count in sidebar

### DIFF
--- a/app/components/Sidebar/components/DraftsLink.tsx
+++ b/app/components/Sidebar/components/DraftsLink.tsx
@@ -6,6 +6,7 @@ import Flex from "~/components/Flex";
 import Text from "~/components/Text";
 import useStores from "~/hooks/useStores";
 import * as Scenes from "~/routes/scenes";
+import { popIn } from "~/styles/animations";
 import { draftsPath } from "~/utils/routeHelpers";
 import { useDropToUnpublish } from "../hooks/useDragAndDrop";
 import SidebarLink from "./SidebarLink";
@@ -25,7 +26,7 @@ export const DraftsLink = observer(() => {
           <Flex align="center" justify="space-between">
             {t("Drafts")}
             {documents.totalDrafts > 0 ? (
-              <Drafts size="xsmall" type="tertiary">
+              <Drafts key={documents.totalDrafts} size="xsmall" type="tertiary">
                 {documents.totalDrafts > 25 ? "25+" : documents.totalDrafts}
               </Drafts>
             ) : null}
@@ -38,5 +39,7 @@ export const DraftsLink = observer(() => {
 });
 
 const Drafts = styled(Text)`
+  display: inline-block;
   margin: 0 4px;
+  animation: ${popIn} 250ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
 `;

--- a/app/components/Sidebar/components/DraftsLink.tsx
+++ b/app/components/Sidebar/components/DraftsLink.tsx
@@ -15,6 +15,8 @@ export const DraftsLink = observer(() => {
   const { t } = useTranslation();
   const { documents } = useStores();
   const [{ isOver, canDrop }, dropRef] = useDropToUnpublish();
+  const totalDrafts =
+    documents.totalDrafts > 25 ? "25+" : String(documents.totalDrafts);
 
   return (
     <div ref={dropRef}>
@@ -26,8 +28,8 @@ export const DraftsLink = observer(() => {
           <Flex align="center" justify="space-between">
             {t("Drafts")}
             {documents.totalDrafts > 0 ? (
-              <Drafts key={documents.totalDrafts} size="xsmall" type="tertiary">
-                {documents.totalDrafts > 25 ? "25+" : documents.totalDrafts}
+              <Drafts key={totalDrafts} size="xsmall" type="tertiary">
+                {totalDrafts}
               </Drafts>
             ) : null}
           </Flex>

--- a/app/styles/animations.ts
+++ b/app/styles/animations.ts
@@ -133,6 +133,23 @@ export const bounceIn = keyframes`
   }
 `;
 
+export const popIn = keyframes`
+  0% {
+    opacity: 0;
+    transform: scale(0.6);
+  }
+
+  60% {
+    opacity: 1;
+    transform: scale(1.15);
+  }
+
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+`;
+
 export const pulsate = keyframes`
   0% { opacity: 1; }
   50% { opacity: 0.5; }


### PR DESCRIPTION
The drafts count in the sidebar now appears with a brief pop instead of snapping in.

- Adds a shared `popIn` keyframe for reuse by other counts and badges
- Replays the animation when the count changes, not only on first appearance
- Respects `prefers-reduced-motion` through the existing global rule