### PR TITLE
perf: Refactor `y-prosemirror` loading

### DIFF
--- a/app/editor/extensions/CommentGutter.tsx
+++ b/app/editor/extensions/CommentGutter.tsx
@@ -72,7 +72,11 @@ export default class CommentGutter extends Extension {
             }
 
             return {
-              decorations: mapDecorations(pluginState.decorations, tr),
+              decorations: mapDecorations(
+                pluginState.decorations,
+                tr,
+                newState
+              ),
             };
           },
         },

--- a/app/editor/extensions/Multiplayer.ts
+++ b/app/editor/extensions/Multiplayer.ts
@@ -14,24 +14,13 @@ import {
 } from "y-prosemirror";
 import * as Y from "yjs";
 import Extension from "@shared/editor/lib/Extension";
+import type { MultiplayerState } from "@shared/editor/lib/multiplayer";
 import {
   isRemoteTransaction,
-  registerMultiplayerHooks,
+  multiplayerPluginKey,
 } from "@shared/editor/lib/multiplayer";
 import { EditorStyleHelper } from "@shared/editor/styles/EditorStyleHelper";
 import { Second } from "@shared/utils/time";
-
-registerMultiplayerHooks({
-  isRemoteTransaction: (tr) => {
-    const meta = tr.getMeta(ySyncPluginKey);
-
-    // This logic seems to be flipped? But it's correct.
-    return !!meta?.isChangeOrigin;
-  },
-  stopCapturing: (view) => {
-    yUndoPluginKey.getState(view.state)?.undoManager?.stopCapturing();
-  },
-});
 
 type UserAwareness = {
   user?: {
@@ -142,9 +131,27 @@ export default class Multiplayer extends Extension<MultiplayerOptions> {
         selectionBuilder,
       }),
       yUndoPlugin(),
-      new Plugin({
+      // Facade plugin that exposes the collaboration operations to shared
+      // code without a static dependency on the collaboration libraries.
+      new Plugin<MultiplayerState>({
+        key: multiplayerPluginKey,
+        state: {
+          init: (): MultiplayerState => ({
+            isRemoteTransaction: (tr) => {
+              const meta = tr.getMeta(ySyncPluginKey);
+
+              // This logic seems to be flipped? But it's correct.
+              return !!meta?.isChangeOrigin;
+            },
+            stopCapturing: (state) => {
+              yUndoPluginKey.getState(state)?.undoManager?.stopCapturing();
+            },
+          }),
+          apply: (_tr, value) => value,
+        },
         props: {
-          handleScrollToSelection: (view) => isRemoteTransaction(view.state.tr),
+          handleScrollToSelection: (view) =>
+            isRemoteTransaction(view.state.tr, view.state),
         },
       }),
     ];

--- a/app/editor/extensions/Multiplayer.ts
+++ b/app/editor/extensions/Multiplayer.ts
@@ -3,8 +3,10 @@ import { isEqual } from "es-toolkit/compat";
 import { Plugin } from "prosemirror-state";
 import {
   ySyncPlugin,
+  ySyncPluginKey,
   yCursorPlugin,
   yUndoPlugin,
+  yUndoPluginKey,
   undo,
   redo,
   undoCommand,
@@ -12,9 +14,24 @@ import {
 } from "y-prosemirror";
 import * as Y from "yjs";
 import Extension from "@shared/editor/lib/Extension";
-import { isRemoteTransaction } from "@shared/editor/lib/multiplayer";
+import {
+  isRemoteTransaction,
+  registerMultiplayerHooks,
+} from "@shared/editor/lib/multiplayer";
 import { EditorStyleHelper } from "@shared/editor/styles/EditorStyleHelper";
 import { Second } from "@shared/utils/time";
+
+registerMultiplayerHooks({
+  isRemoteTransaction: (tr) => {
+    const meta = tr.getMeta(ySyncPluginKey);
+
+    // This logic seems to be flipped? But it's correct.
+    return !!meta?.isChangeOrigin;
+  },
+  stopCapturing: (view) => {
+    yUndoPluginKey.getState(view.state)?.undoManager?.stopCapturing();
+  },
+});
 
 type UserAwareness = {
   user?: {

--- a/app/editor/extensions/PasteHandler.tsx
+++ b/app/editor/extensions/PasteHandler.tsx
@@ -326,7 +326,7 @@ export default class PasteHandler extends Extension {
         },
         state: {
           init: () => DecorationSet.empty,
-          apply: (tr, set) => {
+          apply: (tr, set, _oldState, newState) => {
             let mapping = tr.mapping;
 
             // See if the transaction adds or removes any placeholders
@@ -352,7 +352,7 @@ export default class PasteHandler extends Extension {
               return DecorationSet.create(tr.doc, decorations);
             }
 
-            if (hasDecorations && (isRemoteTransaction(tr) || meta)) {
+            if (hasDecorations && (isRemoteTransaction(tr, newState) || meta)) {
               try {
                 mapping = recreateTransform(tr.before, tr.doc, {
                   complexSteps: true,

--- a/app/editor/index.tsx
+++ b/app/editor/index.tsx
@@ -560,7 +560,7 @@ export class Editor extends React.PureComponent<
         ) {
           self.handleChange({
             remote: transactions.some(
-              (tr) => tr.docChanged && isRemoteTransaction(tr)
+              (tr) => tr.docChanged && isRemoteTransaction(tr, state)
             ),
           });
         }

--- a/shared/editor/extensions/Mermaid.ts
+++ b/shared/editor/extensions/Mermaid.ts
@@ -384,7 +384,11 @@ export default function Mermaid({
             mermaidMeta && "editingId" in mermaidMeta
               ? mermaidMeta.editingId
               : pluginState.editingId,
-          decorationSet: mapDecorations(pluginState.decorationSet, transaction),
+          decorationSet: mapDecorations(
+            pluginState.decorationSet,
+            transaction,
+            state
+          ),
         };
 
         if (
@@ -427,7 +431,7 @@ export default function Mermaid({
           mermaidMeta ||
           themeToggled ||
           codeBlockChanged ||
-          isRemoteTransaction(transaction)
+          isRemoteTransaction(transaction, state)
         ) {
           return getNewState({
             doc: transaction.doc,
@@ -437,7 +441,7 @@ export default function Mermaid({
               codeBlockChanged &&
               transaction.docChanged &&
               !isPaste &&
-              !isRemoteTransaction(transaction),
+              !isRemoteTransaction(transaction, state),
           });
         }
 

--- a/shared/editor/lib/closeHistory.ts
+++ b/shared/editor/lib/closeHistory.ts
@@ -19,5 +19,5 @@ export function closeHistory(view: EditorView): void {
     view.dispatch(pmCloseHistory(view.state.tr));
   }
 
-  stopCapturingUndo(view);
+  stopCapturingUndo(view.state);
 }

--- a/shared/editor/lib/closeHistory.ts
+++ b/shared/editor/lib/closeHistory.ts
@@ -4,7 +4,7 @@ import {
   undoDepth,
 } from "prosemirror-history";
 import type { EditorView } from "prosemirror-view";
-import { yUndoPluginKey } from "y-prosemirror";
+import { stopCapturingUndo } from "./multiplayer";
 
 /**
  * Closes the current history item so that subsequent changes start a new undo
@@ -19,6 +19,5 @@ export function closeHistory(view: EditorView): void {
     view.dispatch(pmCloseHistory(view.state.tr));
   }
 
-  const yUndoState = yUndoPluginKey.getState(view.state);
-  yUndoState?.undoManager?.stopCapturing();
+  stopCapturingUndo(view);
 }

--- a/shared/editor/lib/multiplayer.ts
+++ b/shared/editor/lib/multiplayer.ts
@@ -1,7 +1,29 @@
 import type { Transaction } from "prosemirror-state";
-import type { DecorationSet } from "prosemirror-view";
-import { ySyncPluginKey } from "y-prosemirror";
+import type { DecorationSet, EditorView } from "prosemirror-view";
 import { recreateTransform } from "./prosemirror-recreate-transform";
+
+/**
+ * Hooks into the collaboration plugins, registered by the multiplayer
+ * extension when it is loaded.
+ */
+export interface MultiplayerHooks {
+  /** Returns true if the transaction originated from a remote client. */
+  isRemoteTransaction: (tr: Transaction) => boolean;
+  /** Stops the collaborative undo manager from capturing further changes. */
+  stopCapturing: (view: EditorView) => void;
+}
+
+let hooks: MultiplayerHooks | undefined;
+
+/**
+ * Registers the multiplayer hooks. Called by the multiplayer extension so
+ * that editors without collaboration do not load the collaboration libraries.
+ *
+ * @param value the hooks to register.
+ */
+export function registerMultiplayerHooks(value: MultiplayerHooks): void {
+  hooks = value;
+}
 
 /**
  * Checks if a transaction is a remote transaction
@@ -10,10 +32,17 @@ import { recreateTransform } from "./prosemirror-recreate-transform";
  * @returns true if the transaction is a remote transaction
  */
 export function isRemoteTransaction(tr: Transaction): boolean {
-  const meta = tr.getMeta(ySyncPluginKey);
+  return hooks?.isRemoteTransaction(tr) ?? false;
+}
 
-  // This logic seems to be flipped? But it's correct.
-  return !!meta?.isChangeOrigin;
+/**
+ * Stops the collaborative undo manager from capturing further changes, if
+ * the multiplayer extension is loaded.
+ *
+ * @param view The editor view.
+ */
+export function stopCapturingUndo(view: EditorView): void {
+  hooks?.stopCapturing(view);
 }
 
 /**

--- a/shared/editor/lib/multiplayer.ts
+++ b/shared/editor/lib/multiplayer.ts
@@ -1,48 +1,49 @@
-import type { Transaction } from "prosemirror-state";
-import type { DecorationSet, EditorView } from "prosemirror-view";
+import type { EditorState, Transaction } from "prosemirror-state";
+import { PluginKey } from "prosemirror-state";
+import type { DecorationSet } from "prosemirror-view";
 import { recreateTransform } from "./prosemirror-recreate-transform";
 
 /**
- * Hooks into the collaboration plugins, registered by the multiplayer
- * extension when it is loaded.
+ * State of the facade plugin mounted by the multiplayer extension. It exposes
+ * the collaboration operations to shared code without a static dependency on
+ * the collaboration libraries.
  */
-export interface MultiplayerHooks {
+export interface MultiplayerState {
   /** Returns true if the transaction originated from a remote client. */
   isRemoteTransaction: (tr: Transaction) => boolean;
   /** Stops the collaborative undo manager from capturing further changes. */
-  stopCapturing: (view: EditorView) => void;
+  stopCapturing: (state: EditorState) => void;
 }
-
-let hooks: MultiplayerHooks | undefined;
 
 /**
- * Registers the multiplayer hooks. Called by the multiplayer extension so
- * that editors without collaboration do not load the collaboration libraries.
- *
- * @param value the hooks to register.
+ * Key of the facade plugin mounted by the multiplayer extension.
  */
-export function registerMultiplayerHooks(value: MultiplayerHooks): void {
-  hooks = value;
-}
+export const multiplayerPluginKey = new PluginKey<MultiplayerState>(
+  "multiplayer-facade"
+);
 
 /**
  * Checks if a transaction is a remote transaction
  *
  * @param tr The Prosemirror transaction
+ * @param state The editor state
  * @returns true if the transaction is a remote transaction
  */
-export function isRemoteTransaction(tr: Transaction): boolean {
-  return hooks?.isRemoteTransaction(tr) ?? false;
+export function isRemoteTransaction(
+  tr: Transaction,
+  state: EditorState
+): boolean {
+  return multiplayerPluginKey.getState(state)?.isRemoteTransaction(tr) ?? false;
 }
 
 /**
  * Stops the collaborative undo manager from capturing further changes, if
- * the multiplayer extension is loaded.
+ * the multiplayer extension is mounted in the editor.
  *
- * @param view The editor view.
+ * @param state The editor state
  */
-export function stopCapturingUndo(view: EditorView): void {
-  hooks?.stopCapturing(view);
+export function stopCapturingUndo(state: EditorState): void {
+  multiplayerPluginKey.getState(state)?.stopCapturing(state);
 }
 
 /**
@@ -50,18 +51,20 @@ export function stopCapturingUndo(view: EditorView): void {
  *
  * @param set The current set of decorations
  * @param tr The Prosemirror transaction
+ * @param state The editor state
  * @param force Whether to force recalculation for map even for local transactions
  * @returns The mapped set of decorations
  */
 export function mapDecorations(
   set: DecorationSet,
   tr: Transaction,
+  state: EditorState,
   force: boolean = false
 ): DecorationSet {
   let mapping = tr.mapping;
   const hasDecorations = set.find().length;
 
-  if (hasDecorations && (isRemoteTransaction(tr) || force)) {
+  if (hasDecorations && (isRemoteTransaction(tr, state) || force)) {
     try {
       mapping = recreateTransform(tr.before, tr.doc, {
         complexSteps: true,

--- a/shared/editor/lib/uploadPlaceholder.tsx
+++ b/shared/editor/lib/uploadPlaceholder.tsx
@@ -11,11 +11,11 @@ const uploadPlaceholder = new Plugin({
     init() {
       return DecorationSet.empty;
     },
-    apply(this: Plugin, tr, set: DecorationSet) {
+    apply(this: Plugin, tr, set: DecorationSet, _oldState, newState) {
       // See if the transaction adds or removes any placeholders – the placeholder display is
       // different depending on if we're uploading an image, video or plain file
       const action = tr.getMeta(this);
-      set = mapDecorations(set, tr, !!action);
+      set = mapDecorations(set, tr, newState, !!action);
 
       if (action?.add) {
         if (action.add.replaceExisting) {

--- a/shared/editor/nodes/CodeFence.ts
+++ b/shared/editor/nodes/CodeFence.ts
@@ -476,7 +476,7 @@ export default class CodeFence extends Node<CodeFenceOptions> {
             if (tr.docChanged) {
               const tallBlocks = findTallBlocks(newState.doc);
               const collapsedBlocks = new Set<number>();
-              const isRemote = isRemoteTransaction(tr);
+              const isRemote = isRemoteTransaction(tr, newState);
 
               const inverse = tr.mapping.invert();
               for (const pos of tallBlocks) {

--- a/shared/editor/nodes/ToggleBlock.ts
+++ b/shared/editor/nodes/ToggleBlock.ts
@@ -164,7 +164,7 @@ export default class ToggleBlock extends Node {
         },
 
         apply: (tr, pluginState, _oldState, newState) => {
-          if (isRemoteTransaction(tr)) {
+          if (isRemoteTransaction(tr, newState)) {
             const foldedIds = this.initFoldedIds(newState);
             return {
               foldedIds,

--- a/shared/editor/plugins/AnchorPlugin.ts
+++ b/shared/editor/plugins/AnchorPlugin.ts
@@ -19,7 +19,10 @@ export class AnchorPlugin extends Plugin {
             return pluginState;
           }
 
-          if (isRemoteTransaction(tr) || this.hasAnchorableChange(tr)) {
+          if (
+            isRemoteTransaction(tr, newState) ||
+            this.hasAnchorableChange(tr)
+          ) {
             return { decorations: this.createDecorations(newState) };
           }
 

--- a/shared/editor/plugins/CodeHighlightingPlugin.ts
+++ b/shared/editor/plugins/CodeHighlightingPlugin.ts
@@ -218,7 +218,7 @@ export function CodeHighlighting({
           codeBlockChanged ||
           isPaste ||
           langLoaded ||
-          isRemoteTransaction(transaction)
+          isRemoteTransaction(transaction, state)
         ) {
           // Invalidate cached entries for blocks whose language just loaded
           // so getDecorations rebuilds them with syntax highlighting applied.

--- a/shared/editor/plugins/CodeWordDecorationsPlugin.ts
+++ b/shared/editor/plugins/CodeWordDecorationsPlugin.ts
@@ -32,7 +32,10 @@ class CodeWordDecorationsPlugin extends Plugin {
             return pluginState;
           }
 
-          if (isRemoteTransaction(tr) || this.hasCodeInlineChange(tr)) {
+          if (
+            isRemoteTransaction(tr, newState) ||
+            this.hasCodeInlineChange(tr)
+          ) {
             return {
               decorations: this.createDecorations(newState, finalConfig),
             };

--- a/shared/editor/plugins/CommentedImagePlugin.ts
+++ b/shared/editor/plugins/CommentedImagePlugin.ts
@@ -22,7 +22,7 @@ export class CommentedImagePlugin extends Plugin {
             return pluginState;
           }
 
-          if (isRemoteTransaction(tr) || this.hasImageChange(tr)) {
+          if (isRemoteTransaction(tr, newState) || this.hasImageChange(tr)) {
             return { decorations: this.createDecorations(newState) };
           }
 

--- a/shared/editor/plugins/DraftCommentAnchorPlugin.ts
+++ b/shared/editor/plugins/DraftCommentAnchorPlugin.ts
@@ -52,7 +52,11 @@ export class DraftCommentAnchorPlugin extends Plugin<PluginState> {
             return pluginState;
           }
 
-          let decorations = mapDecorations(pluginState.decorations, tr);
+          let decorations = mapDecorations(
+            pluginState.decorations,
+            tr,
+            newState
+          );
 
           if (meta?.add) {
             const { id, from, to, isNode, userId } = meta.add;
@@ -88,7 +92,7 @@ export class DraftCommentAnchorPlugin extends Plugin<PluginState> {
           // local decoration in favor of the real mark.
           if (
             tr.docChanged &&
-            isRemoteTransaction(tr) &&
+            isRemoteTransaction(tr, newState) &&
             decorations.find().length > 0
           ) {
             const markIds = new Set(

--- a/shared/editor/plugins/SuggestionsMenuPlugin.ts
+++ b/shared/editor/plugins/SuggestionsMenuPlugin.ts
@@ -100,7 +100,7 @@ export class SuggestionsMenuPlugin extends Plugin<PluginState> {
       // changes to the document, including those made by other users.
       state: {
         init: (): PluginState => ({ decorations: DecorationSet.empty }),
-        apply: (tr, pluginState): PluginState => {
+        apply: (tr, pluginState, _oldState, newState): PluginState => {
           const range: TriggerRange | undefined | null = tr.getMeta(key);
 
           if (range !== undefined) {
@@ -127,7 +127,11 @@ export class SuggestionsMenuPlugin extends Plugin<PluginState> {
             return pluginState;
           }
 
-          const decorations = mapDecorations(pluginState.decorations, tr);
+          const decorations = mapDecorations(
+            pluginState.decorations,
+            tr,
+            newState
+          );
           const [decoration] = decorations.find();
           const { trigger } = extensionState;
 


### PR DESCRIPTION
Move y-prosemirror dep so it is not loaded in non-multiplayer editors