### PR TITLE
Make the markdown representation of shared links discoverable

### DIFF
--- a/server/routes/app.ts
+++ b/server/routes/app.ts
@@ -85,6 +85,7 @@ export const renderApp = async (
     shortcutIcon?: string;
     rootShareId?: string;
     isShare?: boolean;
+    markdownUrl?: string;
     analytics?: Integration<IntegrationType.Analytics>[];
     allowIndexing?: boolean;
   } = {}
@@ -133,9 +134,14 @@ export const renderApp = async (
       <script type="module" nonce="${ctx.state.cspNonce}" src="${viteHost}/static/${entry}"></script>
     `;
 
+  const alternateTag = options.markdownUrl
+    ? `<link rel="alternate" type="text/markdown" href="${escape(options.markdownUrl)}" />`
+    : "";
+
   let headTags = `
     <meta name="robots" content="${allowIndexing ? "index, follow" : "noindex, nofollow"}" />
     <link rel="canonical" href="${escape(canonical)}" />
+    ${alternateTag}
     <link
       rel="shortcut icon"
       type="image/png"
@@ -179,6 +185,15 @@ export const renderApp = async (
     `;
   }
 
+  // Advertise the markdown representation so that clients can discover it from
+  // the response headers alone, without parsing the page.
+  if (options.markdownUrl) {
+    ctx.response.set(
+      "Link",
+      `<${options.markdownUrl}>; rel="alternate"; type="text/markdown"`
+    );
+  }
+
   // Ensure no caching is performed
   ctx.response.set("Cache-Control", "no-cache, must-revalidate");
   ctx.response.set("Expires", "-1");
@@ -202,6 +217,9 @@ export const renderShare = async (ctx: Context, next: Next) => {
   const shareId = rootShareId ?? ctx.params.shareId;
   const collectionSlug = ctx.params.collectionSlug;
   const documentSlug = ctx.params.documentSlug;
+
+  // The response depends on the Accept header, caches must key on it.
+  ctx.vary("Accept");
 
   // Find the share record if published so that the document title can be returned
   // in the server-rendered HTML. This allows it to appear in unfurls more reliably.
@@ -250,6 +268,16 @@ export const renderShare = async (ctx: Context, next: Next) => {
     ctx.status = 404;
   }
 
+  // The markdown representation lives at the same path with a .md suffix, only
+  // on the routes that accept a format suffix.
+  const markdownPath = ctx.params.shareId
+    ? `/s/${ctx.params.shareId}${documentSlug ? `/doc/${documentSlug}` : ""}`
+    : undefined;
+  const markdownUrl =
+    markdownPath && markdownPath === ctx.request.path
+      ? `${ctx.request.URL.origin}${markdownPath}.md`
+      : undefined;
+
   // If the client explicitly requests markdown and prefers it over HTML,
   // or the URL path ends with .md, return the document as markdown. This is
   // useful for LLMs and API clients.
@@ -282,6 +310,8 @@ export const renderShare = async (ctx: Context, next: Next) => {
     }
 
     ctx.type = "text/markdown";
+    ctx.response.set("Cache-Control", "no-cache, must-revalidate");
+    ctx.response.set("Expires", "-1");
     ctx.body = markdown;
     return;
   }
@@ -341,5 +371,6 @@ export const renderShare = async (ctx: Context, next: Next) => {
     rootShareId,
     canonical: canonicalUrl,
     allowIndexing: share?.allowIndexing,
+    markdownUrl: document || collection ? markdownUrl : undefined,
   });
 };

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -109,6 +109,59 @@ describe("/s/:id", () => {
     expect(body).toContain(`<title>${document.title}</title>`);
   });
 
+  it("should vary on Accept and advertise the markdown alternate in html", async () => {
+    const document = await buildDocument();
+    const share = await buildShare({
+      documentId: document.id,
+      teamId: document.teamId,
+    });
+    const res = await server.get(`/s/${share.id}`);
+    const body = await res.text();
+    expect(res.status).toEqual(200);
+    expect(res.headers.get("vary")).toContain("Accept");
+    const origin = new URL(res.url).origin;
+    expect(res.headers.get("link")).toEqual(
+      `<${origin}/s/${share.id}.md>; rel="alternate"; type="text/markdown"`
+    );
+    expect(body).toContain(
+      `<link rel="alternate" type="text/markdown" href="${origin}/s/${share.id}.md" />`
+    );
+  });
+
+  it("should advertise the markdown alternate for a nested document", async () => {
+    const document = await buildDocument();
+    const share = await buildShare({
+      documentId: document.id,
+      teamId: document.teamId,
+    });
+    const res = await server.get(`/s/${share.id}/doc/${document.urlId}`);
+    expect(res.status).toEqual(200);
+    const origin = new URL(res.url).origin;
+    expect(res.headers.get("link")).toEqual(
+      `<${origin}/s/${share.id}/doc/${document.urlId}.md>; rel="alternate"; type="text/markdown"`
+    );
+  });
+
+  it("should not advertise the markdown alternate when share is not found", async () => {
+    const res = await server.get(`/s/junk`);
+    expect(res.status).toEqual(404);
+    expect(res.headers.get("link")).toEqual(null);
+  });
+
+  it("should vary on Accept and prevent caching of markdown", async () => {
+    const document = await buildDocument();
+    const share = await buildShare({
+      documentId: document.id,
+      teamId: document.teamId,
+    });
+    const res = await server.get(`/s/${share.id}.md`);
+    expect(res.status).toEqual(200);
+    expect(res.headers.get("vary")).toContain("Accept");
+    expect(res.headers.get("cache-control")).toEqual(
+      "no-cache, must-revalidate"
+    );
+  });
+
   it("should include child documents list in markdown when includeChildDocuments is true", async () => {
     const parent = await buildDocument();
     const child1 = await buildDocument({


### PR DESCRIPTION
Shared links already return markdown when the client asks for it, but a client had no way to learn this short of guessing the `.md` suffix.

- Vary on `Accept`, so a shared cache cannot serve markdown to a browser or HTML to an agent
- Send a `Link` rel="alternate" header on the HTML, so the markdown is discoverable from a HEAD request alone
- Emit a matching link tag next to the canonical in the head, for clients that parse HTML but not headers
- Give the markdown response the same cache directives as the HTML, which previously had none

The alternate is only advertised on the routes where the suffix actually resolves, so share custom domains and wildcard paths are unaffected.