### PR TITLE
fix: Revision diff mismatching node closing tokens

### DIFF
--- a/shared/editor/lib/ChangesetHelper.test.ts
+++ b/shared/editor/lib/ChangesetHelper.test.ts
@@ -235,6 +235,63 @@ describe("ChangesetHelper.getChangeset", () => {
     expect(changes[0].inserted).toHaveLength(1);
   });
 
+  describe("node boundary tokens", () => {
+    it("reports the change to a node's closing token when its type changes", () => {
+      // Converting a paragraph to a heading rewrites both of the node's
+      // boundary tokens. The closing tokens of the two node types must not
+      // compare as equal, or only the opening one is reported.
+      const changes = changesFor(
+        {
+          type: "doc",
+          content: [
+            {
+              type: "heading",
+              attrs: { level: 1 },
+              content: [{ type: "text", text: "Alpha" }],
+            },
+          ],
+        },
+        para("Alpha")
+      );
+
+      expect(changes).toHaveLength(2);
+      // The paragraph opens at 0 and closes at 6, either side of "Alpha".
+      expect([changes[0].fromA, changes[0].toA]).toEqual([0, 1]);
+      expect([changes[1].fromA, changes[1].toA]).toEqual([6, 7]);
+    });
+
+    it("places an inserted wrapper's closing token outside the node it wraps", () => {
+      // Wrapping the paragraph in a blockquote inserts the quote's closing
+      // token after the paragraph, at the end of the old document. Matching it
+      // to the paragraph's own closing token instead would report the
+      // insertion at 6, inside the paragraph.
+      const changes = changesFor(
+        {
+          type: "doc",
+          content: [
+            {
+              type: "blockquote",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Alpha" }],
+                },
+              ],
+            },
+          ],
+        },
+        para("Alpha")
+      );
+
+      expect(changes).toHaveLength(2);
+      expect([changes[0].fromA, changes[0].toA]).toEqual([0, 0]);
+      expect([changes[1].fromA, changes[1].toA]).toEqual([7, 7]);
+      // In the new document the change is the blockquote's closing token at
+      // 8, not the paragraph's at 7.
+      expect([changes[1].fromB, changes[1].toB]).toEqual([8, 9]);
+    });
+  });
+
   describe("complexity guard", () => {
     const texts = Array.from(
       { length: 500 },

--- a/shared/editor/lib/ChangesetHelper.ts
+++ b/shared/editor/lib/ChangesetHelper.ts
@@ -246,11 +246,12 @@ class AttributeEncoder implements TokenEncoder<string | number> {
 
   // See: https://github.com/ProseMirror/prosemirror-changeset/blob/23f67c002e5489e454a0473479e407decb238afe/src/diff.ts#L26
   public encodeNodeEnd({ type }: Node): number {
-    let cache: Record<string, number> =
+    const cache: Record<string, number> =
       type.schema.cached.changeSetIDs ||
       (type.schema.cached.changeSetIDs = Object.create(null));
+    // The cache has a null prototype, so a miss reads as undefined.
     let id = cache[type.name];
-    if (id === null) {
+    if (id === undefined) {
       cache[type.name] = id =
         Object.keys(type.schema.nodes).indexOf(type.name) + 1;
     }


### PR DESCRIPTION
The changeset token encoder caches node type ids in a null-prototype object, but tested for a cache miss with `=== null` — which never matches, since a miss reads as undefined. The cache was never filled and every node end encoded to the same value.

- Closing tokens of unrelated node types compared as equal
- Revision diffs could omit a node's closing token when its type changed
- An inserted wrapper's closing token could be attributed to the node it wraps

Now tests for `undefined`, matching upstream prosemirror-changeset.