### PR TITLE
fix: Keep OIDC provider identifier in sync with configured domain

### DIFF
--- a/plugins/oidc/server/auth/oidcRouter.ts
+++ b/plugins/oidc/server/auth/oidcRouter.ts
@@ -164,8 +164,24 @@ export function createOIDCRouter(
 
             // Derive a providerId from the OIDC location if there is no existing provider.
             const oidcURL = new URL(endpoints.authorizationURL);
-            const providerId =
+            let providerId =
               authenticationProvider?.providerId ?? oidcURL.hostname;
+
+            // The provider can move to a different domain, in which case the
+            // stored identifier must follow the configured location.
+            if (authenticationProvider && providerId !== oidcURL.hostname) {
+              try {
+                await authenticationProvider.update({
+                  providerId: oidcURL.hostname,
+                });
+                providerId = oidcURL.hostname;
+              } catch (error) {
+                Logger.warn(
+                  "Could not update OIDC authentication provider identifier",
+                  { providerId, hostname: oidcURL.hostname, error }
+                );
+              }
+            }
 
             if (!domain) {
               throw OIDCMalformedUserInfoError();


### PR DESCRIPTION
On each OIDC sign in the router reuses the identifier stored on the team's existing provider record. That value is only ever derived from the configured authorization URL at first sign in, so moving the identity provider to a new domain left the old hostname persisted and displayed in settings, with a manual database edit as the only remedy.

- Update the stored provider identifier when it no longer matches the configured OIDC location
- Guard the update so a conflicting record cannot interrupt sign in

closes #13572