### PR TITLE
feat: show the heading in a link to a document anchor

### DIFF
--- a/app/editor/extensions/PasteHandler.tsx
+++ b/app/editor/extensions/PasteHandler.tsx
@@ -11,6 +11,7 @@ import Extension from "@shared/editor/lib/Extension";
 import { codeLanguages } from "@shared/editor/lib/code";
 import isMarkdown from "@shared/editor/lib/isMarkdown";
 import normalizePastedMarkdown from "@shared/editor/lib/markdown/normalize";
+import { documentMentionAttrs } from "@shared/editor/lib/mention";
 import { isRemoteTransaction } from "@shared/editor/lib/multiplayer";
 import { recreateTransform } from "@shared/editor/lib/prosemirror-recreate-transform";
 import { isInCode } from "@shared/editor/queries/isInCode";
@@ -21,6 +22,7 @@ import { determineIconType } from "@shared/utils/icon";
 import parseCollectionSlug from "@shared/utils/parseCollectionSlug";
 import parseDocumentSlug from "@shared/utils/parseDocumentSlug";
 import { isCollectionUrl, isDocumentUrl, isUrl } from "@shared/utils/urls";
+import { ProsemirrorHelper } from "~/models/helpers/ProsemirrorHelper";
 import stores from "~/stores";
 import { PasteMenu } from "../components/PasteMenu";
 
@@ -138,10 +140,23 @@ export default class PasteHandler extends Extension {
                           return;
                         }
                         if (document) {
-                          if (state.schema.nodes.mention) {
-                            const { hash } = new URL(trimmedText);
-                            const trimmedHash = hash.substring(1);
+                          const { hash } = new URL(trimmedText);
+                          const pastedAnchorId = hash.substring(1) || undefined;
+                          const heading =
+                            pastedAnchorId && document.data
+                              ? ProsemirrorHelper.getHeadingTitle(
+                                  document,
+                                  pastedAnchorId
+                                )
+                              : undefined;
+                          const { label, anchorId } = documentMentionAttrs({
+                            title: document.titleWithDefault,
+                            heading,
+                            anchorId: pastedAnchorId,
+                            sameDocument: document.id === this.editor.props.id,
+                          });
 
+                          if (state.schema.nodes.mention) {
                             view.dispatch(
                               view.state.tr.replaceWith(
                                 state.selection.from,
@@ -149,23 +164,18 @@ export default class PasteHandler extends Extension {
                                 state.schema.nodes.mention.create({
                                   type: MentionType.Document,
                                   modelId: document.id,
-                                  label: document.titleWithDefault,
+                                  label,
                                   id: uuidv4(),
-                                  anchorId: trimmedHash.length
-                                    ? trimmedHash
-                                    : undefined,
+                                  anchorId,
                                 })
                               )
                             );
                           } else {
-                            const { hash } = new URL(trimmedText);
                             const hasEmoji =
                               determineIconType(document.icon) ===
                               IconType.Emoji;
 
-                            const title = `${hasEmoji ? document.icon + " " : ""}${
-                              document.titleWithDefault
-                            }`;
+                            const title = `${hasEmoji ? document.icon + " " : ""}${label}`;
 
                             this.insertLink(`${document.path}${hash}`, title);
                           }

--- a/app/models/helpers/ProsemirrorHelper.test.ts
+++ b/app/models/helpers/ProsemirrorHelper.test.ts
@@ -1,0 +1,56 @@
+import type { ProsemirrorData } from "@shared/types";
+import { ProsemirrorHelper } from "./ProsemirrorHelper";
+
+const heading = (text: string, level: number) => ({
+  type: "heading",
+  attrs: { level },
+  content: [{ type: "text", text }],
+});
+
+const document = (...content: object[]) => ({
+  data: { type: "doc", content } as ProsemirrorData,
+});
+
+describe("getHeadingTitle", () => {
+  it("finds the heading that an anchor points at", () => {
+    expect(
+      ProsemirrorHelper.getHeadingTitle(
+        document(heading("Q3 goals", 2)),
+        "h-q3-goals"
+      )
+    ).toBe("Q3 goals");
+  });
+
+  it("finds a heading through the percent encoding a url puts on its anchor", () => {
+    expect(
+      ProsemirrorHelper.getHeadingTitle(
+        document(heading("\u306b\u307b\u3093\u3054", 2)),
+        "h-%E3%81%AB%E3%81%BB%E3%82%93%E3%81%94"
+      )
+    ).toBe("\u306b\u307b\u3093\u3054");
+  });
+
+  it("returns undefined when the heading no longer exists", () => {
+    expect(
+      ProsemirrorHelper.getHeadingTitle(
+        document(heading("Q4 goals", 2)),
+        "h-q3-goals"
+      )
+    ).toBeUndefined();
+  });
+
+  it("distinguishes repeated headings by the suffix on their anchor", () => {
+    const repeated = document(
+      heading("Goals", 2),
+      heading("Timeline", 2),
+      heading("Goals", 3)
+    );
+
+    expect(ProsemirrorHelper.getHeadingTitle(repeated, "h-goals-1")).toBe(
+      "Goals"
+    );
+    expect(
+      ProsemirrorHelper.getHeadingTitle(repeated, "h-goals-2")
+    ).toBeUndefined();
+  });
+});

--- a/app/models/helpers/ProsemirrorHelper.ts
+++ b/app/models/helpers/ProsemirrorHelper.ts
@@ -4,6 +4,7 @@ import type { ProsemirrorData } from "@shared/types";
 import { ProsemirrorHelper as SharedProsemirrorHelper } from "@shared/utils/ProsemirrorHelper";
 import { Schema } from "prosemirror-model";
 import { Node } from "prosemirror-model";
+import { decodeURIComponentSafe } from "~/utils/urls";
 
 interface HasData {
   data: ProsemirrorData;
@@ -44,5 +45,21 @@ export class ProsemirrorHelper {
       Node.fromJSON(schema, document.data)
     );
     return text;
+  };
+
+  /**
+   * Returns the title of the heading that an anchor id points at in the document.
+   *
+   * @param document the document the anchor points into.
+   * @param anchorId the anchor id from a link to a heading in that document.
+   * @returns the heading title, or undefined if the document has no such heading.
+   */
+  static getHeadingTitle = (document: HasData, anchorId: string) => {
+    const doc = Node.fromJSON(schema, document.data);
+    const id = decodeURIComponentSafe(anchorId);
+
+    return SharedProsemirrorHelper.getHeadings(doc).find(
+      (heading) => heading.id === id
+    )?.title;
   };
 }

--- a/app/scenes/Document/components/Comments/CommentForm.tsx
+++ b/app/scenes/Document/components/Comments/CommentForm.tsx
@@ -381,6 +381,7 @@ function CommentForm({
           )}
           <React.Suspense fallback={<div style={{ height: 24 }} />}>
             <CommentEditor
+              id={documentId}
               key={`${forceRender}`}
               ref={mergeRefs([editorRef, handleMounted])}
               defaultValue={draft}

--- a/app/scenes/Document/components/Comments/CommentThreadItem.tsx
+++ b/app/scenes/Document/components/Comments/CommentThreadItem.tsx
@@ -232,6 +232,7 @@ function CommentThreadItem({
         <Body ref={formRef} onSubmit={handleSubmit}>
           <React.Suspense fallback={null}>
             <StyledCommentEditor
+              id={comment.documentId}
               key={String(isEditing)}
               readOnly={!isEditing}
               value={comment.data}

--- a/shared/editor/components/Mentions.tsx
+++ b/shared/editor/components/Mentions.tsx
@@ -3,6 +3,7 @@ import {
   DocumentIcon,
   EmailIcon,
   CollectionIcon,
+  HashtagIcon,
   WarningIcon,
 } from "outline-icons";
 import type { Node } from "prosemirror-model";
@@ -31,6 +32,7 @@ import {
   type JSONValue,
   type UnfurlResponse,
 } from "../../types";
+import { isSectionMention } from "../lib/mention";
 import { cn } from "../styles/utils";
 import type { ComponentProps } from "../types";
 import { toDisplayUrl, cdnPath, sanitizeImageSrc } from "../../utils/urls";
@@ -107,6 +109,7 @@ export const MentionDocument = observer(function MentionDocument_(
   const doc = documents.get(node.attrs.modelId);
   const modelId = node.attrs.modelId;
   const anchorId = node.attrs.anchorId;
+  const label = node.attrs.label;
   const { className, unfurl, ...attrs } = getAttributesFromNode(node);
 
   React.useEffect(() => {
@@ -116,6 +119,7 @@ export const MentionDocument = observer(function MentionDocument_(
   }, [modelId, documents]);
 
   const documentPath = doc?.path ?? `/doc/${node.attrs.modelId}`;
+  const isSection = isSectionMention({ anchorId, label });
 
   return (
     <Link
@@ -125,7 +129,9 @@ export const MentionDocument = observer(function MentionDocument_(
       })}
       to={anchorId ? `${documentPath}#${anchorId}` : documentPath}
     >
-      {doc?.icon ? (
+      {isSection ? (
+        <HashtagIcon size={18} />
+      ) : doc?.icon ? (
         <Icon
           value={doc.icon}
           initial={doc.initial}
@@ -135,7 +141,7 @@ export const MentionDocument = observer(function MentionDocument_(
       ) : (
         <DocumentIcon size={18} />
       )}
-      <span>{doc?.title || node.attrs.label}</span>
+      <span>{anchorId ? label : doc?.title || label}</span>
     </Link>
   );
 });

--- a/shared/editor/lib/mention.test.ts
+++ b/shared/editor/lib/mention.test.ts
@@ -1,0 +1,69 @@
+import { documentMentionAttrs, isSectionMention } from "./mention";
+
+const onboarding = {
+  title: "Onboarding",
+  heading: "First week",
+  anchorId: "h-first-week",
+};
+
+describe("documentMentionAttrs", () => {
+  it("is the document title alone when the link carries no anchor", () => {
+    expect(documentMentionAttrs({ title: "Onboarding" })).toEqual({
+      label: "Onboarding",
+      anchorId: undefined,
+    });
+  });
+
+  it("names the document before the heading when it points at another document", () => {
+    expect(documentMentionAttrs(onboarding)).toEqual({
+      label: "Onboarding \u203a First week",
+      anchorId: "h-first-week",
+    });
+  });
+
+  it("drops the title it would repeat when it points into the document being written", () => {
+    expect(documentMentionAttrs({ ...onboarding, sameDocument: true })).toEqual(
+      { label: "First week", anchorId: "h-first-week" }
+    );
+  });
+
+  it("drops an anchor that resolved to no heading, leaving a link to the document", () => {
+    expect(
+      documentMentionAttrs({ title: "Onboarding", anchorId: "h-fourth-week" })
+    ).toEqual({ label: "Onboarding", anchorId: undefined });
+  });
+});
+
+describe("isSectionMention", () => {
+  it("reads a heading referenced from elsewhere in its own document as a section", () => {
+    expect(
+      isSectionMention(
+        documentMentionAttrs({ ...onboarding, sameDocument: true })
+      )
+    ).toBe(true);
+  });
+
+  it("reads a heading referenced from a comment on that document as a section", () => {
+    const comment = documentMentionAttrs({ ...onboarding, sameDocument: true });
+
+    expect(isSectionMention(comment)).toBe(true);
+  });
+
+  it("reads a heading in another document as a document", () => {
+    expect(isSectionMention(documentMentionAttrs(onboarding))).toBe(false);
+  });
+
+  it("reads a link whose anchor resolved to no heading as a document", () => {
+    expect(
+      isSectionMention(
+        documentMentionAttrs({ title: "Onboarding", anchorId: "h-fourth-week" })
+      )
+    ).toBe(false);
+  });
+
+  it("reads a document whose own title carries the separator as a document", () => {
+    expect(
+      isSectionMention(documentMentionAttrs({ title: "Q3 \u203a Q4 planning" }))
+    ).toBe(false);
+  });
+});

--- a/shared/editor/lib/mention.ts
+++ b/shared/editor/lib/mention.ts
@@ -3,6 +3,57 @@ import type { Primitive } from "utility-types";
 import { v4 as uuidv4 } from "uuid";
 import { isList } from "../queries/isList";
 
+/** Separates a document title from the heading that a mention's anchor points at. */
+export const ANCHOR_SEPARATOR = "\u203a";
+
+/**
+ * Builds the attributes of a mention that links to a document, decided once when
+ * the mention is created and read verbatim wherever it is rendered.
+ *
+ * A reference to a heading in the document being written drops the document
+ * title it would otherwise repeat, and an anchor that resolved to no heading is
+ * dropped with it, which together make an anchored label without a separator a
+ * section of the document that holds it.
+ *
+ * @param options the document title, the heading the pasted anchor resolved to,
+ * that anchor, and whether the mention is being written in that same document.
+ * @returns the label and anchor to store on the mention.
+ */
+export function documentMentionAttrs({
+  title,
+  heading,
+  anchorId,
+  sameDocument,
+}: {
+  title: string;
+  heading?: string;
+  anchorId?: string;
+  sameDocument?: boolean;
+}): { label: string; anchorId?: string } {
+  if (!heading) {
+    return { label: title, anchorId: undefined };
+  }
+
+  return {
+    label: sameDocument ? heading : `${title} ${ANCHOR_SEPARATOR} ${heading}`,
+    anchorId,
+  };
+}
+
+/**
+ * Whether a document mention refers to a heading in the document that holds it,
+ * in which case its label is that heading alone.
+ *
+ * @param attrs the mention's anchor id and label.
+ * @returns true if the mention reads as a section rather than a document.
+ */
+export function isSectionMention(attrs: {
+  anchorId?: string;
+  label: string;
+}): boolean {
+  return !!attrs.anchorId && !attrs.label.includes(ANCHOR_SEPARATOR);
+}
+
 export function transformListToMentions(
   listNode: Node,
   schema: Schema,

--- a/shared/editor/nodes/Mention.test.ts
+++ b/shared/editor/nodes/Mention.test.ts
@@ -152,6 +152,32 @@ describe("Mention serialization", () => {
       ).toBe(`[Onboarding](/doc/${modelId})`);
     });
 
+    it("serializes a document mention with an anchor as a link carrying the heading", () => {
+      expect(
+        serializeMention(
+          {
+            type: MentionType.Document,
+            label: "Onboarding \u203a First week",
+            anchorId: "h-first-week",
+          },
+          { commonMark: true }
+        )
+      ).toBe(`[Onboarding \u203a First week](/doc/${modelId}#h-first-week)`);
+    });
+
+    it("serializes a section mention as a link carrying only its heading", () => {
+      expect(
+        serializeMention(
+          {
+            type: MentionType.Document,
+            label: "First week",
+            anchorId: "h-first-week",
+          },
+          { commonMark: true }
+        )
+      ).toBe(`[First week](/doc/${modelId}#h-first-week)`);
+    });
+
     it("serializes a collection mention as an internal link", () => {
       expect(
         serializeMention(


### PR DESCRIPTION
## Summary

Follows the discussion with the maintainer in [outline/outline#13620](https://github.com/outline/outline/discussions/13620).

A link pasted into a document becomes a mention, and a mention showed only the document title. A link to a heading therefore read exactly like a link to the document it lives in, which made a reference to a section of the document you were already reading useless. The heading now travels with the mention, so a reference reads as what it points at: `Onboarding › First week` from elsewhere, `# First week` from inside Onboarding itself.

## User flow

Copy a heading link with the copy button that appears on every heading, paste it into a document or a comment. The paste resolves the anchor against the target document and writes the mention:

- into another document: the document title, the heading, and the target document's icon.
- into the document that owns the heading, or into a comment on it: the heading alone with a hashtag, because the title would repeat what the reader is already looking at.
- when the heading no longer exists: a plain mention of the document, and the dead anchor is dropped so the link goes where it can still land.
- where the schema has no mention node: the same text as a plain link, unchanged from today.

## Behavior changes

| Pasted link | Before | After |
|---|---|---|
| Heading in another document | `Onboarding` | `Onboarding › First week` |
| Heading in the document being written | `Onboarding` | `# First week` |
| Heading in a comment on that document | `Onboarding` | `# First week` |
| Heading that no longer exists | `Onboarding`, anchor kept | `Onboarding`, anchor dropped |
| Document with no anchor | `Onboarding` | unchanged |
| Markdown export of the first two | `[Onboarding](/doc/id#h-first-week)` | `[Onboarding › First week](/doc/id#h-first-week)`, `[First week](/doc/id#h-first-week)` |

## Visual changes

**A section of the document you are reading, in the body and in a comment**

![Document and comment, desktop](https://github.com/fcatuhe/outline/raw/repository-assets/.pr-assets/1/document_and_comment_desktop.png)

![Document and comment, mobile](https://github.com/fcatuhe/outline/raw/repository-assets/.pr-assets/1/document_mobile.png)

**A heading in another document, in the body and in a comment, beside a plain document mention and a link whose heading is gone**

![Another document, desktop](https://github.com/fcatuhe/outline/raw/repository-assets/.pr-assets/1/other_document_desktop.png)

![Another document, mobile](https://github.com/fcatuhe/outline/raw/repository-assets/.pr-assets/1/other_document_mobile.png)

<sub>Screenshots live on the long-lived `repository-assets` branch.</sub>

## Implementation notes

No new attribute on the mention node. The heading rides in `label`, the string that already carries the document title and that every consumer outside the editor reads: markdown export, plain text copy, static HTML, notification email.

`documentMentionAttrs` decides `label` and `anchorId` together, once, when the link is pasted. It drops the document title when the paste happens in that same document, and drops the anchor when no heading resolved. Those two rules give the label an invariant a renderer can read: an anchored label with no separator can only be a heading of the document holding it, which is what `isSectionMention` tests to pick the hashtag icon.

The heading text is resolved by `ProsemirrorHelper.getHeadingTitle` against the app's full schema rather than the editor's own, because a comment's schema has no heading node to parse the target document with. Comment editors now receive the id of the document they belong to, which is what lets a comment recognise its own document; it also scopes attachments uploaded from a comment to that document and lets a comment mark serialize the document it belongs to.

## Design decisions

The first version stored the heading in a `headingTitle` attribute. Dropped on the maintainer's comment in the discussion above, to rely on the label itself: a second stored field to keep in sync with `label`, invisible to every consumer that reads the label.

The second version kept the full label and decided the section form at render, comparing the mention to the id of the editor painting it. It flickered. While a collaborative document loads, the cached read-only render is built from a prop list that omits `id`, so every mention drew as a document until the real editor took over ([fcatuhe/outline#2](https://github.com/fcatuhe/outline/issues/2), unrelated fix). Deciding at paste removed the dependency on the editor entirely, which also makes the icon right in an export and in another reader's editor, where there is no current document to compare against.

A dead anchor is dropped rather than kept: the mention then reads as what it now is, a link to the document, and the invariant the icon relies on stays airtight.

## Risks and edge cases

- A label is a snapshot, like every other mention label: renaming the document or the heading does not rewrite existing mentions.
- A same-document mention copied into another document keeps its section label, so it reads as a section of the document it lands in while still linking to the original.
- A heading whose own text contains `›` reads as a cross-document label and shows a document icon.
- If the target document arrives without `data`, no heading resolves and the anchor is dropped. Web clients always receive `data`; only `includeData: false` callers (MCP tools, webhooks) do not.

## Tests

- `shared/editor/lib/mention.test.ts`: the label and anchor written for a heading in another document, in the document being written, in a comment on that document, and for an anchor that resolved to nothing; and the reading taken back off each of those, including a document whose own title carries the separator.
- `shared/editor/nodes/Mention.test.ts`: markdown serialization of an anchored mention and of a section mention.
- `app/models/helpers/ProsemirrorHelper.test.ts`: heading lookup by anchor, through percent encoding, for repeated headings, and for a heading that no longer exists.
