### PR TITLE
perf: Read deletion candidates from the replica in CleanupDeletedDocumentsTask

### DIFF
--- a/server/commands/documentPermanentDeleter.test.ts
+++ b/server/commands/documentPermanentDeleter.test.ts
@@ -215,4 +215,43 @@ describe("documentPermanentDeleter", () => {
       })
     ).toEqual(1);
   });
+
+  it("should not touch documents restored since they were read", async () => {
+    const document = await buildDocument({
+      publishedAt: subDays(new Date(), 90),
+      deletedAt: new Date(),
+    });
+    const attachment = await buildAttachment({
+      teamId: document.teamId,
+      documentId: document.id,
+    });
+    document.text = `![text](${attachment.redirectUrl})`;
+    await document.save();
+
+    // Restore in the database only, leaving the in-memory record as the caller
+    // read it. Stands in for a restore that a replica has not yet caught up to.
+    await Document.unscoped().update(
+      { deletedAt: null },
+      { where: { id: document.id }, paranoid: false }
+    );
+
+    const countDeletedDoc = await documentPermanentDeleter([document]);
+    expect(countDeletedDoc).toEqual(0);
+    expect(schedule).not.toHaveBeenCalled();
+    expect(
+      await Attachment.count({
+        where: {
+          teamId: document.teamId,
+        },
+      })
+    ).toEqual(1);
+    expect(
+      await Document.unscoped().count({
+        where: {
+          teamId: document.teamId,
+        },
+        paranoid: false,
+      })
+    ).toEqual(1);
+  });
 });

--- a/server/commands/documentPermanentDeleter.ts
+++ b/server/commands/documentPermanentDeleter.ts
@@ -17,6 +17,29 @@ export default async function documentPermanentDeleter(documents: Document[]) {
     );
   }
 
+  if (documents.length === 0) {
+    return 0;
+  }
+
+  // Re-check deletedAt on the primary to exclude documents that were restored
+  // between the caller's query and now. The caller may have read its candidates
+  // from a read replica, so this has to happen before anything irreversible:
+  // scheduling an attachment for deletion, or clearing parentDocumentId and
+  // detaching the children of a restored parent.
+  const stillDeleted = await Document.unscoped().findAll({
+    attributes: ["id"],
+    where: {
+      id: documents.map((document) => document.id),
+      deletedAt: { [Op.ne]: null },
+    },
+    paranoid: false,
+  });
+  const stillDeletedIds = new Set(stillDeleted.map((document) => document.id));
+  const deletedDocuments = documents.filter((document) =>
+    stillDeletedIds.has(document.id)
+  );
+  const deletedIds = deletedDocuments.map((document) => document.id);
+
   const query = `
     SELECT COUNT(id)
     FROM documents
@@ -25,7 +48,7 @@ export default async function documentPermanentDeleter(documents: Document[]) {
     "id" != :documentId
   `;
 
-  for (const document of documents) {
+  for (const document of deletedDocuments) {
     // Find any attachments that are referenced in the text content
     const attachmentIdsInText = ProsemirrorHelper.parseAttachmentIds(
       DocumentHelper.toProsemirror(document)
@@ -76,21 +99,6 @@ export default async function documentPermanentDeleter(documents: Document[]) {
       })
     );
   }
-
-  const documentIds = documents.map((document) => document.id);
-
-  // Re-check deletedAt in the database to exclude documents that were restored
-  // between the caller's query and now. Otherwise the parentDocumentId clear
-  // below would detach children of a restored parent, breaking the hierarchy.
-  const stillDeleted = await Document.unscoped().findAll({
-    attributes: ["id"],
-    where: {
-      id: documentIds,
-      deletedAt: { [Op.ne]: null },
-    },
-    paranoid: false,
-  });
-  const deletedIds = stillDeleted.map((document) => document.id);
 
   for (const batch of chunk(deletedIds, 100)) {
     // Unscoped so that drafts and templates are detached too, otherwise the

--- a/server/commands/documentPermanentDeleter.ts
+++ b/server/commands/documentPermanentDeleter.ts
@@ -22,10 +22,7 @@ export default async function documentPermanentDeleter(documents: Document[]) {
   }
 
   // Re-check deletedAt on the primary to exclude documents that were restored
-  // between the caller's query and now. The caller may have read its candidates
-  // from a read replica, so this has to happen before anything irreversible:
-  // scheduling an attachment for deletion, or clearing parentDocumentId and
-  // detaching the children of a restored parent.
+  // between the caller's query and now.
   const stillDeleted = await Document.unscoped().findAll({
     attributes: ["id"],
     where: {

--- a/server/queues/tasks/CleanupDeletedDocumentsTask.ts
+++ b/server/queues/tasks/CleanupDeletedDocumentsTask.ts
@@ -1,8 +1,8 @@
 import { subDays } from "date-fns";
-import { Op } from "sequelize";
 import documentPermanentDeleter from "@server/commands/documentPermanentDeleter";
 import Logger from "@server/logging/Logger";
 import { Document } from "@server/models";
+import { sequelizeReadOnly } from "@server/storage/database";
 import { TaskPriority } from "./base/BaseTask";
 import { Minute } from "@shared/utils/time";
 import type { Props } from "./base/CronTask";
@@ -14,17 +14,38 @@ export default class CleanupDeletedDocumentsTask extends CronTask {
       "task",
       `Permanently destroying upto ${limit} documents older than 30 days…`
     );
-    const documents = await Document.unscoped().findAll({
-      attributes: ["id", "teamId", "deletedAt", "content", "state", "text"],
-      where: {
-        deletedAt: {
-          [Op.lt]: subDays(new Date(), 30),
+
+    const [startId, endId] = this.getPartitionBounds(partition);
+
+    // Candidates are read from the replica, the deletion itself still runs on
+    // the primary.
+    const documents = await sequelizeReadOnly.query(
+      `
+      SELECT
+        "id",
+        "teamId",
+        "deletedAt",
+        "content",
+        CASE WHEN "content" IS NULL THEN "state" END AS "state",
+        CASE WHEN "content" IS NULL AND "state" IS NULL THEN "text" END AS "text"
+      FROM "documents"
+      WHERE "deletedAt" < :threshold
+        AND "id" >= :startId::uuid
+        AND "id" <= :endId::uuid
+      LIMIT :limit
+      `,
+      {
+        replacements: {
+          threshold: subDays(new Date(), 30),
+          startId,
+          endId,
+          limit,
         },
-        ...this.getPartitionWhereClause("id", partition),
-      },
-      paranoid: false,
-      limit,
-    });
+        model: Document,
+        mapToModel: true,
+      }
+    );
+
     const countDeletedDocument = await documentPermanentDeleter(documents);
     Logger.info("task", `Destroyed ${countDeletedDocument} documents`);
   }


### PR DESCRIPTION
The hourly deleted-document cleanup was one of the largest consumers of read IOPS on the production primary, which is currently saturated at its provisioned ceiling.

- Moves the candidate scan to the read replica; the permanent deletion still runs on the primary
- Loads only the first body representation `toProsemirror` would actually use, instead of `content`, `state` and `text` together — all three are TOASTed, so each run was pulling three copies of every document body off disk

Replica lag is already safe here: `documentPermanentDeleter` re-checks `deletedAt` on the primary before detaching children, and the destroy is guarded the same way.