### PR TITLE
fix: Consistent rate limiter keys across path variants

### DIFF
--- a/server/middlewares/rateLimiter.test.ts
+++ b/server/middlewares/rateLimiter.test.ts
@@ -118,6 +118,70 @@ describe("rateLimiter middleware", () => {
     expect(limiter.points).toBe(1);
   });
 
+  it("registers one limiter for case and trailing slash variants of a path", async () => {
+    const registerMiddleware = rateLimiter({ duration: 60, requests: 5 });
+
+    await registerMiddleware(
+      createContext({ path: "/documents.export", mountPath: "/api" }),
+      vi.fn()
+    );
+    await registerMiddleware(
+      createContext({ path: "/Documents.Export", mountPath: "/API" }),
+      vi.fn()
+    );
+    await registerMiddleware(
+      createContext({ path: "/documents.export/", mountPath: "/api" }),
+      vi.fn()
+    );
+
+    expect(RateLimiter.rateLimiterMap.size).toBe(1);
+
+    const limiter = RateLimiter.getRateLimiter("/api/documents.export");
+    for (const variant of [
+      "/API/Documents.Export",
+      "/api/documents.export/",
+      "/API/Documents.Export/",
+    ]) {
+      expect(RateLimiter.hasRateLimiter(variant)).toBe(true);
+      expect(RateLimiter.getRateLimiter(variant)).toBe(limiter);
+    }
+  });
+
+  it("consumes one bucket for case and trailing slash variants of a path", async () => {
+    const registerMiddleware = rateLimiter({ duration: 60, requests: 5 });
+    await registerMiddleware(
+      createContext({ path: "/documents.export", mountPath: "/api" }),
+      vi.fn()
+    );
+
+    const customLimiter = RateLimiter.getRateLimiter("/api/documents.export");
+    const consumeSpy = vi
+      .spyOn(customLimiter, "consume")
+      .mockResolvedValue({} as never);
+
+    const middleware = defaultRateLimiter();
+    for (const path of [
+      "/documents.export",
+      "/Documents.Export",
+      "/documents.export/",
+    ]) {
+      await middleware(
+        createContext({ path, mountPath: "/api", ip: "127.0.0.1" }),
+        vi.fn()
+      );
+    }
+
+    expect(consumeSpy.mock.calls.map(([key]) => key)).toEqual([
+      "/api/documents.export:127.0.0.1",
+      "/api/documents.export:127.0.0.1",
+      "/api/documents.export:127.0.0.1",
+    ]);
+  });
+
+  it("keeps the root path when normalizing", () => {
+    expect(RateLimiter.normalizePath("/")).toBe("/");
+  });
+
   it("should use default rate limiter when no custom rate limiter is registered", async () => {
     const fullPath = "/some/random/path";
     expect(RateLimiter.hasRateLimiter(fullPath)).toBe(false);

--- a/server/middlewares/rateLimiter.ts
+++ b/server/middlewares/rateLimiter.ts
@@ -65,7 +65,9 @@ export function defaultRateLimiter() {
       return next();
     }
 
-    const fullPath = `${ctx.mountPath ?? ""}${ctx.path}`;
+    const fullPath = RateLimiter.normalizePath(
+      `${ctx.mountPath ?? ""}${ctx.path}`
+    );
     const identifiers = await getRateLimiterIdentifiers(ctx);
     const isPathScoped = RateLimiter.hasRateLimiter(fullPath);
     const limiter = RateLimiter.getRateLimiter(fullPath);
@@ -127,7 +129,9 @@ export function rateLimiter(config: RateLimiterConfig) {
       return next();
     }
 
-    const fullPath = `${ctx.mountPath ?? ""}${ctx.path}`;
+    const fullPath = RateLimiter.normalizePath(
+      `${ctx.mountPath ?? ""}${ctx.path}`
+    );
 
     if (!RateLimiter.hasRateLimiter(fullPath)) {
       const points = Math.max(

--- a/server/utils/RateLimiter.ts
+++ b/server/utils/RateLimiter.ts
@@ -51,6 +51,21 @@ export default class RateLimiter {
   }
 
   /**
+   * Normalizes a request path into the key that identifies its rate limiter.
+   * The router matches paths case-insensitively and with an optional trailing
+   * slash, so every one of those variants must collapse onto a single key.
+   *
+   * @param path the request path to normalize.
+   * @returns the normalized path.
+   */
+  static normalizePath(path: string): string {
+    const lowercased = path.toLowerCase();
+    return lowercased.length > 1 && lowercased.endsWith("/")
+      ? lowercased.slice(0, -1)
+      : lowercased;
+  }
+
+  /**
    * Returns the rate limiter registered for a path, falling back to the
    * default rate limiter.
    *

--- a/server/utils/RateLimiter.ts
+++ b/server/utils/RateLimiter.ts
@@ -67,34 +67,39 @@ export default class RateLimiter {
 
   /**
    * Returns the rate limiter registered for a path, falling back to the
-   * default rate limiter.
+   * default rate limiter. The path is normalized before lookup.
    *
    * @param path the request path to look up.
    * @returns the rate limiter for the path.
    */
   static getRateLimiter(path: string): RateLimiterRedis {
-    return this.rateLimiterMap.get(path) || this.defaultRateLimiter;
+    return (
+      this.rateLimiterMap.get(this.normalizePath(path)) ||
+      this.defaultRateLimiter
+    );
   }
 
   /**
-   * Registers a rate limiter with a custom configuration for a path.
+   * Registers a rate limiter with a custom configuration for a path. The path
+   * is normalized before registration.
    *
    * @param path the request path to register the rate limiter for.
    * @param config the rate limiter configuration.
    */
   static setRateLimiter(path: string, config: IRateLimiterStoreOptions): void {
     const rateLimiter = new RateLimiterRedis(config);
-    this.rateLimiterMap.set(path, rateLimiter);
+    this.rateLimiterMap.set(this.normalizePath(path), rateLimiter);
   }
 
   /**
-   * Checks whether a custom rate limiter is registered for a path.
+   * Checks whether a custom rate limiter is registered for a path. The path is
+   * normalized before lookup.
    *
    * @param path the request path to check.
    * @returns true if a custom rate limiter is registered.
    */
   static hasRateLimiter(path: string): boolean {
-    return this.rateLimiterMap.has(path);
+    return this.rateLimiterMap.has(this.normalizePath(path));
   }
 
   /**


### PR DESCRIPTION
- The router matches routes case-insensitively and with an optional trailing slash, so each casing and slash variant of a path was previously keyed as if it were a separate route.
- Registration and consumption now normalize the path first, so every variant shares one bucket and one registered limiter.
- Also keeps the in-memory limiter map from growing an entry per variant.