### PR TITLE
fix: Treat an unreadable request stream as a client closed request

### DIFF
--- a/server/onerror.test.ts
+++ b/server/onerror.test.ts
@@ -127,6 +127,20 @@ describe("onerror", () => {
     expect(ctx.body).toContain("request_timeout");
   });
 
+  it("should convert an unreadable request stream into a client closed request", () => {
+    const error = new Error("stream is not readable") as ReportableError & {
+      type?: string;
+    };
+    error.status = 500;
+    error.type = "stream.not.readable";
+
+    app.context.onerror.call(ctx, error);
+
+    expect(requestErrorHandler).not.toHaveBeenCalled();
+    expect(ctx.status).toBe(499);
+    expect(ctx.body).toContain("client_closed_request");
+  });
+
   it("should set the response status code when the response is not writable", () => {
     ctx.writable = false;
 

--- a/server/onerror.ts
+++ b/server/onerror.ts
@@ -32,9 +32,14 @@ export default function onerror(app: Koa) {
         err = ClientClosedRequestError();
       }
     } else if (
+      // The connection ended part way through the request message.
       err.code === "HPE_INVALID_EOF_STATE" ||
+      // The client closed the connection before the response was sent.
       err.code === "ECONNRESET" ||
-      err.code === "EPIPE"
+      // The client closed the connection while the response was written.
+      err.code === "EPIPE" ||
+      // Raised by the body parser when the request stream was already destroyed.
+      err.type === "stream.not.readable"
     ) {
       err = ClientClosedRequestError();
     } else if (isQueryCanceledError(err)) {


### PR DESCRIPTION
The body parser rejects with a 500 "stream is not readable" when the request stream was already destroyed before parsing started — the client had gone away. These arrive in bursts across many unrelated workspaces at the same second, which points at connections dropped on restart rather than anything the request did wrong.

- Map the parser's `stream.not.readable` error onto the existing client closed request error, so it answers 499 and is no longer reported to the bug tracker
- Add a short comment to each of the neighbouring client disconnect conditions