### PR TITLE
fix: Escape MCP attachment PUT upload command arguments

### DIFF
--- a/server/tools/attachments.ts
+++ b/server/tools/attachments.ts
@@ -113,10 +113,10 @@ export function attachmentTools(server: McpServer, scopes: string[]) {
               const curlCommand = `curl -X PUT ${Object.entries(
                 presignedPut.headers
               )
-                .map(([k, v]) => `-H '${k}: ${v}'`)
-                .join(
-                  " "
-                )} --data-binary '@/path/to/file' '${presignedPut.url}'`;
+                .map(([k, v]) => `-H ${quoteShellArgument(`${k}: ${v}`)}`)
+                .join(" ")} --data-binary '@/path/to/file' ${quoteShellArgument(
+                presignedPut.url
+              )}`;
 
               return success({
                 mode: "put",


### PR DESCRIPTION
Applies the same shell quoting introduced for the POST branch in #13597
to the presigned PUT branch, so user-supplied content type and filename
values cannot break out of the suggested curl command's quoting.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011rde2HKVLJC4GWU4wHcrKz