### PR TITLE
feat: WebMCP support

### DIFF
--- a/app/actions/definitions/documents.tsx
+++ b/app/actions/definitions/documents.tsx
@@ -1364,7 +1364,8 @@ export const searchDocumentsForQueryActionFactory = (query: string) =>
     priority: -1,
     icon: <SearchIcon />,
     to: searchPath({ query }),
-    visible: ({ location }) => location.pathname !== searchPath(),
+    visible: ({ location, isMCP }) =>
+      !isMCP && location.pathname !== searchPath(),
   });
 
 export const moveDocumentToCollection = createAction({

--- a/app/actions/definitions/navigation.tsx
+++ b/app/actions/definitions/navigation.tsx
@@ -55,6 +55,7 @@ export const navigateToRecentSearchQueryActionFactory = (
     name: searchQuery.query,
     analyticsName: "Navigate to recent search query",
     icon: <SearchIcon />,
+    visible: ({ isMCP }) => !isMCP,
     to: searchPath({ query: searchQuery.query }),
   });
 

--- a/app/actions/definitions/webmcp.ts
+++ b/app/actions/definitions/webmcp.ts
@@ -1,0 +1,76 @@
+import { createAction } from "~/actions";
+import { DocumentsSection, NavigationSection } from "~/actions/sections";
+
+/**
+ * Actions that are only registered as WebMCP tools, never in menus or the
+ * command bar. Names and descriptions are intentionally not translated as
+ * they are read by agents, not users.
+ */
+export const getCurrentContext = createAction({
+  name: "Get current context",
+  analyticsName: "Get current context",
+  section: NavigationSection,
+  description:
+    "Returns the user's current location in the app as JSON, including the active document and collection if any.",
+  mcp: {},
+  perform: ({ stores, location }) => {
+    const document = stores.documents.active;
+    const collection = stores.collections.active;
+
+    return JSON.stringify({
+      path: location.pathname,
+      user: stores.auth.user
+        ? { id: stores.auth.user.id, name: stores.auth.user.name }
+        : undefined,
+      document: document
+        ? {
+            id: document.id,
+            title: document.titleWithDefault,
+            path: document.url,
+          }
+        : undefined,
+      collection: collection
+        ? { id: collection.id, name: collection.name, path: collection.path }
+        : undefined,
+    });
+  },
+});
+
+export const searchWorkspace = createAction({
+  name: "Search workspace",
+  analyticsName: "Search workspace",
+  section: DocumentsSection,
+  description:
+    "Searches all documents the user can access and returns the top matches as JSON, each with an id, title, path, and a snippet of matching context.",
+  mcp: {
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "The text to search for.",
+        },
+      },
+      required: ["query"],
+    },
+  },
+  perform: async ({ stores, mcpArgs }) => {
+    const query = typeof mcpArgs?.query === "string" ? mcpArgs.query : "";
+    if (!query) {
+      return "A query argument is required.";
+    }
+
+    const results = await stores.documents.search({ query, limit: 10 });
+
+    return JSON.stringify(
+      results.map((result) => ({
+        id: result.document.id,
+        title: result.document.titleWithDefault,
+        path: result.document.url,
+        context: result.context,
+      }))
+    );
+  },
+});
+
+export const rootWebMCPActions = [getCurrentContext, searchWorkspace];

--- a/app/actions/index.ts
+++ b/app/actions/index.ts
@@ -56,7 +56,9 @@ export function createAction(
                 ? "button"
                 : context.isCommandBar
                   ? "commandbar"
-                  : "contextmenu",
+                  : context.isMCP
+                    ? "webmcp"
+                    : "contextmenu",
             });
           }
           return definition.perform(context);

--- a/app/actions/index.ts
+++ b/app/actions/index.ts
@@ -357,6 +357,10 @@ export async function performAction(
 
   if (result instanceof Promise) {
     return result.catch((err: Error) => {
+      // WebMCP callers surface errors to the agent instead of a toast.
+      if (context.isMCP) {
+        throw err;
+      }
       toast.error(err.message);
     });
   }

--- a/app/components/AuthenticatedLayout.tsx
+++ b/app/components/AuthenticatedLayout.tsx
@@ -8,8 +8,10 @@ import Layout from "~/components/Layout";
 import RegisterKeyDown from "~/components/RegisterKeyDown";
 import { RightSidebarProvider } from "~/components/RightSidebarContext";
 import Sidebar from "~/components/Sidebar";
+import { rootWebMCPActions } from "~/actions/definitions/webmcp";
 import useCurrentTeam from "~/hooks/useCurrentTeam";
 import useKeyDown from "~/hooks/useKeyDown";
+import useWebMCPActions from "~/hooks/useWebMCPActions";
 import { usePostLoginPath } from "~/hooks/useLastVisitedPath";
 import usePolicy from "~/hooks/usePolicy";
 import useStores from "~/hooks/useStores";
@@ -45,6 +47,7 @@ const AuthenticatedLayout: React.FC = ({ children }: Props) => {
   const [spendPostLoginPath] = usePostLoginPath();
 
   useKeyDown(".", () => ui.toggleCollapsedSidebar(), { metaKey: true });
+  useWebMCPActions(rootWebMCPActions);
 
   const goToSearch = (ev: KeyboardEvent) => {
     if (!ev.metaKey && !ev.ctrlKey) {

--- a/app/components/CommandBar/useRecentDocumentActions.tsx
+++ b/app/components/CommandBar/useRecentDocumentActions.tsx
@@ -46,6 +46,7 @@ const useRecentDocumentActions = (count = recentDocumentCount) => {
           name: item.titleWithDefault,
           analyticsName: "Recently viewed document",
           section: RecentSection,
+          visible: ({ isMCP }) => !isMCP,
           description: documentBreadcrumbText(item, t),
           icon: item.icon ? (
             <Icon

--- a/app/components/CommandBar/useTemplatesAction.tsx
+++ b/app/components/CommandBar/useTemplatesAction.tsx
@@ -36,7 +36,10 @@ const useTemplatesAction = () => {
             <NewDocumentIcon />
           ),
           keywords: "create",
-          visible: ({ currentTeamId, activeCollectionId, stores }) => {
+          visible: ({ currentTeamId, activeCollectionId, stores, isMCP }) => {
+            if (isMCP) {
+              return false;
+            }
             if (activeCollectionId) {
               return (
                 stores.policies.abilities(activeCollectionId).createDocument &&

--- a/app/components/SearchActions.tsx
+++ b/app/components/SearchActions.tsx
@@ -92,6 +92,7 @@ function SearchActions() {
           keywords: searchQuery,
           analyticsName: "Open search result",
           section: SearchResultsSection,
+          visible: ({ isMCP }) => !isMCP,
           priority: toActionPriority(index, results.length),
           icon: <SearchResultIcon document={result.document} />,
           badge: result.document.isArchived ? (

--- a/app/hooks/useCommandBarActions.ts
+++ b/app/hooks/useCommandBarActions.ts
@@ -4,10 +4,12 @@ import { useLocation } from "react-router-dom";
 import { actionToKBar } from "~/actions";
 import type { ActionVariant } from "~/types";
 import useActionContext from "./useActionContext";
+import useWebMCPActions from "./useWebMCPActions";
 
 /**
  * Hook to add actions to the command bar while the hook is inside a mounted
- * component.
+ * component. The same actions are also exposed as WebMCP tools in supported
+ * browsers.
  *
  * @param actions actions to make available
  */
@@ -19,6 +21,8 @@ export default function useCommandBarActions(
   const context = useActionContext({
     isCommandBar: true,
   });
+
+  useWebMCPActions(actions, additionalDeps);
 
   const registerable = flattenDeep(
     actions.map((action) => actionToKBar(action, context))

--- a/app/hooks/useWebMCPActions.ts
+++ b/app/hooks/useWebMCPActions.ts
@@ -1,0 +1,137 @@
+import { snakeCase } from "es-toolkit";
+import * as React from "react";
+import { useLocation } from "react-router-dom";
+import { TeamPreference } from "@shared/types";
+import { performAction, resolve } from "~/actions";
+import type {
+  ActionContext,
+  ActionGroup,
+  ActionSeparator,
+  ActionVariant,
+  ActionWithChildren,
+} from "~/types";
+import {
+  isModelContextSupported,
+  registerModelContextTool,
+} from "~/utils/ModelContext";
+import useActionContext from "./useActionContext";
+import useStores from "./useStores";
+
+type PerformableAction = Exclude<ActionVariant, ActionWithChildren>;
+
+/**
+ * Hook to expose actions as WebMCP tools while the hook is inside a mounted
+ * component. Tools are unregistered automatically on unmount or navigation.
+ *
+ * @param actions actions to make available as tools.
+ */
+export default function useWebMCPActions(
+  actions: ActionVariant[],
+  additionalDeps: React.DependencyList = []
+) {
+  const location = useLocation();
+  const { auth } = useStores();
+  const context = useActionContext({ isMCP: true });
+
+  const enabled =
+    isModelContextSupported() && !!auth.team?.getPreference(TeamPreference.MCP);
+
+  const performable = enabled ? flattenActions(actions, context) : [];
+  const toolNames = performable.map((action) =>
+    snakeCase(action.analyticsName ?? "")
+  );
+
+  // Refs keep `execute` callbacks working against the latest context and
+  // action list without re-registering tools on every render.
+  const contextRef = React.useRef(context);
+  contextRef.current = context;
+  const performableRef = React.useRef(performable);
+  performableRef.current = performable;
+
+  React.useEffect(() => {
+    if (!enabled || performableRef.current.length === 0) {
+      return;
+    }
+
+    const controller = new AbortController();
+
+    for (const action of performableRef.current) {
+      const ctx = contextRef.current;
+      const name = snakeCase(action.analyticsName ?? "");
+      const title = resolve<React.ReactNode>(action.name, ctx);
+      const description =
+        resolve<string | undefined>(action.description, ctx) ??
+        (typeof title === "string" ? title : action.analyticsName);
+
+      if (!name || !description) {
+        continue;
+      }
+
+      registerModelContextTool(
+        {
+          name,
+          description,
+          inputSchema: action.mcp?.inputSchema,
+          execute: async (args) => {
+            const result = await performAction(action, {
+              ...contextRef.current,
+              mcpArgs: args,
+            });
+            return {
+              content: [
+                {
+                  type: "text",
+                  text:
+                    typeof result === "string"
+                      ? result
+                      : result === undefined
+                        ? "Done"
+                        : JSON.stringify(result),
+                },
+              ],
+            };
+          },
+        },
+        controller.signal
+      );
+    }
+
+    return () => controller.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, toolNames.join(","), location.pathname, ...additionalDeps]);
+}
+
+function flattenActions(
+  actions: (ActionVariant | ActionGroup | ActionSeparator)[],
+  context: ActionContext
+): PerformableAction[] {
+  const result: PerformableAction[] = [];
+
+  for (const action of actions) {
+    if (action.type === "action_separator") {
+      continue;
+    }
+    if (action.type === "action_group") {
+      result.push(...flattenActions(action.actions, context));
+      continue;
+    }
+    if (resolve<boolean>(action.visible, context) === false) {
+      continue;
+    }
+    if (action.variant === "action_with_children") {
+      const children = resolve<
+        (ActionVariant | ActionGroup | ActionSeparator)[]
+      >(action.children, context);
+      result.push(...flattenActions(children, context));
+      continue;
+    }
+    if (action.variant === "action" && action.dangerous) {
+      continue;
+    }
+    if (action.analyticsName) {
+      result.push(action);
+    }
+  }
+
+  return result;
+}

--- a/app/hooks/useWebMCPActions.ts
+++ b/app/hooks/useWebMCPActions.ts
@@ -2,6 +2,7 @@ import { snakeCase } from "es-toolkit";
 import * as React from "react";
 import { useLocation } from "react-router-dom";
 import { TeamPreference } from "@shared/types";
+import { toError } from "@shared/utils/error";
 import { performAction, resolve } from "~/actions";
 import type {
   ActionContext,
@@ -73,23 +74,30 @@ export default function useWebMCPActions(
           description,
           inputSchema: action.mcp?.inputSchema,
           execute: async (args) => {
-            const result = await performAction(action, {
-              ...contextRef.current,
-              mcpArgs: args,
-            });
-            return {
-              content: [
-                {
-                  type: "text",
-                  text:
-                    typeof result === "string"
-                      ? result
-                      : result === undefined
-                        ? "Done"
-                        : JSON.stringify(result),
-                },
-              ],
-            };
+            try {
+              const result = await performAction(action, {
+                ...contextRef.current,
+                mcpArgs: args,
+              });
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text:
+                      typeof result === "string"
+                        ? result
+                        : result === undefined
+                          ? "Done"
+                          : JSON.stringify(result),
+                  },
+                ],
+              };
+            } catch (err) {
+              return {
+                isError: true,
+                content: [{ type: "text", text: toError(err).message }],
+              };
+            }
           },
         },
         controller.signal

--- a/app/types.ts
+++ b/app/types.ts
@@ -108,6 +108,10 @@ export type ActionContext = {
   isMenu: boolean;
   isCommandBar: boolean;
   isButton: boolean;
+  /** True when the action runs as a WebMCP tool invoked by an agent. */
+  isMCP?: boolean;
+  /** Arguments supplied by an agent when the action runs as a WebMCP tool. */
+  mcpArgs?: Record<string, unknown>;
   sidebarContext?: SidebarContextType;
 
   // Legacy (backward compatibility) - returns primary active model's ID
@@ -154,6 +158,11 @@ type BaseAction = {
   selected?: ((context: ActionContext) => boolean) | boolean;
   visible?: ((context: ActionContext) => boolean) | boolean;
   disabled?: ((context: ActionContext) => boolean) | boolean;
+  /** Configuration for exposing the action as a WebMCP tool. */
+  mcp?: {
+    /** JSON Schema describing the tool arguments, passed as `mcpArgs`. */
+    inputSchema?: Record<string, unknown>;
+  };
 };
 
 export type Action = BaseAction & {

--- a/app/utils/ModelContext.test.ts
+++ b/app/utils/ModelContext.test.ts
@@ -1,0 +1,85 @@
+import { vi } from "vitest";
+import {
+  isModelContextSupported,
+  registerModelContextTool,
+  type ModelContextTool,
+} from "./ModelContext";
+
+const makeTool = (name: string): ModelContextTool => ({
+  name,
+  description: "A test tool",
+  execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+});
+
+describe("ModelContext", () => {
+  afterEach(() => {
+    delete window.document.modelContext;
+  });
+
+  describe("#isModelContextSupported", () => {
+    it("should return false when the API is unavailable", () => {
+      expect(isModelContextSupported()).toBe(false);
+    });
+
+    it("should return true when the API is available", () => {
+      window.document.modelContext = { registerTool: vi.fn() };
+      expect(isModelContextSupported()).toBe(true);
+    });
+  });
+
+  describe("#registerModelContextTool", () => {
+    it("should return false when the API is unavailable", () => {
+      const controller = new AbortController();
+      expect(registerModelContextTool(makeTool("one"), controller.signal)).toBe(
+        false
+      );
+    });
+
+    it("should register a tool and skip duplicate names", () => {
+      const registerTool = vi.fn();
+      window.document.modelContext = { registerTool };
+      const controller = new AbortController();
+
+      expect(registerModelContextTool(makeTool("two"), controller.signal)).toBe(
+        true
+      );
+      expect(registerModelContextTool(makeTool("two"), controller.signal)).toBe(
+        false
+      );
+      expect(registerTool).toHaveBeenCalledTimes(1);
+
+      controller.abort();
+    });
+
+    it("should allow re-registration after the signal aborts", () => {
+      const registerTool = vi.fn();
+      window.document.modelContext = { registerTool };
+
+      const first = new AbortController();
+      expect(registerModelContextTool(makeTool("three"), first.signal)).toBe(
+        true
+      );
+      first.abort();
+
+      const second = new AbortController();
+      expect(registerModelContextTool(makeTool("three"), second.signal)).toBe(
+        true
+      );
+      expect(registerTool).toHaveBeenCalledTimes(2);
+
+      second.abort();
+    });
+
+    it("should not register when the signal is already aborted", () => {
+      const registerTool = vi.fn();
+      window.document.modelContext = { registerTool };
+      const controller = new AbortController();
+      controller.abort();
+
+      expect(
+        registerModelContextTool(makeTool("four"), controller.signal)
+      ).toBe(false);
+      expect(registerTool).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/utils/ModelContext.test.ts
+++ b/app/utils/ModelContext.test.ts
@@ -70,6 +70,24 @@ describe("ModelContext", () => {
       second.abort();
     });
 
+    it("should free the name when async registration rejects", async () => {
+      const registerTool = vi.fn().mockRejectedValue(new Error("rejected"));
+      window.document.modelContext = { registerTool };
+
+      const first = new AbortController();
+      expect(registerModelContextTool(makeTool("five"), first.signal)).toBe(
+        true
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const second = new AbortController();
+      expect(registerModelContextTool(makeTool("five"), second.signal)).toBe(
+        true
+      );
+
+      second.abort();
+    });
+
     it("should not register when the signal is already aborted", () => {
       const registerTool = vi.fn();
       window.document.modelContext = { registerTool };

--- a/app/utils/ModelContext.ts
+++ b/app/utils/ModelContext.ts
@@ -1,0 +1,93 @@
+import Logger from "~/utils/Logger";
+
+/** A content block returned from a WebMCP tool execution. */
+export interface ModelContextContent {
+  type: "text";
+  text: string;
+}
+
+/** The result payload returned from a WebMCP tool execution. */
+export interface ModelContextToolResult {
+  content: ModelContextContent[];
+  isError?: boolean;
+}
+
+/** A tool descriptor for registration with the browser's model context. */
+export interface ModelContextTool {
+  /** Unique tool identifier, e.g. "star_document". */
+  name: string;
+  /** Natural language description of the tool for agents. */
+  description: string;
+  /** JSON Schema describing the tool arguments. */
+  inputSchema?: Record<string, unknown>;
+  /** Callback invoked when an agent runs the tool. */
+  execute: (
+    args: Record<string, unknown>,
+    options?: { signal?: AbortSignal }
+  ) => Promise<ModelContextToolResult>;
+}
+
+interface ModelContext {
+  registerTool: (
+    tool: ModelContextTool,
+    options?: { signal?: AbortSignal }
+  ) => void | Promise<void>;
+}
+
+declare global {
+  interface Document {
+    /** Experimental WebMCP API, shipping behind a flag in Chrome 146+. */
+    modelContext?: ModelContext;
+  }
+}
+
+/**
+ * Returns true when the browser supports the WebMCP model context API.
+ *
+ * @returns true when `document.modelContext` is available.
+ */
+export function isModelContextSupported(): boolean {
+  return typeof window.document.modelContext?.registerTool === "function";
+}
+
+/**
+ * Registers a tool with the browser's model context, skipping registration
+ * when the API is unavailable or a tool with the same name is already
+ * registered elsewhere in the app.
+ *
+ * @param tool the tool descriptor to register.
+ * @param signal aborting the signal unregisters the tool.
+ * @returns true when the tool was registered.
+ */
+export function registerModelContextTool(
+  tool: ModelContextTool,
+  signal: AbortSignal
+): boolean {
+  if (
+    !isModelContextSupported() ||
+    signal.aborted ||
+    registeredToolNames.has(tool.name)
+  ) {
+    return false;
+  }
+
+  registeredToolNames.add(tool.name);
+  signal.addEventListener(
+    "abort",
+    () => registeredToolNames.delete(tool.name),
+    { once: true }
+  );
+
+  try {
+    void window.document.modelContext?.registerTool(tool, { signal });
+  } catch (_err) {
+    Logger.warn("Failed to register WebMCP tool", { name: tool.name });
+    registeredToolNames.delete(tool.name);
+    return false;
+  }
+
+  return true;
+}
+
+/** Names of tools currently registered, to prevent duplicate registration. */
+const registeredToolNames = new Set<string>();

--- a/app/utils/ModelContext.ts
+++ b/app/utils/ModelContext.ts
@@ -79,7 +79,15 @@ export function registerModelContextTool(
   );
 
   try {
-    void window.document.modelContext?.registerTool(tool, { signal });
+    const result = window.document.modelContext?.registerTool(tool, {
+      signal,
+    });
+    if (result instanceof Promise) {
+      result.catch(() => {
+        Logger.warn("Failed to register WebMCP tool", { name: tool.name });
+        registeredToolNames.delete(tool.name);
+      });
+    }
   } catch (_err) {
     Logger.warn("Failed to register WebMCP tool", { name: tool.name });
     registeredToolNames.delete(tool.name);


### PR DESCRIPTION
Adds experimental support for the draft [WebMCP browser standard](https://github.com/webmachinelearning/webmcp), which lets in-page agents discover and call structured tools via `document.modelContext`.

- Typed wrapper for the experimental API with feature detection and duplicate-name protection
- Actions registered to the command bar are mirrored as WebMCP tools, using the same visibility checks and context; tools unregister on unmount or navigation
- Dangerous actions (deletes, etc.) are excluded
- New MCP-only actions: get_current_context and search_workspace, registered in the authenticated layout only
- Gated behind the existing MCP team preference, and analytics record a webmcp action context

Requires Chrome 146+ with the WebMCP flag enabled.