### PR TITLE
fix: Keep expanded code blocks open after undo

### DIFF
--- a/shared/editor/nodes/CodeFence.ts
+++ b/shared/editor/nodes/CodeFence.ts
@@ -445,7 +445,7 @@ export default class CodeFence extends Node<CodeFenceOptions> {
             const tallBlocks = findTallBlocks(state.doc);
             return build(state.doc, tallBlocks, new Set(tallBlocks));
           },
-          apply: (tr, prev, _oldState, newState) => {
+          apply: (tr, prev, oldState, newState) => {
             const meta = tr.getMeta(collapseKey);
 
             // Toggle collapsed state
@@ -479,7 +479,7 @@ export default class CodeFence extends Node<CodeFenceOptions> {
               const isRemote = isRemoteTransaction(tr, newState);
               const previousBlockDecorations: Decoration[] = [];
               for (const pos of prev.tallBlocks) {
-                const node = _oldState.doc.nodeAt(pos);
+                const node = oldState.doc.nodeAt(pos);
                 if (!node || !isCode(node)) {
                   continue;
                 }
@@ -500,7 +500,7 @@ export default class CodeFence extends Node<CodeFenceOptions> {
               const mappedTallBlocks = new Set<number>();
               const mappedCollapsedBlocks = new Set<number>();
               const previousBlocks = DecorationSet.create(
-                _oldState.doc,
+                oldState.doc,
                 previousBlockDecorations
               );
               for (const decoration of mapDecorations(

--- a/shared/editor/nodes/CodeFence.ts
+++ b/shared/editor/nodes/CodeFence.ts
@@ -42,7 +42,7 @@ import {
   setRecentlyUsedCodeLanguage,
 } from "../lib/code";
 import { isCode, isMermaid } from "../lib/isCode";
-import { isRemoteTransaction } from "../lib/multiplayer";
+import { isRemoteTransaction, mapDecorations } from "../lib/multiplayer";
 import { findBlockNodes } from "../queries/findChildren";
 import type { MarkdownSerializerState } from "../lib/markdown/serializer";
 import { escapeRawTableCell } from "../lib/markdown/tableCell";
@@ -477,14 +477,52 @@ export default class CodeFence extends Node<CodeFenceOptions> {
               const tallBlocks = findTallBlocks(newState.doc);
               const collapsedBlocks = new Set<number>();
               const isRemote = isRemoteTransaction(tr, newState);
+              const previousBlockDecorations: Decoration[] = [];
+              for (const pos of prev.tallBlocks) {
+                const node = _oldState.doc.nodeAt(pos);
+                if (!node || !isCode(node)) {
+                  continue;
+                }
 
-              const inverse = tr.mapping.invert();
+                previousBlockDecorations.push(
+                  Decoration.node(
+                    pos,
+                    pos + node.nodeSize,
+                    {},
+                    {
+                      collapsed: prev.collapsedBlocks.has(pos),
+                      trackedCodeBlock: true,
+                    }
+                  )
+                );
+              }
+
+              const mappedTallBlocks = new Set<number>();
+              const mappedCollapsedBlocks = new Set<number>();
+              const previousBlocks = DecorationSet.create(
+                _oldState.doc,
+                previousBlockDecorations
+              );
+              for (const decoration of mapDecorations(
+                previousBlocks,
+                tr,
+                newState
+              ).find()) {
+                if (!decoration.spec.trackedCodeBlock) {
+                  continue;
+                }
+
+                mappedTallBlocks.add(decoration.from);
+                if (decoration.spec.collapsed) {
+                  mappedCollapsedBlocks.add(decoration.from);
+                }
+              }
+
               for (const pos of tallBlocks) {
-                const oldPos = inverse.map(pos);
-                if (isRemote && !prev.tallBlocks.has(oldPos)) {
+                if (isRemote && !mappedTallBlocks.has(pos)) {
                   // Newly tall blocks start collapsed on load
                   collapsedBlocks.add(pos);
-                } else if (prev.collapsedBlocks.has(oldPos)) {
+                } else if (mappedCollapsedBlocks.has(pos)) {
                   // Preserve previous collapsed state
                   collapsedBlocks.add(pos);
                 }


### PR DESCRIPTION
- Preserve code block expansion state through collaborative document replacements.
- Use reconstructed decoration mappings so undo keeps large blocks open.
- closes #13594