### PR TITLE
fix: MobX out of bounds warning searching an empty document

### DIFF
--- a/app/editor/extensions/FindAndReplace.tsx
+++ b/app/editor/extensions/FindAndReplace.tsx
@@ -205,6 +205,10 @@ export default class FindAndReplaceExtension extends Extension<FindAndReplaceOpt
 
   private goToMatch(direction: number): Command {
     return (state, dispatch) => {
+      if (!this.results.length) {
+        return false;
+      }
+
       if (direction > 0) {
         if (this.currentResultIndex >= this.results.length - 1) {
           this.currentResultIndex = 0;

--- a/app/editor/extensions/FindAndReplace.tsx
+++ b/app/editor/extensions/FindAndReplace.tsx
@@ -111,11 +111,7 @@ export default class FindAndReplaceExtension extends Extension<FindAndReplaceOpt
       // have changed underneath us since the last search.
       this.search(state.doc);
 
-      if (this.currentResultIndex >= this.results.length) {
-        return false;
-      }
-
-      const result = this.results[this.currentResultIndex];
+      const result = this.currentResult;
 
       if (!result) {
         return false;
@@ -190,6 +186,16 @@ export default class FindAndReplaceExtension extends Extension<FindAndReplaceOpt
     };
   }
 
+  /**
+   * The result at the current index, checking the length first so that an index
+   * beyond the end of the results is not read.
+   */
+  private get currentResult() {
+    return this.currentResultIndex < this.results.length
+      ? this.results[this.currentResultIndex]
+      : undefined;
+  }
+
   private get findRegExp() {
     return RegExp(
       this.searchTerm.replace(/\\+$/, ""),
@@ -248,11 +254,7 @@ export default class FindAndReplaceExtension extends Extension<FindAndReplaceOpt
    * Expand any folded toggle blocks that contain the current match.
    */
   private expandFoldedTogglesForCurrentMatch() {
-    if (this.currentResultIndex >= this.results.length) {
-      return;
-    }
-
-    const result = this.results[this.currentResultIndex];
+    const result = this.currentResult;
     if (!result) {
       return;
     }
@@ -305,7 +307,7 @@ export default class FindAndReplaceExtension extends Extension<FindAndReplaceOpt
    * Expand a collapsed code block if it contains the current match.
    */
   private expandCollapsedCodeBlockForCurrentMatch() {
-    const result = this.results[this.currentResultIndex];
+    const result = this.currentResult;
     if (!result) {
       return;
     }


### PR DESCRIPTION
Typing in the find input on a document with no matches logged a MobX "array index out of bounds" warning.

- The current match was read from the results array before its length was checked
- Added a `currentResult` getter that checks the length first, and used it in the three places that read the current match