### PR TITLE
fix: Round reading time up to the next minute

### DIFF
--- a/app/hooks/useTextStats.test.ts
+++ b/app/hooks/useTextStats.test.ts
@@ -27,4 +27,9 @@ describe("getTextStats", () => {
   it("rounds reading time up to a minute for short text", () => {
     expect(getTextStats("Hello world").readingTime).toBe(1);
   });
+
+  it("rounds reading time up to the next minute for long text", () => {
+    expect(getTextStats("word ".repeat(500)).readingTime).toBe(3);
+    expect(getTextStats("word ".repeat(400)).readingTime).toBe(2);
+  });
 });

--- a/app/hooks/useTextStats.ts
+++ b/app/hooks/useTextStats.ts
@@ -13,7 +13,7 @@ export function getTextStats(text: string) {
     words,
     characters: text.length,
     paragraphs: countParagraphs(text),
-    readingTime: words ? Math.max(1, Math.floor(words / 200)) : 0,
+    readingTime: Math.ceil(words / 200),
   };
 }
 


### PR DESCRIPTION
- Reading time was rounded down, so 500 words at 200 wpm showed 2 minutes instead of 3.
- Switched to `Math.ceil`, which also makes the minimum-of-one clamp unnecessary.