### PR TITLE
fix: Unfurl GitLab epics

### DIFF
--- a/plugins/gitlab/server/gitlab.ts
+++ b/plugins/gitlab/server/gitlab.ts
@@ -1,5 +1,6 @@
 import { Gitlab } from "@gitbeaker/rest";
 import type {
+  EpicSchema,
   IssueSchemaWithExpandedLabels,
   MergeRequestSchema,
   ProjectSchema,
@@ -104,6 +105,25 @@ export class GitLab {
     }
 
     return issues[0];
+  }
+
+  /**
+   * Fetches an epic from a GitLab group.
+   *
+   * @param accessToken - The access token for authentication.
+   * @param groupPath - The full path of the group.
+   * @param epicIid - The epic IID (internal ID within the group).
+   * @param customUrl - Optional custom GitLab URL from integration settings.
+   * @returns The epic data.
+   */
+  public static async getEpic(
+    accessToken: string,
+    groupPath: string,
+    epicIid: number,
+    customUrl?: string
+  ) {
+    const client = await this.createClient(accessToken, customUrl);
+    return client.Epics.show(groupPath, epicIid);
   }
 
   /**
@@ -228,7 +248,6 @@ export class GitLab {
 
     try {
       const customUrl = matchedIntegration.settings?.gitlab?.url;
-      const projectPath = `${resource.owner}/${resource.repo}`;
       const { authentication } = matchedIntegration;
       const token = await authentication.refreshTokenIfNeeded(
         async (refreshToken: string) =>
@@ -239,6 +258,19 @@ export class GitLab {
             clientSecret: authentication.clientSecret ?? undefined,
           })
       );
+
+      if ("scope" in resource) {
+        const epic = await this.getEpic(
+          token,
+          resource.owner,
+          resource.id,
+          customUrl
+        );
+
+        return this.transformEpic(epic);
+      }
+
+      const projectPath = `${resource.owner}/${resource.repo}`;
 
       if (resource.type === UnfurlResourceType.Issue) {
         const issue = await this.getIssue(
@@ -379,6 +411,30 @@ export class GitLab {
         color: GitLabUtils.getColorForStatus(issue.state),
       },
       createdAt: issue.created_at,
+    } satisfies UnfurlIssueOrPR;
+  }
+
+  private static transformEpic(epic: EpicSchema) {
+    return {
+      type: UnfurlResourceType.Issue,
+      url: epic.web_url,
+      id: `#${epic.iid}`,
+      title: epic.title,
+      description: GitLabUtils.sanitizeGitLabMarkdown(epic.description),
+      author: {
+        name: epic.author?.username ?? "",
+        avatarUrl: epic.author?.avatar_url ?? "",
+      },
+      labels: (epic.labels ?? []).map((label) =>
+        typeof label === "string"
+          ? { name: label, color: GitLabUtils.defaultLabelColor }
+          : { name: label.name, color: label.color }
+      ),
+      state: {
+        name: epic.state,
+        color: GitLabUtils.getColorForStatus(epic.state),
+      },
+      createdAt: epic.created_at,
     } satisfies UnfurlIssueOrPR;
   }
 

--- a/plugins/gitlab/server/gitlab.ts
+++ b/plugins/gitlab/server/gitlab.ts
@@ -4,6 +4,7 @@ import type {
   IssueSchemaWithExpandedLabels,
   MergeRequestSchema,
   ProjectSchema,
+  SimpleLabelSchema,
   StatisticsSchema,
 } from "@gitbeaker/rest";
 import z from "zod";
@@ -259,26 +260,13 @@ export class GitLab {
           })
       );
 
-      if ("scope" in resource) {
-        const epic = await this.getEpic(
-          token,
-          resource.owner,
-          resource.id,
-          customUrl
-        );
-
-        return this.transformEpic(epic);
-      }
-
       const projectPath = `${resource.owner}/${resource.repo}`;
 
       if (resource.type === UnfurlResourceType.Issue) {
-        const issue = await this.getIssue(
-          token,
-          projectPath,
-          resource.id,
-          customUrl
-        );
+        const issue =
+          resource.scope === "group"
+            ? await this.getEpic(token, resource.owner, resource.id, customUrl)
+            : await this.getIssue(token, projectPath, resource.id, customUrl);
 
         return this.transformIssue(issue);
       } else if (resource.type === UnfurlResourceType.PR) {
@@ -391,7 +379,11 @@ export class GitLab {
     return AccessTokenResponseSchema.parse(resJson);
   }
 
-  private static transformIssue(issue: IssueSchemaWithExpandedLabels) {
+  private static transformIssue(
+    issue: IssueSchemaWithExpandedLabels | EpicSchema
+  ) {
+    const labels: (string | SimpleLabelSchema)[] = issue.labels;
+
     return {
       type: UnfurlResourceType.Issue,
       url: issue.web_url,
@@ -402,39 +394,17 @@ export class GitLab {
         name: issue.author?.username ?? "",
         avatarUrl: issue.author?.avatar_url ?? "",
       },
-      labels: issue.labels.map((label) => ({
-        name: label.name,
-        color: label.color,
-      })),
-      state: {
-        name: issue.state,
-        color: GitLabUtils.getColorForStatus(issue.state),
-      },
-      createdAt: issue.created_at,
-    } satisfies UnfurlIssueOrPR;
-  }
-
-  private static transformEpic(epic: EpicSchema) {
-    return {
-      type: UnfurlResourceType.Issue,
-      url: epic.web_url,
-      id: `#${epic.iid}`,
-      title: epic.title,
-      description: GitLabUtils.sanitizeGitLabMarkdown(epic.description),
-      author: {
-        name: epic.author?.username ?? "",
-        avatarUrl: epic.author?.avatar_url ?? "",
-      },
-      labels: (epic.labels ?? []).map((label) =>
+      // Epics are returned without label color details.
+      labels: labels.map((label) =>
         typeof label === "string"
           ? { name: label, color: GitLabUtils.defaultLabelColor }
           : { name: label.name, color: label.color }
       ),
       state: {
-        name: epic.state,
-        color: GitLabUtils.getColorForStatus(epic.state),
+        name: issue.state,
+        color: GitLabUtils.getColorForStatus(issue.state),
       },
-      createdAt: epic.created_at,
+      createdAt: issue.created_at,
     } satisfies UnfurlIssueOrPR;
   }
 
@@ -492,7 +462,7 @@ export class GitLab {
       },
       labels: (project.topics ?? []).map((topic: string) => ({
         name: topic,
-        color: "#6B7280",
+        color: GitLabUtils.defaultLabelColor,
       })),
       progress,
       createdAt: project.created_at,

--- a/plugins/gitlab/server/gitlab.ts
+++ b/plugins/gitlab/server/gitlab.ts
@@ -260,13 +260,30 @@ export class GitLab {
           })
       );
 
+      // Epics are group-scoped, so they have no project path.
+      if (
+        resource.type === UnfurlResourceType.Issue &&
+        resource.scope === "group"
+      ) {
+        const epic = await this.getEpic(
+          token,
+          resource.owner,
+          resource.id,
+          customUrl
+        );
+
+        return this.transformIssue(epic);
+      }
+
       const projectPath = `${resource.owner}/${resource.repo}`;
 
       if (resource.type === UnfurlResourceType.Issue) {
-        const issue =
-          resource.scope === "group"
-            ? await this.getEpic(token, resource.owner, resource.id, customUrl)
-            : await this.getIssue(token, projectPath, resource.id, customUrl);
+        const issue = await this.getIssue(
+          token,
+          projectPath,
+          resource.id,
+          customUrl
+        );
 
         return this.transformIssue(issue);
       } else if (resource.type === UnfurlResourceType.PR) {

--- a/plugins/gitlab/shared/GitLabUtils.test.ts
+++ b/plugins/gitlab/shared/GitLabUtils.test.ts
@@ -394,6 +394,77 @@ describe("GitLabUtils.parseUrl", () => {
     });
   });
 
+  describe("group URLs", () => {
+    it("should parse a group work_items URL", () => {
+      const result = GitLabUtils.parseUrl(
+        "https://gitlab.com/groups/gitlab-org/-/work_items/1234"
+      );
+      expect(result).toEqual({
+        owner: "gitlab-org",
+        type: UnfurlResourceType.Issue,
+        scope: "group",
+        id: 1234,
+        url: "https://gitlab.com/groups/gitlab-org/-/work_items/1234",
+      });
+    });
+
+    it("should parse a nested group work_items URL", () => {
+      const result = GitLabUtils.parseUrl(
+        "https://gitlab.com/groups/gitlab-org/subgroup/-/work_items/5"
+      );
+      expect(result).toEqual({
+        owner: "gitlab-org/subgroup",
+        type: UnfurlResourceType.Issue,
+        scope: "group",
+        id: 5,
+        url: "https://gitlab.com/groups/gitlab-org/subgroup/-/work_items/5",
+      });
+    });
+
+    it("should parse a legacy group epics URL", () => {
+      const result = GitLabUtils.parseUrl(
+        "https://gitlab.com/groups/gitlab-org/-/epics/1234"
+      );
+      expect(result).toEqual({
+        owner: "gitlab-org",
+        type: UnfurlResourceType.Issue,
+        scope: "group",
+        id: 1234,
+        url: "https://gitlab.com/groups/gitlab-org/-/epics/1234",
+      });
+    });
+
+    it("should parse a group work_items URL with show parameter", () => {
+      const show = btoa(
+        JSON.stringify({ iid: "39", full_path: "gitlab-org", id: 1215135 })
+      );
+      const result = GitLabUtils.parseUrl(
+        `https://gitlab.com/groups/gitlab-org/-/work_items?show=${show}`
+      );
+      expect(result).toEqual({
+        owner: "gitlab-org",
+        type: UnfurlResourceType.Issue,
+        scope: "group",
+        id: 39,
+        url: `https://gitlab.com/groups/gitlab-org/-/work_items?show=${show}`,
+      });
+    });
+
+    it("should return undefined for an unsupported group resource", () => {
+      const result = GitLabUtils.parseUrl(
+        "https://gitlab.com/groups/gitlab-org/-/milestones/3"
+      );
+      expect(result).toBeUndefined();
+    });
+
+    it("should return undefined for a subgroup URL", () => {
+      const result = GitLabUtils.parseUrl(
+        "https://gitlab.com/groups/gitlab-org/subgroup"
+      );
+      expect(result).toBeUndefined();
+    });
+  });
+
   describe("custom GitLab URL", () => {
     it("should parse with a custom URL", () => {
       const result = GitLabUtils.parseUrl(

--- a/plugins/gitlab/shared/GitLabUtils.ts
+++ b/plugins/gitlab/shared/GitLabUtils.ts
@@ -12,6 +12,9 @@ export type OAuthState = {
 export class GitLabUtils {
   public static defaultGitlabUrl = "https://gitlab.com";
 
+  /** Fallback color for labels returned without color details. */
+  public static defaultLabelColor = "#6B7280";
+
   private static supportedResources = [
     UnfurlResourceType.Issue,
     UnfurlResourceType.PR,
@@ -138,6 +141,13 @@ export class GitLabUtils {
       }
     | {
         owner: string;
+        type: UnfurlResourceType.Issue;
+        scope: "group";
+        id: number;
+        url: string;
+      }
+    | {
+        owner: string;
         repo: string;
         type: UnfurlResourceType.Project;
         url: string;
@@ -152,22 +162,24 @@ export class GitLabUtils {
       }
 
       const parts = parsed.pathname.split("/").filter(Boolean);
+      const hasSeparator = parsed.pathname.includes("/-/");
+
+      // Epics are group-scoped, e.g. /groups/owner/-/work_items/123
+      const isGroup = hasSeparator && parts[0] === "groups";
+      if (isGroup) {
+        parts.shift();
+      }
 
       // Try base64-encoded `show` query parameter first
       // e.g. /owner/repo/-/issues?show=eyJ...
       const showParam = parsed.searchParams.get("show");
-      if (showParam && parts.length >= 4) {
+      if (showParam && parts.length >= (isGroup ? 3 : 4)) {
         const resourceType = parts.pop();
         parts.pop(); // separator ("-")
-        const repo = parts.pop();
+        const repo = isGroup ? undefined : parts.pop();
         const owner = parts.join("/");
 
-        const type =
-          resourceType === "issues" || resourceType === "work_items"
-            ? UnfurlResourceType.Issue
-            : resourceType === "merge_requests"
-              ? UnfurlResourceType.PR
-              : undefined;
+        const type = this.getResourceType(resourceType, isGroup);
 
         if (!type || !this.supportedResources.includes(type)) {
           return;
@@ -179,14 +191,22 @@ export class GitLabUtils {
           if (!iid) {
             return;
           }
-          return { owner, repo, type, id: iid, url };
+          return isGroup
+            ? {
+                owner,
+                type: UnfurlResourceType.Issue,
+                scope: "group",
+                id: iid,
+                url,
+              }
+            : { owner, repo, type, id: iid, url };
         } catch {
           return;
         }
       }
 
       // Check if it's a project URL (no -/ separator pattern in path)
-      if (!parsed.pathname.includes("/-/")) {
+      if (!hasSeparator) {
         if (parts.length >= 2 && !this.isSystemPath(parts[0])) {
           const repo = parts[parts.length - 1];
           const owner = parts.slice(0, -1).join("/");
@@ -200,7 +220,7 @@ export class GitLabUtils {
         return;
       }
 
-      if (parts.length < 5) {
+      if (parts.length < (isGroup ? 4 : 5)) {
         return;
       }
 
@@ -209,30 +229,58 @@ export class GitLabUtils {
       const resourceType = parts.pop();
       parts.pop(); // separator ("-")
 
-      const repo = parts.pop();
+      const repo = isGroup ? undefined : parts.pop();
       const owner = parts.join("/");
 
-      const type =
-        resourceType === "issues" || resourceType === "work_items"
-          ? UnfurlResourceType.Issue
-          : resourceType === "merge_requests"
-            ? UnfurlResourceType.PR
-            : undefined;
+      const type = this.getResourceType(resourceType, isGroup);
 
       if (!type || !this.supportedResources.includes(type)) {
         return;
       }
 
-      return {
-        owner,
-        repo,
-        type,
-        id: Number(resourceId),
-        url,
-      };
+      return isGroup
+        ? {
+            owner,
+            type: UnfurlResourceType.Issue,
+            scope: "group",
+            id: Number(resourceId),
+            url,
+          }
+        : {
+            owner,
+            repo,
+            type,
+            id: Number(resourceId),
+            url,
+          };
     } catch {
       return;
     }
+  }
+
+  /**
+   * Maps the resource segment of a GitLab URL to an unfurl resource type.
+   *
+   * @param resourceType - the resource segment of the URL path.
+   * @param isGroup - whether the URL points at a group-scoped resource.
+   * @returns the matching resource type, or undefined when unsupported.
+   */
+  private static getResourceType(
+    resourceType: string | undefined,
+    isGroup: boolean
+  ): UnfurlResourceType.Issue | UnfurlResourceType.PR | undefined {
+    if (isGroup) {
+      // Group-scoped work items are epics, which are shown as issues.
+      return resourceType === "epics" || resourceType === "work_items"
+        ? UnfurlResourceType.Issue
+        : undefined;
+    }
+
+    return resourceType === "issues" || resourceType === "work_items"
+      ? UnfurlResourceType.Issue
+      : resourceType === "merge_requests"
+        ? UnfurlResourceType.PR
+        : undefined;
   }
 
   /**

--- a/plugins/gitlab/shared/GitLabUtils.ts
+++ b/plugins/gitlab/shared/GitLabUtils.ts
@@ -9,17 +9,34 @@ export type OAuthState = {
   nonce: string;
 };
 
+/** The kind of namespace a resource belongs to. */
+export type GitLabScope = "project" | "group";
+
 export class GitLabUtils {
   public static defaultGitlabUrl = "https://gitlab.com";
 
   /** Fallback color for labels returned without color details. */
   public static defaultLabelColor = "#6B7280";
 
-  private static supportedResources = [
-    UnfurlResourceType.Issue,
-    UnfurlResourceType.PR,
-    UnfurlResourceType.Project,
-  ];
+  /** The separator GitLab puts between a namespace and the resource path. */
+  private static separator = "/-/";
+
+  /** Maps the resource segment of a URL to a resource type, per scope. */
+  private static resourceTypes: Record<
+    string,
+    Partial<
+      Record<GitLabScope, UnfurlResourceType.Issue | UnfurlResourceType.PR>
+    >
+  > = {
+    issues: { project: UnfurlResourceType.Issue },
+    merge_requests: { project: UnfurlResourceType.PR },
+    // Group-scoped work items are epics, which are shown as issues.
+    work_items: {
+      project: UnfurlResourceType.Issue,
+      group: UnfurlResourceType.Issue,
+    },
+    epics: { group: UnfurlResourceType.Issue },
+  };
 
   /**
    * Gets the GitLab URL, preferring the provided custom URL over the default.
@@ -135,14 +152,8 @@ export class GitLabUtils {
     | {
         owner: string;
         repo: string | undefined;
+        scope?: "group";
         type: UnfurlResourceType.Issue | UnfurlResourceType.PR;
-        id: number;
-        url: string;
-      }
-    | {
-        owner: string;
-        type: UnfurlResourceType.Issue;
-        scope: "group";
         id: number;
         url: string;
       }
@@ -153,134 +164,84 @@ export class GitLabUtils {
         url: string;
       }
     | undefined {
+    let parsed: URL;
+
     try {
-      const parsed = new URL(url);
-      const urlHostname = new URL(this.getGitlabUrl(customUrl)).hostname;
-
-      if (parsed.hostname !== urlHostname) {
+      parsed = new URL(url);
+      if (parsed.hostname !== new URL(this.getGitlabUrl(customUrl)).hostname) {
         return;
       }
-
-      const parts = parsed.pathname.split("/").filter(Boolean);
-      const hasSeparator = parsed.pathname.includes("/-/");
-
-      // Epics are group-scoped, e.g. /groups/owner/-/work_items/123
-      const isGroup = hasSeparator && parts[0] === "groups";
-      if (isGroup) {
-        parts.shift();
-      }
-
-      // Try base64-encoded `show` query parameter first
-      // e.g. /owner/repo/-/issues?show=eyJ...
-      const showParam = parsed.searchParams.get("show");
-      if (showParam && parts.length >= (isGroup ? 3 : 4)) {
-        const resourceType = parts.pop();
-        parts.pop(); // separator ("-")
-        const repo = isGroup ? undefined : parts.pop();
-        const owner = parts.join("/");
-
-        const type = this.getResourceType(resourceType, isGroup);
-
-        if (!type || !this.supportedResources.includes(type)) {
-          return;
-        }
-
-        try {
-          const decoded = JSON.parse(atob(decodeURIComponent(showParam)));
-          const iid = Number(decoded.iid);
-          if (!iid) {
-            return;
-          }
-          return isGroup
-            ? {
-                owner,
-                type: UnfurlResourceType.Issue,
-                scope: "group",
-                id: iid,
-                url,
-              }
-            : { owner, repo, type, id: iid, url };
-        } catch {
-          return;
-        }
-      }
-
-      // Check if it's a project URL (no -/ separator pattern in path)
-      if (!hasSeparator) {
-        if (parts.length >= 2 && !this.isSystemPath(parts[0])) {
-          const repo = parts[parts.length - 1];
-          const owner = parts.slice(0, -1).join("/");
-          return {
-            owner,
-            repo,
-            type: UnfurlResourceType.Project,
-            url,
-          };
-        }
-        return;
-      }
-
-      if (parts.length < (isGroup ? 4 : 5)) {
-        return;
-      }
-
-      // Direct URL: /owner/repo/-/issues/123 or /owner/repo/-/merge_requests/123
-      const resourceId = parts.pop();
-      const resourceType = parts.pop();
-      parts.pop(); // separator ("-")
-
-      const repo = isGroup ? undefined : parts.pop();
-      const owner = parts.join("/");
-
-      const type = this.getResourceType(resourceType, isGroup);
-
-      if (!type || !this.supportedResources.includes(type)) {
-        return;
-      }
-
-      return isGroup
-        ? {
-            owner,
-            type: UnfurlResourceType.Issue,
-            scope: "group",
-            id: Number(resourceId),
-            url,
-          }
-        : {
-            owner,
-            repo,
-            type,
-            id: Number(resourceId),
-            url,
-          };
     } catch {
       return;
     }
+
+    const { pathname } = parsed;
+    const separatorIndex = pathname.indexOf(this.separator);
+
+    // Project URL, e.g. /owner/repo
+    if (separatorIndex === -1) {
+      const parts = pathname.split("/").filter(Boolean);
+      if (parts.length < 2 || this.isSystemPath(parts[0])) {
+        return;
+      }
+      return {
+        owner: parts.slice(0, -1).join("/"),
+        repo: parts[parts.length - 1],
+        type: UnfurlResourceType.Project,
+        url,
+      };
+    }
+
+    // e.g. /owner/repo/-/issues/123 or /groups/owner/-/work_items/123
+    const namespace = pathname
+      .slice(0, separatorIndex)
+      .split("/")
+      .filter(Boolean);
+    const [segment, resourceId] = pathname
+      .slice(separatorIndex + this.separator.length)
+      .split("/");
+
+    // Epics are group-scoped, and so carry no repo.
+    const scope: GitLabScope = namespace[0] === "groups" ? "group" : "project";
+    if (scope === "group") {
+      namespace.shift();
+    }
+
+    const type = this.resourceTypes[segment]?.[scope];
+    if (!type) {
+      return;
+    }
+
+    // List views carry the id in a base64-encoded `show` parameter instead.
+    const showParam = parsed.searchParams.get("show");
+    const id = showParam ? this.parseShowParam(showParam) : Number(resourceId);
+    if (!id) {
+      return;
+    }
+
+    const repo = scope === "group" ? undefined : namespace.pop();
+    const owner = namespace.join("/");
+    if (!owner) {
+      return;
+    }
+
+    const resource = { owner, repo, type, id, url };
+    return scope === "group" ? { ...resource, scope } : resource;
   }
 
   /**
-   * Maps the resource segment of a GitLab URL to an unfurl resource type.
+   * Parses the base64-encoded `show` query parameter used by GitLab list views.
    *
-   * @param resourceType - the resource segment of the URL path.
-   * @param isGroup - whether the URL points at a group-scoped resource.
-   * @returns the matching resource type, or undefined when unsupported.
+   * @param showParam - the raw query parameter value.
+   * @returns the resource IID, or undefined when it cannot be parsed.
    */
-  private static getResourceType(
-    resourceType: string | undefined,
-    isGroup: boolean
-  ): UnfurlResourceType.Issue | UnfurlResourceType.PR | undefined {
-    if (isGroup) {
-      // Group-scoped work items are epics, which are shown as issues.
-      return resourceType === "epics" || resourceType === "work_items"
-        ? UnfurlResourceType.Issue
-        : undefined;
+  private static parseShowParam(showParam: string): number | undefined {
+    try {
+      const decoded = JSON.parse(atob(decodeURIComponent(showParam)));
+      return Number(decoded.iid) || undefined;
+    } catch {
+      return undefined;
     }
-
-    return resourceType === "issues" || resourceType === "work_items"
-      ? UnfurlResourceType.Issue
-      : resourceType === "merge_requests"
-        ? UnfurlResourceType.PR
-        : undefined;
   }
 
   /**

--- a/shared/editor/components/Mentions.tsx
+++ b/shared/editor/components/Mentions.tsx
@@ -73,7 +73,7 @@ export const MentionUser = observer(function MentionUser_(
       })}
     >
       <EmailIcon size={18} />
-      {user?.name || node.attrs.label}
+      <span>{user?.name || node.attrs.label}</span>
     </span>
   );
 });
@@ -94,7 +94,7 @@ export const MentionGroup = observer(function MentionGroup_(
       })}
     >
       <EmailIcon size={18} />
-      {group?.name || node.attrs.label}
+      <span>{group?.name || node.attrs.label}</span>
     </span>
   );
 });
@@ -135,7 +135,7 @@ export const MentionDocument = observer(function MentionDocument_(
       ) : (
         <DocumentIcon size={18} />
       )}
-      {doc?.title || node.attrs.label}
+      <span>{doc?.title || node.attrs.label}</span>
     </Link>
   );
 });
@@ -173,7 +173,7 @@ export const MentionCollection = observer(function MentionCollection_(
       ) : (
         <CollectionIcon size={18} />
       )}
-      {collection?.title || node.attrs.label}
+      <span>{collection?.title || node.attrs.label}</span>
     </Link>
   );
 });

--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -560,6 +560,27 @@ width: 100%;
   gap: 4px;
   vertical-align: bottom;
 
+  /* Long labels are truncated so a mention never wraps onto a second line. */
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+
+  span {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    /* Text sets white-space: normal, so nowrap cannot simply be inherited. */
+    white-space: nowrap;
+  }
+
+  /* Only the label truncates; icons and trailing identifiers stay whole. */
+  &::before,
+  svg,
+  img,
+  span ~ span {
+    flex-shrink: 0;
+  }
+
   &:${hover} {
     cursor: default;
     background: ${props.theme.mentionHoverBackground};


### PR DESCRIPTION
- Group-scoped work items were parsed as project issues, producing a project path of `groups/<group>` and a 404 from the issues API, so pasting an epic showed an error card instead of a preview.
- Parse the namespace around the `/-/` separator and fetch group-scoped resources via the epics API; legacy group epic links now unfurl as well.
- Mentions with long titles wrapped the pill onto several lines — the label is now elided on a single line, with icons and the trailing identifier kept whole.
- closes #13491