### PR TITLE
fix: Recover from closed IndexedDB connections in store persistence

### DIFF
--- a/app/actions/definitions/developer.tsx
+++ b/app/actions/definitions/developer.tsx
@@ -133,9 +133,10 @@ export const clearIndexedDB = createAction({
   icon: <TrashIcon />,
   keywords: "cache clear database",
   section: DeveloperSection,
-  perform: async ({ t }) => {
+  perform: async ({ t, stores }) => {
     history.push(homePath());
     await deleteAllDatabases();
+    stores.enablePersistence();
     toast.success(t("IndexedDB cache cleared"));
   },
 });

--- a/app/stores/RootStore.ts
+++ b/app/stores/RootStore.ts
@@ -138,6 +138,18 @@ export default class RootStore {
   }
 
   /**
+   * Disable IndexedDB persistence for all stores, closing any open connections
+   * so that the databases can be deleted or upgraded.
+   */
+  public disablePersistence() {
+    Object.values(this).forEach((store) => {
+      if (store instanceof Store) {
+        store.disablePersistence();
+      }
+    });
+  }
+
+  /**
    * Get a store by model name.
    *
    * @param modelName

--- a/app/stores/base/Store.ts
+++ b/app/stores/base/Store.ts
@@ -132,6 +132,16 @@ export default abstract class Store<T extends Model> {
     await this.persistence.hydrate();
   }
 
+  /**
+   * Disables persistence of this store's data, closing the connection to the
+   * database without removing anything that was already persisted. Safe to call
+   * whether or not persistence is currently enabled.
+   */
+  disablePersistence(): void {
+    this.persistence?.close();
+    this.persistence = undefined;
+  }
+
   addPolicies = (policies: Policy[]) => {
     policies?.forEach((policy) => this.rootStore.policies.add(policy));
   };

--- a/app/stores/base/Store.ts
+++ b/app/stores/base/Store.ts
@@ -138,7 +138,7 @@ export default abstract class Store<T extends Model> {
    * whether or not persistence is currently enabled.
    */
   disablePersistence(): void {
-    this.persistence?.close();
+    this.persistence?.disable();
     this.persistence = undefined;
   }
 

--- a/app/stores/base/StorePersistence.test.ts
+++ b/app/stores/base/StorePersistence.test.ts
@@ -173,6 +173,28 @@ describe("StorePersistence", () => {
     vi.restoreAllMocks();
   });
 
+  it("does not recreate the database from a pending flush once disabled", async () => {
+    const teamId = "team-10";
+    const source = new RootStore();
+    const persistence = new StorePersistence(source.policies, teamId);
+    const databaseName = StorePersistence.databaseName(
+      source.policies.apiEndpoint,
+      teamId
+    );
+
+    source.policies.add({ id: "doc-1", abilities: { read: true } });
+    persistence.persist("doc-1");
+
+    // Disabling while a debounced write is still scheduled, as logout does.
+    persistence.disable();
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+
+    const databases = await indexedDB.databases();
+    expect(databases.map((database) => database.name)).not.toContain(
+      databaseName
+    );
+  });
+
   it("does not block another tab from deleting the database", async () => {
     const teamId = "team-9";
     const source = new RootStore();

--- a/app/stores/base/StorePersistence.test.ts
+++ b/app/stores/base/StorePersistence.test.ts
@@ -141,6 +141,67 @@ describe("StorePersistence", () => {
     expect(other.policies.get("doc-1")).toBeTruthy();
   });
 
+  it("reopens the database after the connection is closed underneath it", async () => {
+    const teamId = "team-8";
+    const source = new RootStore();
+    const persistence = new StorePersistence(source.policies, teamId);
+    const opened: IDBDatabase[] = [];
+    const open = indexedDB.open.bind(indexedDB);
+    vi.spyOn(indexedDB, "open").mockImplementation((...args) => {
+      const request = open(...args);
+      request.addEventListener("success", () => opened.push(request.result));
+      return request;
+    });
+
+    source.policies.add({ id: "doc-1", abilities: { read: true } });
+    persistence.persist("doc-1");
+    await persistence.flush();
+
+    // Closing the connection directly leaves a stale one cached, as the browser
+    // does when it reclaims storage – no close event is fired.
+    opened.forEach((database) => database.close());
+
+    source.policies.add({ id: "doc-2", abilities: { read: true } });
+    persistence.persist("doc-2");
+    await persistence.flush();
+
+    expect(
+      await readAll(
+        StorePersistence.databaseName(source.policies.apiEndpoint, teamId)
+      )
+    ).toHaveLength(2);
+    vi.restoreAllMocks();
+  });
+
+  it("does not block another tab from deleting the database", async () => {
+    const teamId = "team-9";
+    const source = new RootStore();
+    const persistence = new StorePersistence(source.policies, teamId);
+    const databaseName = StorePersistence.databaseName(
+      source.policies.apiEndpoint,
+      teamId
+    );
+
+    source.policies.add({ id: "doc-1", abilities: { read: true } });
+    persistence.persist("doc-1");
+    await persistence.flush();
+
+    await new Promise((resolve, reject) => {
+      const request = indexedDB.deleteDatabase(databaseName);
+      request.onsuccess = () => resolve(undefined);
+      request.onerror = () => reject(request.error);
+      request.onblocked = () => reject(new Error("Deletion was blocked"));
+    });
+
+    source.policies.add({ id: "doc-2", abilities: { read: true } });
+    persistence.persist("doc-2");
+    await persistence.flush();
+
+    expect(await readAll(databaseName)).toEqual([
+      { id: "doc-2", abilities: { read: true } },
+    ]);
+  });
+
   it("clear removes all persisted records", async () => {
     const teamId = "team-4";
     const source = new RootStore();

--- a/app/stores/base/StorePersistence.ts
+++ b/app/stores/base/StorePersistence.ts
@@ -49,12 +49,8 @@ export default class StorePersistence<T extends Model> {
    */
   public hydrate = async (): Promise<void> => {
     try {
-      const database = await this.open();
-      const records = await promisifyRequest<Record<string, unknown>[]>(
-        database
-          .transaction(OBJECT_STORE_NAME, "readonly")
-          .objectStore(OBJECT_STORE_NAME)
-          .getAll()
+      const records = await this.transaction("readonly", (objectStore) =>
+        promisifyRequest<Record<string, unknown>[]>(objectStore.getAll())
       );
 
       this.hydrating = true;
@@ -106,20 +102,18 @@ export default class StorePersistence<T extends Model> {
     this.dirty.clear();
 
     try {
-      const database = await this.open();
-      const transaction = database.transaction(OBJECT_STORE_NAME, "readwrite");
-      const objectStore = transaction.objectStore(OBJECT_STORE_NAME);
-
-      for (const id of ids) {
-        const model = this.store.get(id);
-        if (model) {
-          objectStore.put(model.toPersisted());
-        } else {
-          objectStore.delete(id);
+      await this.transaction("readwrite", (objectStore) => {
+        for (const id of ids) {
+          const model = this.store.get(id);
+          if (model) {
+            objectStore.put(model.toPersisted());
+          } else {
+            objectStore.delete(id);
+          }
         }
-      }
 
-      await promisifyTransaction(transaction);
+        return promisifyTransaction(objectStore.transaction);
+      });
     } catch (err) {
       Logger.warn("Failed to write store to IndexedDB", {
         database: this.name,
@@ -141,15 +135,63 @@ export default class StorePersistence<T extends Model> {
     }
 
     try {
-      const database = await this.open();
-      const transaction = database.transaction(OBJECT_STORE_NAME, "readwrite");
-      transaction.objectStore(OBJECT_STORE_NAME).clear();
-      await promisifyTransaction(transaction);
+      await this.transaction("readwrite", (objectStore) => {
+        objectStore.clear();
+        return promisifyTransaction(objectStore.transaction);
+      });
     } catch (err) {
       Logger.warn("Failed to clear persisted store in IndexedDB", {
         database: this.name,
         error: err,
       });
+    }
+  };
+
+  /**
+   * Closes the connection to the database, if one is open. Safe to call at any
+   * time; a later read or write opens a fresh connection.
+   */
+  public close = () => {
+    this.connection?.close();
+    this.forget();
+  };
+
+  /**
+   * Runs an operation against the object store. The connection is opened once
+   * and reused, but it may be closed at any time by the browser or by another
+   * tab deleting the database, so a closed connection is reopened for a single
+   * retry.
+   *
+   * @param mode the mode the transaction should run in.
+   * @param run the operation to run against the object store.
+   * @returns a promise that resolves with the result of the operation.
+   */
+  private transaction = async <R>(
+    mode: IDBTransactionMode,
+    run: (objectStore: IDBObjectStore) => Promise<R>
+  ): Promise<R> => {
+    try {
+      return await run(await this.objectStore(mode));
+    } catch (err) {
+      if (!isConnectionClosedError(err)) {
+        throw err;
+      }
+      this.close();
+      return run(await this.objectStore(mode));
+    }
+  };
+
+  private objectStore = async (
+    mode: IDBTransactionMode
+  ): Promise<IDBObjectStore> => {
+    const database = await this.open();
+    try {
+      return database
+        .transaction(OBJECT_STORE_NAME, mode)
+        .objectStore(OBJECT_STORE_NAME);
+    } catch (err) {
+      this.forget();
+      throw err;
     }
   };
 
@@ -165,11 +207,43 @@ export default class StorePersistence<T extends Model> {
           }
           database.createObjectStore(OBJECT_STORE_NAME, { keyPath: "id" });
         };
-        request.onsuccess = () => resolve(request.result);
-        request.onerror = () => reject(request.error);
+        request.onsuccess = () => {
+          const database = request.result;
+          this.connection = database;
+
+          // Another tab is deleting or upgrading the database – get out of the
+          // way, rather than blocking it, and reopen when next needed.
+          database.onversionchange = () => {
+            database.close();
+            this.forget(database);
+          };
+          database.onclose = () => this.forget(database);
+
+          resolve(database);
+        };
+        request.onerror = () => {
+          this.forget();
+          reject(request.error);
+        };
+        request.onblocked = () => {
+          this.forget();
+          reject(new Error(`Opening ${this.name} was blocked`));
+        };
       });
     }
     return this.database;
+  };
+
+  /**
+   * Discards the cached connection so that the next operation opens a new one,
+   * unless it has already been replaced.
+   */
+  private forget = (database?: IDBDatabase) => {
+    if (database && this.connection !== database) {
+      return;
+    }
+    this.connection = undefined;
+    this.database = undefined;
   };
 
   private scheduleFlush = debounce(() => void this.flush(), FLUSH_DELAY_MS);
@@ -180,11 +254,27 @@ export default class StorePersistence<T extends Model> {
 
   private database?: Promise<IDBDatabase>;
 
+  private connection?: IDBDatabase;
+
   private dirty = new Set<string>();
 
   private disabled = false;
 
   private hydrating = false;
+}
+
+/**
+ * Whether an error was caused by the connection to the database closing, in
+ * which case the operation did not run and can safely be retried.
+ *
+ * @param err the error to check.
+ * @returns true if the connection was closed.
+ */
+function isConnectionClosedError(err: unknown): boolean {
+  return (
+    err instanceof DOMException &&
+    (err.name === "InvalidStateError" || err.name === "AbortError")
+  );
 }
 
 /**
@@ -210,6 +300,10 @@ function promisifyTransaction(transaction: IDBTransaction): Promise<void> {
   return new Promise((resolve, reject) => {
     transaction.oncomplete = () => resolve();
     transaction.onerror = () => reject(transaction.error);
-    transaction.onabort = () => reject(transaction.error);
+    transaction.onabort = () =>
+      reject(
+        transaction.error ??
+          new DOMException("The transaction was aborted", "AbortError")
+      );
   });
 }

--- a/app/stores/base/StorePersistence.ts
+++ b/app/stores/base/StorePersistence.ts
@@ -148,10 +148,22 @@ export default class StorePersistence<T extends Model> {
   };
 
   /**
+   * Stops persisting the store's data and closes the connection to the
+   * database, discarding any writes that have not yet been made. Records that
+   * were already persisted are left untouched.
+   */
+  public disable = () => {
+    this.disabled = true;
+    this.dirty.clear();
+    this.scheduleFlush.cancel();
+    this.close();
+  };
+
+  /**
    * Closes the connection to the database, if one is open. Safe to call at any
    * time; a later read or write opens a fresh connection.
    */
-  public close = () => {
+  private close = () => {
     this.connection?.close();
     this.forget();
   };

--- a/app/utils/developer.ts
+++ b/app/utils/developer.ts
@@ -14,6 +14,10 @@ export async function deleteAllDatabases() {
     return;
   }
 
+  // Close any connections this tab holds open, otherwise the deletions below
+  // are blocked until they are, and in-flight reads and writes are aborted.
+  stores.disablePersistence();
+
   const teamId = stores.auth.currentTeamId;
   if (teamId) {
     Object.values(stores).forEach((store) => {


### PR DESCRIPTION
Store persistence cached a single database connection forever, so once the browser or another tab closed it, every subsequent hydrate, flush and clear threw against a dead handle. This is the cause of the "Failed to write/hydrate/clear store in IndexedDB" errors currently in Sentry.

- Close and forget the connection on `versionchange`, so another tab is never blocked from deleting or upgrading the database
- Discard the cached connection on close, open error and blocked, and retry once against a fresh connection when one was closed underneath us
- Close open connections before `deleteAllDatabases` removes them, which also stops logout recreating the databases it just deleted