### PR TITLE
feat: Provider-agnostic email delivery (Microsoft Graph, Gmail, Amazon SES)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -220,6 +220,28 @@ SMTP_USERNAME=
 SMTP_PASSWORD=
 SMTP_FROM_EMAIL=
 
+# Email can instead be delivered over a provider's API, which avoids needing
+# mailbox credentials at all. SMTP_FROM_EMAIL remains the sender address.
+# EMAIL_PROVIDER=smtp
+
+# Microsoft Graph (EMAIL_PROVIDER=msgraph), for tenants where SMTP AUTH is
+# disabled. Needs an Entra ID app registration with the Mail.Send application
+# permission granted. These are separate from any sign-in credentials above –
+# set them explicitly even when reusing the same app registration.
+# AZURE_MAIL_CLIENT_ID=
+# AZURE_MAIL_CLIENT_SECRET=
+# AZURE_MAIL_TENANT_ID=
+
+# Gmail (EMAIL_PROVIDER=gmail). Needs a service account granted domain-wide
+# delegation for the https://www.googleapis.com/auth/gmail.send scope.
+# GOOGLE_MAIL_CLIENT_EMAIL=
+# GOOGLE_MAIL_PRIVATE_KEY=
+
+# Amazon SES (EMAIL_PROVIDER=ses). Credentials are resolved from the standard
+# AWS credential chain, so an instance role can be used in place of keys.
+# AWS_SES_REGION=
+# AWS_SES_CONFIGURATION_SET=
+
 
 # ––––––––––––––––––––––––––––––––––––––
 # ––––––––––  RATE LIMITER  ––––––––––––

--- a/app.json
+++ b/app.json
@@ -181,6 +181,10 @@
       "value": "26214400",
       "required": false
     },
+    "EMAIL_PROVIDER": {
+      "description": "How email is delivered: 'smtp' (default), 'msgraph', 'gmail' or 'ses' (optional)",
+      "required": false
+    },
     "SMTP_HOST": {
       "description": "smtp.example.com (optional)",
       "required": false
@@ -212,6 +216,34 @@
     "SMTP_SECURE": {
       "value": "true",
       "description": "Use a secure SMTP connection (optional)",
+      "required": false
+    },
+    "AZURE_MAIL_CLIENT_ID": {
+      "description": "Entra ID application with the Mail.Send permission, for EMAIL_PROVIDER=msgraph (optional)",
+      "required": false
+    },
+    "AZURE_MAIL_CLIENT_SECRET": {
+      "description": "(optional)",
+      "required": false
+    },
+    "AZURE_MAIL_TENANT_ID": {
+      "description": "(optional)",
+      "required": false
+    },
+    "GOOGLE_MAIL_CLIENT_EMAIL": {
+      "description": "Service account with domain-wide delegation, for EMAIL_PROVIDER=gmail (optional)",
+      "required": false
+    },
+    "GOOGLE_MAIL_PRIVATE_KEY": {
+      "description": "PEM private key for the service account, base64 encoded (optional)",
+      "required": false
+    },
+    "AWS_SES_REGION": {
+      "description": "The region SES is configured in, for EMAIL_PROVIDER=ses (optional)",
+      "required": false
+    },
+    "AWS_SES_CONFIGURATION_SET": {
+      "description": "SES configuration set used to publish sending events (optional)",
       "required": false
     },
     "SMTP_DISABLE_STARTTLS": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   ],
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1115.0",
+    "@aws-sdk/client-sesv2": "^3.1115.0",
     "@aws-sdk/cloudfront-signer": "^3.1111.0",
     "@aws-sdk/lib-storage": "^3.1115.0",
     "@aws-sdk/s3-presigned-post": "^3.1115.0",

--- a/plugins/azure/server/MicrosoftGraphEmailProvider.test.ts
+++ b/plugins/azure/server/MicrosoftGraphEmailProvider.test.ts
@@ -1,0 +1,224 @@
+import { http, HttpResponse } from "msw";
+import nodemailer from "nodemailer";
+import { server } from "@server/test/msw";
+import env from "./env";
+import { MicrosoftGraphEmailProvider } from "./MicrosoftGraphEmailProvider";
+
+const tokenEndpoint =
+  "https://login.microsoftonline.com/tenant-id/oauth2/v2.0/token";
+const sendEndpoint = "https://graph.microsoft.com/v1.0/users/:mailbox/sendMail";
+
+/** Stubs the token endpoint, returning the requests it received. */
+const mockToken = (expiresIn: number | undefined = 3599) => {
+  const requests: Record<string, string>[] = [];
+  server.use(
+    http.post(tokenEndpoint, async ({ request }) => {
+      requests.push(
+        Object.fromEntries(new URLSearchParams(await request.text()))
+      );
+      return HttpResponse.json({
+        access_token: `token-${requests.length}`,
+        ...(expiresIn === undefined ? {} : { expires_in: expiresIn }),
+        token_type: "Bearer",
+      });
+    })
+  );
+  return requests;
+};
+
+/** Stubs the sendMail endpoint, returning the requests it received. */
+const mockSend = (status = 202) => {
+  const requests: { url: string; headers: Headers; body: string }[] = [];
+  server.use(
+    http.post(sendEndpoint, async ({ request }) => {
+      requests.push({
+        url: request.url,
+        headers: request.headers,
+        body: await request.text(),
+      });
+      return status === 202
+        ? new HttpResponse(null, { status: 202 })
+        : HttpResponse.json(
+            { error: { code: "ErrorAccessDenied", message: "Access denied" } },
+            { status }
+          );
+    })
+  );
+  return requests;
+};
+
+const send = (provider = new MicrosoftGraphEmailProvider()) =>
+  nodemailer.createTransport(provider).sendMail({
+    from: "Outline <outline@example.com>",
+    to: "user@example.com",
+    subject: "Welcome to Outline",
+    text: "Hello there",
+    html: "<p>Hello there</p>",
+  });
+
+describe("MicrosoftGraphEmailProvider", () => {
+  const original = {
+    AZURE_MAIL_CLIENT_ID: env.AZURE_MAIL_CLIENT_ID,
+    AZURE_MAIL_CLIENT_SECRET: env.AZURE_MAIL_CLIENT_SECRET,
+    AZURE_MAIL_TENANT_ID: env.AZURE_MAIL_TENANT_ID,
+    AZURE_MAIL_FROM_USER_ID: env.AZURE_MAIL_FROM_USER_ID,
+    SMTP_FROM_EMAIL: env.SMTP_FROM_EMAIL,
+  };
+
+  beforeEach(() => {
+    env.AZURE_MAIL_CLIENT_ID = "client-id";
+    env.AZURE_MAIL_CLIENT_SECRET = "client-secret";
+    env.AZURE_MAIL_TENANT_ID = "tenant-id";
+    env.AZURE_MAIL_FROM_USER_ID = undefined;
+    env.SMTP_FROM_EMAIL = "Outline <outline@example.com>";
+  });
+
+  afterEach(() => {
+    Object.assign(env, original);
+  });
+
+  it("should post the message to Graph as base64 encoded MIME", async () => {
+    mockToken();
+    const sends = mockSend();
+
+    await send();
+
+    expect(sends.length).toBe(1);
+    expect(sends[0].url).toBe(
+      "https://graph.microsoft.com/v1.0/users/outline%40example.com/sendMail"
+    );
+    expect(sends[0].headers.get("content-type")).toBe("text/plain");
+    expect(sends[0].headers.get("authorization")).toBe("Bearer token-1");
+
+    // The body must be base64, and decode to the assembled message.
+    expect(sends[0].body).toMatch(/^[A-Za-z0-9+/=\r\n]+$/);
+    const mime = Buffer.from(sends[0].body, "base64").toString("utf-8");
+    expect(mime).toContain("Subject: Welcome to Outline");
+    expect(mime).toContain("From: Outline <outline@example.com>");
+    expect(mime).toContain("To: user@example.com");
+    expect(mime).toContain("<p>Hello there</p>");
+  });
+
+  it("should request a token using the client credentials flow", async () => {
+    const tokens = mockToken();
+    mockSend();
+
+    await send();
+
+    expect(tokens.length).toBe(1);
+    expect(tokens[0]).toEqual({
+      client_id: "client-id",
+      client_secret: "client-secret",
+      grant_type: "client_credentials",
+      scope: "https://graph.microsoft.com/.default",
+    });
+  });
+
+  it("should reuse a cached token across sends", async () => {
+    const tokens = mockToken();
+    const sends = mockSend();
+    const provider = new MicrosoftGraphEmailProvider();
+
+    await send(provider);
+    await send(provider);
+
+    expect(tokens.length).toBe(1);
+    expect(sends.length).toBe(2);
+    expect(sends[1].headers.get("authorization")).toBe("Bearer token-1");
+  });
+
+  it("should request a new token once the cached one has expired", async () => {
+    // Tokens are treated as expiring a minute early, so this is already stale.
+    const tokens = mockToken(30);
+    const sends = mockSend();
+    const provider = new MicrosoftGraphEmailProvider();
+
+    await send(provider);
+    await send(provider);
+
+    expect(tokens.length).toBe(2);
+    expect(sends[1].headers.get("authorization")).toBe("Bearer token-2");
+  });
+
+  it("should retain the Bcc header for Graph to resolve recipients", async () => {
+    mockToken();
+    const sends = mockSend();
+
+    await nodemailer
+      .createTransport(new MicrosoftGraphEmailProvider())
+      .sendMail({
+        from: "Outline <outline@example.com>",
+        to: "user@example.com",
+        bcc: "hidden@example.com",
+        subject: "Welcome to Outline",
+        text: "Hello there",
+      });
+
+    const mime = Buffer.from(sends[0].body, "base64").toString("utf-8");
+    expect(mime).toContain("Bcc: hidden@example.com");
+  });
+
+  it("should still cache tokens when the response omits expires_in", async () => {
+    const tokens = mockToken(undefined);
+    const sends = mockSend();
+    const provider = new MicrosoftGraphEmailProvider();
+
+    await send(provider);
+    await send(provider);
+
+    expect(tokens.length).toBe(1);
+    expect(sends.length).toBe(2);
+  });
+
+  it("should resolve the mailbox from configuration, not the message", async () => {
+    // The message's own from address can vary per message, so the sending
+    // mailbox must come from configuration.
+    env.SMTP_FROM_EMAIL = "Outline <fixed@example.com>";
+    mockToken();
+    const sends = mockSend();
+
+    await send();
+
+    expect(sends[0].url).toBe(
+      "https://graph.microsoft.com/v1.0/users/fixed%40example.com/sendMail"
+    );
+  });
+
+  it("should send from the configured mailbox when one is set", async () => {
+    env.AZURE_MAIL_FROM_USER_ID = "shared-mailbox@example.com";
+    mockToken();
+    const sends = mockSend();
+
+    await send();
+
+    expect(sends[0].url).toBe(
+      "https://graph.microsoft.com/v1.0/users/shared-mailbox%40example.com/sendMail"
+    );
+  });
+
+  it("should throw including the response body when Graph rejects the message", async () => {
+    mockToken();
+    mockSend(403);
+
+    await expect(send()).rejects.toThrow(
+      /Microsoft Graph could not send the message \(403\).*ErrorAccessDenied/s
+    );
+  });
+
+  it("should not cache a failed token request", async () => {
+    let attempts = 0;
+    server.use(
+      http.post(tokenEndpoint, () => {
+        attempts++;
+        return HttpResponse.json({ error: "invalid_client" }, { status: 401 });
+      })
+    );
+    const provider = new MicrosoftGraphEmailProvider();
+
+    await expect(send(provider)).rejects.toThrow(
+      /Microsoft Graph rejected the credentials.*invalid_client/s
+    );
+    await expect(send(provider)).rejects.toThrow(/invalid_client/);
+    expect(attempts).toBe(2);
+  });
+});

--- a/plugins/azure/server/MicrosoftGraphEmailProvider.ts
+++ b/plugins/azure/server/MicrosoftGraphEmailProvider.ts
@@ -1,0 +1,100 @@
+import addressparser from "addressparser";
+import type MailMessage from "nodemailer/lib/mailer/mail-message";
+import {
+  type AccessToken,
+  AccessTokenCache,
+  fetchAccessToken,
+} from "@server/emails/providers/AccessTokenCache";
+import {
+  BaseEmailProvider,
+  type SentMessageInfo,
+} from "@server/emails/providers/BaseEmailProvider";
+import { InternalError } from "@server/errors";
+import fetch from "@server/utils/fetch";
+import env from "./env";
+
+/**
+ * Delivers email through the Microsoft Graph API, authenticating with the OAuth
+ * client credentials flow.
+ *
+ * Microsoft 365 tenants increasingly have SMTP AUTH disabled, as it requires
+ * legacy authentication that conflicts with Conditional Access policies. Graph
+ * needs no mailbox password and works with those policies in place.
+ *
+ * Messages are handed over as MIME rather than as a Graph `message` resource,
+ * because Graph only accepts a restricted set of custom headers in the JSON
+ * form – threading and unsubscribe headers would be dropped.
+ *
+ * Note that Graph saves MIME sends to the sending mailbox's Sent Items folder,
+ * and offers no way to opt out.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/user-sendmail
+ */
+export class MicrosoftGraphEmailProvider extends BaseEmailProvider {
+  id = "msgraph";
+
+  name = "Microsoft Graph";
+
+  // Graph resolves Bcc recipients from the message headers and strips them
+  // before delivery, so the header must survive into the MIME output.
+  protected keepBcc = true;
+
+  protected async sendMessage(
+    mail: MailMessage<SentMessageInfo>
+  ): Promise<void> {
+    // Graph identifies the sending mailbox in the path. It is resolved from
+    // configuration rather than the message, because the message's own from
+    // address can vary per message – it is randomized for authentication
+    // emails on cloud-hosted installations.
+    const mailbox =
+      env.AZURE_MAIL_FROM_USER_ID ||
+      (env.SMTP_FROM_EMAIL
+        ? addressparser(env.SMTP_FROM_EMAIL)[0]?.address
+        : undefined) ||
+      mail.message.getEnvelope().from;
+
+    if (!mailbox) {
+      throw InternalError(
+        "A sender mailbox is required to send email with Microsoft Graph – set SMTP_FROM_EMAIL"
+      );
+    }
+
+    const message = await this.getMimeMessage(mail);
+    const accessToken = await this.tokens.get(
+      env.AZURE_MAIL_TENANT_ID ?? "common"
+    );
+
+    const response = await fetch(
+      `${env.AZURE_MAIL_GRAPH_BASE_URL}/v1.0/users/${encodeURIComponent(
+        mailbox
+      )}/sendMail`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          // Signals that the body is a base64-encoded MIME message rather than
+          // a JSON message resource.
+          "Content-Type": "text/plain",
+        },
+        body: message.toString("base64"),
+      }
+    );
+
+    // A successful send is acknowledged with 202 Accepted and an empty body.
+    await this.assertOk(response, "Microsoft Graph could not send the message");
+  }
+
+  private requestAccessToken = (tenantId: string): Promise<AccessToken> =>
+    fetchAccessToken(
+      `${env.AZURE_MAIL_AUTHORITY_URL}/${tenantId}/oauth2/v2.0/token`,
+      {
+        client_id: env.AZURE_MAIL_CLIENT_ID ?? "",
+        client_secret: env.AZURE_MAIL_CLIENT_SECRET ?? "",
+        grant_type: "client_credentials",
+        scope: `${env.AZURE_MAIL_GRAPH_BASE_URL}/.default`,
+      },
+      "Microsoft Graph rejected the credentials in AZURE_MAIL_CLIENT_ID and AZURE_MAIL_CLIENT_SECRET"
+    );
+
+  private tokens = new AccessTokenCache(this.requestAccessToken);
+}

--- a/plugins/azure/server/env.ts
+++ b/plugins/azure/server/env.ts
@@ -25,6 +25,59 @@ class AzurePluginEnvironment extends Environment {
   @IsOptional()
   @CannotUseWithout("AZURE_CLIENT_ID")
   public AZURE_TENANT_ID = this.toOptionalString(environment.AZURE_TENANT_ID);
+
+  /**
+   * Client credentials used to send email through the Microsoft Graph API,
+   * enabled with EMAIL_PROVIDER=msgraph. These are deliberately separate from
+   * the authentication credentials above – the app registration used here must
+   * be granted the Mail.Send application permission, so set them explicitly
+   * even when reusing the sign-in app. Application-level Mail.Send allows
+   * sending as any mailbox in the tenant unless it is narrowed to specific
+   * mailboxes with Exchange Online's role based access control for
+   * applications.
+   * See https://learn.microsoft.com/en-us/graph/auth-limit-mailbox-access
+   */
+  @IsOptional()
+  public AZURE_MAIL_CLIENT_ID = this.toOptionalString(
+    environment.AZURE_MAIL_CLIENT_ID
+  );
+
+  @IsOptional()
+  @CannotUseWithout("AZURE_MAIL_CLIENT_ID")
+  public AZURE_MAIL_CLIENT_SECRET = this.toOptionalString(
+    environment.AZURE_MAIL_CLIENT_SECRET
+  );
+
+  @IsOptional()
+  @CannotUseWithout("AZURE_MAIL_CLIENT_ID")
+  public AZURE_MAIL_TENANT_ID = this.toOptionalString(
+    environment.AZURE_MAIL_TENANT_ID
+  );
+
+  /**
+   * The mailbox to send from, either a user principal name or object id.
+   * Defaults to the address in SMTP_FROM_EMAIL, and only needs setting when the
+   * sending mailbox differs from the address emails appear to come from.
+   */
+  @IsOptional()
+  public AZURE_MAIL_FROM_USER_ID = this.toOptionalString(
+    environment.AZURE_MAIL_FROM_USER_ID
+  );
+
+  /**
+   * Login and Graph endpoints, which only need overriding for sovereign clouds
+   * such as US Government (graph.microsoft.us) or China (microsoftgraph.chinacloudapi.cn).
+   * See https://learn.microsoft.com/en-us/graph/deployments
+   */
+  @IsOptional()
+  public AZURE_MAIL_AUTHORITY_URL =
+    this.toOptionalString(environment.AZURE_MAIL_AUTHORITY_URL) ??
+    "https://login.microsoftonline.com";
+
+  @IsOptional()
+  public AZURE_MAIL_GRAPH_BASE_URL =
+    this.toOptionalString(environment.AZURE_MAIL_GRAPH_BASE_URL) ??
+    "https://graph.microsoft.com";
 }
 
 export default new AzurePluginEnvironment();

--- a/plugins/azure/server/index.ts
+++ b/plugins/azure/server/index.ts
@@ -2,6 +2,7 @@ import { Hook, PluginManager } from "@server/utils/PluginManager";
 import config from "../plugin.json";
 import router from "./auth/azure";
 import env from "./env";
+import { MicrosoftGraphEmailProvider } from "./MicrosoftGraphEmailProvider";
 
 const enabled = !!env.AZURE_CLIENT_ID && !!env.AZURE_CLIENT_SECRET;
 
@@ -10,5 +11,19 @@ if (enabled) {
     ...config,
     type: Hook.AuthProvider,
     value: { router, id: config.id },
+  });
+}
+
+const emailEnabled =
+  !!env.AZURE_MAIL_CLIENT_ID &&
+  !!env.AZURE_MAIL_CLIENT_SECRET &&
+  !!env.AZURE_MAIL_TENANT_ID;
+
+if (emailEnabled) {
+  PluginManager.add({
+    name: config.name,
+    description: "Adds Microsoft Graph as an email provider.",
+    type: Hook.EmailProvider,
+    value: new MicrosoftGraphEmailProvider(),
   });
 }

--- a/plugins/email/server/index.ts
+++ b/plugins/email/server/index.ts
@@ -3,7 +3,7 @@ import { Hook, PluginManager } from "@server/utils/PluginManager";
 import config from "../plugin.json";
 import router from "./auth/email";
 
-const enabled = !!(env.SMTP_HOST || env.SMTP_SERVICE) || env.isDevelopment;
+const enabled = env.EMAIL_ENABLED;
 
 if (enabled) {
   PluginManager.add({

--- a/plugins/google/server/GmailEmailProvider.test.ts
+++ b/plugins/google/server/GmailEmailProvider.test.ts
@@ -1,0 +1,203 @@
+import crypto from "node:crypto";
+import JWT from "jsonwebtoken";
+import { http, HttpResponse } from "msw";
+import nodemailer from "nodemailer";
+import { server } from "@server/test/msw";
+import Logger from "@server/logging/Logger";
+import env from "./env";
+import { GmailEmailProvider } from "./GmailEmailProvider";
+
+const { privateKey, publicKey } = crypto.generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  publicKeyEncoding: { type: "spki", format: "pem" },
+});
+
+const tokenEndpoint = "https://oauth2.googleapis.com/token";
+const sendEndpoint =
+  "https://gmail.googleapis.com/gmail/v1/users/me/messages/send";
+
+/** Stubs the token endpoint, returning the requests it received. */
+const mockToken = (expiresIn = 3599) => {
+  const requests: Record<string, string>[] = [];
+  server.use(
+    http.post(tokenEndpoint, async ({ request }) => {
+      requests.push(
+        Object.fromEntries(new URLSearchParams(await request.text()))
+      );
+      return HttpResponse.json({
+        access_token: `token-${requests.length}`,
+        expires_in: expiresIn,
+        token_type: "Bearer",
+      });
+    })
+  );
+  return requests;
+};
+
+/** Stubs the messages.send endpoint, returning the requests it received. */
+const mockSend = (status = 200) => {
+  const requests: { headers: Headers; body: string }[] = [];
+  server.use(
+    http.post(sendEndpoint, async ({ request }) => {
+      requests.push({
+        headers: request.headers,
+        body: await request.text(),
+      });
+      return status === 200
+        ? HttpResponse.json({ id: "1", labelIds: ["SENT"] })
+        : HttpResponse.json(
+            { error: { code: status, message: "Precondition check failed." } },
+            { status }
+          );
+    })
+  );
+  return requests;
+};
+
+const send = (provider = new GmailEmailProvider()) =>
+  nodemailer.createTransport(provider).sendMail({
+    from: "Outline <outline@example.com>",
+    to: "user@example.com",
+    subject: "Welcome to Outline",
+    text: "Hello there",
+    html: "<p>Hello there</p>",
+  });
+
+describe("GmailEmailProvider", () => {
+  const original = {
+    GOOGLE_MAIL_CLIENT_EMAIL: env.GOOGLE_MAIL_CLIENT_EMAIL,
+    GOOGLE_MAIL_PRIVATE_KEY: env.GOOGLE_MAIL_PRIVATE_KEY,
+    GOOGLE_MAIL_FROM_USER_ID: env.GOOGLE_MAIL_FROM_USER_ID,
+    SMTP_FROM_EMAIL: env.SMTP_FROM_EMAIL,
+  };
+
+  beforeEach(() => {
+    env.GOOGLE_MAIL_CLIENT_EMAIL = "outline@project.iam.gserviceaccount.com";
+    env.GOOGLE_MAIL_PRIVATE_KEY = privateKey;
+    env.GOOGLE_MAIL_FROM_USER_ID = undefined;
+    env.SMTP_FROM_EMAIL = "Outline <outline@example.com>";
+  });
+
+  afterEach(() => {
+    Object.assign(env, original);
+  });
+
+  it("should post the message web-safe base64 encoded", async () => {
+    mockToken();
+    const sends = mockSend();
+
+    await send();
+
+    expect(sends.length).toBe(1);
+    expect(sends[0].headers.get("authorization")).toBe("Bearer token-1");
+
+    const { raw } = JSON.parse(sends[0].body);
+    // Standard base64 would risk + and / being mangled in a JSON string.
+    expect(raw).toMatch(/^[A-Za-z0-9_-]+$/);
+
+    const mime = Buffer.from(raw, "base64url").toString("utf-8");
+    expect(mime).toContain("Subject: Welcome to Outline");
+    expect(mime).toContain("From: Outline <outline@example.com>");
+    expect(mime).toContain("<p>Hello there</p>");
+  });
+
+  it("should authenticate with a signed assertion impersonating the sender", async () => {
+    const tokens = mockToken();
+    mockSend();
+
+    await send();
+
+    expect(tokens.length).toBe(1);
+    expect(tokens[0].grant_type).toBe(
+      "urn:ietf:params:oauth:grant-type:jwt-bearer"
+    );
+
+    // The assertion must verify against the service account's key, and name the
+    // mailbox being sent on behalf of.
+    const claims = JWT.verify(tokens[0].assertion, publicKey, {
+      audience: tokenEndpoint,
+    });
+    expect(claims).toMatchObject({
+      iss: "outline@project.iam.gserviceaccount.com",
+      sub: "outline@example.com",
+      scope: "https://www.googleapis.com/auth/gmail.send",
+      aud: tokenEndpoint,
+    });
+  });
+
+  it("should impersonate the configured mailbox when one is set", async () => {
+    env.GOOGLE_MAIL_FROM_USER_ID = "no-reply@example.com";
+    const tokens = mockToken();
+    mockSend();
+
+    await send();
+
+    expect(
+      JWT.verify(tokens[0].assertion, publicKey, { audience: tokenEndpoint })
+    ).toMatchObject({ sub: "no-reply@example.com" });
+  });
+
+  it("should accept a base64 encoded private key", async () => {
+    env.GOOGLE_MAIL_PRIVATE_KEY = Buffer.from(privateKey).toString("base64");
+    const tokens = mockToken();
+    mockSend();
+
+    await send();
+
+    expect(() =>
+      JWT.verify(tokens[0].assertion, publicKey, { audience: tokenEndpoint })
+    ).not.toThrow();
+  });
+
+  it("should reuse a cached token across sends", async () => {
+    const tokens = mockToken();
+    const sends = mockSend();
+    const provider = new GmailEmailProvider();
+
+    await send(provider);
+    await send(provider);
+
+    expect(tokens.length).toBe(1);
+    expect(sends.length).toBe(2);
+  });
+
+  it("should throw including the response body when Gmail rejects the message", async () => {
+    mockToken();
+    mockSend(400);
+
+    await expect(send()).rejects.toThrow(
+      /Gmail could not send the message \(400\).*Precondition check failed/s
+    );
+  });
+
+  it("should warn once when the impersonated mailbox differs from the sender", async () => {
+    env.GOOGLE_MAIL_FROM_USER_ID = "svc-mailer@example.com";
+    mockToken();
+    mockSend();
+    const warn = vi.spyOn(Logger, "warn").mockImplementation(() => undefined);
+    const provider = new GmailEmailProvider();
+
+    await send(provider);
+    await send(provider);
+
+    const warnings = warn.mock.calls.filter(([message]) =>
+      String(message).includes("send-as alias")
+    );
+    expect(warnings.length).toBe(1);
+    warn.mockRestore();
+  });
+
+  it("should throw when the service account is not configured", async () => {
+    env.GOOGLE_MAIL_PRIVATE_KEY = undefined;
+
+    await expect(send()).rejects.toThrow(
+      /GOOGLE_MAIL_CLIENT_EMAIL and GOOGLE_MAIL_PRIVATE_KEY are required/
+    );
+    // The message must name the Workspace requirement, since this cannot work
+    // with a personal Gmail account however it is configured.
+    await expect(send()).rejects.toThrow(
+      /Google Workspace service account with domain-wide delegation/
+    );
+  });
+});

--- a/plugins/google/server/GmailEmailProvider.ts
+++ b/plugins/google/server/GmailEmailProvider.ts
@@ -1,0 +1,134 @@
+import addressparser from "addressparser";
+import JWT from "jsonwebtoken";
+import type MailMessage from "nodemailer/lib/mailer/mail-message";
+import {
+  type AccessToken,
+  AccessTokenCache,
+  fetchAccessToken,
+} from "@server/emails/providers/AccessTokenCache";
+import {
+  BaseEmailProvider,
+  type SentMessageInfo,
+} from "@server/emails/providers/BaseEmailProvider";
+import { InternalError } from "@server/errors";
+import Logger from "@server/logging/Logger";
+import { decodePem } from "@server/utils/crypto";
+import fetch from "@server/utils/fetch";
+import env from "./env";
+
+const TokenEndpoint = "https://oauth2.googleapis.com/token";
+const SendEndpoint =
+  "https://gmail.googleapis.com/gmail/v1/users/me/messages/send";
+const SendScope = "https://www.googleapis.com/auth/gmail.send";
+
+/**
+ * Delivers email through the Gmail API, authenticating as a service account
+ * that has been granted domain-wide delegation.
+ *
+ * Google Workspace has removed password-based SMTP for accounts with two-step
+ * verification or advanced protection enabled, leaving app passwords as the only
+ * SMTP option. This sends over an API instead, with no mailbox password and no
+ * per-user credential to rotate.
+ *
+ * @see https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.messages/send
+ */
+export class GmailEmailProvider extends BaseEmailProvider {
+  id = "gmail";
+
+  name = "Gmail";
+
+  // Gmail resolves Bcc recipients from the message headers and strips them
+  // before delivery, so the header must survive into the MIME output.
+  protected keepBcc = true;
+
+  protected async sendMessage(
+    mail: MailMessage<SentMessageInfo>
+  ): Promise<void> {
+    const from = mail.message.getEnvelope().from;
+
+    // The mailbox to impersonate is resolved from configuration rather than
+    // the message, because the message's own from address can vary per
+    // message – it is randomized for authentication emails on cloud-hosted
+    // installations – and each distinct mailbox costs a token exchange.
+    const mailbox =
+      env.GOOGLE_MAIL_FROM_USER_ID ||
+      (env.SMTP_FROM_EMAIL
+        ? addressparser(env.SMTP_FROM_EMAIL)[0]?.address
+        : undefined) ||
+      from;
+
+    if (!mailbox) {
+      throw InternalError(
+        "A sender mailbox is required to send email with Gmail – set SMTP_FROM_EMAIL"
+      );
+    }
+
+    // Gmail rewrites the From header to the impersonated mailbox unless the
+    // From address is one of that mailbox's send-as aliases, so a divergence
+    // between the two is worth a warning – it cannot be detected here.
+    if (!this.warnedFromMismatch && from && from !== mailbox) {
+      this.warnedFromMismatch = true;
+      Logger.warn(
+        `Gmail rewrites the From header to ${mailbox} unless ${from} is configured as a send-as alias of that mailbox`
+      );
+    }
+
+    const message = await this.getMimeMessage(mail);
+    // The mailbox is identified by the token's subject, so addressing "me"
+    // cannot disagree with the account being impersonated.
+    const accessToken = await this.tokens.get(mailbox);
+
+    const response = await fetch(SendEndpoint, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      // Gmail expects the message web-safe encoded rather than as standard
+      // base64, so that it survives being carried in a JSON string.
+      body: JSON.stringify({ raw: message.toString("base64url") }),
+    });
+
+    await this.assertOk(response, "Gmail could not send the message");
+  }
+
+  private requestAccessToken = async (
+    mailbox: string
+  ): Promise<AccessToken> => {
+    const privateKey = this.getPrivateKey();
+
+    if (!privateKey || !env.GOOGLE_MAIL_CLIENT_EMAIL) {
+      throw InternalError(
+        "GOOGLE_MAIL_CLIENT_EMAIL and GOOGLE_MAIL_PRIVATE_KEY are required to send email with Gmail. This requires a Google Workspace service account with domain-wide delegation, and cannot be used with a personal Gmail account."
+      );
+    }
+
+    // Domain-wide delegation is requested by signing an assertion that names
+    // the mailbox to impersonate as its subject.
+    const assertion = JWT.sign({ scope: SendScope }, privateKey, {
+      algorithm: "RS256",
+      issuer: env.GOOGLE_MAIL_CLIENT_EMAIL,
+      subject: mailbox,
+      audience: TokenEndpoint,
+      expiresIn: "1h",
+    });
+
+    return fetchAccessToken(
+      TokenEndpoint,
+      {
+        grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        assertion,
+      },
+      `Google rejected the service account assertion for ${mailbox}`
+    );
+  };
+
+  private getPrivateKey(): string | undefined {
+    const key = env.GOOGLE_MAIL_PRIVATE_KEY;
+    return key ? decodePem(key) : undefined;
+  }
+
+  private tokens = new AccessTokenCache(this.requestAccessToken);
+
+  private warnedFromMismatch = false;
+}

--- a/plugins/google/server/env.ts
+++ b/plugins/google/server/env.ts
@@ -16,6 +16,39 @@ class GooglePluginEnvironment extends Environment {
   public GOOGLE_CLIENT_SECRET = this.toOptionalString(
     environment.GOOGLE_CLIENT_SECRET
   );
+
+  /**
+   * The email address of a service account used to send email through the Gmail
+   * API, enabled with EMAIL_PROVIDER=gmail. The service account must be granted
+   * domain-wide delegation for the gmail.send scope in the Workspace admin
+   * console, which is what allows it to send on a mailbox's behalf.
+   * See https://developers.google.com/identity/protocols/oauth2/service-account
+   */
+  @IsOptional()
+  public GOOGLE_MAIL_CLIENT_EMAIL = this.toOptionalString(
+    environment.GOOGLE_MAIL_CLIENT_EMAIL
+  );
+
+  /**
+   * The PEM-encoded private key belonging to the service account, or a
+   * base64-encoded PEM string on a single line.
+   */
+  @IsOptional()
+  @CannotUseWithout("GOOGLE_MAIL_CLIENT_EMAIL")
+  public GOOGLE_MAIL_PRIVATE_KEY = this.toOptionalString(
+    environment.GOOGLE_MAIL_PRIVATE_KEY
+  );
+
+  /**
+   * The mailbox to impersonate when sending. Defaults to the address in
+   * SMTP_FROM_EMAIL. When set to a different mailbox, Gmail rewrites the From
+   * header to this address unless the SMTP_FROM_EMAIL address is configured as
+   * a send-as alias of it.
+   */
+  @IsOptional()
+  public GOOGLE_MAIL_FROM_USER_ID = this.toOptionalString(
+    environment.GOOGLE_MAIL_FROM_USER_ID
+  );
 }
 
 export default new GooglePluginEnvironment();

--- a/plugins/google/server/index.ts
+++ b/plugins/google/server/index.ts
@@ -2,6 +2,7 @@ import { PluginManager, Hook } from "@server/utils/PluginManager";
 import config from "../plugin.json";
 import router from "./auth/google";
 import env from "./env";
+import { GmailEmailProvider } from "./GmailEmailProvider";
 
 const enabled = !!env.GOOGLE_CLIENT_ID && !!env.GOOGLE_CLIENT_SECRET;
 
@@ -11,6 +12,20 @@ if (enabled) {
       ...config,
       type: Hook.AuthProvider,
       value: { router, id: config.id },
+    },
+  ]);
+}
+
+const emailEnabled =
+  !!env.GOOGLE_MAIL_CLIENT_EMAIL && !!env.GOOGLE_MAIL_PRIVATE_KEY;
+
+if (emailEnabled) {
+  PluginManager.add([
+    {
+      name: config.name,
+      description: "Adds Gmail as an email provider.",
+      type: Hook.EmailProvider,
+      value: new GmailEmailProvider(),
     },
   ]);
 }

--- a/plugins/ses/plugin.json
+++ b/plugins/ses/plugin.json
@@ -1,0 +1,5 @@
+{
+  "id": "ses",
+  "name": "Amazon SES",
+  "description": "Adds Amazon SES as an email provider."
+}

--- a/plugins/ses/server/SESEmailProvider.test.ts
+++ b/plugins/ses/server/SESEmailProvider.test.ts
@@ -1,0 +1,132 @@
+import nodemailer from "nodemailer";
+import env from "./env";
+import { SESEmailProvider } from "./SESEmailProvider";
+
+const { mockSend, mockClientConstructor } = vi.hoisted(() => ({
+  mockSend: vi.fn(),
+  mockClientConstructor: vi.fn(),
+}));
+
+// The client is instantiated with `new` through a dynamic import, so it has to
+// be a real class rather than a mock constructor.
+vi.mock("@aws-sdk/client-sesv2", () => ({
+  SESv2Client: class MockSESv2Client {
+    constructor(config: { region?: string }) {
+      mockClientConstructor(config);
+    }
+
+    send = mockSend;
+  },
+  SendEmailCommand: class MockSendEmailCommand {
+    constructor(public input: Record<string, never>) {}
+  },
+}));
+
+const send = (provider = new SESEmailProvider()) =>
+  nodemailer.createTransport(provider).sendMail({
+    from: "Outline <outline@example.com>",
+    to: "user@example.com",
+    subject: "Welcome to Outline",
+    text: "Hello there",
+    html: "<p>Hello there</p>",
+  });
+
+/** The input of the SendEmailCommand passed to the most recent send. */
+const lastCommandInput = () => mockSend.mock.calls.at(-1)?.[0].input;
+
+describe("SESEmailProvider", () => {
+  const original = {
+    AWS_SES_REGION: env.AWS_SES_REGION,
+    AWS_SES_CONFIGURATION_SET: env.AWS_SES_CONFIGURATION_SET,
+  };
+
+  beforeEach(() => {
+    mockSend.mockReset().mockResolvedValue({ MessageId: "message-id" });
+    mockClientConstructor.mockReset();
+    env.AWS_SES_REGION = "us-east-1";
+    env.AWS_SES_CONFIGURATION_SET = undefined;
+  });
+
+  afterEach(() => {
+    Object.assign(env, original);
+  });
+
+  it("should send the assembled message as raw MIME", async () => {
+    await send();
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const mime = Buffer.from(lastCommandInput().Content.Raw.Data).toString(
+      "utf-8"
+    );
+    expect(mime).toContain("Subject: Welcome to Outline");
+    expect(mime).toContain("From: Outline <outline@example.com>");
+    expect(mime).toContain("<p>Hello there</p>");
+  });
+
+  it("should deliver to bcc recipients without exposing them", async () => {
+    await nodemailer.createTransport(new SESEmailProvider()).sendMail({
+      from: "Outline <outline@example.com>",
+      to: "user@example.com",
+      bcc: "hidden@example.com",
+      subject: "Welcome to Outline",
+      text: "Hello there",
+    });
+
+    const input = lastCommandInput();
+
+    // Delivery happens via the envelope, which includes bcc recipients…
+    expect(input.Destination.ToAddresses).toContain("hidden@example.com");
+
+    // …while the message itself must not reveal them to other recipients.
+    const mime = Buffer.from(input.Content.Raw.Data).toString("utf-8");
+    expect(mime).not.toContain("hidden@example.com");
+  });
+
+  it("should take the sender and recipients from the envelope", async () => {
+    await send();
+
+    expect(lastCommandInput()).toMatchObject({
+      FromEmailAddress: "outline@example.com",
+      Destination: { ToAddresses: ["user@example.com"] },
+    });
+  });
+
+  it("should not set a configuration set unless one is configured", async () => {
+    await send();
+
+    expect(lastCommandInput().ConfigurationSetName).toBeUndefined();
+  });
+
+  it("should pass the configured configuration set", async () => {
+    env.AWS_SES_CONFIGURATION_SET = "outline-events";
+
+    await send();
+
+    expect(lastCommandInput().ConfigurationSetName).toBe("outline-events");
+  });
+
+  it("should create the client in the configured region", async () => {
+    env.AWS_SES_REGION = "eu-west-1";
+
+    await send();
+
+    expect(mockClientConstructor).toHaveBeenCalledWith({ region: "eu-west-1" });
+  });
+
+  it("should tag messages with the header SES reads on raw sends", () => {
+    expect(
+      new SESEmailProvider().tagHeaders({
+        category: "notification",
+        template: "InviteEmail",
+      })
+    ).toEqual({
+      "X-SES-MESSAGE-TAGS": "category=notification, template=InviteEmail",
+    });
+  });
+
+  it("should propagate errors so the message can be retried", async () => {
+    mockSend.mockRejectedValue(new Error("Email address is not verified"));
+
+    await expect(send()).rejects.toThrow("Email address is not verified");
+  });
+});

--- a/plugins/ses/server/SESEmailProvider.ts
+++ b/plugins/ses/server/SESEmailProvider.ts
@@ -1,0 +1,71 @@
+import type * as AwsSES from "@aws-sdk/client-sesv2";
+import type { SESv2Client } from "@aws-sdk/client-sesv2";
+import type MailMessage from "nodemailer/lib/mailer/mail-message";
+import {
+  BaseEmailProvider,
+  type EmailTags,
+  type SentMessageInfo,
+  sesTagHeaders,
+} from "@server/emails/providers/BaseEmailProvider";
+import env from "./env";
+
+/**
+ * Delivers email through the Amazon SES API.
+ *
+ * SES also offers an SMTP interface, which needs a dedicated set of long-lived
+ * credentials. Sending over the API instead means the standard AWS credential
+ * chain applies, so an instance role or IRSA can be used and there is no SMTP
+ * password to store or rotate.
+ *
+ * @see https://docs.aws.amazon.com/ses/latest/dg/send-email-raw.html
+ */
+export class SESEmailProvider extends BaseEmailProvider {
+  id = "ses";
+
+  name = "Amazon SES";
+
+  /**
+   * Builds the header SES reads message tags from when a message is supplied
+   * as raw MIME. SES removes the header before the message is delivered.
+   *
+   * @param tags The tags to apply to the message.
+   * @returns A map of headers to set on the message.
+   */
+  public tagHeaders(tags: EmailTags): Record<string, string> {
+    return sesTagHeaders(tags);
+  }
+
+  protected async sendMessage(
+    mail: MailMessage<SentMessageInfo>
+  ): Promise<void> {
+    const envelope = mail.message.getEnvelope();
+    const message = await this.getMimeMessage(mail);
+    const { sdk, client } = await this.getSES();
+
+    await client.send(
+      new sdk.SendEmailCommand({
+        Content: { Raw: { Data: message } },
+        // Supplied explicitly so that the envelope, rather than the message
+        // headers, decides who the message is actually delivered to.
+        FromEmailAddress: envelope.from || undefined,
+        Destination: { ToAddresses: envelope.to },
+        ConfigurationSetName: env.AWS_SES_CONFIGURATION_SET,
+      })
+    );
+  }
+
+  /**
+   * Loads the SES client on first use, so that the AWS SDK is not imported at
+   * startup for installations that do not send email through SES.
+   */
+  private getSES(): Promise<{ sdk: typeof AwsSES; client: SESv2Client }> {
+    this.sesPromise ??= (async () => {
+      const sdk = await import("@aws-sdk/client-sesv2");
+      const client = new sdk.SESv2Client({ region: env.AWS_SES_REGION });
+      return { sdk, client };
+    })();
+    return this.sesPromise;
+  }
+
+  private sesPromise?: Promise<{ sdk: typeof AwsSES; client: SESv2Client }>;
+}

--- a/plugins/ses/server/env.ts
+++ b/plugins/ses/server/env.ts
@@ -1,0 +1,26 @@
+import { IsOptional } from "class-validator";
+import { Environment } from "@server/env";
+import environment from "@server/utils/environment";
+
+class SESPluginEnvironment extends Environment {
+  /**
+   * The region SES is configured in, which defaults to AWS_REGION. SES is only
+   * available in a subset of regions, so it is not always the same region used
+   * for file storage.
+   */
+  @IsOptional()
+  public AWS_SES_REGION =
+    this.toOptionalString(environment.AWS_SES_REGION) ??
+    this.toOptionalString(environment.AWS_REGION);
+
+  /**
+   * An optional SES configuration set, used to attribute sending events to a
+   * destination such as CloudWatch or SNS.
+   */
+  @IsOptional()
+  public AWS_SES_CONFIGURATION_SET = this.toOptionalString(
+    environment.AWS_SES_CONFIGURATION_SET
+  );
+}
+
+export default new SESPluginEnvironment();

--- a/plugins/ses/server/index.ts
+++ b/plugins/ses/server/index.ts
@@ -1,0 +1,18 @@
+import { Hook, PluginManager } from "@server/utils/PluginManager";
+import config from "../plugin.json";
+import env from "./env";
+import { SESEmailProvider } from "./SESEmailProvider";
+
+// A region is the only thing SES needs beyond credentials, which are resolved
+// from the standard AWS credential chain when the client is created.
+const enabled = !!env.AWS_SES_REGION;
+
+if (enabled) {
+  PluginManager.add([
+    {
+      ...config,
+      type: Hook.EmailProvider,
+      value: new SESEmailProvider(),
+    },
+  ]);
+}

--- a/server/emails/mailer.test.tsx
+++ b/server/emails/mailer.test.tsx
@@ -1,0 +1,161 @@
+import type MailMessage from "nodemailer/lib/mailer/mail-message";
+import env from "@server/env";
+import Logger from "@server/logging/Logger";
+import { Hook, PluginManager } from "@server/utils/PluginManager";
+import { Mailer } from "./mailer";
+import {
+  BaseEmailProvider,
+  type EmailTags,
+  type SentMessageInfo,
+} from "./providers/BaseEmailProvider";
+
+/** A provider that records the message it was handed, rather than sending it. */
+class CapturingEmailProvider extends BaseEmailProvider {
+  id = "capturing";
+
+  name = "Capturing";
+
+  mime: string | undefined;
+
+  failure: Error | undefined;
+
+  public tagHeaders(tags: EmailTags): Record<string, string> {
+    return { "X-Test-Tag": tags.template };
+  }
+
+  protected async sendMessage(
+    mail: MailMessage<SentMessageInfo>
+  ): Promise<void> {
+    if (this.failure) {
+      throw this.failure;
+    }
+    this.mime = (await this.getMimeMessage(mail)).toString("utf-8");
+  }
+}
+
+const provider = new CapturingEmailProvider();
+
+const message = {
+  to: "user@example.com",
+  from: { name: "Outline", address: "outline@example.com" },
+  subject: "Welcome to Outline",
+  text: "Hello there",
+  component: <div>Hello there</div>,
+};
+
+describe("Mailer", () => {
+  const original = {
+    EMAIL_PROVIDER: env.EMAIL_PROVIDER,
+    SMTP_HOST: env.SMTP_HOST,
+    SMTP_SERVICE: env.SMTP_SERVICE,
+    URL: env.URL,
+  };
+
+  beforeAll(() => {
+    PluginManager.add({ type: Hook.EmailProvider, value: provider });
+  });
+
+  beforeEach(() => {
+    provider.mime = undefined;
+    provider.failure = undefined;
+  });
+
+  afterEach(() => {
+    Object.assign(env, original);
+  });
+
+  it("should skip sending when no SMTP server is configured", async () => {
+    env.EMAIL_PROVIDER = "smtp";
+    env.SMTP_HOST = undefined;
+    env.SMTP_SERVICE = undefined;
+    const warn = vi.spyOn(Logger, "warn").mockImplementation(() => undefined);
+
+    await new Mailer().sendMail(message);
+
+    expect(warn).toHaveBeenCalledWith("No mail transport available");
+    expect(provider.mime).toBeUndefined();
+    warn.mockRestore();
+  });
+
+  it("should hand the assembled message to the configured provider", async () => {
+    env.EMAIL_PROVIDER = "capturing";
+
+    await new Mailer().sendMail(message);
+
+    expect(provider.mime).toContain("Subject: Welcome to Outline");
+    expect(provider.mime).toContain("To: user@example.com");
+    expect(provider.mime).toContain("From: Outline <outline@example.com>");
+    // Both the rendered HTML and the plain text alternative.
+    expect(provider.mime).toContain("Hello there");
+    expect(provider.mime).toContain("text/html");
+  });
+
+  it("should keep the inline logo attachment on the provider path", async () => {
+    env.EMAIL_PROVIDER = "capturing";
+    // The logo is only attached for self hosted installations.
+    env.URL = "https://wiki.example.com";
+
+    await new Mailer().sendMail(message);
+
+    expect(provider.mime).toContain("filename=header-logo.png");
+    expect(provider.mime).toContain("Content-ID: <header-image>");
+  });
+
+  it("should keep threading and unsubscribe headers on the provider path", async () => {
+    env.EMAIL_PROVIDER = "capturing";
+
+    await new Mailer().sendMail({
+      ...message,
+      messageId: "<abc@outline>",
+      references: ["<one@outline>", "<two@outline>"],
+      unsubscribeUrl: "https://example.com/unsubscribe",
+    });
+
+    expect(provider.mime).toContain("Message-ID: <abc@outline>");
+    expect(provider.mime).toContain("In-Reply-To: <two@outline>");
+    expect(provider.mime).toContain("<one@outline>");
+    expect(provider.mime).toContain(
+      "List-Unsubscribe: <https://example.com/unsubscribe>"
+    );
+  });
+
+  it("should ask the provider how to tag a message", async () => {
+    env.EMAIL_PROVIDER = "capturing";
+
+    await new Mailer().sendMail({
+      ...message,
+      tags: { category: "notification", template: "InviteEmail" },
+    });
+
+    expect(provider.mime).toContain("X-Test-Tag: InviteEmail");
+    // The SMTP provider detection must not also apply.
+    expect(provider.mime).not.toContain("X-SES-MESSAGE-TAGS");
+  });
+
+  it("should not cache a failed transporter creation", async () => {
+    env.EMAIL_PROVIDER = "does-not-exist";
+    const error = vi.spyOn(Logger, "error").mockImplementation(() => undefined);
+    const mailer = new Mailer();
+
+    await expect(mailer.sendMail(message)).rejects.toThrow(/not found/);
+
+    // Fixing the configuration takes effect without a process restart.
+    env.EMAIL_PROVIDER = "capturing";
+    await mailer.sendMail(message);
+
+    expect(provider.mime).toContain("Subject: Welcome to Outline");
+    error.mockRestore();
+  });
+
+  it("should rethrow provider failures so the queue can retry", async () => {
+    env.EMAIL_PROVIDER = "capturing";
+    provider.failure = new Error("provider is down");
+    const error = vi.spyOn(Logger, "error").mockImplementation(() => undefined);
+
+    await expect(new Mailer().sendMail(message)).rejects.toThrow(
+      "provider is down"
+    );
+
+    error.mockRestore();
+  });
+});

--- a/server/emails/mailer.tsx
+++ b/server/emails/mailer.tsx
@@ -8,9 +8,21 @@ import env from "@server/env";
 import { InternalError } from "@server/errors";
 import Logger from "@server/logging/Logger";
 import { trace } from "@server/logging/tracing";
+import {
+  type BaseEmailProvider,
+  type EmailTags,
+  sesTagHeaders,
+} from "./providers/BaseEmailProvider";
+import {
+  DefaultEmailProvider,
+  EmailProviderManager,
+} from "./providers/EmailProviderManager";
 import { baseStyles } from "./templates/components/EmailLayout";
 
-const useTestEmailService = env.isDevelopment && !env.SMTP_USERNAME;
+const useTestEmailService =
+  env.isDevelopment &&
+  !env.SMTP_USERNAME &&
+  env.EMAIL_PROVIDER === DefaultEmailProvider;
 
 type SendMailOptions = {
   /** The email address being sent to. */
@@ -39,13 +51,6 @@ type SendMailOptions = {
   tags?: EmailTags;
 };
 
-type EmailTags = {
-  /** The broad category of the email, e.g. "notification". */
-  category: string;
-  /** The specific template name, e.g. "InviteEmail". */
-  template: string;
-};
-
 /**
  * Mailer class to send emails.
  */
@@ -53,32 +58,6 @@ type EmailTags = {
   serviceName: "mailer",
 })
 export class Mailer {
-  transporter: Transporter | undefined;
-
-  constructor() {
-    if (env.SMTP_HOST || env.SMTP_SERVICE) {
-      this.transporter = nodemailer.createTransport(this.getOptions());
-    }
-    if (useTestEmailService) {
-      Logger.info(
-        "email",
-        "SMTP_USERNAME not provided, generating test account…"
-      );
-
-      void this.getTestTransportOptions().then((options) => {
-        if (!options) {
-          Logger.info(
-            "email",
-            "Couldn't generate a test account with ethereal.email at this time – emails will not be sent."
-          );
-          return;
-        }
-
-        this.transporter = nodemailer.createTransport(options);
-      });
-    }
-  }
-
   template = ({
     title,
     bodyContent,
@@ -144,7 +123,13 @@ export class Mailer {
    * @returns Message ID header from SMTP server
    */
   sendMail = async (data: SendMailOptions): Promise<void> => {
-    const transporter = this.transporter;
+    let transporter: Transporter | undefined;
+    try {
+      transporter = await this.getTransporter();
+    } catch (err) {
+      Logger.error("Error creating email transport", toError(err));
+      throw err; // Re-throw for queue to re-try
+    }
 
     if (env.isDevelopment) {
       Logger.debug(
@@ -210,7 +195,7 @@ export class Mailer {
             ],
       });
 
-      if (useTestEmailService) {
+      if (this.usingTestTransport) {
         Logger.info(
           "email",
           `Preview Url: ${nodemailer.getTestMessageUrl(info)}`
@@ -238,6 +223,11 @@ export class Mailer {
       return undefined;
     }
 
+    // Providers know which headers, if any, their service understands.
+    if (this.provider) {
+      return this.provider.tagHeaders(tags);
+    }
+
     // Mailgun: up to three tags via repeated X-Mailgun-Tag headers.
     // https://documentation.mailgun.com/docs/mailgun/user-manual/tracking-messages/#tagging
     if (this.isMailgun) {
@@ -245,13 +235,8 @@ export class Mailer {
     }
 
     // SES: comma-separated name=value pairs via X-SES-MESSAGE-TAGS.
-    // https://docs.aws.amazon.com/ses/latest/dg/event-publishing-send-email.html
     if (this.isSES) {
-      return {
-        "X-SES-MESSAGE-TAGS": Object.entries(tags)
-          .map(([name, value]) => `${name}=${value}`)
-          .join(", "),
-      };
+      return sesTagHeaders(tags);
     }
 
     // Postmark: a single tag per message via X-PM-Tag.
@@ -264,25 +249,84 @@ export class Mailer {
   }
 
   /** The configured SMTP host and service name, for provider detection. */
-  private get provider(): string {
+  private get smtpProvider(): string {
     return `${env.SMTP_HOST ?? ""} ${env.SMTP_SERVICE ?? ""}`;
   }
 
   /** Whether the configured SMTP provider is Mailgun. */
   private get isMailgun(): boolean {
-    return /mailgun/i.test(this.provider);
+    return /mailgun/i.test(this.smtpProvider);
   }
 
   /** Whether the configured SMTP provider is Amazon SES. */
   private get isSES(): boolean {
     // Detected by the SES SMTP host (email-smtp.<region>.amazonaws.com) or a
     // well-known Nodemailer service key (SES, SES-US-EAST-1, etc.).
-    return /amazonaws|(?:^|\s)ses\b/i.test(this.provider);
+    return /amazonaws|(?:^|\s)ses\b/i.test(this.smtpProvider);
   }
 
   /** Whether the configured SMTP provider is Postmark. */
   private get isPostmark(): boolean {
-    return /postmark/i.test(this.provider);
+    return /postmark/i.test(this.smtpProvider);
+  }
+
+  private provider: BaseEmailProvider | undefined;
+
+  private transporterPromise: Promise<Transporter | undefined> | undefined;
+
+  private usingTestTransport = false;
+
+  /**
+   * Resolves the transporter, creating it on first use. Construction is
+   * deferred because resolving a provider loads plugins, and plugins that
+   * register email templates import this module.
+   *
+   * @returns the transporter, or undefined if email is not configured.
+   */
+  private getTransporter(): Promise<Transporter | undefined> {
+    this.transporterPromise ??= this.createTransporter().catch((err) => {
+      // A failed attempt must not be cached, or a single failure here would
+      // disable email for the lifetime of the process.
+      this.transporterPromise = undefined;
+      throw err;
+    });
+    return this.transporterPromise;
+  }
+
+  private async createTransporter(): Promise<Transporter | undefined> {
+    const provider = EmailProviderManager.getProvider();
+
+    if (provider) {
+      Logger.debug("email", `Using email provider: ${provider.name}`);
+      this.provider = provider;
+      return nodemailer.createTransport(provider);
+    }
+
+    // In development the test account takes precedence over any configured
+    // SMTP server, so that emails are captured rather than delivered.
+    if (useTestEmailService) {
+      Logger.info(
+        "email",
+        "SMTP_USERNAME not provided, generating test account…"
+      );
+
+      const options = await this.getTestTransportOptions();
+      if (options) {
+        this.usingTestTransport = true;
+        return nodemailer.createTransport(options);
+      }
+
+      Logger.info(
+        "email",
+        "Couldn't generate a test account with ethereal.email at this time."
+      );
+    }
+
+    if (env.SMTP_HOST || env.SMTP_SERVICE) {
+      return nodemailer.createTransport(this.getOptions());
+    }
+
+    return undefined;
   }
 
   private getOptions(): SMTPTransport.Options {

--- a/server/emails/providers/AccessTokenCache.test.ts
+++ b/server/emails/providers/AccessTokenCache.test.ts
@@ -1,0 +1,117 @@
+import { AccessTokenCache } from "./AccessTokenCache";
+
+describe("AccessTokenCache", () => {
+  it("should request a token on first use", async () => {
+    const request = vi.fn().mockResolvedValue({
+      value: "token",
+      expiresAt: Date.now() + 60_000,
+    });
+
+    const cache = new AccessTokenCache(request);
+
+    expect(await cache.get("key")).toBe("token");
+    expect(request).toHaveBeenCalledWith("key");
+  });
+
+  it("should reuse an unexpired token", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValue({ value: "token", expiresAt: Date.now() + 60_000 });
+
+    const cache = new AccessTokenCache(request);
+    await cache.get("key");
+    await cache.get("key");
+
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it("should request a new token once the cached one expires", async () => {
+    let count = 0;
+    const request = vi.fn().mockImplementation(() =>
+      Promise.resolve({
+        value: `token-${++count}`,
+        // Already expired, so it is never reused.
+        expiresAt: Date.now() - 1,
+      })
+    );
+
+    const cache = new AccessTokenCache(request);
+
+    expect(await cache.get("key")).toBe("token-1");
+    expect(await cache.get("key")).toBe("token-2");
+  });
+
+  it("should cache tokens separately per key", async () => {
+    const request = vi.fn().mockImplementation((key: string) =>
+      Promise.resolve({
+        value: `token-${key}`,
+        expiresAt: Date.now() + 60_000,
+      })
+    );
+
+    const cache = new AccessTokenCache(request);
+
+    expect(await cache.get("one")).toBe("token-one");
+    expect(await cache.get("two")).toBe("token-two");
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it("should collapse concurrent requests for the same key", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValue({ value: "token", expiresAt: Date.now() + 60_000 });
+
+    const cache = new AccessTokenCache(request);
+    const results = await Promise.all([
+      cache.get("key"),
+      cache.get("key"),
+      cache.get("key"),
+    ]);
+
+    expect(results).toEqual(["token", "token", "token"]);
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it("should collapse concurrent requests when the cached token has expired", async () => {
+    let count = 0;
+    const request = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          count += 1;
+          const value = `token-${count}`;
+          // The first token is already expired, so the concurrent callers
+          // below all observe a stale cache entry at the same time.
+          const expiresAt = count === 1 ? Date.now() - 1 : Date.now() + 60_000;
+          setTimeout(() => resolve({ value, expiresAt }), 5);
+        })
+    );
+
+    const cache = new AccessTokenCache(request);
+    await cache.get("key");
+
+    const results = await Promise.all([
+      cache.get("key"),
+      cache.get("key"),
+      cache.get("key"),
+    ]);
+
+    expect(results).toEqual(["token-2", "token-2", "token-2"]);
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it("should not cache a failed request", async () => {
+    const request = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("nope"))
+      .mockResolvedValueOnce({
+        value: "token",
+        expiresAt: Date.now() + 60_000,
+      });
+
+    const cache = new AccessTokenCache(request);
+
+    await expect(cache.get("key")).rejects.toThrow("nope");
+    expect(await cache.get("key")).toBe("token");
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+});

--- a/server/emails/providers/AccessTokenCache.ts
+++ b/server/emails/providers/AccessTokenCache.ts
@@ -1,0 +1,115 @@
+import { InternalError } from "@server/errors";
+import fetch from "@server/utils/fetch";
+
+/** An access token and the time at which it stops being usable. */
+export interface AccessToken {
+  /** The bearer token value. */
+  value: string;
+  /** When the token expires, in milliseconds since the epoch. */
+  expiresAt: number;
+}
+
+/**
+ * Requests an access token from an OAuth token endpoint using form-encoded
+ * parameters, with shared handling of the token expiry.
+ *
+ * @param endpoint The token endpoint URL.
+ * @param params Form parameters for the grant being requested.
+ * @param errorMessage Context prefixed to the error when the request fails.
+ * @returns the token and its expiry.
+ * @throws if the endpoint rejects the request.
+ */
+export async function fetchAccessToken(
+  endpoint: string,
+  params: Record<string, string>,
+  errorMessage: string
+): Promise<AccessToken> {
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams(params),
+  });
+
+  if (!response.ok) {
+    throw InternalError(
+      `${errorMessage} (${response.status}): ${await response.text()}`
+    );
+  }
+
+  const data = await response.json();
+
+  // expires_in is only recommended by the OAuth spec, so fall back to a
+  // conservative lifetime when the response omits it rather than treating
+  // the token as already expired.
+  const expiresIn = Number(data.expires_in);
+
+  return {
+    value: data.access_token,
+    // Expire a minute early so a token is never used as it lapses.
+    expiresAt:
+      Date.now() +
+      (Number.isFinite(expiresIn) ? Math.max(expiresIn - 60, 0) : 300) * 1000,
+  };
+}
+
+/**
+ * Caches short-lived access tokens, one per key, and collapses concurrent
+ * requests for the same key into a single request.
+ *
+ * Email providers that authenticate over OAuth need a token for every send, at
+ * a rate that would otherwise mean a token request per email.
+ */
+export class AccessTokenCache {
+  /**
+   * @param requestToken Called to obtain a token when none is cached, or when
+   * the cached token has expired.
+   */
+  constructor(private requestToken: (key: string) => Promise<AccessToken>) {}
+
+  /**
+   * Returns a usable access token for the given key.
+   *
+   * @param key Identifies the token, for example the tenant or mailbox it was
+   * issued for.
+   * @returns a token that has not expired.
+   * @throws if a token could not be obtained.
+   */
+  public async get(key: string): Promise<string> {
+    for (;;) {
+      const pending = this.tokens.get(key);
+
+      if (pending) {
+        // A rejected request reads as absent, and is replaced below.
+        const token = await pending.catch(() => undefined);
+        if (token && token.expiresAt > Date.now()) {
+          return token.value;
+        }
+
+        // The awaited entry is stale. If another caller already replaced it
+        // while this one was waiting, use the replacement rather than making
+        // a competing request.
+        if (this.tokens.get(key) !== pending) {
+          continue;
+        }
+      }
+
+      // Claim the slot synchronously – there is no await between the check
+      // above and this set, so concurrent callers coalesce onto one request.
+      const request = this.requestToken(key);
+      this.tokens.set(key, request);
+
+      try {
+        return (await request).value;
+      } catch (err) {
+        if (this.tokens.get(key) === request) {
+          this.tokens.delete(key);
+        }
+        throw err;
+      }
+    }
+  }
+
+  private tokens = new Map<string, Promise<AccessToken>>();
+}

--- a/server/emails/providers/BaseEmailProvider.ts
+++ b/server/emails/providers/BaseEmailProvider.ts
@@ -1,0 +1,174 @@
+import type { Transport } from "nodemailer";
+import type MailMessage from "nodemailer/lib/mailer/mail-message";
+import type MimeNode from "nodemailer/lib/mime-node";
+import { toError } from "@shared/utils/error";
+import { InternalError } from "@server/errors";
+
+/** Tags used for reporting, where supported by the email provider. */
+export interface EmailTags {
+  /** The broad category of the email, e.g. "notification". */
+  category: string;
+  /** The specific template name, e.g. "InviteEmail". */
+  template: string;
+}
+
+/**
+ * The result of a send, returned to Nodemailer and surfaced as the resolved
+ * value of `transporter.sendMail`.
+ */
+export interface SentMessageInfo {
+  /** The envelope the message was sent with. */
+  envelope: MimeNode.Envelope;
+  /** The Message-ID header of the message. */
+  messageId: string;
+  /** The id of the provider that handled the message. */
+  provider: string;
+}
+
+/**
+ * Formats tags in the header format Amazon SES reads, as comma-separated
+ * name=value pairs in X-SES-MESSAGE-TAGS. Shared between the SES email
+ * provider and the mailer's legacy SES-over-SMTP detection so the two cannot
+ * drift apart.
+ *
+ * @param tags The tags to apply to the message.
+ * @returns A map of headers to set on the message.
+ * @see https://docs.aws.amazon.com/ses/latest/dg/event-publishing-send-email.html
+ */
+export function sesTagHeaders(tags: EmailTags): Record<string, string> {
+  return {
+    "X-SES-MESSAGE-TAGS": Object.entries(tags)
+      .map(([name, value]) => `${name}=${value}`)
+      .join(", "),
+  };
+}
+
+/**
+ * Abstract base class for email providers.
+ *
+ * A provider is responsible for one thing: taking a message that Nodemailer has
+ * already assembled and handing it to a delivery service. Rendering, MIME
+ * assembly, threading headers, attachments and unsubscribe headers all happen
+ * upstream, so implementations only deal with transport and authentication.
+ *
+ * Most non-SMTP services accept a complete RFC 5322 message, which is available
+ * from `getMimeMessage`. Preferring that over a service's own JSON message
+ * schema keeps providers at parity with SMTP – there is no per-provider field
+ * mapping to fall out of date as email templates change.
+ *
+ * Implementations satisfy Nodemailer's `Transport` interface so they can be
+ * passed to `nodemailer.createTransport`, and are registered under
+ * `Hook.EmailProvider` to become selectable with the `EMAIL_PROVIDER` env var.
+ */
+export abstract class BaseEmailProvider implements Transport<SentMessageInfo> {
+  /** Unique identifier for this provider, matched against `EMAIL_PROVIDER`. */
+  abstract id: string;
+
+  /** Human readable name of the provider, used in logs. */
+  abstract name: string;
+
+  /** Version reported to Nodemailer, which includes it in the X-Mailer header. */
+  version = "1.0.0";
+
+  /**
+   * Nodemailer transport entry point, which adapts the callback interface to
+   * the promise returned by a provider's `sendMessage`.
+   *
+   * @param mail The message to send.
+   * @param callback Called with the result of the send, or an error on failure.
+   */
+  public send(
+    mail: MailMessage<SentMessageInfo>,
+    callback: (err: Error | null, info: SentMessageInfo) => void
+  ): void {
+    mail.message.keepBcc = this.keepBcc;
+
+    this.sendMessage(mail).then(
+      () => callback(null, this.getSentMessageInfo(mail)),
+      (err: unknown) => callback(toError(err), this.getSentMessageInfo(mail))
+    );
+  }
+
+  /**
+   * Builds the provider-specific headers used to tag a message for reporting.
+   * Providers that do not support tagging need not implement this.
+   *
+   * @param _tags The tags to apply to the message.
+   * @returns A map of headers to set on the message, or undefined.
+   */
+  public tagHeaders(
+    _tags: EmailTags
+  ): Record<string, string | string[]> | undefined {
+    return undefined;
+  }
+
+  /**
+   * Whether the Bcc header is retained in the generated message. Submission
+   * endpoints that carry no envelope (Microsoft Graph, Gmail) resolve Bcc
+   * recipients from the headers and strip them before delivery, so they need
+   * the header kept. Providers that carry recipients separately from the
+   * message (SES) must leave it stripped, or every recipient would see the
+   * Bcc list.
+   */
+  protected keepBcc = false;
+
+  /**
+   * Deliver an assembled message. Implementations throw on failure, and the
+   * error is passed back to the caller so the email queue can retry.
+   *
+   * @param mail The message to send.
+   */
+  protected abstract sendMessage(
+    mail: MailMessage<SentMessageInfo>
+  ): Promise<void>;
+
+  /**
+   * Throws a descriptive error when a provider API response indicates
+   * failure, including the response body for diagnosis.
+   *
+   * @param response The response to check.
+   * @param message Context describing the request that failed.
+   * @throws if the response has a non-2xx status.
+   */
+  protected async assertOk(
+    response: { ok: boolean; status: number; text(): Promise<string> },
+    message: string
+  ): Promise<void> {
+    if (!response.ok) {
+      throw InternalError(
+        `${message} (${response.status}): ${await response.text()}`
+      );
+    }
+  }
+
+  /**
+   * Serializes a message to a complete RFC 5322 MIME document.
+   *
+   * @param mail The message to serialize.
+   * @returns The encoded message.
+   */
+  protected getMimeMessage(
+    mail: MailMessage<SentMessageInfo>
+  ): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      const stream = mail.message.createReadStream();
+
+      stream.on("data", (chunk: Buffer | string) =>
+        chunks.push(Buffer.from(chunk))
+      );
+      stream.once("error", reject);
+      stream.once("end", () => resolve(Buffer.concat(chunks)));
+    });
+  }
+
+  private getSentMessageInfo(
+    mail: MailMessage<SentMessageInfo>
+  ): SentMessageInfo {
+    return {
+      envelope: mail.message.getEnvelope(),
+      messageId: mail.message.messageId(),
+      provider: this.id,
+    };
+  }
+}

--- a/server/emails/providers/EmailProviderManager.test.ts
+++ b/server/emails/providers/EmailProviderManager.test.ts
@@ -1,0 +1,84 @@
+import type MailMessage from "nodemailer/lib/mailer/mail-message";
+import env from "@server/env";
+import { Hook, PluginManager } from "@server/utils/PluginManager";
+import { BaseEmailProvider, type SentMessageInfo } from "./BaseEmailProvider";
+import { EmailProviderManager } from "./EmailProviderManager";
+
+class TestEmailProvider extends BaseEmailProvider {
+  id = "test-provider";
+
+  name = "Test Provider";
+
+  protected sendMessage(_mail: MailMessage<SentMessageInfo>): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+describe("EmailProviderManager", () => {
+  const original = env.EMAIL_PROVIDER;
+  const provider = new TestEmailProvider();
+
+  beforeAll(() => {
+    PluginManager.add({ type: Hook.EmailProvider, value: provider });
+  });
+
+  afterEach(() => {
+    env.EMAIL_PROVIDER = original;
+  });
+
+  it("should return no provider for the default SMTP configuration", () => {
+    env.EMAIL_PROVIDER = "smtp";
+    expect(EmailProviderManager.getProvider()).toBeUndefined();
+  });
+
+  it("should return a registered provider matching EMAIL_PROVIDER", () => {
+    env.EMAIL_PROVIDER = "test-provider";
+    expect(EmailProviderManager.getProvider()).toBe(provider);
+  });
+
+  it("should re-resolve when EMAIL_PROVIDER changes", () => {
+    env.EMAIL_PROVIDER = "test-provider";
+    expect(EmailProviderManager.getProvider()).toBe(provider);
+
+    env.EMAIL_PROVIDER = "smtp";
+    expect(EmailProviderManager.getProvider()).toBeUndefined();
+  });
+
+  it("should validate a correctly configured provider", () => {
+    const originalFrom = env.SMTP_FROM_EMAIL;
+    env.SMTP_FROM_EMAIL = "hello@example.com";
+    env.EMAIL_PROVIDER = "test-provider";
+
+    expect(() => EmailProviderManager.validate()).not.toThrow();
+    env.SMTP_FROM_EMAIL = originalFrom;
+  });
+
+  it("should pass validation for the default SMTP configuration", () => {
+    env.EMAIL_PROVIDER = "smtp";
+    expect(() => EmailProviderManager.validate()).not.toThrow();
+  });
+
+  it("should fail validation when a provider is configured without a sender", () => {
+    const originalFrom = env.SMTP_FROM_EMAIL;
+    env.SMTP_FROM_EMAIL = undefined;
+    env.EMAIL_PROVIDER = "test-provider";
+
+    expect(() => EmailProviderManager.validate()).toThrow(
+      /SMTP_FROM_EMAIL is required/
+    );
+    env.SMTP_FROM_EMAIL = originalFrom;
+  });
+
+  it("should fail validation for an unregistered provider", () => {
+    env.EMAIL_PROVIDER = "carrier-pigeon";
+    expect(() => EmailProviderManager.validate()).toThrow(/not found/);
+  });
+
+  it("should throw listing available providers when none matches", () => {
+    env.EMAIL_PROVIDER = "carrier-pigeon";
+
+    expect(() => EmailProviderManager.getProvider()).toThrow(
+      /Email provider "carrier-pigeon" not found. Available providers: smtp/
+    );
+  });
+});

--- a/server/emails/providers/EmailProviderManager.ts
+++ b/server/emails/providers/EmailProviderManager.ts
@@ -1,0 +1,68 @@
+import env from "@server/env";
+import { InternalError } from "@server/errors";
+import { Hook, PluginManager } from "@server/utils/PluginManager";
+import type { BaseEmailProvider } from "./BaseEmailProvider";
+
+/** The id of the built-in SMTP provider, used when none is configured. */
+export const DefaultEmailProvider = "smtp";
+
+/**
+ * Resolves the active email provider from the `EMAIL_PROVIDER` environment
+ * variable. Resolution is cheap and the mailer memoizes the transporter built
+ * from the result, so no caching happens here.
+ */
+export class EmailProviderManager {
+  /**
+   * Returns the active email provider, or undefined when the built-in SMTP
+   * transport should be used. The provider is determined by matching
+   * `EMAIL_PROVIDER` against registered `Hook.EmailProvider` plugins.
+   *
+   * @returns the active email provider, or undefined for SMTP.
+   * @throws if the configured provider is not registered.
+   */
+  public static getProvider(): BaseEmailProvider | undefined {
+    const providerId = env.EMAIL_PROVIDER;
+
+    // SMTP is not a plugin – Nodemailer provides the transport directly, so
+    // there is nothing to look up.
+    if (providerId === DefaultEmailProvider) {
+      return undefined;
+    }
+
+    const plugins = PluginManager.getHooks(Hook.EmailProvider);
+    const provider = plugins.find(
+      (plugin) => plugin.value.id === providerId
+    )?.value;
+
+    if (!provider) {
+      throw InternalError(
+        `Email provider "${providerId}" not found. Available providers: ${[
+          DefaultEmailProvider,
+          ...plugins.map((plugin) => plugin.value.id),
+        ].join(", ")}`
+      );
+    }
+
+    return provider;
+  }
+
+  /**
+   * Validates the email provider configuration, failing fast on problems that
+   * would otherwise only surface as per-email failures in the queue. Intended
+   * to be called at startup, after plugins have loaded.
+   *
+   * @throws if EMAIL_PROVIDER names a provider that is not registered, or if
+   * a provider is configured without the sender address it needs.
+   */
+  public static validate(): void {
+    const provider = this.getProvider();
+
+    // Every email is dropped in BaseEmail.schedule without a sender address,
+    // so a provider configured without one cannot work.
+    if (provider && !env.SMTP_FROM_EMAIL) {
+      throw InternalError(
+        `SMTP_FROM_EMAIL is required to send email with EMAIL_PROVIDER=${env.EMAIL_PROVIDER}`
+      );
+    }
+  }
+}

--- a/server/env.ts
+++ b/server/env.ts
@@ -394,6 +394,17 @@ export class Environment {
   // Third-party services
 
   /**
+   * The provider used to deliver email. Defaults to "smtp", which connects to
+   * the SMTP server configured below. Alternative providers, such as those that
+   * deliver over a vendor API, can be registered via plugins. Values are
+   * case-insensitive, and are validated against the registered providers when
+   * the server starts.
+   */
+  @IsOptional()
+  public EMAIL_PROVIDER =
+    this.toOptionalString(environment.EMAIL_PROVIDER)?.toLowerCase() ?? "smtp";
+
+  /**
    * The host of your SMTP server for enabling emails.
    */
   @CannotUseWith("SMTP_SERVICE")
@@ -407,9 +418,16 @@ export class Environment {
   @IsInCaseInsensitive(Object.keys(wellKnownServices))
   public SMTP_SERVICE = this.toOptionalString(environment.SMTP_SERVICE);
 
+  /**
+   * Whether email delivery is configured. True when an SMTP server is set, when
+   * a provider other than SMTP has been selected, or in development where a
+   * test account is generated automatically.
+   */
   @Public
   public EMAIL_ENABLED =
-    !!(this.SMTP_HOST || this.SMTP_SERVICE) || this.isDevelopment;
+    !!(this.SMTP_HOST || this.SMTP_SERVICE) ||
+    this.EMAIL_PROVIDER !== "smtp" ||
+    this.isDevelopment;
 
   /**
    * Optional hostname of the client, used for identifying to the server

--- a/server/main.ts
+++ b/server/main.ts
@@ -17,6 +17,7 @@ import onerror from "./onerror";
 import onupgrade, { rejectUnhandledUpgrades } from "./onupgrade";
 import services from "./services";
 import { sequelize } from "./storage/database";
+import { EmailProviderManager } from "./emails/providers/EmailProviderManager";
 import { getArg } from "./utils/args";
 import { CacheHelper } from "./utils/CacheHelper";
 import { PluginManager } from "./utils/PluginManager";
@@ -37,6 +38,16 @@ import { checkUpdates } from "./utils/updates";
 export async function start(id: number, disconnect: () => void) {
   // Ensure plugins are loaded
   PluginManager.loadPlugins();
+
+  // Fail fast on email misconfiguration. EMAIL_ENABLED advertises email
+  // features from the environment alone, so a provider that never registered
+  // would otherwise surface only as repeated failures in the email queue.
+  try {
+    EmailProviderManager.validate();
+  } catch (err) {
+    Logger.fatal("Invalid EMAIL_PROVIDER configuration", toError(err));
+    return;
+  }
 
   // Clear unfurl cache in development so code changes take effect immediately
   if (env.isDevelopment) {

--- a/server/storage/files/S3Storage.ts
+++ b/server/storage/files/S3Storage.ts
@@ -10,6 +10,7 @@ import invariant from "invariant";
 import { compact } from "es-toolkit/compat";
 import { toError } from "@shared/utils/error";
 import env from "@server/env";
+import { decodePem } from "@server/utils/crypto";
 import Logger from "@server/logging/Logger";
 import AttachmentHelper from "@server/models/helpers/AttachmentHelper";
 import BaseStorage from "./BaseStorage";
@@ -394,15 +395,7 @@ export default class S3Storage extends BaseStorage {
 
   private getCloudFrontPrivateKey(): string | undefined {
     const key = env.AWS_CLOUDFRONT_PRIVATE_KEY;
-    if (!key) {
-      return undefined;
-    }
-
-    if (key.includes("BEGIN")) {
-      return key;
-    }
-
-    return Buffer.from(key, "base64").toString("utf-8");
+    return key ? decodePem(key) : undefined;
   }
 
   private getS3PresignedUrl = async (

--- a/server/utils/PluginManager.ts
+++ b/server/utils/PluginManager.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { glob } from "glob";
 import type Router from "koa-router";
 import { isArray, sortBy } from "es-toolkit/compat";
+import type { BaseEmailProvider } from "@server/emails/providers/BaseEmailProvider";
 import type BaseEmail from "@server/emails/templates/BaseEmail";
 import env from "@server/env";
 import Logger from "@server/logging/Logger";
@@ -30,6 +31,7 @@ export enum PluginPriority {
 export enum Hook {
   API = "api",
   AuthProvider = "authProvider",
+  EmailProvider = "emailProvider",
   EmailTemplate = "emailTemplate",
   IssueProvider = "issueProvider",
   Processor = "processor",
@@ -47,6 +49,7 @@ export enum Hook {
 type PluginValueMap = {
   [Hook.API]: Router;
   [Hook.AuthProvider]: { router: Router | Promise<Router>; id: string };
+  [Hook.EmailProvider]: BaseEmailProvider;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- typeof BaseEmail<EmailProps> isn't assignable from BaseEmail<Subtype>; plugins register heterogeneous template Props.
   [Hook.EmailTemplate]: typeof BaseEmail<any>;
   [Hook.IssueProvider]: BaseIssueProvider;

--- a/server/utils/crypto.ts
+++ b/server/utils/crypto.ts
@@ -19,6 +19,23 @@ export function safeEqual(a?: string, b?: string) {
 }
 
 /**
+ * Normalize a PEM-encoded key read from an environment variable, accepting
+ * either the PEM itself – optionally with escaped newlines, as commonly
+ * happens when a key is copied into an env var – or a base64-encoded PEM on
+ * a single line.
+ *
+ * @param value The environment variable value
+ * @returns The PEM-encoded key
+ */
+export function decodePem(value: string): string {
+  if (value.includes("BEGIN")) {
+    return value.replace(/\\n/g, "\n");
+  }
+
+  return Buffer.from(value, "base64").toString("utf-8");
+}
+
+/**
  * Hash a string using SHA-256.
  *
  * @param input The input string to hash

--- a/yarn.lock
+++ b/yarn.lock
@@ -99,6 +99,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/client-sesv2@npm:^3.1115.0":
+  version: 3.1116.0
+  resolution: "@aws-sdk/client-sesv2@npm:3.1116.0"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.9"
+    "@aws-sdk/credential-provider-node": "npm:^3.972.81"
+    "@aws-sdk/signature-v4-multi-region": "npm:^3.996.46"
+    "@aws-sdk/types": "npm:^3.974.5"
+    "@smithy/core": "npm:^3.33.3"
+    "@smithy/fetch-http-handler": "npm:^5.7.2"
+    "@smithy/node-http-handler": "npm:^4.11.3"
+    "@smithy/types": "npm:^4.17.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/bda11a7baa737aab11e5a5905b06e5ad5d9a7bf0a89238e7785801e64f556019e7d8e8f754618a53c8509df5c6052983fa9649907e7e3d4829a504ad541a6d47
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/cloudfront-signer@npm:^3.1111.0":
   version: 3.1111.0
   resolution: "@aws-sdk/cloudfront-signer@npm:3.1111.0"
@@ -125,6 +142,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/core@npm:^3.977.9":
+  version: 3.977.9
+  resolution: "@aws-sdk/core@npm:3.977.9"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.974.5"
+    "@aws-sdk/xml-builder": "npm:^3.972.40"
+    "@aws/lambda-invoke-store": "npm:^0.3.0"
+    "@smithy/core": "npm:^3.33.3"
+    "@smithy/signature-v4": "npm:^5.6.12"
+    "@smithy/types": "npm:^4.17.2"
+    bowser: "npm:^2.11.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/9118a8d05b7c27fe55fb5e793840193d1b311b6c0c2958e591bcada391a71783536ed9c8f4913cc9c4b7258dba650d625ed782669a12875348544c33f35aa8d6
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/credential-provider-env@npm:^3.972.69":
   version: 3.972.69
   resolution: "@aws-sdk/credential-provider-env@npm:3.972.69"
@@ -135,6 +168,19 @@ __metadata:
     "@smithy/types": "npm:^4.16.1"
     tslib: "npm:^2.6.2"
   checksum: 10c0/c81fd8fb18ecd49db7ee2b0793bfbf0ab232c5e4dca3d4b9529df88b830cd5bbc86fa6a52c8f2baabb1b6ebbe1a0e07134e2132e2b32f2bd55aa1e125bcacdec
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-env@npm:^3.972.70":
+  version: 3.972.70
+  resolution: "@aws-sdk/credential-provider-env@npm:3.972.70"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.9"
+    "@aws-sdk/types": "npm:^3.974.5"
+    "@smithy/core": "npm:^3.33.3"
+    "@smithy/types": "npm:^4.17.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/f5d8f3f1021a83911f617dd6b36277486d0bdb174c107c4f7776a7e2c609a101aa03ada1cca9d97229ac79aea7797ec6392fe449029b87f7cd013360592bddf3
   languageName: node
   linkType: hard
 
@@ -150,6 +196,21 @@ __metadata:
     "@smithy/types": "npm:^4.16.1"
     tslib: "npm:^2.6.2"
   checksum: 10c0/b57f2fea7cb6fc38f3ce0369cb6b3a39f2789757838c25b44c0797676353a9ccbcb215ad9c3d5288ce5d8fbea0c34c04d0b884c6adcee1c6d7ebced986b0dd15
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-http@npm:^3.972.72":
+  version: 3.972.72
+  resolution: "@aws-sdk/credential-provider-http@npm:3.972.72"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.9"
+    "@aws-sdk/types": "npm:^3.974.5"
+    "@smithy/core": "npm:^3.33.3"
+    "@smithy/fetch-http-handler": "npm:^5.7.2"
+    "@smithy/node-http-handler": "npm:^4.11.3"
+    "@smithy/types": "npm:^4.17.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/aaa67dc42ce00713d92f931c620e36cb199533e6f1f892a6be76553986c86977442924e76f3743732a7b65e6f6777271789a6edbc70d5a86e0a9b6b5a3ef25f3
   languageName: node
   linkType: hard
 
@@ -174,6 +235,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/credential-provider-ini@npm:^3.973.15":
+  version: 3.973.15
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.973.15"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.9"
+    "@aws-sdk/credential-provider-env": "npm:^3.972.70"
+    "@aws-sdk/credential-provider-http": "npm:^3.972.72"
+    "@aws-sdk/credential-provider-login": "npm:^3.972.77"
+    "@aws-sdk/credential-provider-process": "npm:^3.972.70"
+    "@aws-sdk/credential-provider-sso": "npm:^3.973.14"
+    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.76"
+    "@aws-sdk/nested-clients": "npm:^3.997.44"
+    "@aws-sdk/types": "npm:^3.974.5"
+    "@smithy/core": "npm:^3.33.3"
+    "@smithy/credential-provider-imds": "npm:^4.4.16"
+    "@smithy/types": "npm:^4.17.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/1fe5f8c84cb9877a62084f9cbedebaed605ecc34891c44254d979ccd1282a5e164840d6dbb340773c311c028568f9ea642649bebf4b38cebb2d6d0039ad9de12
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/credential-provider-login@npm:^3.972.76":
   version: 3.972.76
   resolution: "@aws-sdk/credential-provider-login@npm:3.972.76"
@@ -185,6 +267,20 @@ __metadata:
     "@smithy/types": "npm:^4.16.1"
     tslib: "npm:^2.6.2"
   checksum: 10c0/15fb81fb904a47aee0f2954b66b21c5e3358499b7f33dea3546de5d6d82793bac1774bb53f57c8c396a277861d20a13b4bcf22df5dcae39559825938eed1f307
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-login@npm:^3.972.77":
+  version: 3.972.77
+  resolution: "@aws-sdk/credential-provider-login@npm:3.972.77"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.9"
+    "@aws-sdk/nested-clients": "npm:^3.997.44"
+    "@aws-sdk/types": "npm:^3.974.5"
+    "@smithy/core": "npm:^3.33.3"
+    "@smithy/types": "npm:^4.17.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/9be54fdf406325d462abdc0a2a182ba1ed39009fa18b60035705e6c3fae92dfe1afe5dba24a4fa3c8376f7cd2e1dad7a91152909f3b96dde0b215a88dfcd5330
   languageName: node
   linkType: hard
 
@@ -207,6 +303,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/credential-provider-node@npm:^3.972.81":
+  version: 3.972.81
+  resolution: "@aws-sdk/credential-provider-node@npm:3.972.81"
+  dependencies:
+    "@aws-sdk/credential-provider-env": "npm:^3.972.70"
+    "@aws-sdk/credential-provider-http": "npm:^3.972.72"
+    "@aws-sdk/credential-provider-ini": "npm:^3.973.15"
+    "@aws-sdk/credential-provider-process": "npm:^3.972.70"
+    "@aws-sdk/credential-provider-sso": "npm:^3.973.14"
+    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.76"
+    "@aws-sdk/types": "npm:^3.974.5"
+    "@smithy/core": "npm:^3.33.3"
+    "@smithy/credential-provider-imds": "npm:^4.4.16"
+    "@smithy/types": "npm:^4.17.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/b0e60a641a4648dcae0e20b3f2fe3866bb1b5aeba64617146888b4208d94878a8421cd74bbf1f8b921a50cc1e8410fa707ca30af0349ec54be43ce5e8004a748
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/credential-provider-process@npm:^3.972.69":
   version: 3.972.69
   resolution: "@aws-sdk/credential-provider-process@npm:3.972.69"
@@ -217,6 +332,19 @@ __metadata:
     "@smithy/types": "npm:^4.16.1"
     tslib: "npm:^2.6.2"
   checksum: 10c0/73216e292ee76085c92108237e52c4c6ec9f6fdcfcb87ad9388a829fe590e0464b6b7887dd8365f4ecb0db1f4a35eb14c0874c908b9e79a6de5003d6b72d2551
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-process@npm:^3.972.70":
+  version: 3.972.70
+  resolution: "@aws-sdk/credential-provider-process@npm:3.972.70"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.9"
+    "@aws-sdk/types": "npm:^3.974.5"
+    "@smithy/core": "npm:^3.33.3"
+    "@smithy/types": "npm:^4.17.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/87ea5f575f611461a538312b6c502baf86ce33eef6974bb2f9e85bd32147cb8f6b518e80f5a5d8ef371fceb03d517f4d3b6c07ddeb7f15d5a2f56c6dcbf8e8ba
   languageName: node
   linkType: hard
 
@@ -235,6 +363,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/credential-provider-sso@npm:^3.973.14":
+  version: 3.973.14
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.973.14"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.9"
+    "@aws-sdk/nested-clients": "npm:^3.997.44"
+    "@aws-sdk/token-providers": "npm:3.1116.0"
+    "@aws-sdk/types": "npm:^3.974.5"
+    "@smithy/core": "npm:^3.33.3"
+    "@smithy/types": "npm:^4.17.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/12132e57c07277b4c115c835bb7a14b2a62e4f30a69998eca501a171d46be469439b3e7b33c970165362bd261b8689389dd06ba0a959657d97330f3e5172ec52
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/credential-provider-web-identity@npm:^3.972.75":
   version: 3.972.75
   resolution: "@aws-sdk/credential-provider-web-identity@npm:3.972.75"
@@ -246,6 +389,20 @@ __metadata:
     "@smithy/types": "npm:^4.16.1"
     tslib: "npm:^2.6.2"
   checksum: 10c0/2b84691ae132f0cb146a8240991fa31295f6112423a1314979a424c2408124fc92b8b76bf74ce1d442777e7dc39dcc910ab29bacd26e02af49ac6b0e7330e538
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-web-identity@npm:^3.972.76":
+  version: 3.972.76
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.972.76"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.9"
+    "@aws-sdk/nested-clients": "npm:^3.997.44"
+    "@aws-sdk/types": "npm:^3.974.5"
+    "@smithy/core": "npm:^3.33.3"
+    "@smithy/types": "npm:^4.17.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/5efcf6a4b10e49b5b3f9bf76b638ff0b0ce84d26126197f0d28cecbd01458f5d84a074a4cdc8817a7310a940a36a8ad164c1531eb031713bd1485d52bef8c877
   languageName: node
   linkType: hard
 
@@ -306,6 +463,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/nested-clients@npm:^3.997.44":
+  version: 3.997.44
+  resolution: "@aws-sdk/nested-clients@npm:3.997.44"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.9"
+    "@aws-sdk/signature-v4-multi-region": "npm:^3.996.46"
+    "@aws-sdk/types": "npm:^3.974.5"
+    "@smithy/core": "npm:^3.33.3"
+    "@smithy/fetch-http-handler": "npm:^5.7.2"
+    "@smithy/node-http-handler": "npm:^4.11.3"
+    "@smithy/types": "npm:^4.17.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/947c2049a69a02399f600bd448f34bcaaf3a97b5bbb9b43e9ce932e84d4e9c3131687d330b9c48391da4365582890dd72bf4b8dfafe0693c041e48aa0f5c972d
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/s3-presigned-post@npm:^3.1115.0":
   version: 3.1115.0
   resolution: "@aws-sdk/s3-presigned-post@npm:3.1115.0"
@@ -362,6 +535,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/signature-v4-multi-region@npm:^3.996.46":
+  version: 3.996.46
+  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.996.46"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.974.5"
+    "@smithy/signature-v4": "npm:^5.6.12"
+    "@smithy/types": "npm:^4.17.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/069dfb7a95663cad2e0aec1d87df8a800abad33cb49dfbe9412dad2d63ab6350328c6165166b12d50e609d8dbe5a5536aa6b1101be4d91584fbca76b2fea4d00
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/token-providers@npm:3.1111.0":
   version: 3.1111.0
   resolution: "@aws-sdk/token-providers@npm:3.1111.0"
@@ -376,6 +561,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/token-providers@npm:3.1116.0":
+  version: 3.1116.0
+  resolution: "@aws-sdk/token-providers@npm:3.1116.0"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.977.9"
+    "@aws-sdk/nested-clients": "npm:^3.997.44"
+    "@aws-sdk/types": "npm:^3.974.5"
+    "@smithy/core": "npm:^3.33.3"
+    "@smithy/types": "npm:^4.17.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/e720401f6b6d5682984cf1927d3e4c86663b750086bac3b58827a3b9b8585c8b06fb93af82a03a40d5a8ca48c89c0f47c1ac48ea81822c52ddecc3e36ef7cf17
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/types@npm:^3.974.4":
   version: 3.974.4
   resolution: "@aws-sdk/types@npm:3.974.4"
@@ -383,6 +582,16 @@ __metadata:
     "@smithy/types": "npm:^4.16.1"
     tslib: "npm:^2.6.2"
   checksum: 10c0/64f6ed62d7da705c6af02ec3579f49a9dee800d198fcbdf5b2b6a11cc5f03f64f5105429edc5a454fc3c8672237dfa851d6002ec24a25914267750f63e184e1b
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/types@npm:^3.974.5":
+  version: 3.974.5
+  resolution: "@aws-sdk/types@npm:3.974.5"
+  dependencies:
+    "@smithy/types": "npm:^4.17.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/803aaaa1c0675dcb564803993f3c47d96302fad461af8af80e75afc40c72228ebf669593c18e44ca09fc5acf0d1bd25966261de07844d8f11ad82aa2650252d0
   languageName: node
   linkType: hard
 
@@ -402,6 +611,16 @@ __metadata:
     "@smithy/types": "npm:^4.16.1"
     tslib: "npm:^2.6.2"
   checksum: 10c0/0f217f53264c943aaeba61450b95a479adaf435bfb19716a2cefb9f6f2b90848e202eb210ecc9371616138c9c0ae931294033582ee1aaa8288790684bef75514
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/xml-builder@npm:^3.972.40":
+  version: 3.972.40
+  resolution: "@aws-sdk/xml-builder@npm:3.972.40"
+  dependencies:
+    "@smithy/types": "npm:^4.17.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/5b06fa0466b5ddb0e33138dc16f6a30e11e52fc5ea71f3ed72af7b24621d29c9e8103df3eed9c4f14cef50f4d345dd9e7021242a8c155a67869ee4ce79982bb4
   languageName: node
   linkType: hard
 
@@ -6025,6 +6244,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/core@npm:^3.33.2, @smithy/core@npm:^3.33.3":
+  version: 3.33.3
+  resolution: "@smithy/core@npm:3.33.3"
+  dependencies:
+    "@smithy/types": "npm:^4.17.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/57c5c6c1834d84eddfff905932350973afa20e1006024b82d6599af4c8d1e75b243e06b93c998acc95946399f1342ddc298c6941e0030384e6541ceec4007376
+  languageName: node
+  linkType: hard
+
 "@smithy/credential-provider-imds@npm:^4.4.16":
   version: 4.4.16
   resolution: "@smithy/credential-provider-imds@npm:4.4.16"
@@ -6044,6 +6273,28 @@ __metadata:
     "@smithy/types": "npm:^4.16.1"
     tslib: "npm:^2.6.2"
   checksum: 10c0/028ba8794a6c487ebefae7f40d0124f70e51a1f4e0e465457845c1a44fd607320cd3c64d4a961f159aef59470f0fd43f0d2011b44ee5ef753b7e1dccbdf32ca3
+  languageName: node
+  linkType: hard
+
+"@smithy/fetch-http-handler@npm:^5.7.2":
+  version: 5.7.2
+  resolution: "@smithy/fetch-http-handler@npm:5.7.2"
+  dependencies:
+    "@smithy/core": "npm:^3.33.2"
+    "@smithy/types": "npm:^4.17.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/9f4541cb743a5207f33d6abd135642a5310cc24f0ed5d46836bf3692901110216f64e09df977488a652762332156fe914b934c780f6a95ef8b1c7d3235c99c7f
+  languageName: node
+  linkType: hard
+
+"@smithy/node-http-handler@npm:^4.11.3":
+  version: 4.11.3
+  resolution: "@smithy/node-http-handler@npm:4.11.3"
+  dependencies:
+    "@smithy/core": "npm:^3.33.3"
+    "@smithy/types": "npm:^4.17.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/b1ec5956281d7ab5a5d1d4ca890b5d9f84f6540bb80c07e5b0eb31426bad27ff03ae56851e95c3fc8efb52ac9d432df86f9735e1be01db7ecdd1559a85683589
   languageName: node
   linkType: hard
 
@@ -6075,6 +6326,15 @@ __metadata:
   dependencies:
     tslib: "npm:^2.6.2"
   checksum: 10c0/e024d9d148deca7bd21d032a9316db109bbe7cf256ffbb8d3981655b9f4f7695c08ec9b87f5a8cf1442e783ba26cb27e4f09603c5bfa3ba1e526c41b1b3e94d2
+  languageName: node
+  linkType: hard
+
+"@smithy/types@npm:^4.17.2":
+  version: 4.17.2
+  resolution: "@smithy/types@npm:4.17.2"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/7a11f38e6dacdf2247c17bcd50a68ce6200a09dc6a7ecd8d563de94855a25c1da45c4d98f586e3c6fe94727ddbbde6d88ff212ac8eabf7d49779902d1a99a715
   languageName: node
   linkType: hard
 
@@ -15663,6 +15923,7 @@ __metadata:
   resolution: "outline@workspace:."
   dependencies:
     "@aws-sdk/client-s3": "npm:^3.1115.0"
+    "@aws-sdk/client-sesv2": "npm:^3.1115.0"
     "@aws-sdk/cloudfront-signer": "npm:^3.1111.0"
     "@aws-sdk/lib-storage": "npm:^3.1115.0"
     "@aws-sdk/s3-presigned-post": "npm:^3.1115.0"


### PR DESCRIPTION
Implements the provider-agnostic email delivery discussed in #13019, where SMTP AUTH being disabled on Microsoft 365 tenants leaves no way to send Outline email. Naming and env-only configuration per your comments there.

## Design

- `BaseEmailProvider` implements nodemailer's `Transport`; each provider implements a single `sendMessage(mail)` method and can serialize the fully assembled RFC 5322 message via `getMimeMessage()`. Because providers receive the assembled message rather than mapping onto each vendor's JSON schema, threading headers, `List-Unsubscribe`, and inline attachments behave identically across providers with no per-provider field mapping to maintain.
- Selected with a new `EMAIL_PROVIDER` env var (default `smtp`, existing behavior unchanged) resolved through a new `Hook.EmailProvider` — mirroring `SEARCH_PROVIDER` / `BaseSearchProvider`.
- `EMAIL_PROVIDER` is validated against registered providers at startup, so a typo or missing provider credentials fails fast at boot instead of surfacing as per-email queue failures. `SMTP_FROM_EMAIL` is required whenever a provider is configured.

## Providers

| Provider | Auth | Why |
|---|---|---|
| `msgraph` (plugins/azure) | OAuth client credentials → `users/{mailbox}/sendMail` (MIME) | M365 tenants with SMTP AUTH disabled; works with Conditional Access |
| `gmail` (plugins/google) | Service account + domain-wide delegation → `messages/send` | Google Workspace without app passwords |
| `ses` (plugins/ses) | Standard AWS credential chain → SES v2 `SendEmail` (raw) | Instance roles/IRSA — no SMTP credentials to store or rotate |

Details handled: per-provider message tagging (SES tags preserved between SMTP and API paths), Bcc semantics per transport (submission endpoints keep the header, SES strips it and delivers via the envelope), OAuth token caching with coalesced concurrent refresh, sovereign-cloud endpoint overrides for Graph, and base64/escaped-PEM key handling.

## Testing

63 tests across the new code drive real nodemailer through mocked provider endpoints (msw) and assert on the decoded wire format — including cryptographic verification of the Gmail JWT assertion against a generated keypair. Full server suite passes. Not yet exercised against live M365/Workspace/SES tenants.

Docs updated in `.env.sample` and `app.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
