### PR TITLE
Exclude archived documents from MCP search by default

### DIFF
--- a/server/tools/documents.test.ts
+++ b/server/tools/documents.test.ts
@@ -251,6 +251,93 @@ describe("list_documents", () => {
     expect(ids).toContain(document.id);
   });
 
+  it("excludes archived documents from search by default", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const document = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+      title: "Blackberry",
+    });
+    const archived = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+      title: "Blackberry",
+      archivedAt: new Date(),
+    });
+
+    const res = await callMcpTool(server, accessToken, "list_documents", {
+      query: "Blackberry",
+    });
+    const data = parseMcpListContent<{ document: { id: string } }>(
+      res?.result?.content
+    );
+    const ids = data.map((d) => d.document.id);
+
+    expect(ids).toContain(document.id);
+    expect(ids).not.toContain(archived.id);
+  });
+
+  it("includes archived documents in search when requested", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const archived = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+      title: "Blackberry",
+      archivedAt: new Date(),
+    });
+
+    const res = await callMcpTool(server, accessToken, "list_documents", {
+      query: "Blackberry",
+      includeArchived: true,
+    });
+    const data = parseMcpListContent<{ document: { id: string } }>(
+      res?.result?.content
+    );
+    const ids = data.map((d) => d.document.id);
+
+    expect(ids).toContain(archived.id);
+  });
+
+  it("includes archived documents in recent documents when requested", async () => {
+    const { user, accessToken } = await buildOAuthUser();
+    const collection = await buildCollection({
+      teamId: user.teamId,
+      userId: user.id,
+    });
+    const archived = await buildDocument({
+      teamId: user.teamId,
+      userId: user.id,
+      collectionId: collection.id,
+      archivedAt: new Date(),
+    });
+
+    const excluded = parseMcpListContent<{ document: { id: string } }>(
+      (await callMcpTool(server, accessToken, "list_documents"))?.result
+        ?.content
+    ).map((d) => d.document.id);
+    expect(excluded).not.toContain(archived.id);
+
+    const included = parseMcpListContent<{ document: { id: string } }>(
+      (
+        await callMcpTool(server, accessToken, "list_documents", {
+          includeArchived: true,
+        })
+      )?.result?.content
+    ).map((d) => d.document.id);
+    expect(included).toContain(archived.id);
+  });
+
   it("records the search query with an mcp source", async () => {
     const { user, accessToken } = await buildOAuthUser();
     const collection = await buildCollection({

--- a/server/tools/documents.ts
+++ b/server/tools/documents.ts
@@ -10,6 +10,7 @@ import documentRestorer from "@server/commands/documentRestorer";
 import documentUpdater from "@server/commands/documentUpdater";
 import { Collection, Document, SearchQuery, Template } from "@server/models";
 import { SearchQuerySource } from "@server/models/SearchQuery";
+import { combineFilters } from "@server/models/helpers/Filters";
 import DocumentImportTask from "@server/queues/tasks/DocumentImportTask";
 import { sequelize } from "@server/storage/database";
 import { authorize, can } from "@server/policies";
@@ -72,7 +73,7 @@ export function documentTools(server: McpServer, scopes: string[]) {
       {
         title: "Search documents",
         description:
-          "Searches documents the user has access to. Performs full-text search across document content when a query is provided, or lists recent documents when no query is given. Optionally filter by collection. To retrieve the full contents or hierarchy of a specific collection, use list_collection_documents instead.",
+          "Searches documents the user has access to. Performs full-text search across document content when a query is provided, or lists recent documents when no query is given. Archived documents are excluded unless includeArchived is set. Optionally filter by collection. To retrieve the full contents or hierarchy of a specific collection, use list_collection_documents instead.",
         annotations: {
           idempotentHint: true,
           readOnlyHint: true,
@@ -84,6 +85,12 @@ export function documentTools(server: McpServer, scopes: string[]) {
           collectionId: optionalString().describe(
             "A collection ID to filter documents by."
           ),
+          includeArchived: z
+            .boolean()
+            .optional()
+            .describe(
+              "Whether to include archived documents in the results. Defaults to false, as archived documents are usually outdated."
+            ),
           offset: z.coerce
             .number()
             .int()
@@ -103,7 +110,10 @@ export function documentTools(server: McpServer, scopes: string[]) {
       },
       withTracing(
         "list_documents",
-        async ({ query, collectionId, offset, limit }, extra) => {
+        async (
+          { query, collectionId, includeArchived, offset, limit },
+          extra
+        ) => {
           try {
             const user = getActorFromContext(extra);
             const effectiveOffset = offset ?? 0;
@@ -146,17 +156,25 @@ export function documentTools(server: McpServer, scopes: string[]) {
               }
 
               const searchStartedAt = Date.now();
+              const searchFilters: Filter[] = [];
+              if (!includeArchived) {
+                searchFilters.push({
+                  field: "archivedAt",
+                  operator: "isNull",
+                });
+              }
+              if (collectionId) {
+                searchFilters.push({
+                  field: "collectionId",
+                  operator: "eq",
+                  value: collectionId,
+                });
+              }
               const { results, total } = await searchProvider.searchForUser(
                 user,
                 {
                   query,
-                  filter: collectionId
-                    ? {
-                        field: "collectionId",
-                        operator: "eq",
-                        value: collectionId,
-                      }
-                    : undefined,
+                  filter: combineFilters(searchFilters),
                   offset: effectiveOffset,
                   limit: effectiveLimit,
                 }
@@ -241,9 +259,11 @@ export function documentTools(server: McpServer, scopes: string[]) {
             // access control matches the search path exactly.
             const searchProvider = SearchProviderManager.getProvider();
             const filters: Filter[] = [
-              { field: "archivedAt", operator: "isNull" },
               { field: "publishedAt", operator: "isNotNull" },
             ];
+            if (!includeArchived) {
+              filters.push({ field: "archivedAt", operator: "isNull" });
+            }
             if (collectionId) {
               filters.push({
                 field: "collectionId",


### PR DESCRIPTION
Archived documents are often outdated but still full of terms that match unrelated queries, so they add noise to MCP search results.

- The `list_documents` tool now excludes archived documents from full-text search results
- Adds an `includeArchived` option to opt back in, for both the search and recent-documents paths
- Exact lookups by document ID still resolve archived documents, since those are a deliberate request for one document
- Matches the behavior the recent-documents path and the documents.list API route already had