### PR TITLE
fix: Search result context cut mid-word by earlier highlights

### DIFF
--- a/plugins/search-postgres/server/PostgresSearchProvider.test.ts
+++ b/plugins/search-postgres/server/PostgresSearchProvider.test.ts
@@ -773,6 +773,31 @@ describe("PostgresSearchProvider", () => {
       expect(total).toBe(1);
     });
 
+    it("should return context that is not shifted by earlier highlights", async () => {
+      const team = await buildTeam();
+      const user = await buildUser({ teamId: team.id });
+      const collection = await buildCollection({
+        teamId: team.id,
+        userId: user.id,
+      });
+      await buildDocument({
+        teamId: team.id,
+        userId: user.id,
+        collectionId: collection.id,
+        title: "change",
+        text: "world war two was a very large conflict that involved many nations over six years. Later on, hello world became the canonical first program.",
+      });
+      const { results } = await provider.searchForUser(user, {
+        query: "hello world",
+      });
+      expect(results.length).toBe(1);
+      // The earlier "world" is highlighted too, which must not move the start
+      // of the slice into the middle of a word.
+      expect(results[0].context).toBe(
+        " conflict that involved many nations over six years. Later on, <b>hello world</b> became the canonical first program"
+      );
+    });
+
     it("should correctly handle removal of trailing spaces", async () => {
       const team = await buildTeam();
       const user = await buildUser({ teamId: team.id });

--- a/plugins/search-postgres/server/PostgresSearchProvider.test.ts
+++ b/plugins/search-postgres/server/PostgresSearchProvider.test.ts
@@ -798,6 +798,28 @@ describe("PostgresSearchProvider", () => {
       );
     });
 
+    it("should return context for text with no word boundaries", async () => {
+      const team = await buildTeam();
+      const user = await buildUser({ teamId: team.id });
+      const collection = await buildCollection({
+        teamId: team.id,
+        userId: user.id,
+      });
+      const text = "abcdefghij".repeat(40);
+      await buildDocument({
+        teamId: team.id,
+        userId: user.id,
+        collectionId: collection.id,
+        title: "hello world",
+        text,
+      });
+      const { results } = await provider.searchForUser(user, {
+        query: "hello world",
+      });
+      expect(results.length).toBe(1);
+      expect(results[0].context).toBe(text.slice(0, 250));
+    });
+
     it("should correctly handle removal of trailing spaces", async () => {
       const team = await buildTeam();
       const user = await buildUser({ teamId: team.id });

--- a/plugins/search-postgres/server/PostgresSearchProvider.ts
+++ b/plugins/search-postgres/server/PostgresSearchProvider.ts
@@ -591,7 +591,11 @@ export default class PostgresSearchProvider extends BaseSearchProvider {
         ? 0
         : regexIndexOf(text, breakCharsRegex, offsetStartIndex)
     );
-    const endIndex = regexLastIndexOf(text, breakCharsRegex, startIndex + 250);
+    // Ends on the last word boundary within the window, or at the window
+    // itself when the text has none.
+    const maxEndIndex = Math.min(text.length, startIndex + 250);
+    const breakIndex = regexLastIndexOf(text, breakCharsRegex, maxEndIndex);
+    const endIndex = breakIndex > startIndex ? breakIndex : maxEndIndex;
 
     // Highlight after slicing, as the inserted tags shift every index that
     // follows an earlier match.

--- a/plugins/search-postgres/server/PostgresSearchProvider.ts
+++ b/plugins/search-postgres/server/PostgresSearchProvider.ts
@@ -591,14 +591,13 @@ export default class PostgresSearchProvider extends BaseSearchProvider {
         ? 0
         : regexIndexOf(text, breakCharsRegex, offsetStartIndex)
     );
-    const context = text.replace(highlightRegex, "<b>$&</b>");
-    const endIndex = regexLastIndexOf(
-      context,
-      breakCharsRegex,
-      startIndex + 250
-    );
+    const endIndex = regexLastIndexOf(text, breakCharsRegex, startIndex + 250);
 
-    return context.slice(startIndex, endIndex);
+    // Highlight after slicing, as the inserted tags shift every index that
+    // follows an earlier match.
+    return text
+      .slice(startIndex, endIndex)
+      .replace(highlightRegex, "<b>$&</b>");
   }
 
   /**


### PR DESCRIPTION
Search result snippets could begin in the middle of a word, or inside a bold tag.

- Snippet start and end were calculated against the plain document text, then used to slice the highlighted copy.
- Every highlight before the slice start adds seven characters, so the slice landed too far along.
- Any single word of the query is highlighted, not only the full phrase, so one earlier occurrence is enough to trigger it.
- Slice first and highlight the slice, so both indexes apply to the same string.