### PR TITLE
fix: Crash inserting a math block from the suggestions menu

### DIFF
--- a/app/editor/components/SuggestionsMenu.tsx
+++ b/app/editor/components/SuggestionsMenu.tsx
@@ -419,7 +419,13 @@ function SuggestionsMenu<T extends MenuItem>(props: Props<T>) {
 
   const close = React.useCallback(() => {
     props.onClose();
-    view.focus();
+
+    // Don't steal focus back from a nested editor, such as the one inside a
+    // math node, that took it while the menu was closing.
+    const focused = view.dom.ownerDocument.activeElement;
+    if (focused === view.dom || !view.dom.contains(focused)) {
+      view.focus();
+    }
   }, [props, view]);
 
   const handleLinkInputKeydown = (


### PR DESCRIPTION
Inserting a math block opens the nested math editor, which takes focus and so dismisses the suggestions menu. The menu then restored focus to the outer view, re-entering the node view's selection handling before it had finished and throwing "inner view should not exist!".

- Menu only restores focus when a nested editor inside the document does not already hold it
- Also keeps the caret in the math editor after insert, instead of pulling it back out

Fixes OUTLINE-CLOUD-BZA