### PR TITLE
fix: Crash opening document menu on mobile

### DIFF
--- a/app/menus/DocumentMenu.tsx
+++ b/app/menus/DocumentMenu.tsx
@@ -10,7 +10,7 @@ import type Document from "~/models/Document";
 import type Template from "~/models/Template";
 import { DropdownMenu } from "~/components/Menu/DropdownMenu";
 import { OverflowMenuButton } from "~/components/Menu/OverflowMenuButton";
-import { toMenuItems } from "~/components/Menu/transformer";
+import { toMenuItems, toMobileMenuItems } from "~/components/Menu/transformer";
 import Switch from "~/components/Switch";
 import { actionToMenuItem } from "~/actions";
 import { changeHeadingPrefix } from "~/actions/definitions/documents";
@@ -223,7 +223,37 @@ function DocumentMenu({
  */
 const HeadingPrefixMenuItem = observer(function HeadingPrefixMenuItem_() {
   const context = useActionContext({ isMenu: true });
-  return <>{toMenuItems([actionToMenuItem(changeHeadingPrefix, context)])}</>;
+  const isMobile = useMobile();
+  const item = actionToMenuItem(changeHeadingPrefix, context);
+
+  // On mobile the display options are appended to a drawer rather than to menu
+  // content, so there is no menu root for the submenu primitives to attach to.
+  // Flatten the submenu into an inline group of options instead, which also
+  // matches the toggles it sits alongside — picking one leaves the drawer open.
+  if (isMobile) {
+    if (item.type !== "submenu") {
+      return null;
+    }
+
+    return (
+      <>
+        {toMobileMenuItems(
+          [
+            {
+              type: "group",
+              title: item.title,
+              visible: item.visible,
+              items: item.items,
+            },
+          ],
+          noop,
+          noop
+        )}
+      </>
+    );
+  }
+
+  return <>{toMenuItems([item])}</>;
 });
 
 const ToggleMenuItem = styled(Switch)`

--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -716,8 +716,6 @@ width: 100%;
   h5 { font-size: var(--font-size-h5); }
   h6 { font-size: var(--font-size-h6); }
 
-  // Matches the tone of the heading anchor beside it, which is the primary
-  // text color held at the same opacity.
   [data-heading-prefix]::before {
     content: attr(data-heading-prefix);
     color: ${props.theme.text};

--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -2683,16 +2683,18 @@ del {
 }
 
 @media print {
+  // The heading level labels are an editing affordance, but the same pseudo
+  // element carries the heading prefix, which is content and must be printed.
   .placeholder::before,
   .block-menu-trigger,
   .heading-anchor,
   button.show-source-button,
-  h1:not(.placeholder)::before,
-  h2:not(.placeholder)::before,
-  h3:not(.placeholder)::before,
-  h4:not(.placeholder)::before,
-  h5:not(.placeholder)::before,
-  h6:not(.placeholder)::before {
+  h1:not(.placeholder):not([data-heading-prefix])::before,
+  h2:not(.placeholder):not([data-heading-prefix])::before,
+  h3:not(.placeholder):not([data-heading-prefix])::before,
+  h4:not(.placeholder):not([data-heading-prefix])::before,
+  h5:not(.placeholder):not([data-heading-prefix])::before,
+  h6:not(.placeholder):not([data-heading-prefix])::before {
     display: none;
   }
 

--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -716,9 +716,12 @@ width: 100%;
   h5 { font-size: var(--font-size-h5); }
   h6 { font-size: var(--font-size-h6); }
 
+  // Matches the tone of the heading anchor beside it, which is the primary
+  // text color held at the same opacity.
   [data-heading-prefix]::before {
     content: attr(data-heading-prefix);
-    color: ${props.theme.textSecondary};
+    color: ${props.theme.text};
+    opacity: 0.75;
     margin-inline-end: 0.25em;
   }
 


### PR DESCRIPTION
Flatten the submenu into an inline group of options on mobile, matching the toggles it sits alongside.

Fixes OUTLINE-CLOUD-D1X
