### PR TITLE
fix: preserve tables in quoted document patches

### DIFF
--- a/server/commands/documentUpdater.test.ts
+++ b/server/commands/documentUpdater.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import * as Y from "yjs";
-import { TextEditMode } from "@shared/types";
+import { TextEditMode, type ProsemirrorData } from "@shared/types";
 import { APIUpdateExtension } from "@server/collaboration/APIUpdateExtension";
 import { Event } from "@server/models";
 import { parser } from "@server/editor";
@@ -1391,6 +1391,130 @@ describe("documentUpdater", () => {
 
       // Second paragraph with comment mark preserved exactly
       expect(blockquote.content![1]).toEqual(secondPara);
+    });
+
+    it("should preserve a blockquote containing a table when patching a later link", async () => {
+      const user = await buildUser();
+      const document = await buildDocument({ teamId: user.teamId });
+      const fillerParagraphs: ProsemirrorData[] = Array.from(
+        { length: 242 },
+        (_, index) => ({
+          type: "paragraph",
+          content: [{ type: "text", text: `Quoted paragraph ${index + 1}` }],
+        })
+      );
+
+      document.content = {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "Before quote" }],
+          },
+          {
+            type: "blockquote",
+            content: [
+              {
+                type: "heading",
+                attrs: { level: 1 },
+                content: [{ type: "text", text: "Quoted source" }],
+              },
+              {
+                type: "table",
+                content: [
+                  {
+                    type: "tr",
+                    content: [
+                      {
+                        type: "th",
+                        content: [
+                          {
+                            type: "paragraph",
+                            content: [{ type: "text", text: "Key" }],
+                          },
+                        ],
+                      },
+                      {
+                        type: "th",
+                        content: [
+                          {
+                            type: "paragraph",
+                            content: [{ type: "text", text: "Value" }],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    type: "tr",
+                    content: [
+                      {
+                        type: "td",
+                        content: [
+                          {
+                            type: "paragraph",
+                            content: [{ type: "text", text: "Alpha" }],
+                          },
+                        ],
+                      },
+                      {
+                        type: "td",
+                        content: [
+                          {
+                            type: "paragraph",
+                            content: [{ type: "text", text: "Keep this row" }],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+              ...fillerParagraphs,
+              {
+                type: "paragraph",
+                content: [
+                  { type: "text", text: "See " },
+                  {
+                    type: "text",
+                    marks: [
+                      {
+                        type: "link",
+                        attrs: { href: "https://example.com/reference" },
+                      },
+                    ],
+                    text: "Reference",
+                  },
+                  { type: "text", text: "." },
+                ],
+              },
+              {
+                type: "paragraph",
+                content: [{ type: "text", text: "Tail sentinel." }],
+              },
+            ],
+          },
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "After quote" }],
+          },
+        ],
+      };
+      await document.save();
+
+      const beforeDoc = DocumentHelper.toProsemirror(document).toJSON();
+      const expected = structuredClone(beforeDoc);
+      expected.content[1].content[244].content[1].marks[0].attrs.href =
+        "https://example.com/reference#h-target";
+
+      const result = DocumentHelper.applyMarkdownToDocument(
+        document,
+        "> See [Reference](https://example.com/reference#h-target).",
+        TextEditMode.Patch,
+        "> See [Reference](https://example.com/reference)."
+      );
+
+      expect(result.content).toEqual(expected);
     });
 
     it("should always patch the first occurrence when findText appears multiple times", async () => {

--- a/shared/editor/lib/markdown/serializer.ts
+++ b/shared/editor/lib/markdown/serializer.ts
@@ -482,10 +482,12 @@ export class MarkdownSerializerState {
     });
 
     // Ensure there is an empty newline above all tables
+    this.write();
     this.append("\n");
 
     // Render rows
     node.forEach((row, _, i) => {
+      this.write();
       row.forEach((cell, _, j) => {
         this.append(j === 0 ? "| " : " | ");
 
@@ -528,6 +530,7 @@ export class MarkdownSerializerState {
 
       // Header separator after first row
       if (i === 0) {
+        this.write();
         headerRow.forEach((cell, _, j) => {
           const width = columnWidths[j];
           if (cell.attrs.alignment === "center") {


### PR DESCRIPTION
- Preserve the active Markdown container prefix when serializing table rows and separators.
- Keep tables inside their blockquote during document patch round trips.
- closes #13579