### PR TITLE
perf: Use follower for exports

### DIFF
--- a/server/queues/tasks/ExportDocumentTreeTask.ts
+++ b/server/queues/tasks/ExportDocumentTreeTask.ts
@@ -12,6 +12,7 @@ import { DocumentHelper } from "@server/models/helpers/DocumentHelper";
 import HTMLHelper from "@server/models/helpers/HTMLHelper";
 import { ProsemirrorHelper } from "@server/models/helpers/ProsemirrorHelper";
 import TextBundleHelper from "@server/models/helpers/TextBundleHelper";
+import { sequelizeReadOnly } from "@server/storage/database";
 import ZipHelper from "@server/utils/ZipHelper";
 import { serializeFilename } from "@server/utils/fs";
 import ExportTask from "./ExportTask";
@@ -60,10 +61,35 @@ export default abstract class ExportDocumentTreeTask extends ExportTask {
     pathMap: Map<string, string>;
   }) {
     Logger.debug("task", `Adding document to archive`, { documentId });
-    const document = await Document.findByPk(documentId);
-    if (!document) {
+    const result = await sequelizeReadOnly.transaction(async (transaction) => {
+      const document = await Document.findByPk(documentId, { transaction });
+      if (!document) {
+        return;
+      }
+
+      const attachmentIds = includeAttachments
+        ? ProsemirrorHelper.parseAttachmentIds(
+            DocumentHelper.toProsemirror(document)
+          )
+        : [];
+      const attachments = attachmentIds.length
+        ? await Attachment.findAll({
+            where: {
+              teamId: document.teamId,
+              id: attachmentIds,
+            },
+            transaction,
+          })
+        : [];
+
+      return { attachments, document };
+    });
+
+    if (!result) {
       return;
     }
+
+    const { attachments, document } = result;
 
     let text =
       format === FileOperationFormat.HTMLZip
@@ -78,20 +104,6 @@ export default abstract class ExportDocumentTreeTask extends ExportTask {
       ? path.join(pathInZip, TextBundleHelper.textFileName)
       : pathInZip;
     const usedAssetNames = new Set<string>();
-
-    const attachmentIds = includeAttachments
-      ? ProsemirrorHelper.parseAttachmentIds(
-          DocumentHelper.toProsemirror(document)
-        )
-      : [];
-    const attachments = attachmentIds.length
-      ? await Attachment.findAll({
-          where: {
-            teamId: document.teamId,
-            id: attachmentIds,
-          },
-        })
-      : [];
 
     // Add any referenced attachments to the zip file and replace the
     // reference in the document with the path to the attachment in the zip

--- a/server/queues/tasks/ExportJSONTask.test.ts
+++ b/server/queues/tasks/ExportJSONTask.test.ts
@@ -1,0 +1,50 @@
+import fs from "fs-extra";
+import { vi } from "vitest";
+import { Attachment } from "@server/models";
+import {
+  buildCollection,
+  buildDocument,
+  buildFileOperation,
+  buildTeam,
+  buildUser,
+} from "@server/test/factories";
+import ExportJSONTask from "./ExportJSONTask";
+
+describe("ExportJSONTask", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should not query attachments when no attachment IDs are present", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const collection = await buildCollection({
+      teamId: team.id,
+      userId: user.id,
+      description: "No attachments",
+    });
+    const document = await buildDocument({
+      teamId: team.id,
+      userId: user.id,
+      collectionId: collection.id,
+      text: "No attachments",
+    });
+    await collection.addDocumentToStructure(document);
+    const fileOperation = await buildFileOperation({
+      teamId: team.id,
+      userId: user.id,
+    });
+    const findAll = vi.spyOn(Attachment, "findAll");
+
+    const filePath = await new ExportJSONTask().exportCollections(
+      [collection],
+      fileOperation
+    );
+
+    try {
+      expect(findAll).not.toHaveBeenCalled();
+    } finally {
+      await fs.remove(filePath);
+    }
+  });
+});

--- a/server/queues/tasks/ExportJSONTask.ts
+++ b/server/queues/tasks/ExportJSONTask.ts
@@ -7,6 +7,7 @@ import { Attachment, Document } from "@server/models";
 import { DocumentHelper } from "@server/models/helpers/DocumentHelper";
 import { ProsemirrorHelper } from "@server/models/helpers/ProsemirrorHelper";
 import { presentAttachment, presentCollection } from "@server/presenters";
+import { sequelizeReadOnly } from "@server/storage/database";
 import type { CollectionJSONExport, JSONExportMetadata } from "@server/types";
 import ZipHelper from "@server/utils/ZipHelper";
 import { serializeFilename } from "@server/utils/fs";
@@ -97,26 +98,40 @@ export default class ExportJSONTask extends ExportTask {
 
     const addDocumentTree = async (nodes: NavigationNode[]) => {
       for (const node of nodes) {
-        const document = await Document.findByPk(node.id, {
-          includeState: true,
-        });
+        const result = await sequelizeReadOnly.transaction(
+          async (transaction) => {
+            const document = await Document.findByPk(node.id, {
+              includeState: true,
+              transaction,
+            });
 
-        if (!document) {
+            if (!document) {
+              return;
+            }
+
+            const attachments = includeAttachments
+              ? await Attachment.findAll({
+                  where: {
+                    teamId: document.teamId,
+                    id: ProsemirrorHelper.parseAttachmentIds(
+                      DocumentHelper.toProsemirror(document)
+                    ),
+                  },
+                  transaction,
+                })
+              : [];
+
+            return { attachments, document };
+          }
+        );
+
+        if (!result) {
           continue;
         }
 
-        const documentAttachments = includeAttachments
-          ? await Attachment.findAll({
-              where: {
-                teamId: document.teamId,
-                id: ProsemirrorHelper.parseAttachmentIds(
-                  DocumentHelper.toProsemirror(document)
-                ),
-              },
-            })
-          : [];
+        const { attachments, document } = result;
 
-        addAttachments(documentAttachments);
+        addAttachments(attachments);
 
         output.documents[document.id] = {
           id: document.id,
@@ -144,14 +159,17 @@ export default class ExportJSONTask extends ExportTask {
     };
 
     const collectionAttachments = includeAttachments
-      ? await Attachment.findAll({
-          where: {
-            teamId: collection.teamId,
-            id: ProsemirrorHelper.parseAttachmentIds(
-              DocumentHelper.toProsemirror(collection)
-            ),
-          },
-        })
+      ? await sequelizeReadOnly.transaction((transaction) =>
+          Attachment.findAll({
+            where: {
+              teamId: collection.teamId,
+              id: ProsemirrorHelper.parseAttachmentIds(
+                DocumentHelper.toProsemirror(collection)
+              ),
+            },
+            transaction,
+          })
+        )
       : [];
 
     addAttachments(collectionAttachments);

--- a/server/queues/tasks/ExportJSONTask.ts
+++ b/server/queues/tasks/ExportJSONTask.ts
@@ -109,13 +109,16 @@ export default class ExportJSONTask extends ExportTask {
               return;
             }
 
-            const attachments = includeAttachments
+            const attachmentIds = includeAttachments
+              ? ProsemirrorHelper.parseAttachmentIds(
+                  DocumentHelper.toProsemirror(document)
+                )
+              : [];
+            const attachments = attachmentIds.length
               ? await Attachment.findAll({
                   where: {
                     teamId: document.teamId,
-                    id: ProsemirrorHelper.parseAttachmentIds(
-                      DocumentHelper.toProsemirror(document)
-                    ),
+                    id: attachmentIds,
                   },
                   transaction,
                 })
@@ -158,14 +161,17 @@ export default class ExportJSONTask extends ExportTask {
       }
     };
 
-    const collectionAttachments = includeAttachments
+    const collectionAttachmentIds = includeAttachments
+      ? ProsemirrorHelper.parseAttachmentIds(
+          DocumentHelper.toProsemirror(collection)
+        )
+      : [];
+    const collectionAttachments = collectionAttachmentIds.length
       ? await sequelizeReadOnly.transaction((transaction) =>
           Attachment.findAll({
             where: {
               teamId: collection.teamId,
-              id: ProsemirrorHelper.parseAttachmentIds(
-                DocumentHelper.toProsemirror(collection)
-              ),
+              id: collectionAttachmentIds,
             },
             transaction,
           })

--- a/server/queues/tasks/ExportTask.ts
+++ b/server/queues/tasks/ExportTask.ts
@@ -1,6 +1,8 @@
 import { Readable } from "node:stream";
 import fs from "fs-extra";
 import { truncate } from "es-toolkit/compat";
+import { Op } from "sequelize";
+import type { WhereOptions } from "sequelize";
 import type { ZipFile } from "yazl";
 import { toError } from "@shared/utils/error";
 import type { NavigationNode } from "@shared/types";
@@ -21,11 +23,9 @@ import {
   User,
 } from "@server/models";
 import fileOperationPresenter from "@server/presenters/fileOperation";
+import { sequelizeReadOnly } from "@server/storage/database";
 import FileStorage from "@server/storage/files";
 import { BaseTask, TaskPriority } from "./base/BaseTask";
-import { Op } from "sequelize";
-import { sequelizeReadOnly } from "@server/storage/database";
-import type { WhereOptions } from "sequelize";
 
 type Props = {
   fileOperationId: string;
@@ -126,13 +126,16 @@ export default abstract class ExportTask extends BaseTask<Props> {
     user: User
   ): Promise<string> {
     if (fileOperation.documentId) {
-      const document = await Document.findByPk(fileOperation.documentId!, {
-        include: {
-          model: Collection.scope("withDocumentStructure"),
-          as: "collection",
-        },
-        rejectOnEmpty: true,
-      });
+      const document = await sequelizeReadOnly.transaction((transaction) =>
+        Document.findByPk(fileOperation.documentId!, {
+          include: {
+            model: Collection.scope("withDocumentStructure"),
+            as: "collection",
+          },
+          rejectOnEmpty: true,
+          transaction,
+        })
+      );
 
       const documentStructure = document.collection?.getDocumentTree(
         document.id
@@ -189,10 +192,11 @@ export default abstract class ExportTask extends BaseTask<Props> {
       };
     }
 
-    const collections = await Collection.scope("withDocumentStructure").findAll(
-      {
+    const collections = await sequelizeReadOnly.transaction((transaction) =>
+      Collection.scope("withDocumentStructure").findAll({
         where,
-      }
+        transaction,
+      })
     );
 
     return this.exportCollections(collections, fileOperation);


### PR DESCRIPTION
- Route export collection, document, and attachment reads through the configured follower.
- Keep transactions limited to database reads while accepting follower delay for recent edits.