### PR TITLE
fix: Preserve MCP attachment form values

### DIFF
--- a/server/tools/attachments.ts
+++ b/server/tools/attachments.ts
@@ -147,7 +147,7 @@ export function attachmentTools(server: McpServer, scopes: string[]) {
               };
 
               const formArgs = Object.entries(form)
-                .map(([k, v]) => `-F '${k}=${v}'`)
+                .map(([k, v]) => `--form-string '${k}=${v}'`)
                 .join(" ");
               const curlCommand = `curl -X POST ${formArgs} -F 'file=@/path/to/file' '${uploadUrl}'`;
 

--- a/server/tools/attachments.ts
+++ b/server/tools/attachments.ts
@@ -175,5 +175,5 @@ export function attachmentTools(server: McpServer, scopes: string[]) {
 }
 
 function quoteShellArgument(value: string) {
-  return `'${value.replaceAll("'", "'\\''")}'`;
+  return `'${value.replace(/'/g, "'\\''")}'`;
 }

--- a/server/tools/attachments.ts
+++ b/server/tools/attachments.ts
@@ -147,7 +147,9 @@ export function attachmentTools(server: McpServer, scopes: string[]) {
               };
 
               const formArgs = Object.entries(form)
-                .map(([k, v]) => `--form-string '${k}=${v}'`)
+                .map(
+                  ([k, v]) => `--form-string ${quoteShellArgument(`${k}=${v}`)}`
+                )
                 .join(" ");
               const curlCommand = `curl -X POST ${formArgs} -F 'file=@/path/to/file' '${uploadUrl}'`;
 
@@ -170,4 +172,8 @@ export function attachmentTools(server: McpServer, scopes: string[]) {
       )
     );
   }
+}
+
+function quoteShellArgument(value: string) {
+  return `'${value.replaceAll("'", "'\\''")}'`;
 }


### PR DESCRIPTION
- Use `--form-string` for presigned POST metadata so curl sends exact field values.
- Keep `-F` for file body uploads.
- closes #13595