### PR TITLE
fix: Properly bind and unbind listeners in `useHover`

### DIFF
--- a/app/hooks/useHover.ts
+++ b/app/hooks/useHover.ts
@@ -38,10 +38,18 @@ const useHover = ({ ref, duration }: Props): boolean => {
   });
 
   React.useEffect(() => {
-    if (ref.current) {
-      ref.current.onmouseenter = onMouseEnter;
-      ref.current.onmouseleave = onMouseLeave;
+    const element = ref.current;
+    if (!element) {
+      return;
     }
+
+    element.addEventListener("mouseenter", onMouseEnter);
+    element.addEventListener("mouseleave", onMouseLeave);
+
+    return () => {
+      element.removeEventListener("mouseenter", onMouseEnter);
+      element.removeEventListener("mouseleave", onMouseLeave);
+    };
   }, [ref, onMouseEnter, onMouseLeave]);
 
   return hovered;


### PR DESCRIPTION
addEventListener / removeEventListener replace the onmouseenter / onmouseleave property assignments. The hook no longer overwrites a handler that other code set on the same node.
