### PR TITLE
fix(History): scroll to first change when opening a revision

### DIFF
--- a/app/scenes/Document/components/RevisionViewer.tsx
+++ b/app/scenes/Document/components/RevisionViewer.tsx
@@ -1,5 +1,6 @@
 import { observer } from "mobx-react";
 import * as React from "react";
+import { mergeRefs } from "react-merge-refs";
 import { colorPalette } from "@shared/constants";
 import type Document from "~/models/Document";
 import type Revision from "~/models/Revision";
@@ -43,6 +44,7 @@ function RevisionViewer(props: Props, ref: React.Ref<TEditor>) {
   const { document, children, revision } = props;
   const { revisions } = useStores();
   const query = useQuery();
+  const localRef = React.useRef<TEditor | null>(null);
   const showChanges = props.showChanges ?? query.has("changes");
   const compareToParam = query.get("compareTo");
 
@@ -79,18 +81,20 @@ function RevisionViewer(props: Props, ref: React.Ref<TEditor>) {
    * Create editor extensions with the Diff extension configured to render
    * the calculated changes as decorations in the editor.
    */
-  const extensions = React.useMemo(() => {
+  const { extensions, hasChanges } = React.useMemo(() => {
     const changeset = ChangesetHelper.getChangeset(
       revision.data,
       comparisonData
     );
-    return [
-      CodeWordBreak,
-      ...withComments(richExtensions),
-      ...(showChanges && changeset?.changes
-        ? [new Diff({ changes: changeset?.changes })]
-        : []),
-    ];
+    const hasChanges = !!(showChanges && changeset?.changes);
+    return {
+      extensions: [
+        CodeWordBreak,
+        ...withComments(richExtensions),
+        ...(hasChanges ? [new Diff({ changes: changeset?.changes })] : []),
+      ],
+      hasChanges,
+    };
   }, [revision.data, comparisonData, showChanges]);
 
   // The editor builds its extensions once, on mount, so it has to be remounted
@@ -103,6 +107,16 @@ function RevisionViewer(props: Props, ref: React.Ref<TEditor>) {
     compareToRevisionId ?? revision.before?.id ?? "none",
     comparisonData ? "loaded" : "pending",
   ].join("-");
+
+  // Once the diff decorations are in place, move the viewport to the first
+  // change so that long documents don't leave it at the top, away from the
+  // highlighted difference. `nextChange` only scrolls when the first change
+  // is not already in view.
+  React.useEffect(() => {
+    if (hasChanges) {
+      localRef.current?.commands.nextChange();
+    }
+  }, [editorKey, hasChanges]);
 
   return (
     <Flex auto column>
@@ -121,7 +135,7 @@ function RevisionViewer(props: Props, ref: React.Ref<TEditor>) {
       />
       <Editor
         key={editorKey}
-        ref={ref}
+        ref={mergeRefs([localRef, ref])}
         defaultValue={revision.data}
         extensions={extensions}
         dir={revision.dir}


### PR DESCRIPTION
## Description

Opening a revision from the History sidebar renders the diff highlights but always leaves the viewport at the top of the document. In long documents the changed content is often below the fold, so nothing on screen indicates where the revision differs.

The root cause is that the Diff extension initializes with no change selected (`currentChangeIndex = -1`), and only the next/prev controls in the header ever trigger navigation — nothing moves the viewport when a revision is first shown.

This PR triggers `nextChange` once from `RevisionViewer` after the diff editor has mounted with its decorations in place. That reuses the existing navigation behavior:

- scrolls to the first change only when it is not already in view (`scrollMode: "if-needed"`, centered),
- highlights it as the current change,
- and updates the header counter to "1 of N changes" so the arrows continue from there.

The effect is keyed on the same `editorKey` that remounts the editor whenever the diff configuration changes, so it also re-positions the viewport when switching between revisions in the list, and is a no-op when change highlighting is disabled.

Fixes #13567

## Testing

Automated: `oxlint` and `oxfmt` clean; existing `Diff` extension tests pass.

Manual test plan: open a long document with revisions whose change is below the fold and click a revision in History — the viewport should land centered on the first change with the "1 of N changes" counter in the header; revisions with the first change already visible stay put; with "Highlight changes" off there should be no scrolling or counter change; switching revisions in the list should re-position to the new first change.