### PR TITLE
chore: Remove unused validation helpers

### DIFF
--- a/server/validation.ts
+++ b/server/validation.ts
@@ -1,13 +1,9 @@
-import { isArrayLike } from "es-toolkit/compat";
 import sanitize from "sanitize-filename";
 import type { Primitive } from "utility-types";
-import validator from "validator";
 import isIn from "validator/lib/isIn";
 import isUUID from "validator/lib/isUUID";
-import { CollectionPermission, MentionType } from "@shared/types";
+import { MentionType } from "@shared/types";
 import { UrlHelper } from "@shared/utils/UrlHelper";
-import { validateColorHex } from "@shared/utils/color";
-import { validateIndexCharacters } from "@shared/utils/indexCharacters";
 import parseMentionUrl from "@shared/utils/parseMentionUrl";
 import { isUrl } from "@shared/utils/urls";
 import { ParamRequiredError, ValidationError } from "./errors";
@@ -23,15 +19,6 @@ export const assertPresent = (value: IncomingValue, message: string) => {
   }
 };
 
-export function assertArray(
-  value: IncomingValue,
-  message?: string
-): asserts value {
-  if (!isArrayLike(value)) {
-    throw ValidationError(message ?? `${String(value)} is not an array`);
-  }
-}
-
 export const assertIn = (
   value: string,
   options: Primitive[],
@@ -40,149 +27,6 @@ export const assertIn = (
   if (!options.includes(value)) {
     throw ValidationError(message ?? `Must be one of ${options.join(", ")}`);
   }
-};
-
-/**
- * Asserts that an object contains no other keys than specified
- * by a type
- *
- * @param obj The object to check for assertion
- * @param type The type to check against
- * @throws {ValidationError}
- */
-export function assertKeysIn(
-  obj: Record<string, unknown>,
-  type: { [key: string]: number | string }
-) {
-  Object.keys(obj).forEach((key) => assertIn(key, Object.values(type)));
-}
-
-export const assertSort = (
-  value: string,
-  model: { rawAttributes: Record<string, unknown> },
-  message?: string
-) => {
-  if (!Object.keys(model.rawAttributes).includes(value)) {
-    throw ValidationError(
-      message ?? `${String(value)} is not a valid sort field`
-    );
-  }
-};
-
-export function assertNotEmpty(
-  value: IncomingValue,
-  message: string
-): asserts value {
-  assertPresent(value, message);
-
-  if (typeof value === "string" && value.trim() === "") {
-    throw ValidationError(message ?? `${String(value)} is empty`);
-  }
-}
-
-export function assertEmail(
-  value: IncomingValue = "",
-  message?: string
-): asserts value {
-  if (typeof value !== "string" || !validator.isEmail(value)) {
-    throw ValidationError(message ?? `${String(value)} is not a valid email`);
-  }
-}
-
-export function assertUrl(
-  value: IncomingValue = "",
-  message?: string
-): asserts value {
-  if (
-    typeof value !== "string" ||
-    !validator.isURL(value, {
-      protocols: ["http", "https"],
-      require_valid_protocol: true,
-    })
-  ) {
-    throw ValidationError(message ?? `${String(value)} is an invalid url`);
-  }
-}
-
-/**
- * Asserts that the passed value is a valid boolean
- *
- * @param value The value to check for assertion
- * @param [message] The error message to show
- * @throws {ValidationError}
- */
-export function assertBoolean(
-  value: IncomingValue,
-  message?: string
-): asserts value {
-  if (typeof value !== "boolean") {
-    throw ValidationError(message ?? `${String(value)} is not a boolean`);
-  }
-}
-
-export function assertUuid(
-  value: IncomingValue,
-  message?: string
-): asserts value {
-  if (typeof value !== "string") {
-    throw ValidationError(
-      message ?? `${String(value)} is not a string, expected UUID`
-    );
-  }
-  if (!validator.isUUID(value)) {
-    throw ValidationError(message ?? `${String(value)} is not a valid UUID`);
-  }
-}
-
-export const assertPositiveInteger = (
-  value: IncomingValue,
-  message?: string
-) => {
-  if (
-    !validator.isInt(String(value), {
-      min: 0,
-    })
-  ) {
-    throw ValidationError(
-      message ?? `${String(value)} is not a positive integer`
-    );
-  }
-};
-
-export const assertHexColor = (value: string, message?: string) => {
-  if (!validateColorHex(value)) {
-    throw ValidationError(
-      message ?? `${String(value)} is not a valid hex color`
-    );
-  }
-};
-
-export const assertValueInArray = (
-  value: string,
-  values: string[],
-  message?: string
-) => {
-  if (!values.includes(value)) {
-    throw ValidationError(
-      message ?? `${String(value)} is not in the allowed values`
-    );
-  }
-};
-
-export const assertIndexCharacters = (
-  value: string,
-  message = "index must be between x20 to x7E ASCII"
-) => {
-  if (!validateIndexCharacters(value)) {
-    throw ValidationError(message ?? `${String(value)} is not a valid index`);
-  }
-};
-
-export const assertCollectionPermission = (
-  value: string,
-  message = "Invalid permission"
-) => {
-  assertIn(value, [...Object.values(CollectionPermission), null], message);
 };
 
 export class ValidateKey {

--- a/shared/utils/files.ts
+++ b/shared/utils/files.ts
@@ -113,26 +113,6 @@ export function getDataTransferFiles(
 }
 
 /**
- * Get an array of DataTransferItems from a drag event
- *
- * @param event The react or native drag event
- * @returns An array of DataTransferItems
- */
-export function getDataTransferItems(
-  event: React.DragEvent<HTMLElement> | DragEvent
-): DataTransferItem[] {
-  const dt = event.dataTransfer;
-
-  if (dt) {
-    if ("items" in dt && dt.items.length) {
-      return dt.items ? Array.prototype.slice.call(dt.items) : [];
-    }
-  }
-
-  return [];
-}
-
-/**
  * Get an array of Files from an input event
  *
  * @param event The react or native input event


### PR DESCRIPTION
Removes dead code that has no callers anywhere in the repo.

- Drops thirteen legacy assertion helpers from `server/validation.ts` that were superseded by Zod schemas, along with the imports that only served them. `assertPresent` and `assertIn` remain in use and are kept.
- Drops the unused `getDataTransferItems` util from shared file helpers.