### PR TITLE
perf: Limit PWA precache and skip service worker on share views

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -114,7 +114,13 @@ window.addEventListener("load", async () => {
   });
 });
 
-if ("serviceWorker" in navigator && env.ENVIRONMENT !== "development") {
+// Skip registration on public share views, anonymous visitors gain nothing
+// from having the app precached.
+if (
+  "serviceWorker" in navigator &&
+  env.ENVIRONMENT !== "development" &&
+  !env.isShare
+) {
   window.addEventListener("load", () => {
     // see: https://bugs.chromium.org/p/chromium/issues/detail?id=1097616
     // In some rare (<0.1% of cases) this call can return `undefined`

--- a/server/presenters/env.ts
+++ b/server/presenters/env.ts
@@ -9,10 +9,12 @@ export default function present(
   options: {
     analytics?: Integration<IntegrationType.Analytics>[];
     rootShareId?: string | null;
+    isShare?: boolean;
   } = {}
 ): PublicEnv {
   return {
     ROOT_SHARE_ID: options.rootShareId || undefined,
+    isShare: options.isShare || undefined,
     analytics: (options.analytics ?? []).map((integration) => ({
       service: integration?.service,
       settings: integration?.settings,

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -135,7 +135,10 @@ export enum MentionType {
 }
 
 export type PublicEnv = {
+  /** ID of the share mounted at the root of a custom domain, if any. */
   ROOT_SHARE_ID?: string;
+  /** Whether the page is a publicly shared view. */
+  isShare?: boolean;
   analytics: {
     service: IntegrationService;
     settings: IntegrationSettings<IntegrationType.Analytics>;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -61,7 +61,7 @@ export default ({ mode }: ConfigEnv) =>
         registerType: "autoUpdate",
         workbox: {
           maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
-          globPatterns: ["**/*.{js,css,ico,png,svg}"],
+          globPatterns: ["**/*.{css,ico,png,svg}"],
           navigateFallback: null,
           modifyURLPrefix: {
             "": `${environment.CDN_URL ?? ""}/static/`,
@@ -70,6 +70,24 @@ export default ({ mode }: ConfigEnv) =>
           clientsClaim: true,
           cleanupOutdatedCaches: true,
           runtimeCaching: [
+            {
+              // Chunks are content-hashed and immutable, so cache them on
+              // first use rather than precaching the entire build.
+              urlPattern: ({ url }) =>
+                url.pathname.startsWith("/static/assets/") &&
+                url.pathname.endsWith(".js"),
+              handler: "CacheFirst",
+              options: {
+                cacheName: "js-cache",
+                expiration: {
+                  maxEntries: 200,
+                  maxAgeSeconds: 2592000, // 30 days
+                },
+                cacheableResponse: {
+                  statuses: [200],
+                },
+              },
+            },
             {
               urlPattern: /api\/urls\.unfurl$/,
               handler: "CacheOnly",


### PR DESCRIPTION
The service worker precached every JS chunk (~590 files, ~7MB) in the background for every visitor, and re-downloaded changed chunks after each deploy.

- Precache no longer includes JS; chunks are content-hashed and immutable, so a `CacheFirst` runtime route caches them on first use instead
- Skips service worker registration entirely on public share views via a new `isShare` flag in `window.env` — anonymous visitors gain nothing from it, and this also stops PWA install prompts on shared documents