### PR TITLE
fix: Update GitLab token handling for compatibility with older instances

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             General Outline, Inc.
-Licensed Work:        Outline 1.9.1
+Licensed Work:        Outline 1.9.2
                       The Licensed Work is (c) 2026 General Outline, Inc.
 Additional Use Grant: You may make use of the Licensed Work, provided that
                       you may not use the Licensed Work for a Document
@@ -15,7 +15,7 @@ Additional Use Grant: You may make use of the Licensed Work, provided that
                       Licensed Work by creating teams and documents
                       controlled by such third parties.
 
-Change Date:          2030-07-13
+Change Date:          2030-07-21
 
 Change License:       Apache License, Version 2.0
 

--- a/package.json
+++ b/package.json
@@ -382,6 +382,6 @@
     "uuid": "^11.1.1",
     "nodemailer@npm:9.0.0": "^9.0.1"
   },
-  "version": "1.9.1",
+  "version": "1.9.2",
   "packageManager": "yarn@4.11.0"
 }

--- a/plugins/gitlab/server/api/gitlab.ts
+++ b/plugins/gitlab/server/api/gitlab.ts
@@ -227,7 +227,7 @@ router.get(
         await pendingAuth.update(
           {
             token: oauth.access_token,
-            refreshToken: oauth.refresh_token,
+            refreshToken: oauth.refresh_token ?? pendingAuth.refreshToken,
             expiresAt: oauth.expires_in
               ? addSeconds(Date.now(), oauth.expires_in)
               : undefined,
@@ -243,7 +243,7 @@ router.get(
             userId: user.id,
             teamId: user.teamId,
             token: oauth.access_token,
-            refreshToken: oauth.refresh_token,
+            refreshToken: oauth.refresh_token ?? "",
             expiresAt: oauth.expires_in
               ? addSeconds(Date.now(), oauth.expires_in)
               : undefined,

--- a/plugins/gitlab/server/gitlab.ts
+++ b/plugins/gitlab/server/gitlab.ts
@@ -28,10 +28,11 @@ import env from "./env";
 const AccessTokenResponseSchema = z.object({
   access_token: z.string(),
   token_type: z.string(),
-  expires_in: z.number(),
-  refresh_token: z.string(),
+  // Older self-hosted GitLab (<15 / non-expiring tokens) may omit these.
+  expires_in: z.number().optional(),
+  refresh_token: z.string().optional(),
   scope: z.string(),
-  created_at: z.number(),
+  created_at: z.number().optional(),
 });
 
 export class GitLab {

--- a/server/models/IntegrationAuthentication.ts
+++ b/server/models/IntegrationAuthentication.ts
@@ -24,7 +24,8 @@ import { addSeconds } from "date-fns";
 export interface TokenRefreshResponse {
   access_token: string;
   refresh_token?: string;
-  expires_in: number;
+  /** Omitted by older GitLab instances that issue non-expiring tokens. */
+  expires_in?: number;
 }
 
 export type TokenRefreshCallback = (
@@ -135,7 +136,9 @@ class IntegrationAuthentication extends IdModel<
               token: tokenResponse.access_token,
               refreshToken:
                 tokenResponse.refresh_token || lockedAuth.refreshToken,
-              expiresAt: addSeconds(Date.now(), tokenResponse.expires_in),
+              expiresAt: tokenResponse.expires_in
+                ? addSeconds(Date.now(), tokenResponse.expires_in)
+                : lockedAuth.expiresAt,
             },
             { transaction }
           );


### PR DESCRIPTION
- Made `expires_in` and `refresh_token` optional in the AccessTokenResponseSchema to accommodate older self-hosted GitLab versions( Gitlab version < 15 ) that may not provide these fields.
- Adjusted token handling in the API to use fallback values for `refreshToken` when not provided.
- Updated IntegrationAuthentication to handle optional `expires_in` when calculating `expiresAt` for tokens.