### PR TITLE
Unpin and context menu controls on pinned documents

### DIFF
--- a/app/actions/definitions/documents.tsx
+++ b/app/actions/definitions/documents.tsx
@@ -928,23 +928,25 @@ export const duplicateDocument = createAction({
   },
 });
 
+function pinToCollectionName({ getActiveModels, t, stores }: ActionContext) {
+  const documents = getActiveModels(Document);
+  if (documents.length === 1) {
+    const collectionName = stores.documents.getCollectionForDocument(
+      documents[0]
+    )?.name;
+    return t("Pin to {{collectionName}}", {
+      collectionName: collectionName ?? t("collection"),
+    });
+  }
+  return t("Pin");
+}
+
 /**
  * Pin a document to a collection. Pinned documents will be displayed at the top
  * of the collection for all collection members to see.
  */
 export const pinDocumentToCollection = createAction({
-  name: ({ getActiveModels, t, stores }) => {
-    const documents = getActiveModels(Document);
-    if (documents.length === 1) {
-      const collectionName = stores.documents.getCollectionForDocument(
-        documents[0]
-      )?.name;
-      return t("Pin to {{collectionName}}", {
-        collectionName: collectionName ?? t("collection"),
-      });
-    }
-    return t("Pin");
-  },
+  name: pinToCollectionName,
   analyticsName: "Pin document to collection",
   section: ActiveDocumentSection,
   icon: <PinIcon />,
@@ -1006,14 +1008,6 @@ export const pinDocumentToHome = createAction({
   },
 });
 
-export const pinDocument = createActionWithChildren({
-  name: ({ t }) => t("Pin"),
-  analyticsName: "Pin document",
-  section: ActiveDocumentSection,
-  icon: <PinIcon />,
-  children: [pinDocumentToCollection, pinDocumentToHome],
-});
-
 export const unpinDocument = createAction({
   name: ({ t }) => t("Unpin"),
   analyticsName: "Unpin document",
@@ -1037,6 +1031,74 @@ export const unpinDocument = createAction({
           ? t("Unpinned")
           : t("{{ count }} documents unpinned", { count: succeeded })
     ),
+});
+
+/**
+ * Toggle whether a document is pinned to its collection, the current state is
+ * reflected in the item so the label does not change between the two.
+ */
+export const togglePinDocumentToCollection = createAction({
+  name: pinToCollectionName,
+  analyticsName: "Toggle pin document to collection",
+  section: ActiveDocumentSection,
+  icon: <PinIcon />,
+  iconInContextMenu: false,
+  selected: (context) =>
+    everyActiveModel(context, Document, (document) => document.pinned),
+  visible: (context) =>
+    everyActiveModel(context, Document, (document) => {
+      const can = context.stores.policies.abilities(document.id);
+      return !!document.collectionId && (document.pinned ? can.unpin : can.pin);
+    }),
+  perform: (context) =>
+    everyActiveModel(context, Document, (document) => document.pinned)
+      ? unpinDocument.perform(context)
+      : pinDocumentToCollection.perform(context),
+});
+
+/**
+ * Toggle whether a document is pinned to team home, the current state is
+ * reflected in the item so the label does not change between the two.
+ */
+export const togglePinDocumentToHome = createAction({
+  name: ({ t }) => t("Pin to home"),
+  analyticsName: "Toggle pin document to home",
+  section: ActiveDocumentSection,
+  icon: <PinIcon />,
+  iconInContextMenu: false,
+  selected: ({ activeDocumentId, stores }) =>
+    !!activeDocumentId &&
+    !!stores.documents.get(activeDocumentId)?.pinnedToHome,
+  visible: ({ activeDocumentId, currentTeamId, stores }) =>
+    !!currentTeamId &&
+    !!activeDocumentId &&
+    !!stores.policies.abilities(activeDocumentId).pinToHome,
+  perform: async (context) => {
+    const { activeDocumentId, location, t, stores } = context;
+    if (!activeDocumentId) {
+      return;
+    }
+    const document = stores.documents.get(activeDocumentId);
+
+    if (!document?.pinnedToHome) {
+      await pinDocumentToHome.perform(context);
+      return;
+    }
+
+    await document.unpin();
+
+    if (location.pathname !== homePath()) {
+      toast.success(t("Unpinned"));
+    }
+  },
+});
+
+export const pinDocument = createActionWithChildren({
+  name: ({ t }) => t("Pin"),
+  analyticsName: "Pin document",
+  section: ActiveDocumentSection,
+  icon: <PinIcon />,
+  children: [togglePinDocumentToCollection, togglePinDocumentToHome],
 });
 
 export const searchInDocument = createInternalLinkAction({

--- a/app/actions/definitions/documents.tsx
+++ b/app/actions/definitions/documents.tsx
@@ -1033,6 +1033,12 @@ export const unpinDocument = createAction({
     ),
 });
 
+const allPinnedToCollection = (context: ActionContext) =>
+  everyActiveModel(context, Document, (document) => document.pinned);
+
+const nonePinnedToCollection = (context: ActionContext) =>
+  everyActiveModel(context, Document, (document) => !document.pinned);
+
 /**
  * Toggle whether a document is pinned to its collection, the current state is
  * reflected in the item so the label does not change between the two.
@@ -1043,15 +1049,17 @@ export const togglePinDocumentToCollection = createAction({
   section: ActiveDocumentSection,
   icon: <PinIcon />,
   iconInContextMenu: false,
-  selected: (context) =>
-    everyActiveModel(context, Document, (document) => document.pinned),
+  selected: allPinnedToCollection,
   visible: (context) =>
+    // A mixed selection has no single state to toggle to, the one-way Pin and
+    // Unpin actions cover that case instead.
+    (allPinnedToCollection(context) || nonePinnedToCollection(context)) &&
     everyActiveModel(context, Document, (document) => {
       const can = context.stores.policies.abilities(document.id);
       return !!document.collectionId && (document.pinned ? can.unpin : can.pin);
     }),
   perform: (context) =>
-    everyActiveModel(context, Document, (document) => document.pinned)
+    allPinnedToCollection(context)
       ? unpinDocument.perform(context)
       : pinDocumentToCollection.perform(context),
 });

--- a/app/components/DocumentCard.tsx
+++ b/app/components/DocumentCard.tsx
@@ -20,6 +20,7 @@ import NudeButton from "~/components/NudeButton";
 import Time from "~/components/Time";
 import usePolicy from "~/hooks/usePolicy";
 import useStores from "~/hooks/useStores";
+import { DocumentContextMenu } from "~/menus/DocumentContextMenu";
 import CollectionIcon from "./Icons/CollectionIcon";
 import Text from "./Text";
 import Tooltip from "./Tooltip";
@@ -73,13 +74,19 @@ function DocumentCard(props: Props) {
   };
 
   const handleUnpin = useCallback(
-    async (ev) => {
+    async (ev: React.MouseEvent) => {
       ev.preventDefault();
       ev.stopPropagation();
       await pin?.delete();
     },
     [pin]
   );
+
+  // Keep the drag sensor from claiming the pointer, otherwise holding the
+  // button for longer than the activation delay starts a drag
+  const handleActionsPointerDown = useCallback((ev: React.PointerEvent) => {
+    ev.stopPropagation();
+  }, []);
 
   // If the document was updated within the last 7 days, show a timestamp instead of reading time
   const isRecentlyUpdated =
@@ -113,78 +120,84 @@ function DocumentCard(props: Props) {
         }}
         exit={{ opacity: 0, scale: 0.95 }}
       >
-        <DocumentLink
-          dir={document.dir}
-          $isDragging={isDragging}
-          to={{
-            pathname: document.path,
-            state: {
-              title: document.titleWithDefault,
-            },
-          }}
-        >
-          <Content justify="space-between" column>
-            <Fold
-              width="20"
-              height="21"
-              viewBox="0 0 20 21"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path d="M19.5 20.5H6C2.96243 20.5 0.5 18.0376 0.5 15V0.5H0.792893L19.5 19.2071V20.5Z" />
-              <path d="M19.5 19.5H6C2.96243 19.5 0.5 17.0376 0.5 14V0.5H0.792893L19.5 19.2071V19.5Z" />
-            </Fold>
-
-            {document.icon ? (
-              <DocumentSquircle
-                icon={document.icon}
-                color={document.color ?? undefined}
-                initial={document.initial}
-              />
-            ) : (
-              <Squircle
-                color={
-                  collection?.color ??
-                  (pinnedToHome ? theme.slateLight : theme.slateDark)
-                }
+        <DocumentContextMenu document={document}>
+          <DocumentLink
+            dir={document.dir}
+            $isDragging={isDragging}
+            to={{
+              pathname: document.path,
+              state: {
+                title: document.titleWithDefault,
+              },
+            }}
+          >
+            <Content justify="space-between" column>
+              <Fold
+                width="20"
+                height="21"
+                viewBox="0 0 20 21"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                {collection?.icon &&
-                collection?.icon !== "letter" &&
-                collection?.icon !== "collection" &&
-                pinnedToHome ? (
-                  <CollectionIcon collection={collection} color="white" />
-                ) : (
-                  <DocumentIcon color="white" />
-                )}
-              </Squircle>
+                <path d="M19.5 20.5H6C2.96243 20.5 0.5 18.0376 0.5 15V0.5H0.792893L19.5 19.2071V20.5Z" />
+                <path d="M19.5 19.5H6C2.96243 19.5 0.5 17.0376 0.5 14V0.5H0.792893L19.5 19.2071V19.5Z" />
+              </Fold>
+
+              {document.icon ? (
+                <DocumentSquircle
+                  icon={document.icon}
+                  color={document.color ?? undefined}
+                  initial={document.initial}
+                />
+              ) : (
+                <Squircle
+                  color={
+                    collection?.color ??
+                    (pinnedToHome ? theme.slateLight : theme.slateDark)
+                  }
+                >
+                  {collection?.icon &&
+                  collection?.icon !== "letter" &&
+                  collection?.icon !== "collection" &&
+                  pinnedToHome ? (
+                    <CollectionIcon collection={collection} color="white" />
+                  ) : (
+                    <DocumentIcon color="white" />
+                  )}
+                </Squircle>
+              )}
+              <div>
+                <Heading dir={document.dir}>
+                  {hasEmojiInTitle
+                    ? document.titleWithDefault.replace(document.icon!, "")
+                    : document.titleWithDefault}
+                </Heading>
+                <DocumentMeta size="xsmall">
+                  {isRecentlyUpdated ? (
+                    updatedAt
+                  ) : (
+                    <Suspense fallback={updatedAt}>
+                      <ReadingTime document={document} />
+                    </Suspense>
+                  )}
+                </DocumentMeta>
+              </div>
+            </Content>
+            {canUnpin && !isDragging && pin && (
+              <Actions
+                dir={document.dir}
+                gap={4}
+                onPointerDown={handleActionsPointerDown}
+              >
+                <Tooltip content={t("Unpin")}>
+                  <PinButton onClick={handleUnpin} aria-label={t("Unpin")}>
+                    <CloseIcon />
+                  </PinButton>
+                </Tooltip>
+              </Actions>
             )}
-            <div>
-              <Heading dir={document.dir}>
-                {hasEmojiInTitle
-                  ? document.titleWithDefault.replace(document.icon!, "")
-                  : document.titleWithDefault}
-              </Heading>
-              <DocumentMeta size="xsmall">
-                {isRecentlyUpdated ? (
-                  updatedAt
-                ) : (
-                  <Suspense fallback={updatedAt}>
-                    <ReadingTime document={document} />
-                  </Suspense>
-                )}
-              </DocumentMeta>
-            </div>
-          </Content>
-          {canUnpin && !isDragging && pin && (
-            <Actions dir={document.dir} gap={4}>
-              <Tooltip content={t("Unpin")}>
-                <PinButton onClick={handleUnpin} aria-label={t("Unpin")}>
-                  <CloseIcon />
-                </PinButton>
-              </Tooltip>
-            </Actions>
-          )}
-        </DocumentLink>
+          </DocumentLink>
+        </DocumentContextMenu>
       </AnimatePresence>
     </Reorderable>
   );

--- a/app/components/DocumentChip.tsx
+++ b/app/components/DocumentChip.tsx
@@ -1,5 +1,7 @@
 import { observer } from "mobx-react";
-import { DocumentIcon } from "outline-icons";
+import { CloseIcon, DocumentIcon } from "outline-icons";
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 import Icon from "@shared/components/Icon";
@@ -7,10 +9,17 @@ import { s, hover, ellipsis } from "@shared/styles";
 import { IconType } from "@shared/types";
 import { determineIconType } from "@shared/utils/icon";
 import type Document from "~/models/Document";
+import type Pin from "~/models/Pin";
+import NudeButton from "~/components/NudeButton";
+import Tooltip from "~/components/Tooltip";
+import usePolicy from "~/hooks/usePolicy";
+import { DocumentContextMenu } from "~/menus/DocumentContextMenu";
 
 type Props = {
   /** The document to display */
   document: Document;
+  /** The pin related to the document, when given an unpin control is shown */
+  pin?: Pin;
 };
 
 /**
@@ -19,32 +28,58 @@ type Props = {
  */
 export const DocumentChip = observer(function DocumentChip_({
   document,
+  pin,
 }: Props) {
+  const { t } = useTranslation();
   const { icon, color } = document;
+  const canPin = usePolicy(pin);
+  const canDocument = usePolicy(document);
   const title = document.titleWithDefault;
   const isEmoji = determineIconType(icon) === IconType.Emoji;
 
+  // Pins in a collection are governed by the document policy, pins on home by
+  // the policy of the pin itself.
+  const canUnpin = pin?.collectionId ? canDocument.unpin : canPin.delete;
+
+  const handleUnpin = useCallback(
+    async (ev: React.MouseEvent) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      await pin?.delete();
+    },
+    [pin]
+  );
+
   return (
-    <Chip
-      dir={document.dir}
-      to={{
-        pathname: document.path,
-        state: {
-          title,
-        },
-      }}
-    >
-      {icon ? (
-        <Icon
-          value={icon}
-          color={color ?? undefined}
-          initial={document.initial}
-        />
-      ) : (
-        <DocumentIcon />
-      )}
-      <Title>{isEmoji ? title.replace(icon!, "") : title}</Title>
-    </Chip>
+    <DocumentContextMenu document={document}>
+      <Chip
+        dir={document.dir}
+        to={{
+          pathname: document.path,
+          state: {
+            title,
+          },
+        }}
+      >
+        {icon ? (
+          <Icon
+            value={icon}
+            color={color ?? undefined}
+            initial={document.initial}
+          />
+        ) : (
+          <DocumentIcon />
+        )}
+        <Title>{isEmoji ? title.replace(icon!, "") : title}</Title>
+        {pin && canUnpin && (
+          <Tooltip content={t("Unpin")}>
+            <PinButton onClick={handleUnpin} aria-label={t("Unpin")}>
+              <CloseIcon size={18} />
+            </PinButton>
+          </Tooltip>
+        )}
+      </Chip>
+    </DocumentContextMenu>
   );
 });
 
@@ -53,6 +88,20 @@ const Title = styled.span`
   font-size: 14px;
   font-weight: 500;
   color: ${s("text")};
+`;
+
+const PinButton = styled(NudeButton)`
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  color: ${s("textTertiary")};
+  opacity: 0;
+  transition: opacity 100ms ease-in-out;
+
+  &:${hover},
+  &:active {
+    color: ${s("text")};
+  }
 `;
 
 const Chip = styled(Link)`
@@ -72,5 +121,10 @@ const Chip = styled(Link)`
   &:active,
   &:focus-visible {
     background: ${s("listItemHoverBackground")};
+  }
+
+  &:${hover} ${PinButton},
+  &:focus-within ${PinButton} {
+    opacity: 1;
   }
 `;

--- a/app/components/DocumentListItem.tsx
+++ b/app/components/DocumentListItem.tsx
@@ -34,7 +34,7 @@ import { useDragDocument } from "./Sidebar/hooks/useDragAndDrop";
 import { ActionContextProvider } from "~/hooks/useActionContext";
 import { useDocumentMenuAction } from "~/hooks/useDocumentMenuAction";
 import { ContextMenu } from "./Menu/ContextMenu";
-import useStores from "~/hooks/useStores";
+import { useDocumentActiveModels } from "~/hooks/useDocumentActiveModels";
 
 type Props = {
   document: Document;
@@ -60,7 +60,6 @@ function DocumentListItem(
   const { t } = useTranslation();
   const user = useCurrentUser();
   const theme = useTheme();
-  const { userMemberships, groupMemberships } = useStores();
   const locationSidebarContext = useLocationSidebarContext();
   const [menuOpen, handleMenuOpen, handleMenuClose] = useBoolean();
   const isMobile = useMobile();
@@ -122,10 +121,7 @@ function DocumentListItem(
     }
   };
 
-  const isShared = !!(
-    userMemberships.getByDocumentId(document.id) ||
-    groupMemberships.getByDocumentId(document.id)
-  );
+  const activeModels = useDocumentActiveModels(document);
 
   const sidebarContext = determineSidebarContext({
     document,
@@ -153,14 +149,7 @@ function DocumentListItem(
   );
 
   return (
-    <ActionContextProvider
-      value={{
-        activeModels: [
-          document,
-          ...(!isShared && document.collection ? [document.collection] : []),
-        ],
-      }}
-    >
+    <ActionContextProvider value={{ activeModels }}>
       <ContextMenu
         action={contextMenuAction}
         ariaLabel={t("Document options")}

--- a/app/components/Menu/ContextMenu.tsx
+++ b/app/components/Menu/ContextMenu.tsx
@@ -91,7 +91,7 @@ export const ContextMenu = observer(
     return (
       <MenuProvider variant="context">
         <Menu open={open} onOpenChange={handleOpenChange}>
-          <MenuTrigger aria-label={ariaLabel}>{children}</MenuTrigger>
+          <MenuTrigger>{children}</MenuTrigger>
           <MenuContent
             aria-label={ariaLabel}
             onAnimationStart={disablePointerEvents}

--- a/app/components/PinnedDocuments.tsx
+++ b/app/components/PinnedDocuments.tsx
@@ -149,8 +149,10 @@ function PinnedDocuments({
           <Chips>
             {items.map((documentId) => {
               const document = documents.get(documentId);
+              const pin = pins.find((p) => p.documentId === documentId);
+
               return document ? (
-                <DocumentChip key={documentId} document={document} />
+                <DocumentChip key={documentId} document={document} pin={pin} />
               ) : null;
             })}
           </Chips>

--- a/app/hooks/useDocumentActiveModels.ts
+++ b/app/hooks/useDocumentActiveModels.ts
@@ -1,0 +1,25 @@
+import type Document from "~/models/Document";
+import type Model from "~/models/base/Model";
+import useStores from "~/hooks/useStores";
+
+/**
+ * Returns the models that document actions should operate on – the document
+ * itself, and its collection unless the document is only reachable through a
+ * direct share with the user.
+ *
+ * @param document the document the actions will be performed on.
+ * @returns the active models to provide to the action context.
+ */
+export function useDocumentActiveModels(document: Document): Model[] {
+  const { userMemberships, groupMemberships } = useStores();
+
+  const isShared = !!(
+    userMemberships.getByDocumentId(document.id) ||
+    groupMemberships.getByDocumentId(document.id)
+  );
+
+  return [
+    document,
+    ...(!isShared && document.collection ? [document.collection] : []),
+  ];
+}

--- a/app/menus/DocumentContextMenu.tsx
+++ b/app/menus/DocumentContextMenu.tsx
@@ -1,0 +1,47 @@
+import { observer } from "mobx-react";
+import type * as React from "react";
+import { useTranslation } from "react-i18next";
+import type Document from "~/models/Document";
+import { ContextMenu } from "~/components/Menu/ContextMenu";
+import { ActionContextProvider } from "~/hooks/useActionContext";
+import { useDocumentActiveModels } from "~/hooks/useDocumentActiveModels";
+import { useDocumentMenuAction } from "~/hooks/useDocumentMenuAction";
+
+type Props = {
+  /** Document for which the menu is to be shown */
+  document: Document;
+  /** The element that opens the menu when right clicked */
+  children: React.ReactNode;
+  /** Invoked when menu is opened */
+  onOpen?: () => void;
+  /** Invoked when menu is closed */
+  onClose?: () => void;
+};
+
+/**
+ * Wraps its children in a right click context menu offering the standard
+ * document actions.
+ */
+export const DocumentContextMenu = observer(function DocumentContextMenu_({
+  document,
+  children,
+  onOpen,
+  onClose,
+}: Props) {
+  const { t } = useTranslation();
+  const action = useDocumentMenuAction({ documentId: document.id });
+  const activeModels = useDocumentActiveModels(document);
+
+  return (
+    <ActionContextProvider value={{ activeModels }}>
+      <ContextMenu
+        action={action}
+        ariaLabel={t("Document options")}
+        onOpen={onOpen}
+        onClose={onClose}
+      >
+        {children}
+      </ContextMenu>
+    </ActionContextProvider>
+  );
+});

--- a/app/menus/DocumentMenu.tsx
+++ b/app/menus/DocumentMenu.tsx
@@ -13,6 +13,7 @@ import { OverflowMenuButton } from "~/components/Menu/OverflowMenuButton";
 import Switch from "~/components/Switch";
 import { ActionContextProvider } from "~/hooks/useActionContext";
 import useCurrentUser from "~/hooks/useCurrentUser";
+import { useDocumentActiveModels } from "~/hooks/useDocumentActiveModels";
 import useMobile from "~/hooks/useMobile";
 import usePolicy from "~/hooks/usePolicy";
 import useRequest from "~/hooks/useRequest";
@@ -60,13 +61,8 @@ function DocumentMenu({
   const isMobile = useMobile();
   const can = usePolicy(document);
 
-  const { userMemberships, groupMemberships, subscriptions, pins } =
-    useStores();
-
-  const isShared = !!(
-    userMemberships.getByDocumentId(document.id) ||
-    groupMemberships.getByDocumentId(document.id)
-  );
+  const { subscriptions, pins } = useStores();
+  const activeModels = useDocumentActiveModels(document);
 
   const {
     loading: auxDataLoading,
@@ -197,14 +193,7 @@ function DocumentMenu({
   ]);
 
   return (
-    <ActionContextProvider
-      value={{
-        activeModels: [
-          document,
-          ...(!isShared && document.collection ? [document.collection] : []),
-        ],
-      }}
-    >
+    <ActionContextProvider value={{ activeModels }}>
       <DropdownMenu
         action={rootAction}
         align={align}

--- a/app/scenes/Collection/index.tsx
+++ b/app/scenes/Collection/index.tsx
@@ -186,7 +186,11 @@ const CollectionScene = observer(function CollectionScene_() {
             isEditing={isEditRoute || !user?.separateEditMode}
           />
 
-          <PinnedDocuments pins={pins} placeholderCount={count} />
+          <PinnedDocuments
+            pins={pins}
+            placeholderCount={count}
+            collapseKey={collection.id}
+          />
 
           <Content>
             <Navigation


### PR DESCRIPTION
- Adds an unpin control to document chips in the collapsed pinned view, matching the one on the cards
- Adds the collapse toggle to collections, previously only available on home
- Makes the Pin menu items toggles with a selected state, so a document can be unpinned from the same place it was pinned
- Adds a document context menu to pinned cards and chips
- Fixes the unpin button on cards being hard to press — the drag sensor claimed the pointer before the click landed
- Drops the aria-label from the context menu trigger, which was overriding the accessible name of every element it wrapped