### PR TITLE
fix: Document update rejected when preferences are null

### DIFF
--- a/server/commands/documentUpdater.ts
+++ b/server/commands/documentUpdater.ts
@@ -25,7 +25,7 @@ type Props = {
   /** If the document should be displayed full-width on the screen */
   fullWidth?: boolean;
   /** Display preferences for the document, merged with existing values */
-  preferences?: DocumentPreferences;
+  preferences?: DocumentPreferences | null;
   /** Whether insights should be visible on the document */
   insightsEnabled?: boolean;
   /** The edit mode: "replace", "append", "prepend", or "patch" */

--- a/server/routes/api/documents/documents.test.ts
+++ b/server/routes/api/documents/documents.test.ts
@@ -7,6 +7,7 @@ import {
   CollectionPermission,
   DocumentPermission,
   ExportContentType,
+  HeadingPrefixStyle,
   StatusFilter,
   UserRole,
 } from "@shared/types";
@@ -6285,6 +6286,44 @@ describe("#documents.update", () => {
       },
     });
     expect(events.length).toEqual(1);
+  });
+
+  it("should update document with a null preferences value", async () => {
+    const user = await buildUser();
+    const document = await buildDocument({
+      userId: user.id,
+      teamId: user.teamId,
+    });
+    const res = await server.post("/api/documents.update", user, {
+      body: {
+        id: document.id,
+        title: "Updated title",
+        preferences: null,
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.data.title).toBe("Updated title");
+    expect(body.data.preferences).toBe(null);
+  });
+
+  it("should update document preferences", async () => {
+    const user = await buildUser();
+    const document = await buildDocument({
+      userId: user.id,
+      teamId: user.teamId,
+    });
+    const res = await server.post("/api/documents.update", user, {
+      body: {
+        id: document.id,
+        preferences: { headingPrefix: HeadingPrefixStyle.Numeric },
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.data.preferences).toEqual({
+      headingPrefix: HeadingPrefixStyle.Numeric,
+    });
   });
 
   it("should update document when lastRevision matches", async () => {

--- a/server/routes/api/documents/schema.ts
+++ b/server/routes/api/documents/schema.ts
@@ -404,7 +404,7 @@ export const DocumentsUpdateSchema = BaseSchema.extend({
         /** The style of prefix displayed before headings in the doc */
         headingPrefix: z.enum(HeadingPrefixStyle).optional(),
       })
-      .optional(),
+      .nullish(),
 
     /** Boolean to denote if insights should be visible on the doc */
     insightsEnabled: z.boolean().optional(),
@@ -602,7 +602,7 @@ export const DocumentsCreateSchema = BaseSchema.extend({
         /** The style of prefix displayed before headings in the document */
         headingPrefix: z.enum(HeadingPrefixStyle).optional(),
       })
-      .optional(),
+      .nullish(),
   }),
 }).refine(
   (req) =>


### PR DESCRIPTION
Users saw "preferences: Invalid input: expected object, received null" when saving a document created before the preferences column existed.

- The client serializes every `@Field` on save, so those documents post `preferences: null`
- The documents create and update schemas only accepted an object or undefined, so the request failed validation
- Accept null in both schemas, matching the other nullable fields; a null value leaves stored preferences untouched