### PR TITLE
fix: Insert files dropped around the document at the nearest editor position

### DIFF
--- a/app/components/Editor.tsx
+++ b/app/components/Editor.tsx
@@ -1,22 +1,16 @@
 import { difference } from "es-toolkit/compat";
 import { observer } from "mobx-react";
-import { DOMParser as ProsemirrorDOMParser } from "prosemirror-model";
-import { TextSelection } from "prosemirror-state";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { mergeRefs } from "react-merge-refs";
 import type { Optional } from "utility-types";
-import insertFiles from "@shared/editor/commands/insertFiles";
 import EditorContainer from "@shared/editor/components/Styles";
 import { AttachmentPreset } from "@shared/types";
 import { ProsemirrorHelper } from "@shared/utils/ProsemirrorHelper";
-import { getDataTransferFiles } from "@shared/utils/files";
-import { AttachmentValidation } from "@shared/validations";
 import ClickablePadding from "~/components/ClickablePadding";
 import ErrorBoundary from "~/components/ErrorBoundary";
 import type { Props as EditorProps, Editor as SharedEditor } from "~/editor";
-import { toastNotice } from "~/editor/toastNotice";
 import useCurrentUser from "~/hooks/useCurrentUser";
 import useEditorClickHandlers from "~/hooks/useEditorClickHandlers";
 import useEmbeds from "~/hooks/useEmbeds";
@@ -135,61 +129,9 @@ function Editor(props: Props, ref: React.RefObject<SharedEditor> | null) {
   }, [localRef]);
 
   const handleDrop = React.useCallback(
-    (event: React.DragEvent<HTMLDivElement>) => {
-      event.preventDefault();
-      event.stopPropagation();
-      const files = getDataTransferFiles(event);
-
-      const view = localRef?.current?.view;
-      if (!view) {
-        return;
-      }
-
-      // Find a valid position at the end of the document to insert our content
-      const pos = TextSelection.near(
-        view.state.doc.resolve(view.state.doc.nodeSize - 2)
-      ).from;
-
-      // If there are no files in the drop event attempt to parse the html
-      // as a fragment and insert it at the end of the document
-      if (files.length === 0) {
-        const text =
-          event.dataTransfer.getData("text/html") ||
-          event.dataTransfer.getData("text/plain");
-
-        const dom = new DOMParser().parseFromString(text, "text/html");
-
-        view.dispatch(
-          view.state.tr.insert(
-            pos,
-            ProsemirrorDOMParser.fromSchema(view.state.schema).parse(dom)
-          )
-        );
-
-        return;
-      }
-
-      // Insert all files as attachments if any of the files are not images.
-      const isAttachment = files.some(
-        (file) => !AttachmentValidation.imageContentTypes.includes(file.type)
-      );
-
-      return insertFiles(view, event, pos, files, {
-        uploadFile: handleUploadFile,
-        onFileUploadStart: handleFileUploadStart,
-        onFileUploadStop: handleFileUploadStop,
-        onFileUploadProgress: handleFileUploadProgress,
-        onNotice: toastNotice,
-        isAttachment,
-      });
-    },
-    [
-      localRef,
-      handleFileUploadStart,
-      handleFileUploadStop,
-      handleFileUploadProgress,
-      handleUploadFile,
-    ]
+    (event: React.DragEvent<HTMLDivElement>) =>
+      localRef.current?.insertDroppedContent(event),
+    []
   );
 
   // see: https://stackoverflow.com/a/50233827/192065

--- a/app/components/EditorAwareHTML5Backend.ts
+++ b/app/components/EditorAwareHTML5Backend.ts
@@ -29,6 +29,14 @@ const topHandlerNames = [
 const isWithinEditor = (target: EventTarget | null): boolean =>
   target instanceof Element && Boolean(target.closest(".ProseMirror"));
 
+// A file dragged over an element marked `data-drop-area`, which accepts native
+// file drops itself. react-dnd never tracks these drags, so its handlers would
+// otherwise reject them.
+const isFileOverDropArea = (event: DragEvent): boolean =>
+  Boolean(event.dataTransfer?.types.includes("Files")) &&
+  event.target instanceof Element &&
+  Boolean(event.target.closest("[data-drop-area]"));
+
 /**
  * An HTML5 drag-and-drop backend that ignores drag events originating within the
  * rich text editor so that ProseMirror can handle them itself.
@@ -57,7 +65,7 @@ export const EditorAwareHTML5Backend: BackendFactory = (
     const original = handlers[name];
     if (typeof original === "function") {
       handlers[name] = (event: DragEvent) => {
-        if (isWithinEditor(event.target)) {
+        if (isWithinEditor(event.target) || isFileOverDropArea(event)) {
           return;
         }
         // A drag that began or entered the page over the editor is never

--- a/app/editor/index.tsx
+++ b/app/editor/index.tsx
@@ -9,7 +9,11 @@ import { gapCursor } from "prosemirror-gapcursor";
 import type { InputRule } from "prosemirror-inputrules";
 import { keymap } from "prosemirror-keymap";
 import type { NodeSpec, MarkSpec } from "prosemirror-model";
-import { Schema, Node as ProsemirrorNode } from "prosemirror-model";
+import {
+  Schema,
+  Node as ProsemirrorNode,
+  DOMParser as ProsemirrorDOMParser,
+} from "prosemirror-model";
 import type { Plugin, Transaction } from "prosemirror-state";
 import { EditorState, Selection, TextSelection } from "prosemirror-state";
 import type { MarkdownParser } from "prosemirror-markdown";
@@ -36,6 +40,7 @@ import { inputRules } from "@shared/editor/lib/inputRules";
 import type { MarkdownSerializer } from "@shared/editor/lib/markdown/serializer";
 import { isRemoteTransaction } from "@shared/editor/lib/multiplayer";
 import textBetween from "@shared/editor/lib/textBetween";
+import { findNearestPos } from "@shared/editor/queries/findNearestPos";
 import { basicExtensions as extensions } from "@shared/editor/nodes";
 import type ReactNode from "@shared/editor/nodes/ReactNode";
 import type {
@@ -52,6 +57,8 @@ import { HeadingPrefixStyle } from "@shared/types";
 import { headingPrefixPluginKey } from "@shared/editor/extensions/HeadingPrefix";
 import { ProsemirrorHelper } from "@shared/utils/ProsemirrorHelper";
 import EventEmitter from "@shared/utils/events";
+import { getDataTransferFiles } from "@shared/utils/files";
+import { AttachmentValidation } from "@shared/validations";
 import type Document from "~/models/Document";
 import Flex from "~/components/Flex";
 import { PortalContext } from "~/components/Portal";
@@ -744,6 +751,57 @@ export class Editor extends React.PureComponent<
       files,
       this.props
     );
+
+  /**
+   * Insert the content of a drop event at the position nearest to where it
+   * occurred. Intended for drops that land outside of the editor itself.
+   *
+   * @param event The drop event.
+   */
+  public insertDroppedContent = (event: React.DragEvent<HTMLElement>) => {
+    const { view } = this;
+    if (!view.editable) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const pos = findNearestPos(view, {
+      left: event.clientX,
+      top: event.clientY,
+    });
+    const files = getDataTransferFiles(event);
+
+    // Without files, attempt to parse the payload as an HTML fragment.
+    if (files.length === 0) {
+      const text =
+        event.dataTransfer.getData("text/html") ||
+        event.dataTransfer.getData("text/plain");
+      if (!text) {
+        return;
+      }
+
+      const dom = new DOMParser().parseFromString(text, "text/html");
+      view.dispatch(
+        view.state.tr.insert(
+          pos,
+          ProsemirrorDOMParser.fromSchema(view.state.schema).parse(dom)
+        )
+      );
+      return;
+    }
+
+    // Insert all files as attachments if any of the files are not images.
+    const isAttachment = files.some(
+      (file) => !AttachmentValidation.imageContentTypes.includes(file.type)
+    );
+
+    return insertFiles(view, event, pos, files, {
+      ...this.props,
+      isAttachment,
+    });
+  };
 
   /**
    * Returns true if the trimmed content of the editor is an empty string.

--- a/app/scenes/Document/components/Document.tsx
+++ b/app/scenes/Document/components/Document.tsx
@@ -206,6 +206,37 @@ function DocumentScene({
     [readOnly, abilities.update, history, document, sidebarContext]
   );
 
+  // Files dropped in the margins around the document are inserted at the
+  // closest point in the editor, rather than being ignored by the browser.
+  const isFileDrag = useCallback(
+    (event: React.DragEvent<HTMLElement>) =>
+      !readOnly && !revision && event.dataTransfer.types.includes("Files"),
+    [readOnly, revision]
+  );
+
+  const handleDragOver = useCallback(
+    (event: React.DragEvent<HTMLElement>) => {
+      if (isFileDrag(event)) {
+        event.dataTransfer.dropEffect = "copy";
+        event.preventDefault();
+      }
+    },
+    [isFileDrag]
+  );
+
+  const handleDrop = useCallback(
+    (event: React.DragEvent<HTMLElement>) => {
+      // A drop that landed inside the editor has already been handled.
+      if (event.defaultPrevented || !isFileDrag(event)) {
+        return;
+      }
+      // Prevent the browser from navigating to the file if it cannot be added.
+      event.preventDefault();
+      void editorRef.current?.insertDroppedContent(event);
+    },
+    [isFileDrag]
+  );
+
   const goToHistory = useCallback(
     (ev: KeyboardEvent) => {
       if (!readOnly) {
@@ -315,6 +346,9 @@ function DocumentScene({
         key={revision ? revision.id : document.id}
         column
         auto
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
+        data-drop-area
       >
         <PageTitle title={pageTitle} favicon={favicon} />
         {(isUploading || isSaving) && <LoadingIndicator />}

--- a/shared/editor/commands/insertFiles.ts
+++ b/shared/editor/commands/insertFiles.ts
@@ -48,7 +48,7 @@ const insertFiles = async function (
   event:
     | Event
     | React.ChangeEvent<HTMLInputElement>
-    | React.DragEvent<HTMLDivElement>,
+    | React.DragEvent<HTMLElement>,
   pos: number,
   files: File[],
   options: Options

--- a/shared/editor/queries/findNearestPos.ts
+++ b/shared/editor/queries/findNearestPos.ts
@@ -1,0 +1,31 @@
+import { clamp } from "es-toolkit";
+import { TextSelection } from "prosemirror-state";
+import type { EditorView } from "prosemirror-view";
+
+/**
+ * Find the position in the document nearest to the given viewport coordinates.
+ * Unlike `posAtCoords`, coordinates that fall outside of the editor are clamped
+ * to its bounds so that a position is always returned.
+ *
+ * @param view the editor view.
+ * @param coords the viewport coordinates.
+ * @returns a position in the document that a selection can be placed at.
+ */
+export function findNearestPos(
+  view: EditorView,
+  coords: { left: number; top: number }
+): number {
+  const { doc } = view.state;
+  const rect = view.dom.getBoundingClientRect();
+  const top = clamp(coords.top, rect.top + 1, rect.bottom - 1);
+  const result =
+    view.posAtCoords({
+      left: clamp(coords.left, rect.left + 1, rect.right - 1),
+      top,
+    }) ??
+    // The clamped point can still land in the space between two blocks, in
+    // which case fall back to the start of the nearest line.
+    view.posAtCoords({ left: rect.left + 1, top });
+
+  return TextSelection.near(doc.resolve(result?.pos ?? doc.nodeSize - 2)).from;
+}


### PR DESCRIPTION
Dropping a file into the margins around a document did nothing, and the click-to-focus padding below the content was silently rejecting drops too.

- Files dropped anywhere on the document page are now inserted at the closest point in the editor, rather than always at the end.
- New `findNearestPos` query clamps the drop coordinates into the editor bounds so a position is always resolved, even for drops in the gutters, above the title, or below the content.
- Drop handling moved onto the editor as a single `insertDroppedContent` method, replacing the duplicated logic in the wrapper component.
- Root cause of the dead margins: react-dnd's window level dragover handler forced the drop effect to "none" for any target outside the editor, so the browser never dispatched a drop event. Its handlers now stand aside for file drags over an area that opts in.