### PR TITLE
fix: Raise OAuth redirect_uris limit and log client errors

### DIFF
--- a/server/routes/oauth/middlewares/oauthErrorHandler.ts
+++ b/server/routes/oauth/middlewares/oauthErrorHandler.ts
@@ -4,6 +4,12 @@ import {
   EmptyResultError as SequelizeEmptyResultError,
 } from "sequelize";
 import { errToString } from "@shared/utils/error";
+import Logger from "@server/logging/Logger";
+
+interface OAuthErrorBody {
+  error: string;
+  error_description: string;
+}
 
 /** Extract the first numeric status-like property from an unknown error. */
 function statusCodeFromError(err: unknown): number {
@@ -31,36 +37,47 @@ export default function oauthErrorHandler() {
     try {
       await next();
     } catch (err) {
+      let status: number;
+      let body: OAuthErrorBody;
+
       if (err instanceof SequelizeEmptyResultError) {
-        ctx.status = 404;
-        ctx.body = {
+        status = 404;
+        body = {
           error: "invalid_request",
           error_description: "Resource not found",
         };
-        return;
-      }
-      if (err instanceof SequelizeValidationError) {
-        ctx.status = 400;
-        ctx.body = {
+      } else if (err instanceof SequelizeValidationError) {
+        status = 400;
+        body = {
           error: "invalid_request",
           error_description: err.errors[0].message,
         };
-        return;
+      } else {
+        status = statusCodeFromError(err);
+        // Map common HTTP status codes to OAuth error types
+        let errorType = "server_error";
+        if (status === 400) {
+          errorType = "invalid_request";
+        } else if (status === 401) {
+          errorType = "invalid_client";
+        }
+
+        body = {
+          error: errorType,
+          error_description: errToString(err),
+        };
       }
 
-      ctx.status = statusCodeFromError(err);
-      // Map common HTTP status codes to OAuth error types
-      let errorType = "server_error";
-      if (ctx.status === 400) {
-        errorType = "invalid_request";
-      } else if (ctx.status === 401) {
-        errorType = "invalid_client";
-      }
+      ctx.status = status;
+      ctx.body = body;
 
-      ctx.body = {
-        error: errorType,
-        error_description: errToString(err),
-      };
+      if (status < 500) {
+        Logger.info("authentication", "OAuth request rejected", {
+          path: ctx.path,
+          status,
+          ...body,
+        });
+      }
     }
   };
 }

--- a/server/routes/oauth/oauth.test.ts
+++ b/server/routes/oauth/oauth.test.ts
@@ -1,6 +1,7 @@
 import { faker } from "@faker-js/faker";
 import sharedEnv from "@shared/env";
 import { TeamPreference } from "@shared/types";
+import { OAuthClientValidation } from "@shared/validations";
 import env from "@server/env";
 import { OAuthClient } from "@server/models";
 import {
@@ -154,6 +155,46 @@ describe("#oauth.register", () => {
     });
 
     expect(res.status).toEqual(400);
+  });
+
+  it("should allow the maximum number of redirect_uris", async () => {
+    const res = await server.post("/oauth/register", {
+      body: {
+        client_name: "Test Client",
+        redirect_uris: Array.from(
+          { length: OAuthClientValidation.maxRedirectUris },
+          (_, index) => `https://example.com/callback/${index}`
+        ),
+      },
+      headers: {
+        host: `${subdomain}.outline.dev`,
+      },
+    });
+
+    expect(res.status).toEqual(201);
+  });
+
+  it("should reject too many redirect_uris and report the received count", async () => {
+    const count = OAuthClientValidation.maxRedirectUris + 1;
+    const res = await server.post("/oauth/register", {
+      body: {
+        client_name: "Test Client",
+        redirect_uris: Array.from(
+          { length: count },
+          (_, index) => `https://example.com/callback/${index}`
+        ),
+      },
+      headers: {
+        host: `${subdomain}.outline.dev`,
+      },
+    });
+
+    expect(res.status).toEqual(400);
+    const body = await res.json();
+    expect(body.error).toEqual("invalid_request");
+    expect(body.error_description).toEqual(
+      `redirect_uris: expected array to have <=${OAuthClientValidation.maxRedirectUris} items, received ${count}`
+    );
   });
 
   it("should reject unsupported grant types", async () => {

--- a/server/routes/oauth/schema.ts
+++ b/server/routes/oauth/schema.ts
@@ -25,6 +25,18 @@ export const TokenRevokeSchema = BaseSchema.extend({
 
 export type TokenRevokeReq = z.infer<typeof TokenRevokeSchema>;
 
+// The received count is included in the message so that clients registering an
+// oversized list, and our own logs, show how far over the limit they are.
+const redirectUris = z
+  .array(z.url().max(OAuthClientValidation.maxRedirectUriLength))
+  .min(1)
+  .max(OAuthClientValidation.maxRedirectUris, {
+    error: (issue) =>
+      `expected array to have <=${OAuthClientValidation.maxRedirectUris} items, received ${
+        Array.isArray(issue.input) ? issue.input.length : "unknown"
+      }`,
+  });
+
 export const RegisterSchema = BaseSchema.extend({
   body: z.object({
     // RFC 7591 §2 marks every metadata field as OPTIONAL; some MCP clients
@@ -35,10 +47,7 @@ export const RegisterSchema = BaseSchema.extend({
       .min(1)
       .max(OAuthClientValidation.maxNameLength)
       .optional(),
-    redirect_uris: z
-      .array(z.url().max(OAuthClientValidation.maxRedirectUriLength))
-      .min(1)
-      .max(10),
+    redirect_uris: redirectUris,
     grant_types: z
       .array(z.enum(["authorization_code", "refresh_token"]))
       .default(["authorization_code"]),
@@ -66,10 +75,7 @@ export type RegisterReq = z.infer<typeof RegisterSchema>;
 export const RegisterUpdateSchema = BaseSchema.extend({
   body: z.object({
     client_name: z.string().min(1).max(OAuthClientValidation.maxNameLength),
-    redirect_uris: z
-      .array(z.url().max(OAuthClientValidation.maxRedirectUriLength))
-      .min(1)
-      .max(10),
+    redirect_uris: redirectUris,
     client_uri: z
       .string()
       .url()

--- a/shared/validations.ts
+++ b/shared/validations.ts
@@ -116,6 +116,9 @@ export const OAuthClientValidation = {
   /** The maximum length of an OAuth client redirect URI */
   maxRedirectUriLength: 1024,
 
+  /** The maximum number of redirect URIs for an OAuth client */
+  maxRedirectUris: 20,
+
   /** The allowed OAuth client types */
   clientTypes: ["confidential", "public"] as const,
 };


### PR DESCRIPTION
Dynamic client registration rejected any client sending more than 10 redirect URIs, with an error that didn't say how many were received.

- Raise the redirect URI limit to 20, shared between the register and update schemas so a client that registers can also be updated
- Report the received count in the too-many error
- Log OAuth 4xx responses with their reason — client errors were previously swallowed, so a failing integration was invisible beyond a status code