### PR TITLE
Superellipse corners for menus, dialogs, and floating surfaces

### DIFF
--- a/app/components/DocumentCard.tsx
+++ b/app/components/DocumentCard.tsx
@@ -10,7 +10,7 @@ import { Link } from "react-router-dom";
 import styled, { useTheme } from "styled-components";
 import Icon from "@shared/components/Icon";
 import Squircle from "@shared/components/Squircle";
-import { s, hover, ellipsis, squircle } from "@shared/styles";
+import { s, hover, ellipsis, borderRadius } from "@shared/styles";
 import { IconType } from "@shared/types";
 import { determineIconType } from "@shared/utils/icon";
 import type Document from "~/models/Document";
@@ -305,7 +305,7 @@ const DocumentLink = styled(Link)<{
   padding: 12px;
   width: 100%;
   height: 100%;
-  ${squircle(8)}
+  ${borderRadius(8)}
   cursor: var(--pointer);
   background: ${s("background")};
   transition: transform 50ms ease-in-out;

--- a/app/components/DocumentCard.tsx
+++ b/app/components/DocumentCard.tsx
@@ -10,7 +10,7 @@ import { Link } from "react-router-dom";
 import styled, { useTheme } from "styled-components";
 import Icon from "@shared/components/Icon";
 import Squircle from "@shared/components/Squircle";
-import { s, hover, ellipsis } from "@shared/styles";
+import { s, hover, ellipsis, squircle } from "@shared/styles";
 import { IconType } from "@shared/types";
 import { determineIconType } from "@shared/utils/icon";
 import type Document from "~/models/Document";
@@ -305,7 +305,7 @@ const DocumentLink = styled(Link)<{
   padding: 12px;
   width: 100%;
   height: 100%;
-  border-radius: 8px;
+  ${squircle(8)}
   cursor: var(--pointer);
   background: ${s("background")};
   transition: transform 50ms ease-in-out;

--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import breakpoint from "styled-components-breakpoint";
-import { depths, s, squircle } from "@shared/styles";
+import { depths, s, borderRadius } from "@shared/styles";
 import Flex from "~/components/Flex";
 import NudeButton from "~/components/NudeButton";
 import Scrollable from "~/components/Scrollable";
@@ -255,7 +255,7 @@ const Wrapper = styled.div<{
   align-items: flex-start;
   background: ${s("modalBackground")};
   box-shadow: ${s("modalShadow")};
-  ${squircle(10)}
+  ${borderRadius(10)}
   outline: none;
 
   ${NudeButton} {

--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import breakpoint from "styled-components-breakpoint";
-import { depths, s } from "@shared/styles";
+import { depths, s, squircle } from "@shared/styles";
 import Flex from "~/components/Flex";
 import NudeButton from "~/components/NudeButton";
 import Scrollable from "~/components/Scrollable";
@@ -255,7 +255,7 @@ const Wrapper = styled.div<{
   align-items: flex-start;
   background: ${s("modalBackground")};
   box-shadow: ${s("modalShadow")};
-  border-radius: 8px;
+  ${squircle(10)}
   outline: none;
 
   ${NudeButton} {

--- a/app/components/ModelSelectionToolbar.tsx
+++ b/app/components/ModelSelectionToolbar.tsx
@@ -3,7 +3,7 @@ import { CloseIcon } from "outline-icons";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import styled, { css } from "styled-components";
-import { depths, s } from "@shared/styles";
+import { depths, s, squircle } from "@shared/styles";
 import type { ModelSelection } from "~/components/ModelSelection";
 import Flex from "~/components/Flex";
 import NudeButton from "~/components/NudeButton";
@@ -137,7 +137,7 @@ const Wrapper = styled.div<{ $active: boolean }>`
 const Background = styled(Flex)`
   background-color: ${s("menuBackground")};
   box-shadow: ${s("menuShadow")};
-  border-radius: 8px;
+  ${squircle(8)}
   height: 40px;
   padding: 0 8px;
 `;

--- a/app/components/ModelSelectionToolbar.tsx
+++ b/app/components/ModelSelectionToolbar.tsx
@@ -3,7 +3,7 @@ import { CloseIcon } from "outline-icons";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import styled, { css } from "styled-components";
-import { depths, s, squircle } from "@shared/styles";
+import { depths, s, borderRadius } from "@shared/styles";
 import type { ModelSelection } from "~/components/ModelSelection";
 import Flex from "~/components/Flex";
 import NudeButton from "~/components/NudeButton";
@@ -137,7 +137,7 @@ const Wrapper = styled.div<{ $active: boolean }>`
 const Background = styled(Flex)`
   background-color: ${s("menuBackground")};
   box-shadow: ${s("menuShadow")};
-  ${squircle(8)}
+  ${borderRadius(8)}
   height: 40px;
   padding: 0 8px;
 `;

--- a/app/components/UserHoverCard.tsx
+++ b/app/components/UserHoverCard.tsx
@@ -4,7 +4,7 @@ import { ClockIcon } from "outline-icons";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
-import { depths, s, squircle } from "@shared/styles";
+import { depths, s, borderRadius } from "@shared/styles";
 import Avatar, { AvatarSize } from "~/components/Avatar/Avatar";
 import Badge from "~/components/Badge";
 import Flex from "~/components/Flex";
@@ -162,7 +162,7 @@ const Content = styled(HoverCardPrimitive.Content)`
   transform-origin: var(--radix-hover-card-content-transform-origin);
   background: ${s("menuBackground")};
   box-shadow: ${s("menuShadow")};
-  ${squircle(8)}
+  ${borderRadius(8)}
   padding: 12px;
   min-width: 180px;
   max-width: 320px;

--- a/app/components/UserHoverCard.tsx
+++ b/app/components/UserHoverCard.tsx
@@ -4,7 +4,7 @@ import { ClockIcon } from "outline-icons";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
-import { depths, s } from "@shared/styles";
+import { depths, s, squircle } from "@shared/styles";
 import Avatar, { AvatarSize } from "~/components/Avatar/Avatar";
 import Badge from "~/components/Badge";
 import Flex from "~/components/Flex";
@@ -162,7 +162,7 @@ const Content = styled(HoverCardPrimitive.Content)`
   transform-origin: var(--radix-hover-card-content-transform-origin);
   background: ${s("menuBackground")};
   box-shadow: ${s("menuShadow")};
-  border-radius: 6px;
+  ${squircle(8)}
   padding: 12px;
   min-width: 180px;
   max-width: 320px;

--- a/app/components/primitives/Drawer.tsx
+++ b/app/components/primitives/Drawer.tsx
@@ -2,7 +2,7 @@ import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import * as React from "react";
 import styled from "styled-components";
 import { Drawer as DrawerPrimitive } from "vaul";
-import { depths, s, squircle } from "@shared/styles";
+import { depths, s, borderRadius } from "@shared/styles";
 import Flex from "../Flex";
 import Text from "../Text";
 import { Overlay } from "./components/Overlay";
@@ -95,7 +95,7 @@ const StyledContent = styled(m.div)`
   min-height: 44px;
   max-height: 90vh;
 
-  ${squircle(8)}
+  ${borderRadius(8)}
 
   background: ${s("menuBackground")};
 `;

--- a/app/components/primitives/Drawer.tsx
+++ b/app/components/primitives/Drawer.tsx
@@ -2,7 +2,7 @@ import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import * as React from "react";
 import styled from "styled-components";
 import { Drawer as DrawerPrimitive } from "vaul";
-import { depths, s } from "@shared/styles";
+import { depths, s, squircle } from "@shared/styles";
 import Flex from "../Flex";
 import Text from "../Text";
 import { Overlay } from "./components/Overlay";
@@ -95,7 +95,7 @@ const StyledContent = styled(m.div)`
   min-height: 44px;
   max-height: 90vh;
 
-  border-radius: 6px;
+  ${squircle(8)}
 
   background: ${s("menuBackground")};
 `;

--- a/app/components/primitives/InputSelect.tsx
+++ b/app/components/primitives/InputSelect.tsx
@@ -2,7 +2,7 @@ import * as InputSelectPrimitive from "@radix-ui/react-select";
 import * as React from "react";
 import styled from "styled-components";
 import Text from "@shared/components/Text";
-import { depths, s } from "@shared/styles";
+import { depths, s, squircle } from "@shared/styles";
 import type { Props as ButtonProps } from "~/components/Button";
 import { fadeAndSlideDown, fadeAndSlideUp } from "~/styles/animations";
 import {
@@ -145,7 +145,7 @@ const StyledContent = styled(InputSelectPrimitive.Content)`
   max-height: 350px;
 
   padding: 4px;
-  border-radius: 6px;
+  ${squircle(8)}
   background: ${s("menuBackground")};
   box-shadow: ${s("menuShadow")};
   transform-origin: 50% 0;

--- a/app/components/primitives/InputSelect.tsx
+++ b/app/components/primitives/InputSelect.tsx
@@ -2,7 +2,7 @@ import * as InputSelectPrimitive from "@radix-ui/react-select";
 import * as React from "react";
 import styled from "styled-components";
 import Text from "@shared/components/Text";
-import { depths, s, squircle } from "@shared/styles";
+import { depths, s, borderRadius } from "@shared/styles";
 import type { Props as ButtonProps } from "~/components/Button";
 import { fadeAndSlideDown, fadeAndSlideUp } from "~/styles/animations";
 import {
@@ -145,7 +145,7 @@ const StyledContent = styled(InputSelectPrimitive.Content)`
   max-height: 350px;
 
   padding: 4px;
-  ${squircle(8)}
+  ${borderRadius(8)}
   background: ${s("menuBackground")};
   box-shadow: ${s("menuShadow")};
   transform-origin: 50% 0;

--- a/app/components/primitives/Popover.tsx
+++ b/app/components/primitives/Popover.tsx
@@ -2,7 +2,7 @@ import * as PopoverPrimitive from "@radix-ui/react-popover";
 import * as React from "react";
 import { mergeRefs } from "react-merge-refs";
 import styled from "styled-components";
-import { depths, s } from "@shared/styles";
+import { depths, s, squircle } from "@shared/styles";
 import { fadeAndScaleIn } from "~/styles/animations";
 import { usePortalContext } from "../Portal";
 
@@ -110,7 +110,7 @@ const StyledContent = styled(PopoverPrimitive.Content)<StyledContentProps>`
 
   background: ${s("menuBackground")};
   box-shadow: ${s("menuShadow")};
-  border-radius: 6px;
+  ${squircle(8)}
   outline: none;
 
   padding: ${({ $shrink }) => ($shrink ? "6px 0" : "12px 24px")};

--- a/app/components/primitives/Popover.tsx
+++ b/app/components/primitives/Popover.tsx
@@ -2,7 +2,7 @@ import * as PopoverPrimitive from "@radix-ui/react-popover";
 import * as React from "react";
 import { mergeRefs } from "react-merge-refs";
 import styled from "styled-components";
-import { depths, s, squircle } from "@shared/styles";
+import { depths, s, borderRadius } from "@shared/styles";
 import { fadeAndScaleIn } from "~/styles/animations";
 import { usePortalContext } from "../Portal";
 
@@ -110,7 +110,7 @@ const StyledContent = styled(PopoverPrimitive.Content)<StyledContentProps>`
 
   background: ${s("menuBackground")};
   box-shadow: ${s("menuShadow")};
-  ${squircle(8)}
+  ${borderRadius(8)}
   outline: none;
 
   padding: ${({ $shrink }) => ($shrink ? "6px 0" : "12px 24px")};

--- a/app/components/primitives/components/Menu.tsx
+++ b/app/components/primitives/components/Menu.tsx
@@ -3,7 +3,7 @@ import { ellipsis } from "polished";
 import { Link } from "react-router-dom";
 import styled, { css } from "styled-components";
 import breakpoint from "styled-components-breakpoint";
-import { depths, s, squircle } from "@shared/styles";
+import { depths, s, borderRadius } from "@shared/styles";
 import Scrollable from "~/components/Scrollable";
 import { fadeAndScaleIn } from "~/styles/animations";
 
@@ -202,7 +202,7 @@ export const MenuContent = styled(Scrollable).attrs<MenuContentProps>(
 
   background: ${s("menuBackground")};
   box-shadow: ${s("menuShadow")};
-  ${squircle(8)}
+  ${borderRadius(8)}
   // Vertical spacing comes from spacers rather than padding so that the bottom
   // fade, which is confined to the content box, can reach the menu's edge.
   padding: 0 6px;

--- a/app/components/primitives/components/Menu.tsx
+++ b/app/components/primitives/components/Menu.tsx
@@ -3,7 +3,7 @@ import { ellipsis } from "polished";
 import { Link } from "react-router-dom";
 import styled, { css } from "styled-components";
 import breakpoint from "styled-components-breakpoint";
-import { depths, s } from "@shared/styles";
+import { depths, s, squircle } from "@shared/styles";
 import Scrollable from "~/components/Scrollable";
 import { fadeAndScaleIn } from "~/styles/animations";
 
@@ -202,7 +202,7 @@ export const MenuContent = styled(Scrollable).attrs<MenuContentProps>(
 
   background: ${s("menuBackground")};
   box-shadow: ${s("menuShadow")};
-  border-radius: 6px;
+  ${squircle(8)}
   // Vertical spacing comes from spacers rather than padding so that the bottom
   // fade, which is confined to the content box, can reach the menu's edge.
   padding: 0 6px;

--- a/shared/components/Calendar.tsx
+++ b/shared/components/Calendar.tsx
@@ -79,7 +79,7 @@ const Wrapper = styled.div`
     background: none;
     border-radius: 4px;
     color: ${s("textSecondary")};
-    cursor: pointer;
+    cursor: var(--pointer);
     transition: background 100ms ease;
 
     &:hover {
@@ -124,7 +124,7 @@ const Wrapper = styled.div`
     font-size: 13px;
     font-variant-numeric: tabular-nums;
     color: ${s("text")};
-    cursor: pointer;
+    cursor: var(--pointer);
     transition: background 100ms ease;
 
     &:hover:not([disabled]):not(.rdp-day_selected) {

--- a/shared/editor/components/ColorHoverCard.tsx
+++ b/shared/editor/components/ColorHoverCard.tsx
@@ -1,7 +1,7 @@
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 import type { ReactNode } from "react";
 import styled from "styled-components";
-import { depths, s, squircle } from "../../styles";
+import { depths, s, borderRadius } from "../../styles";
 import type { EditorNotice } from "../types";
 import { ColorPreview } from "./ColorPreview";
 
@@ -67,7 +67,7 @@ const Card = styled.div`
   z-index: ${depths.modal};
   background: ${s("menuBackground")};
   box-shadow: ${s("menuShadow")};
-  ${squircle(8)}
+  ${borderRadius(8)}
   outline: none;
 
   &[data-state="open"] {

--- a/shared/editor/components/ColorHoverCard.tsx
+++ b/shared/editor/components/ColorHoverCard.tsx
@@ -1,7 +1,7 @@
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 import type { ReactNode } from "react";
 import styled from "styled-components";
-import { depths, s } from "../../styles";
+import { depths, s, squircle } from "../../styles";
 import type { EditorNotice } from "../types";
 import { ColorPreview } from "./ColorPreview";
 
@@ -67,7 +67,7 @@ const Card = styled.div`
   z-index: ${depths.modal};
   background: ${s("menuBackground")};
   box-shadow: ${s("menuShadow")};
-  border-radius: 8px;
+  ${squircle(8)}
   outline: none;
 
   &[data-state="open"] {

--- a/shared/editor/components/DateMentionPicker.tsx
+++ b/shared/editor/components/DateMentionPicker.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next";
 import { RemoveScroll } from "react-remove-scroll";
 import styled from "styled-components";
 import { Calendar } from "../../components/Calendar";
-import { depths, s } from "../../styles";
+import { depths, s, squircle } from "../../styles";
 import { dateLocale, toISODate, toISODateTime } from "../../utils/date";
 
 type Props = {
@@ -100,7 +100,7 @@ const DatePopoverContent = styled.div`
   z-index: ${depths.modal};
   background: ${s("menuBackground")};
   box-shadow: ${s("menuShadow")};
-  border-radius: 8px;
+  ${squircle(8)}
   outline: none;
 
   &[data-state="open"] {

--- a/shared/editor/components/DateMentionPicker.tsx
+++ b/shared/editor/components/DateMentionPicker.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next";
 import { RemoveScroll } from "react-remove-scroll";
 import styled from "styled-components";
 import { Calendar } from "../../components/Calendar";
-import { depths, s, squircle } from "../../styles";
+import { depths, s, borderRadius } from "../../styles";
 import { dateLocale, toISODate, toISODateTime } from "../../utils/date";
 
 type Props = {
@@ -100,7 +100,7 @@ const DatePopoverContent = styled.div`
   z-index: ${depths.modal};
   background: ${s("menuBackground")};
   box-shadow: ${s("menuShadow")};
-  ${squircle(8)}
+  ${borderRadius(8)}
   outline: none;
 
   &[data-state="open"] {

--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -586,6 +586,16 @@ width: 100%;
     background: ${props.theme.mentionHoverBackground};
   }
 
+  /* Date mentions only open the picker when editable, so no hover affordance
+     in read-only mode. */
+  ${
+    props.readOnly
+      ? `&[data-type="date"]:${hover} {
+    background: ${props.theme.mentionBackground};
+  }`
+      : ""
+  }
+
   &[data-type="user"],
   &[data-type="group"] {
     gap: 0;

--- a/shared/styles/index.ts
+++ b/shared/styles/index.ts
@@ -47,6 +47,24 @@ export const hideScrollbars = () => `
 `;
 
 /**
+ * Mixin to give an element superellipse ("squircle") corners in browsers that
+ * support `corner-shape`, with a standard border radius elsewhere.
+ *
+ * @param radius the border radius in pixels.
+ * @param exponent the superellipse exponent, where 2 is a squircle.
+ * @returns string of CSS
+ */
+export const squircle = (radius: number, exponent = 2) => `
+  border-radius: ${radius}px;
+
+  @supports (corner-shape: superellipse(2)) {
+    // A superellipse is tighter than a circular arc, so increase the radius to compensate.
+    border-radius: ${Math.round(radius * 1.8)}px;
+    corner-shape: superellipse(${exponent});
+  }
+`;
+
+/**
  * Mixin on any component with relative positioning to add additional hidden clickable/hoverable area
  *
  * @param pixels

--- a/shared/styles/index.ts
+++ b/shared/styles/index.ts
@@ -54,11 +54,11 @@ export const hideScrollbars = () => `
  * @param exponent the superellipse exponent, where 2 is a squircle.
  * @returns string of CSS
  */
-export const squircle = (radius: number, exponent = 2) => `
+export const borderRadius = (radius: number, exponent = 2) => `
   border-radius: ${radius}px;
 
   @supports (corner-shape: superellipse(2)) {
-    // A superellipse is tighter than a circular arc, so increase the radius to compensate.
+    /* A superellipse is tighter than a circular arc, so increase the radius to compensate. */
     border-radius: ${Math.round(radius * 1.8)}px;
     corner-shape: superellipse(${exponent});
   }


### PR DESCRIPTION
Adds a \`borderRadius()\` CSS mixin in shared styles that applies the new \`corner-shape: superellipse()\` property with a compensated radius, and falls back to a standard border radius in browsers without support.

- Applied to menus, modals, popovers, select dropdowns, hover cards, the date mention picker, the mobile drawer, the selection toolbar, and document cards
- 6px surfaces are normalized to an 8px base radius for consistency
- Also: the calendar now uses the \`--pointer\` cursor preference, and date mentions no longer show a hover state in read-only documents