### PR TITLE
fix(History): show revision author in meta when viewing a revision

### DIFF
--- a/app/components/DocumentMeta.tsx
+++ b/app/components/DocumentMeta.tsx
@@ -86,7 +86,9 @@ const DocumentMeta: React.FC<Props> = ({
       <span>
         {revision.createdBy?.id === user.id
           ? t("You updated")
-          : t("{{ userName }} updated", { userName })}{" "}
+          : t("{{ userName }} updated", {
+              userName: revision.createdBy?.name ?? t("Unknown"),
+            })}{" "}
         <Time dateTime={revision.createdAt} addSuffix />
       </span>
     );


### PR DESCRIPTION
## Summary

- Fixes #13570
- When a revision is opened from the History panel, the meta line attributed it to the document's current last editor (`updatedBy`) instead of the revision's author (`revision.createdBy`). The "You updated" case already keyed off `revision.createdBy`; only the displayed name was wrong.

## Changes

- `DocumentMeta` now displays `revision.createdBy?.name` when rendering meta for a revision, falling back to "Unknown" when the author is unavailable — matching the existing `deletedBy` handling.

## Verification

- In a document edited by two users, open the earlier editor's revision in History: the meta now shows that user's name (or "You updated" when viewing your own revision) instead of the document's current last editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)