### PR TITLE
Return 404 for unhandled paths under the MCP endpoint

### DIFF
--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -341,6 +341,13 @@ describe("scanner path 404s", () => {
     expect(res.status).toEqual(200);
   });
 
+  it("returns 404 for the legacy SSE transport probe", async () => {
+    const res = await server.get("/sse");
+    const body = await res.text();
+    expect(res.status).toEqual(404);
+    expect(body).not.toContain("<title>");
+  });
+
   it("still serves the OAuth well-known endpoint", async () => {
     const res = await server.get("/.well-known/oauth-authorization-server");
     expect(res.status).toEqual(200);

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -174,6 +174,12 @@ router.get(
   }
 );
 
+// MCP clients sometimes probe the origin for a legacy HTTP+SSE endpoint. The
+// application shell is not a valid response to that probe, so answer with a 404.
+router.get("/sse", (ctx) => {
+  ctx.status = 404;
+});
+
 router.get("/robots.txt", (ctx) => {
   ctx.body = robotsResponse();
 });

--- a/server/routes/mcp/index.test.ts
+++ b/server/routes/mcp/index.test.ts
@@ -81,6 +81,26 @@ describe("POST /mcp/", () => {
       expect(res.status).toEqual(405);
     });
 
+    it.each(["/mcp/sse", "/mcp/message", "/mcp/manifest.json"])(
+      "should return 404 for %s without rendering the app shell",
+      async (path) => {
+        const res = await server.get(path);
+        const body = await res.text();
+        expect(res.status).toEqual(404);
+        expect(body).not.toContain("<title>");
+      }
+    );
+
+    it("should return 404 for POST to a path below the endpoint", async () => {
+      const { accessToken } = await buildOAuthUser();
+      const { body } = mcpRequest("tools/list");
+      const res = await server.post("/mcp/sse", {
+        headers: mcpHeaders(accessToken),
+        body,
+      });
+      expect(res.status).toEqual(404);
+    });
+
     it("should handle initialize and return capabilities", async () => {
       const { accessToken } = await buildOAuthUser();
       const { body } = mcpRequest("initialize", {

--- a/server/routes/mcp/index.ts
+++ b/server/routes/mcp/index.ts
@@ -222,6 +222,13 @@ router.delete("/", async (ctx) => {
   ctx.body = { error: "Method not allowed. Use POST for MCP requests." };
 });
 
+// Clients probing for a transport we do not implement, such as the legacy
+// HTTP+SSE endpoints, must not fall through to the application shell
+router.all("*", async (ctx) => {
+  ctx.status = 404;
+  ctx.body = { error: "Not found. MCP requests must be sent to /mcp." };
+});
+
 app.use(requestTracer());
 app.use(bodyParser());
 app.use(router.routes());


### PR DESCRIPTION
- Unknown paths below `/mcp`, and the origin-level `/sse` probe, fell through to the application catch-all and returned the app shell with a 200.
- Remote MCP clients that probe for the legacy HTTP+SSE transport before falling back to streamable HTTP can read that as a valid endpoint and then fail to connect.
- Both now return a 404 instead.