### PR TITLE
fix: Prevent overlapping nested list markers

### DIFF
--- a/shared/editor/lib/listInputRule.test.ts
+++ b/shared/editor/lib/listInputRule.test.ts
@@ -6,7 +6,7 @@ import {
   p,
   schema,
 } from "@shared/test/editor";
-import { checkboxListInputRule } from "./listInputRule";
+import { checkboxListInputRule, listWrappingInputRule } from "./listInputRule";
 
 const { bullet_list, ordered_list, list_item, checkbox_list, checkbox_item } =
   schema.nodes;
@@ -80,6 +80,48 @@ const rule = checkboxListInputRule(
   checkbox_list,
   checkbox_item
 );
+
+const bulletRule = listWrappingInputRule(/^\s*([-+*])\s$/, bullet_list);
+const orderedRule = listWrappingInputRule(
+  /^(\d+)\.\s$/,
+  ordered_list,
+  (match) => ({ order: Number(match[1]), listStyle: "number" })
+);
+
+describe("listWrappingInputRule", () => {
+  it("exits a list when the same marker is typed into an empty item", () => {
+    const testDoc = doc([bullet_list.create(null, [li([p("*")])])]);
+
+    const result = typeTrigger(bulletRule, testDoc, "*", " ");
+
+    expect(result.doc.childCount).toBe(1);
+    expect(result.doc.firstChild?.type.name).toBe("paragraph");
+    expect(result.doc.textContent).toBe("");
+  });
+
+  it("converts a list when a different marker is typed into an empty item", () => {
+    const testDoc = doc([bullet_list.create(null, [li([p("1.")])])]);
+
+    const result = typeTrigger(orderedRule, testDoc, "1.", " ");
+
+    expect(result.doc.childCount).toBe(1);
+    expect(result.doc.firstChild?.type.name).toBe("ordered_list");
+    expect(result.doc.firstChild?.firstChild?.type.name).toBe("list_item");
+    expect(result.doc.textContent).toBe("");
+  });
+
+  it("allows a nested list after content in the parent item", () => {
+    const testDoc = doc([
+      bullet_list.create(null, [li([p("parent"), p("*")])]),
+    ]);
+
+    const result = typeTrigger(bulletRule, testDoc, "*", " ");
+
+    const item = result.doc.firstChild?.firstChild;
+    expect(item?.child(0).textContent).toBe("parent");
+    expect(item?.child(1).type.name).toBe("bullet_list");
+  });
+});
 
 describe("checkboxListInputRule", () => {
   it("converts a plain bullet list to a checklist", () => {

--- a/shared/editor/lib/listInputRule.ts
+++ b/shared/editor/lib/listInputRule.ts
@@ -30,6 +30,35 @@ export function listWrappingInputRule(
       return null;
     }
 
+    const { $from } = state.selection;
+    const itemType = state.schema.nodes.list_item;
+    const parent = $from.node(-1);
+    if (itemType && parent.type === itemType && $from.index(-1) === 0) {
+      // Wrapping a list item's first block creates an empty parent item whose
+      // marker overlaps the nested list marker. Convert or exit the current
+      // list instead.
+      const tr = state.tr.delete(start, end);
+      const after = state.apply(tr);
+      let handled = false;
+      let selection = after.selection;
+      toggleList(nodeType, itemType)(after, (toggleTr) => {
+        toggleTr.steps.forEach((step) => tr.step(step));
+        selection = toggleTr.selection;
+        handled = true;
+      });
+
+      if (!handled) {
+        return null;
+      }
+
+      tr.setSelection(
+        TextSelection.near(
+          tr.doc.resolve(Math.min(selection.from, tr.doc.content.size))
+        )
+      );
+      return tr;
+    }
+
     // Otherwise, execute the original wrappingInputRule handler
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return (rule as any).handler(state, match, start, end);


### PR DESCRIPTION
This fixes list markers that overlap when starting another list from an empty list item.

## Expected behavior

- Entering `* ` in an empty bullet-list item should exit the current list.
- Entering `1. ` in an empty bullet-list item should replace it with an ordered list.
- Starting a list after existing content should still create a nested list.

## Actual behavior

The input rule treats the first empty paragraph inside a list item as the beginning of a nested list.

The original list item remains empty while the new list is created inside it, so the outer and inner markers appear in the same position.

## Changes

- `shared/editor/lib/listInputRule.ts`
  - Handle list markers entered in the first block of an existing list item.
  - Use the existing list command to exit the current list or change its type.
  - Keep the existing nested-list behavior for blocks after content.

- `shared/editor/lib/listInputRule.test.ts`
  - Cover `* ` in an empty bullet-list item.
  - Cover `1. ` in an empty bullet-list item.
  - Confirm that lists created after existing content remain nested.