### PR TITLE
fix: Allow editing webhooks without signing secrets

### DIFF
--- a/plugins/webhooks/server/api/schema.ts
+++ b/plugins/webhooks/server/api/schema.ts
@@ -45,7 +45,7 @@ export const WebhookSubscriptionsCreateSchema = z.object({
   body: z.object({
     name: z.string(),
     url: webhookUrl,
-    secret: z.string().optional(),
+    secret: z.string().nullish(),
     events: z.array(z.string()),
   }),
 });
@@ -59,7 +59,7 @@ export const WebhookSubscriptionsUpdateSchema = z.object({
     id: z.uuid(),
     name: z.string(),
     url: webhookUrl,
-    secret: z.string().optional(),
+    secret: z.string().nullish(),
     events: z.array(z.string()),
   }),
 });

--- a/plugins/webhooks/server/api/webhookSubscriptions.test.ts
+++ b/plugins/webhooks/server/api/webhookSubscriptions.test.ts
@@ -256,6 +256,31 @@ describe("#webhookSubscriptions.update", () => {
     expect(webhook.enabled).toEqual(true);
   });
 
+  it("should update a webhook subscription without a signing secret", async () => {
+    const user = await buildAdmin();
+    const name = "Updated webhook name";
+    const existingWebhook = await buildWebhookSubscription({
+      createdById: user.id,
+      teamId: user.teamId,
+      secret: null,
+    });
+
+    const res = await server.post("/api/webhookSubscriptions.update", user, {
+      body: {
+        id: existingWebhook.id,
+        name,
+        url: existingWebhook.url,
+        events: existingWebhook.events,
+        secret: null,
+      },
+    });
+    const body = await res.json();
+
+    expect(res.status).toEqual(200);
+    expect(body.data.name).toEqual(name);
+    expect(body.data.secret).toBeNull();
+  });
+
   it("should activate a disabled webhook subscription when it's updated", async () => {
     const user = await buildAdmin();
     const name = "Updated webhook name";


### PR DESCRIPTION
- Accept null signing secrets in webhook subscription create and update requests.
- Keep webhooks without a secret unchanged when edited.
- closes #13621