### PR TITLE
fix: Only show editing stats toggle when viewing a document

### DIFF
--- a/app/hooks/useDocumentMenuAction.tsx
+++ b/app/hooks/useDocumentMenuAction.tsx
@@ -45,6 +45,8 @@ import { useTemplateMenuActions } from "./useTemplateMenuActions";
 type Props = {
   /** Document ID for which the actions are generated */
   documentId: string;
+  /** Whether the document is currently being viewed */
+  isViewing?: boolean;
   /** Invoked when the "Find and replace" menu item is clicked */
   onFindAndReplace?: () => void;
   /** Invoked when the "Rename" menu item is clicked */
@@ -55,6 +57,7 @@ type Props = {
 
 export function useDocumentMenuAction({
   documentId,
+  isViewing,
   onFindAndReplace,
   onRename,
   onSelectTemplate,
@@ -106,7 +109,7 @@ export function useDocumentMenuAction({
         openDocumentComments,
         openDocumentHistory,
         openDocumentInsights,
-        toggleDocumentStats,
+        ...(isViewing ? [toggleDocumentStats] : []),
         openDocumentInSplit,
         openDocumentInDesktop,
         presentDocument,
@@ -118,6 +121,14 @@ export function useDocumentMenuAction({
         permanentlyDeleteDocument,
         leaveDocument,
       ]),
-    [t, isMobile, templateMenuActions, documentId, onFindAndReplace, onRename]
+    [
+      t,
+      isMobile,
+      isViewing,
+      templateMenuActions,
+      documentId,
+      onFindAndReplace,
+      onRename,
+    ]
   );
 }

--- a/app/hooks/useDocumentMenuAction.tsx
+++ b/app/hooks/useDocumentMenuAction.tsx
@@ -57,7 +57,7 @@ type Props = {
 
 export function useDocumentMenuAction({
   documentId,
-  isViewing,
+  isViewing = false,
   onFindAndReplace,
   onRename,
   onSelectTemplate,

--- a/app/menus/DocumentMenu.tsx
+++ b/app/menus/DocumentMenu.tsx
@@ -129,6 +129,7 @@ function DocumentMenu({
 
   const rootAction = useDocumentMenuAction({
     documentId: document.id,
+    isViewing: showDisplayOptions,
     onFindAndReplace,
     onRename,
     onSelectTemplate,


### PR DESCRIPTION
- "Show editing stats" appeared in every document menu — sidebar links, list items, cards, breadcrumbs and right-click menus — because the action was part of the shared menu action list and only checked that a document was in context.
- The toggle is now limited to the menu of the document currently on screen, alongside the other display options.
- Keyboard shortcut and command bar entry are unchanged.