### PR TITLE
fix: Match PWA chrome to active theme

### DIFF
--- a/app/components/PageTheme.ts
+++ b/app/components/PageTheme.ts
@@ -2,12 +2,18 @@ import { useEffect } from "react";
 import { useTheme } from "styled-components";
 import { light } from "@shared/styles/theme";
 
+/**
+ * Synchronizes browser page colors with the active application theme.
+ *
+ * @returns null.
+ */
 export default function PageTheme() {
   const theme = useTheme();
+  const { background, isDark } = theme;
 
   useEffect(() => {
-    // theme-color adjusts the title bar color for desktop PWA
-    const themeElement = document.querySelector('meta[name="theme-color"]');
+    // theme-color adjusts the browser chrome for installed PWAs
+    const themeElements = document.querySelectorAll('meta[name="theme-color"]');
 
     // color-scheme controls user-agent controls, scrollbars and the page canvas
     const colorSchemeElement = document.querySelector(
@@ -19,17 +25,19 @@ export default function PageTheme() {
       if (document.body) {
         document.body.style.background = background;
       }
-      themeElement?.setAttribute("content", background);
+      themeElements.forEach((element) => {
+        element.setAttribute("content", background);
+      });
       colorSchemeElement?.setAttribute("content", isDark ? "dark" : "light");
     };
 
-    applyTheme(theme.background, theme.isDark);
+    applyTheme(background, isDark);
 
     const handleChange = (event: MediaQueryListEvent) => {
       if (event.matches) {
         applyTheme(light.background, false);
       } else {
-        applyTheme(theme.background, theme.isDark);
+        applyTheme(background, isDark);
       }
     };
 
@@ -39,7 +47,7 @@ export default function PageTheme() {
     const mediaQuery = window.matchMedia("print");
     mediaQuery.addEventListener("change", handleChange);
     return () => mediaQuery.removeEventListener("change", handleChange);
-  }, [theme]);
+  }, [background, isDark]);
 
   return null;
 }

--- a/app/stores/UiStore.ts
+++ b/app/stores/UiStore.ts
@@ -16,6 +16,8 @@ import { startViewTransition } from "~/utils/viewTransition";
 import type RootStore from "./RootStore";
 
 const UI_STORE = "UI_STORE";
+// Used by the static page before the UI store is available.
+const THEME_STORAGE_KEY = "theme";
 
 export enum Theme {
   Light = "light",
@@ -175,6 +177,7 @@ class UiStore {
     this.tocVisible = data.tocVisible;
     this.rightSidebar = data.rightSidebar ?? null;
     this.theme = data.theme || Theme.System;
+    Storage.set(THEME_STORAGE_KEY, this.theme);
 
     // system theme listeners
     if (window.matchMedia) {
@@ -312,6 +315,7 @@ class UiStore {
       flushSync(() => {
         this.theme = theme;
         this.persist();
+        Storage.set(THEME_STORAGE_KEY, this.theme);
       });
     });
   };

--- a/server/static/index.html
+++ b/server/static/index.html
@@ -2,7 +2,43 @@
 <html lang="{lang}">
   <head>
     <title>{title}</title>
-    <meta name="theme-color" content="#FFF" />
+    <meta
+      name="theme-color"
+      content="#FFF"
+      media="(prefers-color-scheme: light)"
+    />
+    <meta
+      name="theme-color"
+      content="#111319"
+      media="(prefers-color-scheme: dark)"
+    />
+    <script nonce="{csp-nonce}">
+      (function () {
+        var theme = "system";
+        var storedTheme;
+
+        try {
+          storedTheme = window.localStorage.getItem("theme");
+          theme = storedTheme ? JSON.parse(storedTheme) : theme;
+        } catch (_err) {
+          // Older versions stored the value without JSON encoding.
+          theme = storedTheme || theme;
+        }
+
+        var isDark =
+          theme === "dark" ||
+          (theme !== "light" &&
+            window.matchMedia &&
+            window.matchMedia("(prefers-color-scheme: dark)").matches);
+        var color = isDark ? "#111319" : "#FFF";
+
+        document
+          .querySelectorAll('meta[name="theme-color"]')
+          .forEach(function (element) {
+            element.setAttribute("content", color);
+          });
+      })();
+    </script>
     <meta name="slack-app-id" content="{slack-app-id}" />
     <meta
       name="viewport"
@@ -75,16 +111,9 @@
     <div id="root"></div>
     {env}
     <script nonce="{csp-nonce}">
-      if (
-        window.localStorage &&
-        window.localStorage.getItem("theme") === "dark"
-      ) {
-        var color = "#111319";
-        document.querySelector("#root").style.background = color;
-        document
-          .querySelector('meta[name="theme-color"]')
-          .setAttribute("content", color);
-      }
+      document.querySelector("#root").style.background = document
+        .querySelector('meta[name="theme-color"]')
+        .getAttribute("content");
     </script>
     {script-tags}
     <div class="screenreader-only">{content}</div>


### PR DESCRIPTION
- Keep manifest colors as defaults while adding light and dark page theme metadata.
- Persist a small theme value for the pre-app script and update all page metadata when the active theme changes.
- closes #13586