### PR TITLE
Add indexes on user foreign key columns

### DIFF
--- a/server/migrations/20260903145856-add-document-createdbyid-index.js
+++ b/server/migrations/20260903145856-add-document-createdbyid-index.js
@@ -1,14 +1,34 @@
 "use strict";
 
+const indexes = [
+  ["documents", "createdById"],
+  ["documents", "lastModifiedById"],
+  ["revisions", "userId"],
+  ["events", "userId"],
+  ["notifications", "actorId"],
+  ["notifications", "userId"],
+  ["attachments", "userId"],
+  ["comments", "createdById"],
+  ["comments", "resolvedById"],
+  ["shares", "userId"],
+  ["shares", "revokedById"],
+  ["reactions", "userId"],
+  ["relationships", "userId"],
+];
+
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up(queryInterface) {
-    await queryInterface.addIndex("documents", ["createdById"], {
-      concurrently: true,
-    });
+    for (const [table, column] of indexes) {
+      await queryInterface.addIndex(table, [column], {
+        concurrently: true,
+      });
+    }
   },
 
   async down(queryInterface) {
-    await queryInterface.removeIndex("documents", ["createdById"]);
+    for (const [table, column] of indexes.slice().reverse()) {
+      await queryInterface.removeIndex(table, [column]);
+    }
   },
 };

--- a/server/migrations/20260903145856-add-document-createdbyid-index.js
+++ b/server/migrations/20260903145856-add-document-createdbyid-index.js
@@ -1,0 +1,14 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.addIndex("documents", ["createdById"], {
+      concurrently: true,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeIndex("documents", ["createdById"]);
+  },
+};

--- a/server/migrations/20260903145856-add-document-createdbyid-index.js
+++ b/server/migrations/20260903145856-add-document-createdbyid-index.js
@@ -1,34 +1,26 @@
 "use strict";
 
-const indexes = [
-  ["documents", "createdById"],
-  ["documents", "lastModifiedById"],
-  ["revisions", "userId"],
-  ["events", "userId"],
-  ["notifications", "actorId"],
-  ["notifications", "userId"],
-  ["attachments", "userId"],
-  ["comments", "createdById"],
-  ["comments", "resolvedById"],
-  ["shares", "userId"],
-  ["shares", "revokedById"],
-  ["reactions", "userId"],
-  ["relationships", "userId"],
-];
-
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up(queryInterface) {
-    for (const [table, column] of indexes) {
-      await queryInterface.addIndex(table, [column], {
-        concurrently: true,
-      });
-    }
+    await queryInterface.addIndex("documents", ["createdById"], {
+      concurrently: true,
+    });
+    await queryInterface.addIndex("documents", ["lastModifiedById"], {
+      concurrently: true,
+    });
+    await queryInterface.addIndex("revisions", ["userId"], {
+      concurrently: true,
+    });
+    await queryInterface.addIndex("events", ["userId"], {
+      concurrently: true,
+    });
   },
 
   async down(queryInterface) {
-    for (const [table, column] of indexes.slice().reverse()) {
-      await queryInterface.removeIndex(table, [column]);
-    }
+    await queryInterface.removeIndex("events", ["userId"]);
+    await queryInterface.removeIndex("revisions", ["userId"]);
+    await queryInterface.removeIndex("documents", ["lastModifiedById"]);
+    await queryInterface.removeIndex("documents", ["createdById"]);
   },
 };


### PR DESCRIPTION
- Adds missing indexes on user-referencing FK columns of the largest tables: documents (createdById, lastModifiedById), revisions (userId), and events (userId), created concurrently to avoid blocking writes
- FK checks against these columns run per-row during user-delete cascades (e.g. team deletion); without indexes each check is a sequential scan, so large deletions run for hours or never complete