### PR TITLE
fix: Self-hosted diagrams.net URLs not offered as an embed

### DIFF
--- a/app/hooks/useEmbeds.ts
+++ b/app/hooks/useEmbeds.ts
@@ -44,9 +44,9 @@ export default function useEmbeds(loadIfMissing = false) {
         const integration: Integration<IntegrationType.Embed> | undefined =
           find(integrations.orderedData, (i) => i.service === e.name);
 
-        if (integration?.settings) {
-          e.settings = integration.settings;
-        }
+        // Descriptors are shared module state, so always assign to clear any
+        // settings left behind by a disconnected integration.
+        e.settings = integration?.settings;
 
         e.disabled = disabledEmbeds.includes(e.id);
 

--- a/server/models/Integration.ts
+++ b/server/models/Integration.ts
@@ -56,6 +56,23 @@ class Integration<T = unknown> extends ParanoidModel<
     });
   }
 
+  /**
+   * Load the embed integrations configured for a team.
+   *
+   * @param teamId The team to load integrations for.
+   * @returns the team's embed integrations.
+   */
+  public static async findEmbedIntegrationsForTeam(
+    teamId: string
+  ): Promise<Integration<IntegrationType.Embed>[]> {
+    return this.findAll({
+      where: {
+        teamId,
+        type: IntegrationType.Embed,
+      },
+    });
+  }
+
   @IsIn([Object.values(IntegrationType)])
   @Column(DataType.STRING)
   type: IntegrationType;

--- a/server/models/helpers/IntegrationHelper.ts
+++ b/server/models/helpers/IntegrationHelper.ts
@@ -1,5 +1,7 @@
 import { uniq } from "es-toolkit/compat";
 import { IntegrationService, type IntegrationType } from "@shared/types";
+import { getInstallationUrl } from "@shared/utils/integrations";
+import { urlRegex } from "@shared/utils/urls";
 import env from "@server/env";
 import type Integration from "@server/models/Integration";
 
@@ -7,6 +9,24 @@ import type Integration from "@server/models/Integration";
  * Helper class for working with integrations.
  */
 export default class IntegrationHelper {
+  /**
+   * Whether a url is served by one of the given embed integrations, for example
+   * a self-hosted diagrams.net installation.
+   *
+   * @param url The url to check.
+   * @param integrations The team's embed integrations.
+   * @returns true if the url matches a configured installation.
+   */
+  public static isConfiguredEmbedUrl(
+    url: string,
+    integrations: Integration<IntegrationType.Embed>[]
+  ): boolean {
+    return integrations.some(
+      (integration) =>
+        !!urlRegex(getInstallationUrl(integration.settings))?.test(url)
+    );
+  }
+
   /**
    * Returns the script sources that must be allowed by the Content Security
    * Policy for the given analytics integrations to load.

--- a/server/routes/api/urls/urls.test.ts
+++ b/server/routes/api/urls/urls.test.ts
@@ -1,6 +1,10 @@
 import type { Mock } from "vitest";
 import { randomString } from "@shared/random";
-import { UnfurlResourceType } from "@shared/types";
+import {
+  IntegrationService,
+  IntegrationType,
+  UnfurlResourceType,
+} from "@shared/types";
 import { createContext } from "@server/context";
 import env from "@server/env";
 import type { User } from "@server/models";
@@ -8,6 +12,7 @@ import { View } from "@server/models";
 import {
   buildCollection,
   buildDocument,
+  buildIntegration,
   buildShare,
   buildTeam,
   buildUser,
@@ -556,6 +561,28 @@ describe("#urls.checkEmbed", () => {
     });
 
     expect(res.status).toEqual(400);
+  });
+
+  it("should return embeddable for a configured embed integration", async () => {
+    await buildIntegration({
+      teamId: user.teamId,
+      type: IntegrationType.Embed,
+      service: IntegrationService.Diagrams,
+      settings: { diagrams: { url: "https://drawio.example.com/" } },
+    });
+
+    const res = await server.post("/api/urls.checkEmbed", user, {
+      body: {
+        url: "https://drawio.example.com/?lightbox=1#R123",
+      },
+    });
+
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.embeddable).toEqual(true);
+    // No reason is returned when the installation is trusted without a request
+    // to the instance itself.
+    expect(body.reason).toBeUndefined();
   });
 
   it("should return a result for valid URLs", async () => {

--- a/server/routes/api/urls/urls.ts
+++ b/server/routes/api/urls/urls.ts
@@ -15,7 +15,16 @@ import {
 import auth from "@server/middlewares/authentication";
 import { rateLimiter } from "@server/middlewares/rateLimiter";
 import validate from "@server/middlewares/validate";
-import { Document, Share, Team, User, Group, GroupUser } from "@server/models";
+import {
+  Document,
+  Share,
+  Team,
+  User,
+  Group,
+  GroupUser,
+  Integration,
+} from "@server/models";
+import IntegrationHelper from "@server/models/helpers/IntegrationHelper";
 import { authorize, can } from "@server/policies";
 import { loadPublicShare } from "@server/commands/shareLoader";
 import presentUnfurl from "@server/presenters/unfurl";
@@ -244,6 +253,17 @@ router.post(
   validate(T.UrlsCheckEmbedSchema),
   async (ctx: APIContext<T.UrlsCheckEmbedReq>) => {
     const { url } = ctx.input.body;
+    const { user } = ctx.state.auth;
+
+    // An installation configured by an admin is trusted in the same way as the
+    // built-in embed providers, and may not be reachable from the server.
+    const integrations = await Integration.findEmbedIntegrationsForTeam(
+      user.teamId
+    );
+    if (IntegrationHelper.isConfiguredEmbedUrl(url, integrations)) {
+      ctx.body = { embeddable: true };
+      return;
+    }
 
     const result = await CacheHelper.getDataOrSet<EmbedCheckResult>(
       RedisPrefixHelper.getEmbedCheckKey(url),

--- a/shared/editor/embeds/Diagrams.tsx
+++ b/shared/editor/embeds/Diagrams.tsx
@@ -7,7 +7,7 @@ function Diagrams({ matches, ...props }: Props) {
   const { embed } = props;
   const embedUrl = matches[0];
   const params = new URL(embedUrl).searchParams;
-  const titlePrefix = embed.settings?.url ? "Draw.io" : "Diagrams.net";
+  const titlePrefix = embed.installationUrl ? "Draw.io" : "Diagrams.net";
   const title = params.get("title")
     ? `${titlePrefix} (${params.get("title")})`
     : titlePrefix;

--- a/shared/editor/embeds/index.test.ts
+++ b/shared/editor/embeds/index.test.ts
@@ -1,0 +1,47 @@
+import { IntegrationService } from "../../types";
+import { EmbedDescriptor } from ".";
+
+describe("EmbedDescriptor", () => {
+  const descriptor = () =>
+    new EmbedDescriptor({
+      id: "diagrams",
+      title: "Diagrams.net",
+      name: IntegrationService.Diagrams,
+      regexMatch: [/^https:\/\/viewer\.diagrams\.net\/(?!proxy).*/],
+    });
+
+  it("matches the built-in domain without settings", () => {
+    expect(
+      descriptor().matcher("https://viewer.diagrams.net/?lightbox=1#R123")
+    ).toBeTruthy();
+    expect(descriptor().matcher("https://drawio.example.com/#R123")).toBe(
+      false
+    );
+  });
+
+  it("matches the installation url nested under the service name", () => {
+    const embed = descriptor();
+    embed.settings = { diagrams: { url: "https://drawio.example.com/" } };
+
+    expect(
+      embed.matcher("https://drawio.example.com/?lightbox=1#R123")
+    ).toBeTruthy();
+    expect(embed.matcher("https://viewer.diagrams.net/#R123")).toBeTruthy();
+    expect(embed.matcher("https://other.example.com/#R123")).toBe(false);
+  });
+
+  it("matches a flat installation url", () => {
+    const embed = descriptor();
+    embed.settings = { url: "https://drawio.example.com/" };
+
+    expect(embed.matcher("https://drawio.example.com/#R123")).toBeTruthy();
+  });
+
+  it("does not match once the settings are removed", () => {
+    const embed = descriptor();
+    embed.settings = { diagrams: { url: "https://drawio.example.com/" } };
+    embed.settings = undefined;
+
+    expect(embed.matcher("https://drawio.example.com/#R123")).toBe(false);
+  });
+});

--- a/shared/editor/embeds/index.test.ts
+++ b/shared/editor/embeds/index.test.ts
@@ -40,8 +40,9 @@ describe("EmbedDescriptor", () => {
   it("does not match once the settings are removed", () => {
     const embed = descriptor();
     embed.settings = { diagrams: { url: "https://drawio.example.com/" } };
-    embed.settings = undefined;
+    expect(embed.matcher("https://drawio.example.com/#R123")).toBeTruthy();
 
+    embed.settings = undefined;
     expect(embed.matcher("https://drawio.example.com/#R123")).toBe(false);
   });
 });

--- a/shared/editor/embeds/index.tsx
+++ b/shared/editor/embeds/index.tsx
@@ -5,6 +5,7 @@ import type { Primitive } from "utility-types";
 import env from "../../env";
 import { IntegrationService } from "../../types";
 import type { IntegrationSettings, IntegrationType } from "../../types";
+import { getInstallationUrl } from "../../utils/integrations";
 import { urlRegex } from "../../utils/urls";
 import Image from "../components/Img";
 import Berrycast from "./Berrycast";
@@ -93,7 +94,7 @@ export class EmbedDescriptor {
   /** Whether this embed has been disabled by the team admin */
   disabled?: boolean;
 
-  constructor(options: Omit<EmbedDescriptor, "matcher">) {
+  constructor(options: Omit<EmbedDescriptor, "matcher" | "installationUrl">) {
     this.id = options.id;
     this.icon = options.icon;
     this.name = options.name;
@@ -112,10 +113,17 @@ export class EmbedDescriptor {
     this.component = options.component;
   }
 
+  /**
+   * The url of the custom installation configured for this embed, if any.
+   *
+   * @returns the installation url, or undefined when none is configured.
+   */
+  get installationUrl(): string | undefined {
+    return getInstallationUrl(this.settings);
+  }
+
   matcher(url: string): false | RegExpMatchArray {
-    const settingsDomainRegex = this.settings?.url
-      ? urlRegex(this.settings?.url)
-      : undefined;
+    const settingsDomainRegex = urlRegex(this.installationUrl);
 
     const regexes = settingsDomainRegex
       ? [settingsDomainRegex, ...(this.regexMatch ?? [])]

--- a/shared/editor/extensions/Diagrams.ts
+++ b/shared/editor/extensions/Diagrams.ts
@@ -273,7 +273,7 @@ export default class Diagrams extends Extension {
     const uiTheme = this.editor.props.theme.isDark ? "dark" : "atlas";
     return (
       sanitizeUrl(
-        integration?.settings?.diagrams?.url ?? "https://embed.diagrams.net/"
+        integration?.installationUrl ?? "https://embed.diagrams.net/"
       ) + `?embed=1&ui=${uiTheme}&spin=1&modified=unsavedChanges&proto=json`
     );
   }

--- a/shared/utils/integrations.ts
+++ b/shared/utils/integrations.ts
@@ -1,0 +1,15 @@
+import type { IntegrationSettings, IntegrationType } from "../types";
+
+/**
+ * Returns the url of the custom installation configured for an embed
+ * integration. Settings are stored nested under the service name, or flat for
+ * services that predate nesting.
+ *
+ * @param settings the embed integration settings.
+ * @returns the installation url, or undefined when none is configured.
+ */
+export function getInstallationUrl(
+  settings: IntegrationSettings<IntegrationType.Embed> | undefined
+): string | undefined {
+  return settings?.diagrams?.url ?? settings?.url;
+}


### PR DESCRIPTION
A configured self-hosted Diagrams.net instance was never recognized when pasting a URL from it.

- The settings screen stores the installation url nested under the service name, while the embed matcher read a flat url – both shapes are now read through one helper
- The server-side embeddability check had no knowledge of team integrations, so a self-hosted instance was judged only on its response headers, which commonly block framing. An installation configured by an admin is now trusted like a built-in provider, and is no longer contacted from the server
- Embed descriptors are shared state, so settings left behind by a disconnected integration are now cleared

closes #13528