### PR TITLE
fix: Ctrl+Left jumping to the start of a heading

### DIFF
--- a/shared/editor/nodes/Heading.ts
+++ b/shared/editor/nodes/Heading.ts
@@ -209,8 +209,9 @@ export default class Heading extends Node<HeadingOptions> {
       // widget (contentEditable=false, ignoreSelection: true), so Prosemirror
       // does not update its model. Subsequent commands like Enter then operate
       // on the stale position. Move the model selection explicitly to keep it
-      // in sync with the visual caret.
-      "Mod-ArrowLeft": ((state, dispatch) => {
+      // in sync with the visual caret. Note this is Cmd rather than Mod, as
+      // Ctrl+Left moves by word on other platforms.
+      "Cmd-ArrowLeft": ((state, dispatch) => {
         const { $from, empty } = state.selection;
         if (!empty || $from.parent.type !== type) {
           return false;


### PR DESCRIPTION
- The heading node bound its caret-sync handler to `Mod-ArrowLeft`, which Prosemirror maps to Ctrl on Linux and Windows.
- On those platforms it moved the selection to the start of the heading, replacing the word-left movement that Ctrl+Left performs in paragraphs, lists and the title.
- Bind `Cmd` rather than `Mod`, so the handler only runs for the macOS Firefox quirk it was written for.

closes #13492