### PR TITLE
fix: match empty-paragraph separators in patch findText

### DIFF
--- a/server/commands/documentUpdater.test.ts
+++ b/server/commands/documentUpdater.test.ts
@@ -453,6 +453,90 @@ describe("documentUpdater", () => {
       });
     });
 
+    it("should patch findText spanning an empty paragraph with a blank-line separator", async () => {
+      const user = await buildUser();
+      const document = await buildDocument({
+        teamId: user.teamId,
+        content: {
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "First paragraph" }],
+            },
+            { type: "paragraph" },
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "Second paragraph" }],
+            },
+          ],
+        },
+      });
+
+      // Internal markdown serializes the empty paragraph as a `\` line.
+      // Clients (MCP retrieval + LLM round-trip) use a standard blank line.
+      const result = DocumentHelper.applyMarkdownToDocument(
+        document,
+        "Replaced both",
+        TextEditMode.Patch,
+        "First paragraph\n\nSecond paragraph"
+      );
+      const content = result.content!.content!;
+
+      expect(content).toHaveLength(1);
+      expect(content[0]).toMatchObject({
+        type: "paragraph",
+        content: [{ type: "text", text: "Replaced both" }],
+      });
+    });
+
+    it("should patch findText retrieved via toMarkdown that spans an empty paragraph", async () => {
+      const user = await buildUser();
+      const document = await buildDocument({
+        teamId: user.teamId,
+        content: {
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "First paragraph" }],
+            },
+            { type: "paragraph" },
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "Second paragraph" }],
+            },
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "Keep this" }],
+            },
+          ],
+        },
+      });
+
+      const markdown = await DocumentHelper.toMarkdown(document, {
+        includeTitle: false,
+      });
+      const findText = markdown.split("Keep this")[0].trim();
+
+      const result = DocumentHelper.applyMarkdownToDocument(
+        document,
+        "Replaced both",
+        TextEditMode.Patch,
+        findText
+      );
+      const content = result.content!.content!;
+
+      expect(content[0]).toMatchObject({
+        type: "paragraph",
+        content: [{ type: "text", text: "Replaced both" }],
+      });
+      expect(content[content.length - 1]).toMatchObject({
+        type: "paragraph",
+        content: [{ type: "text", text: "Keep this" }],
+      });
+    });
+
     it("should throw when findText is not found in document", async () => {
       const user = await buildUser();
       const document = await buildDocument({

--- a/server/models/helpers/DocumentHelper.tsx
+++ b/server/models/helpers/DocumentHelper.tsx
@@ -1,3 +1,4 @@
+import { escapeRegExp } from "es-toolkit/compat";
 import type { JSDOM } from "jsdom";
 import { Node, Fragment, type NodeType } from "prosemirror-model";
 import ukkonen from "ukkonen";
@@ -668,13 +669,13 @@ export class DocumentHelper {
       const { markdown, blockMap } =
         serializer.serializeWithPositions(existingDoc);
 
-      const matchIndex = markdown.indexOf(findText);
-      if (matchIndex === -1) {
+      const range = DocumentHelper.findMarkdownRange(markdown, findText);
+      if (!range) {
         throw ValidationError(
           "The specified text was not found in the document"
         );
       }
-      const matchEnd = matchIndex + findText.length;
+      const { matchIndex, matchEnd } = range;
 
       // Find which top-level blocks overlap the matched range
       const affected = blockMap.filter(
@@ -804,6 +805,38 @@ export class DocumentHelper {
     }
 
     return document;
+  }
+
+  /**
+   * Locate `findText` in serialized markdown. Exact match first; if that
+   * fails, treat a blank line and an empty-paragraph encoding (`\` on its
+   * own line) as equivalent block separators so client round-trips match.
+   */
+  private static findMarkdownRange(
+    markdown: string,
+    findText: string
+  ): { matchIndex: number; matchEnd: number } | null {
+    const exact = markdown.indexOf(findText);
+    if (exact !== -1) {
+      return { matchIndex: exact, matchEnd: exact + findText.length };
+    }
+
+    // Split on blank lines and `\`-escaped empty paragraphs, then allow
+    // either representation (and extra blank lines) between the chunks.
+    const chunks = findText.split(/\n(?:\\?\n)+/);
+    if (chunks.length === 1) {
+      return null;
+    }
+
+    const pattern = chunks
+      .map((chunk) => escapeRegExp(chunk))
+      .join("\\n(?:\\\\?\\n)+");
+    const match = new RegExp(pattern).exec(markdown);
+    if (!match) {
+      return null;
+    }
+
+    return { matchIndex: match.index, matchEnd: match.index + match[0].length };
   }
 
   /**


### PR DESCRIPTION
## Summary
- Patch findText that spans an empty paragraph now matches when the client uses a blank line.
- Exact match still runs first.

Fixes #13510

## Test plan
