### PR TITLE
feat(mcp): paginate document and template content in fetch tool

### DIFF
--- a/server/tools/fetch.test.ts
+++ b/server/tools/fetch.test.ts
@@ -203,4 +203,78 @@ describe("fetch", () => {
 
     expect(res!.result!.content![1].text).toContain("Body of the template");
   });
+
+  it("paginates long document content via offset and limit", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const document = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+      text: Array.from(
+        { length: 1200 },
+        (_, i) => `Line ${i} of a long document used to test pagination.`
+      ).join("\n\n"),
+    });
+
+    // A single call with a limit above the document size returns everything.
+    const full = await callMcpTool(server, accessToken, "fetch", {
+      resource: "document",
+      id: document.id,
+      limit: 100000,
+    });
+    const fullText = full!.result!.content![1].text!;
+    const fullMetadata = JSON.parse(full!.result!.content![0].text ?? "{}");
+    expect(fullMetadata.truncated).toBe(false);
+
+    // The default limit truncates, and successive pages reassemble the text.
+    let assembled = "";
+    let offset = 0;
+    for (let i = 0; i < 10; i++) {
+      const res = await callMcpTool(server, accessToken, "fetch", {
+        resource: "document",
+        id: document.id,
+        offset,
+      });
+      const metadata = JSON.parse(res!.result!.content![0].text ?? "{}");
+      const chunk = res!.result!.content![1].text!;
+      assembled += chunk;
+      expect(chunk.length).toBeLessThanOrEqual(16000);
+      if (!metadata.truncated) {
+        break;
+      }
+      offset = metadata.nextOffset;
+    }
+
+    expect(assembled).toEqual(fullText);
+  });
+
+  it("paginates template body content via offset and limit", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const template = await buildTemplate({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+      text: Array.from(
+        { length: 1200 },
+        (_, i) => `Template line ${i} for pagination testing.`
+      ).join("\n\n"),
+    });
+
+    const res = await callMcpTool(server, accessToken, "fetch", {
+      resource: "template",
+      id: template.id,
+    });
+    const metadata = JSON.parse(res!.result!.content![0].text ?? "{}");
+    expect(metadata.truncated).toBe(true);
+    expect(metadata.textLength).toBeGreaterThan(16000);
+    expect(res!.result!.content![1].text!.length).toBeLessThanOrEqual(16000);
+  });
 });

--- a/server/tools/fetch.ts
+++ b/server/tools/fetch.ts
@@ -16,6 +16,8 @@ import { presentCollection } from "./collections";
 import { presentDocument } from "./documents";
 import { presentTemplate } from "./templates";
 import {
+  DEFAULT_FETCH_LIMIT,
+  MAX_FETCH_LIMIT,
   error,
   success,
   getActorFromContext,
@@ -23,6 +25,7 @@ import {
   getPublicShareUrlForCollection,
   getPublicShareUrlForDocument,
   pathToUrl,
+  sliceMarkdown,
   withTracing,
 } from "./util";
 
@@ -114,140 +117,192 @@ export function fetchTool(server: McpServer, scopes: string[]) {
           .describe(
             'The unique identifier or URL. For users, "current_user" returns the authenticated user.'
           ),
+        offset: z.coerce
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe(
+            "The character offset to start reading document or template content from. Defaults to 0. Use together with limit to read long content in chunks."
+          ),
+        limit: z.coerce
+          .number()
+          .int()
+          .min(1)
+          .max(MAX_FETCH_LIMIT)
+          .optional()
+          .describe(
+            "The maximum number of characters of document or template content to return. Defaults to 16000. When content is longer, the response is truncated and the returned metadata indicates how to continue."
+          ),
       },
     },
-    withTracing("fetch", async ({ resource, id: rawId }, extra) => {
-      try {
-        const actor = getActorFromContext(extra);
-        const id = extractId(rawId);
+    withTracing(
+      "fetch",
+      async ({ resource, id: rawId, offset, limit }, extra) => {
+        try {
+          const actor = getActorFromContext(extra);
+          const id = extractId(rawId);
+          const effectiveOffset = offset ?? 0;
+          const effectiveLimit = limit ?? DEFAULT_FETCH_LIMIT;
 
-        switch (resource) {
-          case "document": {
-            const document = await Document.findByPk(id, {
-              userId: actor.id,
-              rejectOnEmpty: true,
-            });
+          switch (resource) {
+            case "document": {
+              const document = await Document.findByPk(id, {
+                userId: actor.id,
+                rejectOnEmpty: true,
+              });
 
-            authorize(actor, "read", document);
+              authorize(actor, "read", document);
 
-            const [{ text, ...attributes }, breadcrumb, shareUrl] =
-              await Promise.all([
-                presentDocument(document, {
-                  includeData: false,
-                  includeText: true,
-                  includeUpdatedAt: true,
-                  includeCommentCount: true,
-                }),
-                getDocumentBreadcrumb(document, actor),
-                getPublicShareUrlForDocument(actor.team, document.id),
-              ]);
-            return {
-              content: [
-                {
-                  type: "text" as const,
-                  text: JSON.stringify({
-                    document: pathToUrl(actor.team, attributes),
-                    ...(breadcrumb !== undefined && { breadcrumb }),
-                    ...(shareUrl !== undefined && { shareUrl }),
+              const [{ text, ...attributes }, breadcrumb, shareUrl] =
+                await Promise.all([
+                  presentDocument(document, {
+                    includeData: false,
+                    includeText: true,
+                    includeUpdatedAt: true,
+                    includeCommentCount: true,
                   }),
-                },
-                {
-                  type: "text" as const,
-                  text: typeof text === "string" ? text : "",
-                },
-              ],
-            } satisfies CallToolResult;
-          }
-
-          case "collection": {
-            const collection = await Collection.findByPk(id, {
-              userId: actor.id,
-              includeDocumentStructure: true,
-              rejectOnEmpty: true,
-            });
-
-            authorize(actor, "read", collection);
-
-            const [presented, shareUrl] = await Promise.all([
-              presentCollection(collection),
-              getPublicShareUrlForCollection(actor.team, collection.id),
-            ]);
-            return success([
-              {
-                ...pathToUrl(actor.team, presented),
-                ...(shareUrl !== undefined && { shareUrl }),
-              },
-              (collection.documentStructure ?? []).map((node) =>
-                presentNavigationNode(actor.team, node)
-              ),
-            ]);
-          }
-
-          case "user": {
-            const user = SELF_TOKENS.has(id.toLowerCase())
-              ? actor
-              : await User.findByPk(id, { rejectOnEmpty: true });
-
-            authorize(actor, "read", user);
-
-            return success(
-              presentUser(user, {
-                includeEmail: !!can(actor, "readEmail", user),
-                includeDetails: !!can(actor, "readDetails", user),
-              })
-            );
-          }
-
-          case "attachment": {
-            const attachment = await Attachment.findByPk(id, {
-              rejectOnEmpty: true,
-            });
-
-            // Private attachments are accessible to any member of the workspace they
-            // belong to. This is intentional and not a permission bypass – attachments
-            // are owned by the workspace (team), not by individual documents or users.
-            if (attachment.teamId !== actor?.teamId) {
-              throw AuthorizationError();
+                  getDocumentBreadcrumb(document, actor),
+                  getPublicShareUrlForDocument(actor.team, document.id),
+                ]);
+              const fullText = typeof text === "string" ? text : "";
+              const slicedText = sliceMarkdown(
+                fullText,
+                effectiveOffset,
+                effectiveLimit
+              );
+              const textLength = fullText.length;
+              const truncated =
+                effectiveOffset + slicedText.length < textLength;
+              return {
+                content: [
+                  {
+                    type: "text" as const,
+                    text: JSON.stringify({
+                      document: pathToUrl(actor.team, attributes),
+                      ...(breadcrumb !== undefined && { breadcrumb }),
+                      ...(shareUrl !== undefined && { shareUrl }),
+                      textLength,
+                      truncated,
+                      ...(truncated && {
+                        nextOffset: effectiveOffset + slicedText.length,
+                      }),
+                    }),
+                  },
+                  {
+                    type: "text" as const,
+                    text: slicedText,
+                  },
+                ],
+              } satisfies CallToolResult;
             }
 
-            return success({
-              id: attachment.id,
-              name: attachment.name,
-              contentType: attachment.contentType,
-              size: attachment.size,
-              signedUrl: await attachment.signedUrl,
-            });
-          }
+            case "collection": {
+              const collection = await Collection.findByPk(id, {
+                userId: actor.id,
+                includeDocumentStructure: true,
+                rejectOnEmpty: true,
+              });
 
-          case "template": {
-            const template = await Template.findByPk(id, {
-              userId: actor.id,
-              rejectOnEmpty: true,
-            });
+              authorize(actor, "read", collection);
 
-            authorize(actor, "read", template);
-
-            const { text, ...attributes } = await presentTemplate(template);
-            return {
-              content: [
+              const [presented, shareUrl] = await Promise.all([
+                presentCollection(collection),
+                getPublicShareUrlForCollection(actor.team, collection.id),
+              ]);
+              return success([
                 {
-                  type: "text" as const,
-                  text: JSON.stringify(pathToUrl(actor.team, attributes)),
+                  ...pathToUrl(actor.team, presented),
+                  ...(shareUrl !== undefined && { shareUrl }),
                 },
-                {
-                  type: "text" as const,
-                  text,
-                },
-              ],
-            } satisfies CallToolResult;
-          }
+                (collection.documentStructure ?? []).map((node) =>
+                  presentNavigationNode(actor.team, node)
+                ),
+              ]);
+            }
 
-          default:
-            return error(`Unknown resource: ${resource}`);
+            case "user": {
+              const user = SELF_TOKENS.has(id.toLowerCase())
+                ? actor
+                : await User.findByPk(id, { rejectOnEmpty: true });
+
+              authorize(actor, "read", user);
+
+              return success(
+                presentUser(user, {
+                  includeEmail: !!can(actor, "readEmail", user),
+                  includeDetails: !!can(actor, "readDetails", user),
+                })
+              );
+            }
+
+            case "attachment": {
+              const attachment = await Attachment.findByPk(id, {
+                rejectOnEmpty: true,
+              });
+
+              // Private attachments are accessible to any member of the workspace they
+              // belong to. This is intentional and not a permission bypass – attachments
+              // are owned by the workspace (team), not by individual documents or users.
+              if (attachment.teamId !== actor?.teamId) {
+                throw AuthorizationError();
+              }
+
+              return success({
+                id: attachment.id,
+                name: attachment.name,
+                contentType: attachment.contentType,
+                size: attachment.size,
+                signedUrl: await attachment.signedUrl,
+              });
+            }
+
+            case "template": {
+              const template = await Template.findByPk(id, {
+                userId: actor.id,
+                rejectOnEmpty: true,
+              });
+
+              authorize(actor, "read", template);
+
+              const { text, ...attributes } = await presentTemplate(template);
+              const fullText = text;
+              const slicedText = sliceMarkdown(
+                fullText,
+                effectiveOffset,
+                effectiveLimit
+              );
+              const textLength = fullText.length;
+              const truncated =
+                effectiveOffset + slicedText.length < textLength;
+              return {
+                content: [
+                  {
+                    type: "text" as const,
+                    text: JSON.stringify({
+                      ...pathToUrl(actor.team, attributes),
+                      textLength,
+                      truncated,
+                      ...(truncated && {
+                        nextOffset: effectiveOffset + slicedText.length,
+                      }),
+                    }),
+                  },
+                  {
+                    type: "text" as const,
+                    text: slicedText,
+                  },
+                ],
+              } satisfies CallToolResult;
+            }
+
+            default:
+              return error(`Unknown resource: ${resource}`);
+          }
+        } catch (message) {
+          return error(message);
         }
-      } catch (message) {
-        return error(message);
       }
-    })
+    )
   );
 }

--- a/server/tools/util.ts
+++ b/server/tools/util.ts
@@ -70,6 +70,12 @@ export function optionalString() {
 /** The URI of the MCP resource that lists the available named icons. */
 export const iconNamesResourceUri = "outline://icons";
 
+/** The default maximum number of characters returned per fetch of document or template content. */
+export const DEFAULT_FETCH_LIMIT = 16000;
+
+/** The maximum number of characters a fetch of document or template content may return in a single call. */
+export const MAX_FETCH_LIMIT = 100000;
+
 /**
  * Helper function to format successful MCP tool responses.
  *
@@ -94,6 +100,41 @@ export function success<T>(data: T | T[]): CallToolResult {
       text: JSON.stringify(item),
     })),
   };
+}
+
+/**
+ * Slices a text blob into a bounded window aligned to newline boundaries, so
+ * that paginated fetches do not split a markdown block mid-line.
+ *
+ * @param text - the full text to slice.
+ * @param offset - the character index to begin the window at.
+ * @param limit - the maximum number of characters the window may contain.
+ * @returns the sliced text, possibly shorter than limit when aligned to a boundary.
+ */
+export function sliceMarkdown(
+  text: string,
+  offset: number,
+  limit: number
+): string {
+  const total = text.length;
+
+  if (offset >= total) {
+    return "";
+  }
+
+  let end = Math.min(total, offset + limit);
+
+  // When more content follows the window, pull the end back to the previous
+  // newline so a block is never cut in half. Skip this when it would leave the
+  // window empty.
+  if (end < total) {
+    const newline = text.lastIndexOf("\n", end);
+    if (newline > offset) {
+      end = newline;
+    }
+  }
+
+  return text.slice(offset, end);
 }
 
 /**


### PR DESCRIPTION
## What

Adds character-based pagination to the MCP `fetch` tool for `document` and `template` resources, so large content no longer overflows MCP client result limits and gets truncated.

## Why

`fetch` currently returns the entire markdown in a single text block. Large documents exceed client result limits and are silently truncated, leaving the agent unable to read the rest.

## Changes

- `server/tools/fetch.ts` — new `offset` / `limit` inputs; document and template responses slice content and include `textLength`, `truncated`, `nextOffset` metadata.
- `server/tools/util.ts` — `sliceMarkdown` helper (newline-aligned) plus `DEFAULT_FETCH_LIMIT` / `MAX_FETCH_LIMIT`.
- `server/tools/fetch.test.ts` — document and template pagination tests.

## Notes

- Slicing aligns to newline boundaries so markdown blocks aren't split mid-line.
- Reading stays lossless; edits continue to use the existing `patch` mode.

Closes #13502