### PR TITLE
fix: Sidebar context lost when navigating from action menus

### DIFF
--- a/app/actions/definitions/revisions.tsx
+++ b/app/actions/definitions/revisions.tsx
@@ -94,7 +94,7 @@ export const deleteRevision = createAction({
   dangerous: true,
   visible: ({ activeDocumentId }) =>
     !!activeDocumentId && stores.policies.abilities(activeDocumentId).update,
-  perform: async ({ t, event, location, activeDocumentId }) => {
+  perform: async ({ t, event, location, activeDocumentId, sidebarContext }) => {
     event?.preventDefault();
     if (!activeDocumentId) {
       return;
@@ -113,7 +113,7 @@ export const deleteRevision = createAction({
       const revision = stores.revisions.get(revisionId);
       await revision?.delete();
       toast.success(t("This version of the document was deleted"));
-      history.push(documentHistoryPath(document));
+      history.push(documentHistoryPath(document), { sidebarContext });
     }
   },
 });

--- a/app/components/Sidebar/components/CollectionRow.tsx
+++ b/app/components/Sidebar/components/CollectionRow.tsx
@@ -227,7 +227,9 @@ function CollectionRow({
   );
 
   return (
-    <ActionContextProvider value={{ activeModels: [collection] }}>
+    <ActionContextProvider
+      value={{ activeModels: [collection], sidebarContext }}
+    >
       <Relative ref={mergedRef}>
         <DropToImport collectionId={collection.id}>
           {sidebarLinkElement}

--- a/app/components/Sidebar/components/DocumentRow.tsx
+++ b/app/components/Sidebar/components/DocumentRow.tsx
@@ -284,6 +284,7 @@ function DocumentRow({
     <ActionContextProvider
       value={{
         activeModels: document ? [document] : [],
+        sidebarContext,
       }}
     >
       <Relative ref={parentRef}>

--- a/app/hooks/useActionContext.tsx
+++ b/app/hooks/useActionContext.tsx
@@ -67,7 +67,7 @@ export const ActionContextProvider = observer(function ActionContextProvider_({
   // navigation does not invalidate the context value. Action perform/visible
   // callbacks see the current location at call time via history.location,
   // which react-router updates on every navigation.
-  const history = useHistory();
+  const history = useHistory<{ sidebarContext?: SidebarContextType }>();
 
   const {
     activeModels: valueModels,
@@ -174,7 +174,6 @@ export const ActionContextProvider = observer(function ActionContextProvider_({
       ...(isMenu !== undefined ? { isMenu } : {}),
       ...(isCommandBar !== undefined ? { isCommandBar } : {}),
       ...(isButton !== undefined ? { isButton } : {}),
-      ...(sidebarContext !== undefined ? { sidebarContext } : {}),
       ...(event !== undefined ? { event } : {}),
       activeCollectionId,
       activeDocumentId,
@@ -189,6 +188,18 @@ export const ActionContextProvider = observer(function ActionContextProvider_({
     // location without invalidating this memo on navigation.
     Object.defineProperty(result, "location", {
       get: () => history.location,
+      enumerable: true,
+      configurable: true,
+    });
+
+    // The sidebar context is carried in location state, so fall back to the
+    // current location when no ancestor provider supplies one. A getter for the
+    // same reason as `location` above.
+    Object.defineProperty(result, "sidebarContext", {
+      get: () =>
+        sidebarContext ??
+        parentContext?.sidebarContext ??
+        history.location.state?.sidebarContext,
       enumerable: true,
       configurable: true,
     });

--- a/app/scenes/Document/hooks/useDocumentSidebar.tsx
+++ b/app/scenes/Document/hooks/useDocumentSidebar.tsx
@@ -119,13 +119,17 @@ export default function useDocumentSidebar() {
         ? documents.get(slugMatch.params.documentSlug)
         : undefined;
       if (document) {
-        paneHistory.push(documentPath(document));
+        paneHistory.push({
+          pathname: documentPath(document),
+          state: location.state,
+        });
       }
     }
   }, [
     panel,
     isHistoryRoute,
     location.pathname,
+    location.state,
     documents,
     paneHistory,
     ui,


### PR DESCRIPTION
`sidebarContext` is carried in location state, but nothing ever populated it in the action context — so every action that navigates with it (History, Insights, Edit, and others) pushed an empty state, and the document scene then fell back to the collections section.

- Resolve the sidebar context from the nearest provider, then the parent context, then the current location state
- Pass each sidebar row's own context into its action context, so row menus navigate within that row's section
- Keep the context when deleting a revision, and when closing the history panel