### PR TITLE
fix: Mobile toolbar taps and keyboard tracking

### DIFF
--- a/app/editor/components/FloatingToolbar.tsx
+++ b/app/editor/components/FloatingToolbar.tsx
@@ -247,6 +247,7 @@ const FloatingToolbar = React.forwardRef(function FloatingToolbar_(
 ) {
   const menuRef = ref || React.createRef<HTMLDivElement>();
   const [isSelectingText, setSelectingText] = React.useState(false);
+  const raisedClickAt = React.useRef(0);
 
   let position = usePosition({
     menuRef,
@@ -277,13 +278,37 @@ const FloatingToolbar = React.forwardRef(function FloatingToolbar_(
   useKeyboardStickyOffset(menuRef, isMobileToolbarVisible);
 
   // Tapping the bar must not move focus out of the editor, that would dismiss
-  // the on-screen keyboard and take the bar down with it.
-  const handlePointerDown = (event: React.PointerEvent) => {
+  // the on-screen keyboard and take the bar down with it. Mousedown is the
+  // event that assigns focus, and a tap dispatches it only after pointerup.
+  const handleMouseDown = (event: React.MouseEvent) => {
     if (
       event.target instanceof Element &&
       !event.target.closest("input, textarea, [contenteditable='true']")
     ) {
       event.preventDefault();
+    }
+  };
+
+  // Canceling that mousedown cancels the tap's click with it, so the click is
+  // raised here instead, from the pointerup that comes before both.
+  const handlePointerUp = (event: React.PointerEvent) => {
+    if (event.pointerType === "mouse") {
+      return;
+    }
+
+    const button =
+      event.target instanceof Element ? event.target.closest("button") : null;
+    if (button) {
+      raisedClickAt.current = event.timeStamp;
+      button.click();
+    }
+  };
+
+  // A browser that delivers the tap's click anyway must not act twice.
+  const handleClickCapture = (event: React.MouseEvent) => {
+    if (event.isTrusted && event.timeStamp - raisedClickAt.current < 500) {
+      event.preventDefault();
+      event.stopPropagation();
     }
   };
 
@@ -293,7 +318,12 @@ const FloatingToolbar = React.forwardRef(function FloatingToolbar_(
       // useKeyboardStickyOffset, which writes the transform directly.
       return (
         <ReactPortal>
-          <MobileWrapper ref={menuRef} onPointerDown={handlePointerDown}>
+          <MobileWrapper
+            ref={menuRef}
+            onMouseDown={handleMouseDown}
+            onPointerUp={handlePointerUp}
+            onClickCapture={handleClickCapture}
+          >
             <MobileBackground>{props.children}</MobileBackground>
           </MobileWrapper>
         </ReactPortal>
@@ -361,7 +391,7 @@ const MobileWrapper = styled.div`
   right: 0;
   width: 100vw;
   box-sizing: border-box;
-  padding: 0 8px 8px;
+  padding: 0 16px 4px;
   z-index: ${depths.editorToolbar};
   will-change: transform;
 

--- a/app/hooks/useKeyboardStickyOffset.ts
+++ b/app/hooks/useKeyboardStickyOffset.ts
@@ -13,12 +13,13 @@ import { getSafeAreaInsets } from "@shared/utils/browser";
  * translates the element upwards by that amount so it always rests on top of
  * the keyboard.
  *
- * The transform is re-applied after every render (so a parent re-render cannot
- * clobber it) and on visual viewport `resize`/`scroll` events. A short-lived
- * `requestAnimationFrame` loop tracks the keyboard's open/close animation so
- * the element glides with it rather than snapping into place once the
- * transition settles. Writes go directly to the node's style to avoid React
- * re-render latency during the animation.
+ * The measurement is repeated every frame while enabled. A keyboard changes
+ * height without warning – a predictive text strip or an accessory bar comes
+ * and goes, one keyboard type replaces another – and not every change is
+ * announced by a viewport event, so an element positioned once from an event
+ * can be left behind the keyboard. Writes go straight to the node's style, and
+ * only when the offset changes, so a frame that measures the same keyboard
+ * costs a handful of property reads.
  *
  * @param ref A ref to the fixed-position element to keep pinned.
  * @param enabled Whether the behavior should be active.
@@ -27,6 +28,13 @@ export default function useKeyboardStickyOffset(
   ref: React.RefObject<HTMLElement>,
   enabled: boolean
 ) {
+  const applied = React.useRef<number | null>(null);
+
+  // Reading the layout viewport height can force a layout, so it is measured
+  // when it changes rather than on every frame.
+  const safeAreaBottom = React.useRef(0);
+  const layoutHeight = React.useRef(0);
+
   const apply = React.useCallback(() => {
     const viewport = window.visualViewport;
     const node = ref.current;
@@ -41,55 +49,46 @@ export default function useKeyboardStickyOffset(
     // clears the home indicator.
     const keyboardInset = Math.max(
       0,
-      window.innerHeight - (viewport.offsetTop + viewport.height)
+      layoutHeight.current - (viewport.offsetTop + viewport.height)
     );
-    const offset = Math.round(
-      Math.max(keyboardInset, getSafeAreaInsets().bottom)
-    );
+    const offset = Math.round(Math.max(keyboardInset, safeAreaBottom.current));
 
-    node.style.transform = `translate3d(0, ${-offset}px, 0)`;
+    if (offset !== applied.current) {
+      applied.current = offset;
+      node.style.transform = `translate3d(0, ${-offset}px, 0)`;
+    }
   }, [ref, enabled]);
 
-  // Re-apply after every render, before paint, so the keyboard-aware transform
-  // survives parent re-renders and there is no flash on first mount.
-  React.useLayoutEffect(apply);
+  // Re-apply after every render, before paint, so the transform survives a
+  // parent re-render and there is no flash on first mount.
+  React.useLayoutEffect(() => {
+    safeAreaBottom.current = getSafeAreaInsets().bottom;
+    layoutHeight.current = window.innerHeight;
+    applied.current = null;
+    apply();
+  });
 
   React.useEffect(() => {
-    const viewport = window.visualViewport;
-    if (!enabled || !viewport) {
+    if (!enabled || !window.visualViewport) {
       return;
     }
 
-    let frame = 0;
-    let trackUntil = 0;
+    const handleResize = () => {
+      layoutHeight.current = window.innerHeight;
+      safeAreaBottom.current = getSafeAreaInsets().bottom;
+    };
+    window.addEventListener("resize", handleResize);
+    window.addEventListener("orientationchange", handleResize);
 
-    const tick = (now: number) => {
+    let frame = requestAnimationFrame(function tick() {
       apply();
-      frame = now < trackUntil ? requestAnimationFrame(tick) : 0;
-    };
-
-    const schedule = () => {
-      // Keep re-measuring for a short window so the element follows the
-      // keyboard animation rather than jumping once it settles.
-      trackUntil = performance.now() + 350;
-      if (!frame) {
-        frame = requestAnimationFrame(tick);
-      }
-    };
-
-    viewport.addEventListener("resize", schedule);
-    viewport.addEventListener("scroll", schedule);
-    window.addEventListener("focusin", schedule);
-    window.addEventListener("orientationchange", schedule);
+      frame = requestAnimationFrame(tick);
+    });
 
     return () => {
-      if (frame) {
-        cancelAnimationFrame(frame);
-      }
-      viewport.removeEventListener("resize", schedule);
-      viewport.removeEventListener("scroll", schedule);
-      window.removeEventListener("focusin", schedule);
-      window.removeEventListener("orientationchange", schedule);
+      cancelAnimationFrame(frame);
+      window.removeEventListener("resize", handleResize);
+      window.removeEventListener("orientationchange", handleResize);
     };
   }, [enabled, apply]);
 }


### PR DESCRIPTION
Follow-up to #13533, covering two problems found on device.

- Toolbar buttons did nothing when tapped. Canceling `mousedown` is what keeps the editor focused and the keyboard open, but it cancels the tap's click along with it — the click is now raised from `pointerup`, which a tap delivers before either event. A browser that sends the click regardless is ignored, so nothing runs twice.
- The bar could sit behind the keyboard. Its offset is now measured every frame while it is on screen, rather than only from viewport events, which are not fired for every change in keyboard height — a predictive text strip or an accessory bar appearing would leave the bar behind. The style is only written when the offset changes, and the one layout-forcing read is cached.
- Wider inset from the edges of the screen.