### PR TITLE
Batch large table deletes in teamPermanentDeleter

### DIFF
--- a/server/commands/teamPermanentDeleter.ts
+++ b/server/commands/teamPermanentDeleter.ts
@@ -1,3 +1,4 @@
+import type { WhereOptions } from "sequelize";
 import Logger from "@server/logging/Logger";
 import { traceFunction } from "@server/logging/tracing";
 import type { Team } from "@server/models";
@@ -18,6 +19,7 @@ import {
   SearchQuery,
   Share,
 } from "@server/models";
+import type Model from "@server/models/base/Model";
 import { sequelize } from "@server/storage/database";
 import { LockHelper } from "@server/storage/LockHelper";
 
@@ -108,6 +110,13 @@ async function teamPermanentDeleter(team: Team) {
     }
   );
 
+  // The largest tables are destroyed in batches outside of a transaction so
+  // that row locks are held briefly, rather than for the whole deletion.
+  // events must be first due to db constraints
+  await destroyInBatches(Event, { teamId });
+  await destroyInBatches(Collection, { teamId });
+  await destroyInBatches(Document.unscoped(), { teamId });
+
   // Destory team-relation models
   await sequelize.transaction(async (transaction) => {
     const acquired = await LockHelper.tryAcquire(
@@ -124,28 +133,6 @@ async function teamPermanentDeleter(team: Team) {
     }
 
     await AuthenticationProvider.destroy({
-      where: {
-        teamId,
-      },
-      force: true,
-      transaction,
-    });
-    // events must be first due to db constraints
-    await Event.destroy({
-      where: {
-        teamId,
-      },
-      force: true,
-      transaction,
-    });
-    await Collection.destroy({
-      where: {
-        teamId,
-      },
-      force: true,
-      transaction,
-    });
-    await Document.unscoped().destroy({
       where: {
         teamId,
       },
@@ -215,6 +202,35 @@ async function teamPermanentDeleter(team: Team) {
       }
     );
   });
+}
+
+/**
+ * Permanently deletes every row of a model matching the where clause, in
+ * batches of ids so that each statement is short and locks few rows.
+ */
+async function destroyInBatches(
+  model: typeof Model,
+  where: WhereOptions
+): Promise<void> {
+  await model.findAllInBatches<Model>(
+    {
+      attributes: ["id"],
+      where,
+      batchLimit: 1000,
+      paranoid: false,
+    },
+    async (rows) => {
+      if (rows.length === 0) {
+        return;
+      }
+      await model.destroy({
+        where: {
+          id: rows.map((row) => row.id),
+        },
+        force: true,
+      });
+    }
+  );
 }
 
 export default traceFunction({

--- a/server/commands/teamPermanentDeleter.ts
+++ b/server/commands/teamPermanentDeleter.ts
@@ -204,15 +204,23 @@ async function teamPermanentDeleter(team: Team) {
   });
 }
 
+interface BatchDestroyable {
+  findAllInBatches: typeof Model.findAllInBatches;
+  destroy(options: {
+    where: { id: string[] };
+    force: boolean;
+  }): Promise<number>;
+}
+
 /**
  * Permanently deletes every row of a model matching the where clause, in
  * batches of ids so that each statement is short and locks few rows.
  */
 async function destroyInBatches(
-  model: typeof Model,
+  model: BatchDestroyable,
   where: WhereOptions
 ): Promise<void> {
-  await model.findAllInBatches<Model>(
+  await model.findAllInBatches<Model & { id: string }>(
     {
       attributes: ["id"],
       where,

--- a/server/commands/teamPermanentDeleter.ts
+++ b/server/commands/teamPermanentDeleter.ts
@@ -21,7 +21,8 @@ import {
 } from "@server/models";
 import type Model from "@server/models/base/Model";
 import { sequelize } from "@server/storage/database";
-import { LockHelper } from "@server/storage/LockHelper";
+import { MutexLock } from "@server/utils/MutexLock";
+import { Minute } from "@shared/utils/time";
 
 /**
  * Permanently deletes a team and all related data from the database. Note that this does not happen
@@ -37,11 +38,32 @@ async function teamPermanentDeleter(team: Team) {
     );
   }
 
+  const teamId = team.id;
+
+  // A non-blocking lock so that concurrent runs for the same team skip rather
+  // than repeat the batched deletes below.
+  const ran = await MutexLock.tryUsing(
+    `teamPermanentDeleter:${teamId}`,
+    5 * Minute.ms,
+    async () => {
+      await destroyTeamData(team);
+      return true;
+    }
+  );
+  if (!ran) {
+    Logger.info(
+      "commands",
+      `Team ${teamId} is already being destroyed, skipping`
+    );
+  }
+}
+
+async function destroyTeamData(team: Team) {
+  const teamId = team.id;
   Logger.info(
     "commands",
-    `Permanently destroying team ${team.name} (${team.id})`
+    `Permanently destroying team ${team.name} (${teamId})`
   );
-  const teamId = team.id;
 
   // Attachments are destroyed as individual instances (rather than a bulk
   // delete) so the BeforeDestroy hook runs and removes the associated file from
@@ -119,19 +141,6 @@ async function teamPermanentDeleter(team: Team) {
 
   // Destory team-relation models
   await sequelize.transaction(async (transaction) => {
-    const acquired = await LockHelper.tryAcquire(
-      sequelize,
-      `teamPermanentDeleter:${teamId}`,
-      transaction
-    );
-    if (!acquired) {
-      Logger.info(
-        "commands",
-        `Team ${teamId} is already being destroyed, skipping`
-      );
-      return;
-    }
-
     await AuthenticationProvider.destroy({
       where: {
         teamId,

--- a/server/utils/MutexLock.ts
+++ b/server/utils/MutexLock.ts
@@ -110,6 +110,37 @@ export class MutexLock {
   }
 
   /**
+   * Execute a routine in the context of an auto-extending lock, without
+   * waiting when the lock is already held elsewhere. Use this for long
+   * routines that must never run concurrently but can be skipped.
+   *
+   * @param resource The resource to lock.
+   * @param timeout The initial lock duration in milliseconds (auto-extended while running).
+   * @param routine The async routine to execute while holding the lock.
+   * @returns A promise that resolves with the routine's return value, or
+   * undefined if the lock was held elsewhere and the routine did not run.
+   */
+  public static async tryUsing<T>(
+    resource: string,
+    timeout: number,
+    routine: (signal: RedlockAbortSignal) => Promise<T>
+  ): Promise<T | undefined> {
+    try {
+      return await this.lock.using(
+        [resource],
+        timeout,
+        { retryCount: 0 },
+        routine
+      );
+    } catch (err) {
+      if (err instanceof ExecutionError || err instanceof ResourceLockedError) {
+        return undefined;
+      }
+      throw err;
+    }
+  }
+
+  /**
    * Safely release a lock. Releasing is best-effort – a lock that has already
    * expired or been taken over by another process cannot be released, and that
    * is not an error for the caller.

--- a/server/utils/__mocks__/MutexLock.ts
+++ b/server/utils/__mocks__/MutexLock.ts
@@ -13,6 +13,28 @@ export class MutexLock {
   });
 
   /**
+   * Runs the routine without a lock.
+   */
+  public static using = vi.fn(
+    (
+      _resource: string,
+      _timeout: number,
+      routine: (signal: never) => unknown
+    ) => routine(undefined as never)
+  );
+
+  /**
+   * Runs the routine without a lock.
+   */
+  public static tryUsing = vi.fn(
+    (
+      _resource: string,
+      _timeout: number,
+      routine: (signal: never) => unknown
+    ) => routine(undefined as never)
+  );
+
+  /**
    * Releases a mock lock.
    */
   public static release = vi.fn().mockResolvedValue(true);


### PR DESCRIPTION
Permanent team deletion ran a single table-wide DELETE for events, collections, and documents inside one transaction. For large teams that statement ran long and held row locks for the full duration, which blocked the hourly old-events cleanup and drained worker connections.

- Delete events, collections, and documents in batches of 1000 ids before the final transaction, so each statement is short and commits on its own
- Keep the advisory-locked transaction for the small tables and the team row only
- Add a local `destroyInBatches` helper built on the existing keyset batch iterator