### PR TITLE
Stricter validation of team preferences

### DIFF
--- a/server/presenters/team.test.ts
+++ b/server/presenters/team.test.ts
@@ -1,0 +1,33 @@
+import { TeamPreference } from "@shared/types";
+import { Team } from "@server/models";
+import presentTeam from "./team";
+
+it("presents a team", () => {
+  const team = presentTeam(
+    Team.build({
+      id: "123",
+      name: "Test Team",
+    })
+  );
+  expect(team.id).toEqual("123");
+  expect(team.name).toEqual("Test Team");
+});
+
+it("omits unrecognized preferences", () => {
+  const team = Team.build({ id: "123", name: "Test Team" });
+  team.preferences = JSON.parse(
+    '{"publicBranding":true,"unknownPreference":true}'
+  );
+
+  const data = presentTeam(team);
+  expect(data.preferences).toEqual({
+    [TeamPreference.PublicBranding]: true,
+  });
+});
+
+it("presents null preferences", () => {
+  const team = Team.build({ id: "123", name: "Test Team" });
+  team.preferences = null;
+
+  expect(presentTeam(team).preferences).toBeNull();
+});

--- a/server/presenters/team.ts
+++ b/server/presenters/team.ts
@@ -1,3 +1,5 @@
+import { pick } from "es-toolkit";
+import { TeamPreference } from "@shared/types";
 import type { Team } from "@server/models";
 
 export default function presentTeam(team: Team) {
@@ -19,7 +21,10 @@ export default function presentTeam(team: Team) {
     defaultUserRole: team.defaultUserRole,
     inviteRequired: team.inviteRequired,
     allowedDomains: team.allowedDomains?.map((d) => d.name),
-    preferences: team.preferences,
+    // Unrecognized keys are omitted so that clients can safely send the object back.
+    preferences: team.preferences
+      ? pick(team.preferences, Object.values(TeamPreference))
+      : team.preferences,
     guidanceMCP: team.guidanceMCP,
   };
 }

--- a/server/presenters/user.test.ts
+++ b/server/presenters/user.test.ts
@@ -1,3 +1,4 @@
+import { NotificationEventType, UserPreference } from "@shared/types";
 import { User } from "@server/models";
 import presentUser from "./user";
 
@@ -19,4 +20,22 @@ it("presents a user without slack data", async () => {
     })
   );
   expect(user).toMatchSnapshot();
+});
+
+it("omits unrecognized preferences and notification settings", async () => {
+  const user = User.build({ id: "123", name: "Test User" });
+  user.preferences = JSON.parse(
+    '{"seamlessEdit":true,"unknownPreference":true}'
+  );
+  user.notificationSettings = JSON.parse(
+    '{"documents.publish":true,"unknown.event":true}'
+  );
+
+  const data = presentUser(user, { includeDetails: true });
+  expect(data.preferences).toEqual({
+    [UserPreference.SeamlessEdit]: true,
+  });
+  expect(data.notificationSettings).toEqual({
+    [NotificationEventType.PublishDocument]: true,
+  });
 });

--- a/server/presenters/user.ts
+++ b/server/presenters/user.ts
@@ -1,8 +1,10 @@
+import { pick } from "es-toolkit";
 import type {
   NotificationSettings,
   UserPreferences,
   UserRole,
 } from "@shared/types";
+import { NotificationEventType, UserPreference } from "@shared/types";
 import env from "@server/env";
 import type { User } from "@server/models";
 
@@ -51,8 +53,13 @@ export default function presentUser(
   if (options.includeDetails) {
     userData.email = user.email;
     userData.language = user.language || env.DEFAULT_LANGUAGE;
-    userData.preferences = user.preferences;
-    userData.notificationSettings = user.notificationSettings;
+    // Unrecognized keys are omitted so that clients can safely send the object back.
+    userData.preferences = user.preferences
+      ? pick(user.preferences, Object.values(UserPreference))
+      : user.preferences;
+    userData.notificationSettings = user.notificationSettings
+      ? pick(user.notificationSettings, Object.values(NotificationEventType))
+      : user.notificationSettings;
   }
 
   if (options.includeEmail) {

--- a/server/routes/api/teams/schema.ts
+++ b/server/routes/api/teams/schema.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import {
   CommentingAccess,
   EmailDisplay,
+  TeamPreference,
   TOCPosition,
   UserRole,
 } from "@shared/types";
@@ -42,40 +43,42 @@ export const TeamsUpdateSchema = BaseSchema.extend({
     guidanceMCP: z.string().max(TeamValidation.maxGuidanceMCPLength).nullish(),
     /** Team preferences */
     preferences: z
-      .object({
+      .strictObject({
         /** Whether documents have a separate edit mode instead of seamless editing. */
-        seamlessEdit: z.boolean().optional(),
+        [TeamPreference.SeamlessEdit]: z.boolean(),
         /** Whether to use team logo across the app for branding. */
-        publicBranding: z.boolean().optional(),
+        [TeamPreference.PublicBranding]: z.boolean(),
         /** Whether viewers should see download options. */
-        viewersCanExport: z.boolean().optional(),
+        [TeamPreference.ViewersCanExport]: z.boolean(),
         /** Whether members can invite new people to the team. */
-        membersCanInvite: z.boolean().optional(),
+        [TeamPreference.MembersCanInvite]: z.boolean(),
         /** Whether members can create API keys. */
-        membersCanCreateApiKey: z.boolean().optional(),
+        [TeamPreference.MembersCanCreateApiKey]: z.boolean(),
         /** Whether members can delete their user account. */
-        membersCanDeleteAccount: z.boolean().optional(),
+        [TeamPreference.MembersCanDeleteAccount]: z.boolean(),
         /** Whether notification emails include document and comment content. */
-        previewsInEmails: z.boolean().optional(),
+        [TeamPreference.PreviewsInEmails]: z.boolean(),
         /** Who can comment on documents. */
-        commenting: z.enum(CommentingAccess).optional(),
+        [TeamPreference.Commenting]: z.enum(CommentingAccess),
         /** The custom theme for the team. */
-        customTheme: z
-          .object({
-            accent: z.string().min(4).max(7).regex(/^#/).optional(),
-            accentText: z.string().min(4).max(7).regex(/^#/).optional(),
+        [TeamPreference.CustomTheme]: z
+          .strictObject({
+            accent: z.string().min(4).max(7).regex(/^#/),
+            accentText: z.string().min(4).max(7).regex(/^#/),
           })
-          .optional(),
+          .partial(),
         /** Side to display the document's table of contents in relation to the main content. */
-        tocPosition: z.enum(TOCPosition).optional(),
-        emailDisplay: z.enum(EmailDisplay).optional(),
+        [TeamPreference.TocPosition]: z.enum(TOCPosition),
+        /** Who can see user email addresses. */
+        [TeamPreference.EmailDisplay]: z.enum(EmailDisplay),
         /** Whether to prevent shared documents from being embedded in iframes on external websites. */
-        preventDocumentEmbedding: z.boolean().optional(),
+        [TeamPreference.PreventDocumentEmbedding]: z.boolean(),
         /** Whether external MCP clients can connect to the workspace. */
-        mcp: z.boolean().optional(),
+        [TeamPreference.MCP]: z.boolean(),
         /** List of disabled embed provider titles. */
-        disabledEmbeds: z.array(z.string()).optional(),
+        [TeamPreference.DisabledEmbeds]: z.array(z.string()),
       })
+      .partial()
       .optional(),
   }),
 });

--- a/server/routes/api/teams/teams.test.ts
+++ b/server/routes/api/teams/teams.test.ts
@@ -53,6 +53,44 @@ describe("#team.update", () => {
     expect(body.data.name).toEqual(name);
   });
 
+  it("should update team preferences", async () => {
+    const admin = await buildAdmin();
+    const res = await server.post("/api/team.update", admin, {
+      body: {
+        preferences: {
+          publicBranding: true,
+        },
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.data.preferences.publicBranding).toBe(true);
+  });
+
+  it("should fail upon sending unknown team preference", async () => {
+    const admin = await buildAdmin();
+    const res = await server.post("/api/team.update", admin, {
+      body: {
+        preferences: {
+          invalidPreference: true,
+        },
+      },
+    });
+    expect(res.status).toEqual(400);
+  });
+
+  it("should fail upon sending a team preference value of the wrong type", async () => {
+    const admin = await buildAdmin();
+    const res = await server.post("/api/team.update", admin, {
+      body: {
+        preferences: {
+          publicBranding: "yes",
+        },
+      },
+    });
+    expect(res.status).toEqual(400);
+  });
+
   it("should add avatar", async () => {
     const team = await buildTeam();
     const admin = await buildAdmin({ teamId: team.id });


### PR DESCRIPTION
Tightens the `team.update` preferences schema, mirroring the equivalent change to user preferences in #13505.

- Unknown preference keys are now rejected with a 400 instead of being silently stripped
- Keys are declared with the `TeamPreference` enum instead of string literals, so the schema stays in sync with the shared type
- The nested custom theme object is strict as well