### PR TITLE
fix: Respect heading number preference in HTML export

### DIFF
--- a/server/models/helpers/DocumentHelper.test.ts
+++ b/server/models/helpers/DocumentHelper.test.ts
@@ -2,6 +2,7 @@ import Revision from "@server/models/Revision";
 import { buildCollection, buildDocument } from "@server/test/factories";
 import { ChangesetHelper } from "@shared/editor/lib/ChangesetHelper";
 import { EditorStyleHelper } from "@shared/editor/styles/EditorStyleHelper";
+import { HeadingPrefixStyle } from "@shared/types";
 import { DocumentHelper } from "./DocumentHelper";
 
 describe("DocumentHelper", () => {
@@ -179,6 +180,52 @@ describe("DocumentHelper", () => {
       });
       const result = await DocumentHelper.toHTML(document);
       expect(result).not.toContain("katex.min.css");
+    });
+
+    it("should number headings according to the document preference", async () => {
+      const document = await buildDocument({
+        text: "# One\n\n## Two\n\n# Three",
+        preferences: { headingPrefix: HeadingPrefixStyle.Numeric },
+      });
+      const result = await DocumentHelper.toHTML(document, {
+        includeTitle: false,
+        includeStyles: false,
+      });
+
+      expect(result).toContain('data-heading-prefix="1"');
+      expect(result).toContain('data-heading-prefix="1.1"');
+      expect(result).toContain('data-heading-prefix="2"');
+    });
+
+    it("should not number headings without the document preference", async () => {
+      const document = await buildDocument({
+        text: "# One\n\n## Two",
+      });
+      const result = await DocumentHelper.toHTML(document, {
+        includeTitle: false,
+        includeStyles: false,
+      });
+
+      expect(result).not.toContain("data-heading-prefix");
+    });
+
+    it("should number headings of a revision from its document", async () => {
+      const document = await buildDocument({
+        text: "# One\n\n## Two",
+        preferences: { headingPrefix: HeadingPrefixStyle.Numeric },
+      });
+      const revision = new Revision({
+        documentId: document.id,
+        title: document.title,
+        text: document.text,
+      });
+      const result = await DocumentHelper.toHTML(revision, {
+        includeTitle: false,
+        includeStyles: false,
+      });
+
+      expect(result).toContain('data-heading-prefix="1"');
+      expect(result).toContain('data-heading-prefix="1.1"');
     });
 
     it("should render diff classes when changes provided", async () => {

--- a/server/models/helpers/DocumentHelper.tsx
+++ b/server/models/helpers/DocumentHelper.tsx
@@ -11,7 +11,7 @@ import headingToSlug from "@shared/editor/lib/headingToSlug";
 import textBetween from "@shared/editor/lib/textBetween";
 import { EditorStyleHelper } from "@shared/editor/styles/EditorStyleHelper";
 import type { NavigationNode, ProsemirrorData } from "@shared/types";
-import { IconType, TextEditMode } from "@shared/types";
+import { DocumentPreference, IconType, TextEditMode } from "@shared/types";
 import { determineIconType } from "@shared/utils/icon";
 import { ProsemirrorDataHelper } from "@shared/utils/ProsemirrorDataHelper";
 import { parser, serializer, schema } from "@server/editor";
@@ -348,6 +348,15 @@ export class DocumentHelper {
     options?: HTMLOptions
   ) {
     const node = DocumentHelper.toProsemirror(model);
+    // Heading numbering is a preference of the document, which a revision
+    // inherits from the document it belongs to.
+    const document =
+      model instanceof Document
+        ? model
+        : model instanceof Revision
+          ? await model.$get("document")
+          : null;
+
     let output = await ProsemirrorHelper.toHTML(node, {
       title:
         options?.includeTitle !== false
@@ -362,6 +371,7 @@ export class DocumentHelper {
       baseUrl: options?.baseUrl,
       changes: options?.changes,
       cspNonce: options?.cspNonce,
+      headingPrefix: document?.getPreference(DocumentPreference.HeadingPrefix),
     });
 
     addTags({
@@ -371,9 +381,7 @@ export class DocumentHelper {
 
     if (options?.signedUrls) {
       const teamId =
-        model instanceof Collection || model instanceof Document
-          ? model.teamId
-          : (await model.$get("document"))?.teamId;
+        model instanceof Collection ? model.teamId : document?.teamId;
 
       if (!teamId) {
         return output;

--- a/server/models/helpers/ProsemirrorHelper.tsx
+++ b/server/models/helpers/ProsemirrorHelper.tsx
@@ -20,6 +20,7 @@ import {
 import * as Y from "yjs";
 import { toError, errToString } from "@shared/utils/error";
 import Diff from "@shared/editor/extensions/Diff";
+import { HeadingPrefixHelper } from "@shared/editor/extensions/HeadingPrefix";
 import { EditorStyleHelper } from "@shared/editor/styles/EditorStyleHelper";
 import type { ExtendedChange } from "@shared/editor/lib/ChangesetHelper";
 import textBetween from "@shared/editor/lib/textBetween";
@@ -27,7 +28,11 @@ import { withTrailingNode } from "@shared/editor/lib/trailingNode";
 import EditorContainer from "@shared/editor/components/Styles";
 import GlobalStyles from "@shared/styles/globals";
 import light from "@shared/styles/theme";
-import type { ProsemirrorData, UnfurlResponse } from "@shared/types";
+import type {
+  HeadingPrefixStyle,
+  ProsemirrorData,
+  UnfurlResponse,
+} from "@shared/types";
 import { AttachmentPreset, MentionType } from "@shared/types";
 import {
   attachmentRedirectRegex,
@@ -66,6 +71,8 @@ export type HTMLOptions = {
   changes?: readonly ExtendedChange[];
   /** CSP nonce to apply to injected inline scripts */
   cspNonce?: string;
+  /** The style of prefix displayed before headings (defaults to none) */
+  headingPrefix?: HeadingPrefixStyle;
 };
 
 /** The identifiers of a document that another document's content may link to. */
@@ -768,6 +775,16 @@ export class ProsemirrorHelper extends SharedProsemirrorHelper {
         // Flush passive effects so components that mount content asynchronously
         // (e.g. Frame's iframe) commit before serialization, then rewriting.
         await this.flushReactEffects();
+
+        // The heading prefix is a decoration in the editor, which the export
+        // renders without, so the labels are added to the output directly.
+        if (options?.headingPrefix) {
+          HeadingPrefixHelper.applyToDOM(
+            target as HTMLElement,
+            node,
+            options.headingPrefix
+          );
+        }
 
         // Components may render editable regions, such as captions, but the
         // exported document is static.

--- a/shared/editor/extensions/HeadingPrefix.ts
+++ b/shared/editor/extensions/HeadingPrefix.ts
@@ -186,6 +186,40 @@ export class HeadingPrefixHelper {
   }
 
   /**
+   * Adds the prefix labels to the headings of a rendered document, matching
+   * the numbering displayed in the editor. Headings inside tables are skipped.
+   *
+   * @param container the element that holds the rendered document.
+   * @param doc the document the container was rendered from.
+   * @param style the prefix style to format the labels with.
+   */
+  public static applyToDOM(
+    container: Element,
+    doc: ProsemirrorNode,
+    style: HeadingPrefixStyle
+  ): void {
+    if (style === HeadingPrefixStyle.None) {
+      return;
+    }
+
+    const headings = HeadingPrefixHelper.collectHeadings(doc);
+    const queue = HeadingPrefixHelper.labels(
+      headings.map((heading) => heading.level),
+      style
+    );
+
+    container.querySelectorAll("h1, h2, h3, h4, h5, h6").forEach((heading) => {
+      if (heading.closest("table")) {
+        return;
+      }
+      const label = queue.shift();
+      if (label !== undefined) {
+        heading.setAttribute("data-heading-prefix", label);
+      }
+    });
+  }
+
+  /**
    * Removes prefix elements from pasted HTML so that copied numbering does
    * not become part of the document content.
    *


### PR DESCRIPTION
Heading numbers are drawn by an editor decoration, and the server strips all plugin decorations before it serializes, so exported HTML always came out unnumbered.

- Compute the same labels during export and write them to the rendered headings as a `data-heading-prefix` attribute, which the exported editor styles already render
- Applies to single document export, the HTML zip of a document tree, and revision export
- A revision takes the preference from the document it belongs to, replacing the separate query the signed url path made

The number stays out of the content, so an exported file that is imported again does not get numbers baked into the heading text. Markdown export is unchanged.