### PR TITLE
perf: move cleanup reads to follower

### DIFF
--- a/server/commands/documentPermanentDeleter.ts
+++ b/server/commands/documentPermanentDeleter.ts
@@ -6,7 +6,7 @@ import { Document, Attachment } from "@server/models";
 import { DocumentHelper } from "@server/models/helpers/DocumentHelper";
 import { ProsemirrorHelper } from "@server/models/helpers/ProsemirrorHelper";
 import DeleteAttachmentTask from "@server/queues/tasks/DeleteAttachmentTask";
-import { sequelize } from "@server/storage/database";
+import { sequelizeReadOnly } from "@server/storage/database";
 
 export default async function documentPermanentDeleter(documents: Document[]) {
   const activeDocument = documents.find((doc) => !doc.deletedAt);
@@ -52,14 +52,17 @@ export default async function documentPermanentDeleter(documents: Document[]) {
         // Check if the attachment is referenced in any other documents – this
         // is needed as it's easy to copy and paste content between documents.
         // An uploaded attachment may end up referenced in multiple documents.
-        const [{ count }] = await sequelize.query<{ count: string }>(query, {
-          type: QueryTypes.SELECT,
-          replacements: {
-            documentId: document.id,
-            teamId: document.teamId,
-            query: attachmentId,
-          },
-        });
+        const [{ count }] = await sequelizeReadOnly.query<{ count: string }>(
+          query,
+          {
+            type: QueryTypes.SELECT,
+            replacements: {
+              documentId: document.id,
+              teamId: document.teamId,
+              query: attachmentId,
+            },
+          }
+        );
 
         // If the attachment is not referenced in any other documents then
         // delete it from the database and the storage provider.

--- a/server/queues/tasks/CleanupDeletedDocumentsTask.ts
+++ b/server/queues/tasks/CleanupDeletedDocumentsTask.ts
@@ -3,6 +3,7 @@ import { Op } from "sequelize";
 import documentPermanentDeleter from "@server/commands/documentPermanentDeleter";
 import Logger from "@server/logging/Logger";
 import { Document } from "@server/models";
+import { sequelizeReadOnly } from "@server/storage/database";
 import { TaskPriority } from "./base/BaseTask";
 import { Minute } from "@shared/utils/time";
 import type { Props } from "./base/CronTask";
@@ -14,17 +15,20 @@ export default class CleanupDeletedDocumentsTask extends CronTask {
       "task",
       `Permanently destroying upto ${limit} documents older than 30 days…`
     );
-    const documents = await Document.unscoped().findAll({
-      attributes: ["id", "teamId", "deletedAt", "content", "state", "text"],
-      where: {
-        deletedAt: {
-          [Op.lt]: subDays(new Date(), 30),
+    const documents = await sequelizeReadOnly.transaction((transaction) =>
+      Document.unscoped().findAll({
+        attributes: ["id", "teamId", "deletedAt", "content", "state", "text"],
+        where: {
+          deletedAt: {
+            [Op.lt]: subDays(new Date(), 30),
+          },
+          ...this.getPartitionWhereClause("id", partition),
         },
-        ...this.getPartitionWhereClause("id", partition),
-      },
-      paranoid: false,
-      limit,
-    });
+        paranoid: false,
+        limit,
+        transaction,
+      })
+    );
     const countDeletedDocument = await documentPermanentDeleter(documents);
     Logger.info("task", `Destroyed ${countDeletedDocument} documents`);
   }

--- a/server/queues/tasks/CleanupOldEventsTask.ts
+++ b/server/queues/tasks/CleanupOldEventsTask.ts
@@ -2,6 +2,7 @@ import { subDays } from "date-fns";
 import { Op } from "sequelize";
 import Logger from "@server/logging/Logger";
 import { Event } from "@server/models";
+import { sequelizeReadOnly } from "@server/storage/database";
 import { TaskPriority } from "./base/BaseTask";
 import type { Props } from "./base/CronTask";
 import { CronTask, TaskInterval } from "./base/CronTask";
@@ -16,28 +17,31 @@ export default class CleanupOldEventsTask extends CronTask {
     let totalEventsDeleted = 0;
 
     try {
-      await Event.findAllInBatches(
-        {
-          attributes: ["id"],
-          where: {
-            createdAt: {
-              [Op.lt]: cutoffDate,
-            },
-            ...this.getPartitionWhereClause("id", partition),
-          },
-          batchLimit: 1000,
-          totalLimit: maxEventsPerTask,
-          order: [["createdAt", "ASC"]],
-        },
-        async (events) => {
-          totalEventsDeleted += await Event.destroy({
+      await sequelizeReadOnly.transaction(async (transaction) =>
+        Event.findAllInBatches(
+          {
+            attributes: ["id"],
             where: {
-              id: {
-                [Op.in]: events.map((event) => event.id),
+              createdAt: {
+                [Op.lt]: cutoffDate,
               },
+              ...this.getPartitionWhereClause("id", partition),
             },
-          });
-        }
+            batchLimit: 1000,
+            totalLimit: maxEventsPerTask,
+            order: [["createdAt", "ASC"]],
+            transaction,
+          },
+          async (events) => {
+            totalEventsDeleted += await Event.destroy({
+              where: {
+                id: {
+                  [Op.in]: events.map((event) => event.id),
+                },
+              },
+            });
+          }
+        )
       );
     } finally {
       if (totalEventsDeleted > 0) {

--- a/server/queues/tasks/CleanupOldSearchQueriesTask.ts
+++ b/server/queues/tasks/CleanupOldSearchQueriesTask.ts
@@ -2,6 +2,7 @@ import { subDays } from "date-fns";
 import { Op } from "sequelize";
 import Logger from "@server/logging/Logger";
 import { SearchQuery } from "@server/models";
+import { sequelizeReadOnly } from "@server/storage/database";
 import { TaskPriority } from "./base/BaseTask";
 import type { Props } from "./base/CronTask";
 import { CronTask, TaskInterval } from "./base/CronTask";
@@ -16,28 +17,31 @@ export default class CleanupOldSearchQueriesTask extends CronTask {
     let totalSearchQueriesDeleted = 0;
 
     try {
-      await SearchQuery.findAllInBatches(
-        {
-          attributes: ["id"],
-          where: {
-            createdAt: {
-              [Op.lt]: cutoffDate,
-            },
-            ...this.getPartitionWhereClause("id", partition),
-          },
-          batchLimit: 1000,
-          totalLimit: maxSearchQueriesPerTask,
-          order: [["createdAt", "ASC"]],
-        },
-        async (searchQueries) => {
-          totalSearchQueriesDeleted += await SearchQuery.destroy({
+      await sequelizeReadOnly.transaction(async (transaction) =>
+        SearchQuery.findAllInBatches(
+          {
+            attributes: ["id"],
             where: {
-              id: {
-                [Op.in]: searchQueries.map((searchQuery) => searchQuery.id),
+              createdAt: {
+                [Op.lt]: cutoffDate,
               },
+              ...this.getPartitionWhereClause("id", partition),
             },
-          });
-        }
+            batchLimit: 1000,
+            totalLimit: maxSearchQueriesPerTask,
+            order: [["createdAt", "ASC"]],
+            transaction,
+          },
+          async (searchQueries) => {
+            totalSearchQueriesDeleted += await SearchQuery.destroy({
+              where: {
+                id: {
+                  [Op.in]: searchQueries.map((searchQuery) => searchQuery.id),
+                },
+              },
+            });
+          }
+        )
       );
     } finally {
       if (totalSearchQueriesDeleted > 0) {


### PR DESCRIPTION
- Run old event, search-query, and deleted-document cleanup reads on the follower.
- Move attachment reference counts to the follower while keeping safety checks and deletes on the primary.