### PR TITLE
chore: stagger popularity score task away from daily insight rollup

### DIFF
--- a/server/queues/tasks/UpdateDocumentsPopularityScoreTask.test.ts
+++ b/server/queues/tasks/UpdateDocumentsPopularityScoreTask.test.ts
@@ -21,7 +21,7 @@ describe("UpdateDocumentsPopularityScoreTask", () => {
 
   beforeEach(() => {
     task = new UpdateDocumentsPopularityScoreTask();
-    vi.spyOn(Date.prototype, "getHours").mockReturnValue(0);
+    vi.spyOn(Date.prototype, "getHours").mockReturnValue(6);
 
     // Ensure calculation query sees data created in tests by redirecting to main sequelize instance.
     // We only mock if the instances are different to avoid infinite recursion.
@@ -303,7 +303,7 @@ describe("UpdateDocumentsPopularityScoreTask", () => {
     expect(Number(untouched?.popularityScore)).toBe(0);
 
     const onInterval = new Date();
-    onInterval.setHours(0, 0, 0, 0);
+    onInterval.setHours(6, 0, 0, 0);
 
     await task.perform({ ...props, scheduledAt: onInterval.getTime() });
 

--- a/server/queues/tasks/UpdateDocumentsPopularityScoreTask.ts
+++ b/server/queues/tasks/UpdateDocumentsPopularityScoreTask.ts
@@ -31,7 +31,7 @@ const ACTIVITY_WEIGHTS = {
 /**
  * Batch size for processing updates - kept small to minimize lock contention
  */
-const BATCH_SIZE = 100;
+const BATCH_SIZE = 50;
 
 /**
  * Delay between batches in milliseconds to reduce sustained database pressure
@@ -50,6 +50,13 @@ const WORKING_TABLE_PREFIX = "popularity_score_working";
  */
 const SPREAD_HOURS = 1;
 
+/**
+ * Hour offset applied to the update interval so runs do not land on the same
+ * hour as the daily cron tasks, such as RollupDocumentInsightsTask, which are
+ * typically scheduled at midnight.
+ */
+const UPDATE_HOUR_OFFSET = 6;
+
 interface DocumentScore {
   documentId: string;
   score: number;
@@ -66,7 +73,11 @@ export default class UpdateDocumentsPopularityScoreTask extends CronTask {
     // spread over several hours, so this is based on when the run was
     // scheduled rather than when this partition happens to execute.
     const scheduledHour = new Date(scheduledAt ?? Date.now()).getHours();
-    if (scheduledHour % env.POPULARITY_UPDATE_INTERVAL_HOURS !== 0) {
+    if (
+      (scheduledHour + UPDATE_HOUR_OFFSET) %
+        env.POPULARITY_UPDATE_INTERVAL_HOURS !==
+      0
+    ) {
       Logger.debug(
         "task",
         `Skipping popularity score update, will run at next ${env.POPULARITY_UPDATE_INTERVAL_HOURS}-hour interval (scheduled hour: ${scheduledHour})`


### PR DESCRIPTION
- Offsets the popularity score run by 6 hours so it no longer shares the midnight hour with the daily insight rollup task. With the default 12-hour interval it now runs at 06:00 and 18:00.
- Reduces the popularity update batch size from 100 to 50 documents to lower lock contention.