### PR TITLE
fix: Provision OIDC users with locale claim

### DIFF
--- a/app/hooks/useFormatNumber.ts
+++ b/app/hooks/useFormatNumber.ts
@@ -1,6 +1,6 @@
-import { formatNumber } from "~/utils/language";
-import useUserLocale from "./useUserLocale";
 import { unicodeCLDRtoBCP47 } from "@shared/utils/date";
+import { formatNumber } from "@shared/utils/language";
+import useUserLocale from "./useUserLocale";
 
 /**
  * Hook that returns a function to format numbers based on the user's locale.

--- a/app/scenes/Document/components/Editor.tsx
+++ b/app/scenes/Document/components/Editor.tsx
@@ -7,6 +7,7 @@ import styled from "styled-components";
 import Text from "@shared/components/Text";
 import type { CommentAnchor } from "@shared/editor/commands/comment";
 import { richExtensions, withComments } from "@shared/editor/nodes";
+import { getLangFor } from "@shared/utils/language";
 import { DocumentPreference } from "@shared/types";
 import { colorPalette } from "@shared/constants";
 import Comment from "~/models/Comment";
@@ -38,7 +39,6 @@ import MultiplayerEditor from "./AsyncMultiplayerEditor";
 import DocumentMeta from "./DocumentMeta";
 import DocumentTitle from "./DocumentTitle";
 import { first } from "es-toolkit/compat";
-import { getLangFor } from "~/utils/language";
 import useShare from "@shared/hooks/useShare";
 import CodeWordBreak from "@shared/editor/extensions/CodeWordBreak";
 

--- a/app/utils/language.ts
+++ b/app/utils/language.ts
@@ -5,22 +5,6 @@ import { isRTLLanguage } from "@shared/utils/rtl";
 import Desktop from "./Desktop";
 
 /**
- * Formats a number using the user's locale where possible. Use `useFormatNumber` hook
- * instead of this function in React components, to automatically use the user's locale.
- *
- * @param number The number to format
- * @param locale The locale to use for formatting (BCP47 format)
- * @returns The formatted number as a string
- */
-export function formatNumber(number: number, locale: string) {
-  try {
-    return new Intl.NumberFormat(locale).format(number);
-  } catch (_err) {
-    return number.toString();
-  }
-}
-
-/**
  * Detects the user's language based on the browser's language settings.
  *
  * @returns The user's language in CLDR format (en_US)
@@ -54,47 +38,4 @@ export async function changeLanguage(
   if (typeof document !== "undefined") {
     document.documentElement.dir = isRTLLanguage(locale) ? "rtl" : "ltr";
   }
-}
-
-/**
- * Languages with special styling, in ISO 639-1 format.
- */
-const scriptsWithLang = new Set([
-  "th", // Thai
-  "lo", // Lao
-  "km", // Khmer
-  "my", // Burmese
-  "hi", // Hindi
-  "mr", // Marathi
-  "ne", // Nepali
-  "bn", // Bengali
-  "gu", // Gujarati
-  "pa", // Punjabi
-  "te", // Telugu
-  "ta", // Tamil
-  "ml", // Malayalam
-  "si", // Sinhala
-  "bo", // Tibetan
-  "ar", // Arabic
-  "fa", // Persian
-  "ur", // Urdu
-  "he", // Hebrew
-  "am", // Amharic
-  "mn", // Mongolian
-]);
-
-/**
- * Returns the language code if it requires special text styling, otherwise undefined.
- * This is used to determine if a lang attribute should be set on elements for CSS styling.
- *
- * @param langCode The language code to check, in ISO 639-1 format
- * @returns The language code if it requires special styling, otherwise undefined
- */
-export function getLangFor(
-  langCode: string | null | undefined
-): string | undefined {
-  if (!langCode) {
-    return undefined;
-  }
-  return scriptsWithLang.has(langCode) ? langCode : undefined;
 }

--- a/plugins/oidc/server/auth/oidcRouter.ts
+++ b/plugins/oidc/server/auth/oidcRouter.ts
@@ -6,6 +6,7 @@ import { get } from "es-toolkit/compat";
 import { toError } from "@shared/utils/error";
 import { slugifyDomain } from "@shared/utils/domains";
 import { parseEmail } from "@shared/utils/email";
+import { getSupportedLanguage } from "@shared/utils/language";
 import { isBase64Url } from "@shared/utils/urls";
 import accountProvisioner from "@server/commands/accountProvisioner";
 import {
@@ -112,6 +113,7 @@ export function createOIDCRouter(
                 return decoded as {
                   email?: string;
                   email_verified?: boolean | string;
+                  locale?: string;
                   preferred_username?: string;
                   sub?: string;
                 };
@@ -122,6 +124,7 @@ export function createOIDCRouter(
             })();
 
             const email = profile.email ?? token.email ?? null;
+            const language = getSupportedLanguage(profile.locale, token.locale);
 
             if (!email) {
               throw AuthenticationError(
@@ -241,6 +244,7 @@ export function createOIDCRouter(
                 email,
                 emailVerified,
                 avatarUrl,
+                language,
               },
               authenticationProvider: {
                 name: config.id,

--- a/shared/utils/language.test.ts
+++ b/shared/utils/language.test.ts
@@ -1,0 +1,41 @@
+import { formatNumber, getLangFor, getSupportedLanguage } from "./language";
+
+describe("formatNumber", () => {
+  it("formats a number with the specified locale", () => {
+    expect(formatNumber(1234, "en-US")).toEqual("1,234");
+  });
+
+  it("returns the unformatted number for an invalid locale", () => {
+    expect(formatNumber(1234, "invalid_locale")).toEqual("1234");
+  });
+});
+
+describe("getSupportedLanguage", () => {
+  it("converts a supported BCP 47 locale", () => {
+    expect(getSupportedLanguage("pt-BR")).toEqual("pt_BR");
+  });
+
+  it("accepts a supported CLDR locale", () => {
+    expect(getSupportedLanguage("pt_BR")).toEqual("pt_BR");
+  });
+
+  it("returns the first supported locale", () => {
+    expect(getSupportedLanguage(undefined, "en-US")).toEqual("en_US");
+  });
+
+  it("ignores unsupported and malformed locales", () => {
+    expect(getSupportedLanguage("invalid_locale", "en-US")).toEqual("en_US");
+    expect(getSupportedLanguage("en-CA")).toBeUndefined();
+  });
+});
+
+describe("getLangFor", () => {
+  it("returns languages that need special text styling", () => {
+    expect(getLangFor("fa")).toEqual("fa");
+  });
+
+  it("ignores other or empty languages", () => {
+    expect(getLangFor("en")).toBeUndefined();
+    expect(getLangFor(null)).toBeUndefined();
+  });
+});

--- a/shared/utils/language.ts
+++ b/shared/utils/language.ts
@@ -1,0 +1,93 @@
+import { languages } from "../i18n";
+import { unicodeBCP47toCLDR, unicodeCLDRtoBCP47 } from "./date";
+
+/**
+ * Formats a number using the specified locale where possible.
+ *
+ * @param number the number to format.
+ * @param locale the locale to use in BCP 47 format.
+ * @return the formatted number as a string.
+ */
+export function formatNumber(number: number, locale: string): string {
+  try {
+    return new Intl.NumberFormat(locale).format(number);
+  } catch {
+    return number.toString();
+  }
+}
+
+/**
+ * Returns the first supported language from BCP 47 or CLDR locale values.
+ *
+ * @param locales the locale values in priority order.
+ * @return the supported language in CLDR format, or undefined.
+ */
+export function getSupportedLanguage(
+  ...locales: unknown[]
+): string | undefined {
+  for (const locale of locales) {
+    if (typeof locale !== "string") {
+      continue;
+    }
+
+    let canonicalLocale;
+    try {
+      [canonicalLocale] = Intl.getCanonicalLocales(unicodeCLDRtoBCP47(locale));
+    } catch {
+      continue;
+    }
+
+    const language = unicodeBCP47toCLDR(canonicalLocale);
+    const supportedLanguage = languages.find(
+      (candidate) => candidate === language
+    );
+    if (supportedLanguage) {
+      return supportedLanguage;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Returns the language code if it needs special text styling.
+ *
+ * @param language the language code to check in ISO 639-1 format.
+ * @return the language code if it needs special styling, or undefined.
+ */
+export function getLangFor(
+  language: string | null | undefined
+): string | undefined {
+  if (!language) {
+    return undefined;
+  }
+
+  return scriptsWithLang.has(language) ? language : undefined;
+}
+
+/**
+ * Languages with special styling, in ISO 639-1 format.
+ */
+const scriptsWithLang = new Set([
+  "th", // Thai
+  "lo", // Lao
+  "km", // Khmer
+  "my", // Burmese
+  "hi", // Hindi
+  "mr", // Marathi
+  "ne", // Nepali
+  "bn", // Bengali
+  "gu", // Gujarati
+  "pa", // Punjabi
+  "te", // Telugu
+  "ta", // Tamil
+  "ml", // Malayalam
+  "si", // Sinhala
+  "bo", // Tibetan
+  "ar", // Arabic
+  "fa", // Persian
+  "ur", // Urdu
+  "he", // Hebrew
+  "am", // Amharic
+  "mn", // Mongolian
+]);


### PR DESCRIPTION
- Read the locale from OIDC userinfo or the ID token during account provisioning.
- Normalize supported BCP 47 and CLDR locale formats in shared language utilities.
- Keep browser-only language behavior in app utilities.