### PR TITLE
fix: Enforce import restrictions shadowed by nested oxlint configs

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -125,32 +125,6 @@
         "react-hooks/exhaustive-deps": "error"
       },
       "plugins": ["eslint", "oxc", "react", "typescript", "import"]
-    },
-    {
-      "files": ["shared/**/*.{js,jsx,ts,tsx}"],
-      "rules": {
-        "no-restricted-imports": [
-          "error",
-          {
-            "paths": [
-              {
-                "name": "prosemirror-tables",
-                "importNames": [
-                  "addRowBefore",
-                  "addRowAfter",
-                  "addColumnBefore",
-                  "addColumnAfter"
-                ],
-                "message": "Use the wrappers from shared/editor/commands/table instead, which respect the target index and place the cursor in the inserted cell."
-              },
-              {
-                "name": "sonner",
-                "message": "Do not import a toast library within shared; surface notifications through the onNotice callback so shared code stays decoupled from the app's toast implementation."
-              }
-            ]
-          }
-        ]
-      }
     }
   ]
 }

--- a/app/.oxlintrc.json
+++ b/app/.oxlintrc.json
@@ -16,6 +16,18 @@
         "no-restricted-imports": [
           "error",
           {
+            "paths": [
+              {
+                "name": "prosemirror-tables",
+                "importNames": [
+                  "addRowBefore",
+                  "addRowAfter",
+                  "addColumnBefore",
+                  "addColumnAfter"
+                ],
+                "message": "Use the wrappers from shared/editor/commands/table instead, which respect the target index and place the cursor in the inserted cell."
+              }
+            ],
             "patterns": [
               {
                 "group": ["mime-types"],

--- a/shared/.oxlintrc.json
+++ b/shared/.oxlintrc.json
@@ -16,6 +16,22 @@
         "no-restricted-imports": [
           "error",
           {
+            "paths": [
+              {
+                "name": "prosemirror-tables",
+                "importNames": [
+                  "addRowBefore",
+                  "addRowAfter",
+                  "addColumnBefore",
+                  "addColumnAfter"
+                ],
+                "message": "Use the wrappers from shared/editor/commands/table instead, which respect the target index and place the cursor in the inserted cell."
+              },
+              {
+                "name": "sonner",
+                "message": "Do not import a toast library within shared; surface notifications through the onNotice callback so shared code stays decoupled from the app's toast implementation."
+              }
+            ],
             "patterns": [
               {
                 "group": ["@shared/*"],


### PR DESCRIPTION
Nested `.oxlintrc.json` files replace the root config per-rule rather than merging it, so several import restrictions were silently not applied.

- The root's `shared/**` override was dead config — the sonner restriction was not enforced anywhere. A probe file importing sonner inside shared passed lint.
- Moved both restrictions into shared/.oxlintrc.json, where they now fire.
- Added the prosemirror-tables entry to app/.oxlintrc.json, which had the same shadowing for .tsx files.
- Removed the dead root override.

No existing code violated either restriction, so nothing else needed changing.