### PR TITLE
fix: RangeError rendering a diff with sibling node modifications

### DIFF
--- a/shared/editor/extensions/Diff.test.ts
+++ b/shared/editor/extensions/Diff.test.ts
@@ -1,0 +1,103 @@
+import { EditorState } from "prosemirror-state";
+import type { DecorationSet } from "prosemirror-view";
+import Diff from "./Diff";
+import { ChangesetHelper } from "../lib/ChangesetHelper";
+import type { ProsemirrorData } from "../../types";
+
+/**
+ * Builds a document with a single checkbox list, one item per given state.
+ */
+function checkboxDoc(...checked: boolean[]): ProsemirrorData {
+  return {
+    type: "doc",
+    content: [
+      {
+        type: "checkbox_list",
+        content: checked.map((isChecked, index) => ({
+          type: "checkbox_item",
+          attrs: { checked: isChecked },
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: `Task number ${index}` }],
+            },
+          ],
+        })),
+      },
+    ],
+  } as ProsemirrorData;
+}
+
+/**
+ * Builds a document with a single table row, one cell per given node type.
+ */
+function tableDoc(...cellTypes: string[]): ProsemirrorData {
+  return {
+    type: "doc",
+    content: [
+      {
+        type: "table",
+        content: [
+          {
+            type: "tr",
+            content: cellTypes.map((type, index) => ({
+              type,
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: `Cell ${index}` }],
+                },
+              ],
+            })),
+          },
+        ],
+      },
+    ],
+  } as ProsemirrorData;
+}
+
+/**
+ * Builds the diff decorations for the changeset between two documents.
+ */
+function decorationsFor(after: ProsemirrorData, before: ProsemirrorData) {
+  const changeset = ChangesetHelper.getChangeset(after, before);
+  expect(changeset).not.toBeNull();
+
+  const state = EditorState.create({
+    doc: changeset!.doc,
+    plugins: new Diff({ changes: changeset!.changes }).plugins,
+  });
+
+  const decorations = state.plugins[0].getState(state) as DecorationSet;
+  return { decorations, doc: changeset!.doc };
+}
+
+describe("Diff", () => {
+  it("decorates the modified node", () => {
+    const { decorations, doc } = decorationsFor(
+      checkboxDoc(true, false),
+      checkboxDoc(false, false)
+    );
+
+    const firstItem = doc.child(0).child(0);
+    expect(decorations.find()).toEqual([
+      expect.objectContaining({ from: 1, to: 1 + firstItem.nodeSize }),
+    ]);
+  });
+
+  it("keeps modification decorations within the document", () => {
+    const cases: Array<[ProsemirrorData, ProsemirrorData]> = [
+      [checkboxDoc(true, true, true), checkboxDoc(false, false, false)],
+      [tableDoc("th", "th", "th"), tableDoc("td", "td", "td")],
+    ];
+
+    for (const [after, before] of cases) {
+      const { decorations, doc } = decorationsFor(after, before);
+      expect(decorations.find().length).toBeGreaterThan(0);
+      for (const decoration of decorations.find()) {
+        expect(decoration.from).toBeLessThanOrEqual(doc.content.size);
+        expect(decoration.to).toBeLessThanOrEqual(doc.content.size);
+      }
+    }
+  });
+});

--- a/shared/editor/extensions/Diff.ts
+++ b/shared/editor/extensions/Diff.ts
@@ -349,9 +349,17 @@ export default class Diff extends Extension<DiffOptions> {
           return;
         }
 
-        modification.data.slice.content.forEach((node: Node) => {
-          const nodeSize = node.nodeSize;
-          const end = pos + nodeSize;
+        modification.data.slice.content.forEach(() => {
+          // The slice describes the content before the change, and may cover
+          // more nodes than remain at this position, so the node being
+          // decorated is measured in the document itself.
+          const node =
+            pos <= doc.content.size ? doc.resolve(pos).nodeAfter : null;
+          if (!node) {
+            return;
+          }
+
+          const end = pos + node.nodeSize;
 
           // Check if this specific node should use node decoration
           const useNodeDecoration =


### PR DESCRIPTION
The diff extension advanced its cursor with node sizes read from the modification slice, which describes the content *before* the change. When one step replaces several sibling nodes — three checkbox items, three table cells — the changeset emits a change per node, each carrying the whole slice, so the later changes walked past the end of the document and decoration building threw.

- Measure each decorated node in the document being decorated instead, and stop at the end of its parent
- Fixes the crash on both the "document updated" email diff and the client revision viewer

Fixes OUTLINE-CLOUD-D19 and OUTLINE-CLOUD-CT9