### PR TITLE
Limit document search trigger updates

### DIFF
--- a/server/migrations/20260902125149-limit-document-search-trigger-columns.js
+++ b/server/migrations/20260902125149-limit-document-search-trigger-columns.js
@@ -1,0 +1,16 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(
+      'CREATE OR REPLACE TRIGGER documents_tsvectorupdate BEFORE INSERT OR UPDATE OF title, text, "previousTitles" ON documents FOR EACH ROW EXECUTE PROCEDURE documents_search_trigger();'
+    );
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(
+      "CREATE OR REPLACE TRIGGER documents_tsvectorupdate BEFORE INSERT OR UPDATE ON documents FOR EACH ROW EXECUTE PROCEDURE documents_search_trigger();"
+    );
+  },
+};


### PR DESCRIPTION
- Run the document search trigger only for inserts and changes to `title`, `text`, or `"previousTitles"`.
- Restore the prior all-update behavior on rollback.