### PR TITLE
refactor: DRY up app stores with a shared page fetch helper and IndexedStore

### DIFF
--- a/app/stores/CollectionsStore.ts
+++ b/app/stores/CollectionsStore.ts
@@ -10,10 +10,10 @@ import {
 import Collection from "~/models/Collection";
 import type { PaginationParams, Properties } from "~/types";
 import { client } from "~/utils/ApiClient";
+import IndexedStore from "./base/IndexedStore";
 import type RootStore from "./RootStore";
-import Store from "./base/Store";
 
-export default class CollectionsStore extends Store<Collection> {
+export default class CollectionsStore extends IndexedStore<Collection> {
   constructor(rootStore: RootStore) {
     super(rootStore, Collection);
     makeObservable(this);
@@ -38,19 +38,13 @@ export default class CollectionsStore extends Store<Collection> {
 
   @override
   get orderedData(): Collection[] {
-    let collections = Array.from(this.data.values());
-    collections = collections
-      .filter((collection) => !collection.deletedAt)
-      .filter((collection) => {
-        const can = this.rootStore.policies.abilities(collection.id);
-        return isEmpty(can) || can.readDocument;
-      });
-    return collections.sort((a, b) => {
-      if (a.index === b.index) {
-        return a.updatedAt > b.updatedAt ? -1 : 1;
+    return super.orderedData.filter((collection) => {
+      if (collection.deletedAt) {
+        return false;
       }
 
-      return a.index < b.index ? -1 : 1;
+      const can = this.rootStore.policies.abilities(collection.id);
+      return isEmpty(can) || can.readDocument;
     });
   }
 
@@ -164,26 +158,11 @@ export default class CollectionsStore extends Store<Collection> {
     return result;
   }
 
-  @action
   fetchNamedPage = async (
     request = "list",
     options: (PaginationParams & { filters?: Filter[] }) | undefined
-  ): Promise<Collection[]> => {
-    this.isFetching = true;
-
-    try {
-      const res = await client.post(`/collections.${request}`, options);
-      invariant(res?.data, "Collection list not available");
-      return runInAction(() => {
-        const collections = res.data.map(this.add);
-        this.addPolicies(res.policies);
-        this.isLoaded = true;
-        return collections;
-      });
-    } finally {
-      this.isFetching = false;
-    }
-  };
+  ): Promise<Collection[]> =>
+    this.fetchPaginated(`/collections.${request}`, options);
 
   @action
   fetchArchived = async (options?: PaginationParams): Promise<Collection[]> =>

--- a/app/stores/DocumentsStore.ts
+++ b/app/stores/DocumentsStore.ts
@@ -1,5 +1,5 @@
 import invariant from "invariant";
-import { compact, filter, omitBy, orderBy } from "es-toolkit/compat";
+import { compact, omitBy, orderBy } from "es-toolkit/compat";
 import {
   action,
   computed,
@@ -100,7 +100,7 @@ export default class DocumentsStore extends Store<Document> {
 
   @computed
   get all(): Document[] {
-    return filter(this.orderedData, (d) => !d.archivedAt && !d.deletedAt);
+    return this.orderedData.filter((d) => !d.archivedAt && !d.deletedAt);
   }
 
   @computed
@@ -124,15 +124,14 @@ export default class DocumentsStore extends Store<Document> {
 
   createdByUser(userId: string): Document[] {
     return orderBy(
-      filter(this.all, (d) => d.createdBy?.id === userId),
+      this.all.filter((d) => d.createdBy?.id === userId),
       "updatedAt",
       "desc"
     );
   }
 
   inCollection(collectionId: string): Document[] {
-    return filter(
-      this.all,
+    return this.all.filter(
       (document) => document.collectionId === collectionId
     );
   }
@@ -151,12 +150,11 @@ export default class DocumentsStore extends Store<Document> {
           document.isArchived &&
           !document.isDeleted;
 
-    return filter(this.orderedData, filterCond);
+    return this.orderedData.filter(filterCond);
   }
 
   unarchivedInCollection(collectionId: string): Document[] {
-    return filter(
-      this.orderedData,
+    return this.orderedData.filter(
       (document) =>
         document.collectionId === collectionId &&
         !document.isArchived &&
@@ -165,8 +163,7 @@ export default class DocumentsStore extends Store<Document> {
   }
 
   publishedInCollection(collectionId: string): Document[] {
-    return filter(
-      this.all,
+    return this.all.filter(
       (document) =>
         document.collectionId === collectionId && !!document.publishedAt
     );
@@ -256,16 +253,14 @@ export default class DocumentsStore extends Store<Document> {
     );
 
     if (options.userId) {
-      deleted = filter(
-        deleted,
+      deleted = deleted.filter(
         (document) => document.deletedBy?.id === options.userId
       );
     }
 
     if (options.dateFilter) {
       const cutoff = subtractDate(new Date(), options.dateFilter);
-      deleted = filter(
-        deleted,
+      deleted = deleted.filter(
         (document) =>
           !!document.deletedAt && new Date(document.deletedAt) >= cutoff
       );
@@ -285,14 +280,12 @@ export default class DocumentsStore extends Store<Document> {
       collectionId?: string;
     } = {}
   ): Document[] => {
-    let drafts = filter(
-      orderBy(this.all, "updatedAt", "desc"),
+    let drafts = orderBy(this.all, "updatedAt", "desc").filter(
       (doc) => !doc.publishedAt
     );
 
     if (options.dateFilter) {
-      drafts = filter(
-        drafts,
+      drafts = drafts.filter(
         (draft) =>
           new Date(draft.updatedAt) >=
           subtractDate(new Date(), options.dateFilter || "year")
@@ -300,9 +293,9 @@ export default class DocumentsStore extends Store<Document> {
     }
 
     if (options.collectionId) {
-      drafts = filter(drafts, {
-        collectionId: options.collectionId,
-      });
+      drafts = drafts.filter(
+        (draft) => draft.collectionId === options.collectionId
+      );
     }
 
     return drafts;
@@ -371,26 +364,11 @@ export default class DocumentsStore extends Store<Document> {
     });
   };
 
-  @action
   fetchNamedPage = async (
     request = "list",
     options: FetchPageParams | undefined
-  ): Promise<Document[]> => {
-    this.isFetching = true;
-
-    try {
-      const res = await client.post(`/documents.${request}`, options);
-      invariant(res?.data, "Document list not available");
-      return runInAction(() => {
-        const documents = res.data.map(this.add);
-        this.addPolicies(res.policies);
-        this.isLoaded = true;
-        return documents;
-      });
-    } finally {
-      this.isFetching = false;
-    }
-  };
+  ): Promise<Document[]> =>
+    this.fetchPaginated(`/documents.${request}`, options);
 
   @action
   fetchArchived = async (options?: PaginationParams): Promise<Document[]> =>

--- a/app/stores/GroupMembershipsStore.ts
+++ b/app/stores/GroupMembershipsStore.ts
@@ -43,13 +43,10 @@ export default class GroupMembershipsStore extends Store<GroupMembership> {
         ? ["/documents.group_memberships", { id: documentId, ...params }]
         : ["/groupMemberships.list", params];
 
-    return this.fetchPaginated(endpoint, body, {
-      key: "groupMemberships",
-      related: {
-        groups: this.rootStore.groups,
-        documents: this.rootStore.documents,
-      },
-    });
+    return this.fetchPaginated(endpoint, body, [
+      this.rootStore.groups,
+      this.rootStore.documents,
+    ]);
   };
 
   @override

--- a/app/stores/GroupMembershipsStore.ts
+++ b/app/stores/GroupMembershipsStore.ts
@@ -1,5 +1,5 @@
 import invariant from "invariant";
-import { override, runInAction } from "mobx";
+import { override } from "mobx";
 import {
   type CollectionPermission,
   type DocumentPermission,
@@ -8,11 +8,7 @@ import GroupMembership from "~/models/GroupMembership";
 import type { PaginationParams } from "~/types";
 import { client } from "~/utils/ApiClient";
 import type RootStore from "./RootStore";
-import Store, {
-  PAGINATION_SYMBOL,
-  type PaginatedResponse,
-  RPCAction,
-} from "./base/Store";
+import Store, { type PaginatedResponse, RPCAction } from "./base/Store";
 
 export default class GroupMembershipsStore extends Store<GroupMembership> {
   actions = [RPCAction.Create, RPCAction.Delete];
@@ -41,39 +37,19 @@ export default class GroupMembershipsStore extends Store<GroupMembership> {
     collectionId?: string;
     groupId?: string;
   }): Promise<PaginatedResponse<GroupMembership>> => {
-    runInAction(() => {
-      this.isFetching = true;
+    const [endpoint, body] = collectionId
+      ? ["/collections.group_memberships", { id: collectionId, ...params }]
+      : documentId
+        ? ["/documents.group_memberships", { id: documentId, ...params }]
+        : ["/groupMemberships.list", params];
+
+    return this.fetchPaginated(endpoint, body, {
+      key: "groupMemberships",
+      related: {
+        groups: this.rootStore.groups,
+        documents: this.rootStore.documents,
+      },
     });
-
-    try {
-      const res = collectionId
-        ? await client.post(`/collections.group_memberships`, {
-            id: collectionId,
-            ...params,
-          })
-        : documentId
-          ? await client.post(`/documents.group_memberships`, {
-              id: documentId,
-              ...params,
-            })
-          : await client.post(`/groupMemberships.list`, params);
-      invariant(res?.data, "Data not available");
-
-      let response: PaginatedResponse<GroupMembership> = [];
-      runInAction(() => {
-        res.data.groups?.forEach(this.rootStore.groups.add);
-        res.data.documents?.forEach(this.rootStore.documents.add);
-        response = res.data.groupMemberships.map(this.add);
-        this.isLoaded = true;
-      });
-
-      response[PAGINATION_SYMBOL] = res.pagination;
-      return response;
-    } finally {
-      runInAction(() => {
-        this.isFetching = false;
-      });
-    }
   };
 
   @override

--- a/app/stores/GroupUsersStore.ts
+++ b/app/stores/GroupUsersStore.ts
@@ -1,16 +1,11 @@
 import invariant from "invariant";
-import { filter } from "es-toolkit/compat";
 import { action, makeObservable, override, runInAction } from "mobx";
 import GroupUser from "~/models/GroupUser";
 import type { PaginationParams } from "~/types";
 import { GroupPermission } from "@shared/types";
 import { client } from "~/utils/ApiClient";
 import type RootStore from "./RootStore";
-import Store, {
-  type PaginatedResponse,
-  PAGINATION_SYMBOL,
-  RPCAction,
-} from "./base/Store";
+import Store, { type PaginatedResponse, RPCAction } from "./base/Store";
 
 export default class GroupUsersStore extends Store<GroupUser> {
   actions = [RPCAction.Create, RPCAction.Update, RPCAction.Delete];
@@ -22,30 +17,11 @@ export default class GroupUsersStore extends Store<GroupUser> {
 
   fetchPage = async (
     params: PaginationParams | undefined
-  ): Promise<PaginatedResponse<GroupUser>> => {
-    runInAction(() => {
-      this.isFetching = true;
+  ): Promise<PaginatedResponse<GroupUser>> =>
+    this.fetchPaginated("/groups.memberships", params, {
+      key: "groupMemberships",
+      related: { users: this.rootStore.users },
     });
-
-    try {
-      const res = await client.post(`/groups.memberships`, params);
-      invariant(res?.data, "Data not available");
-
-      let response: PaginatedResponse<GroupUser> = [];
-      runInAction(() => {
-        res.data.users.forEach(this.rootStore.users.add);
-        response = res.data.groupMemberships.map(this.add);
-        this.isLoaded = true;
-      });
-
-      response[PAGINATION_SYMBOL] = res.pagination;
-      return response;
-    } finally {
-      runInAction(() => {
-        this.isFetching = false;
-      });
-    }
-  };
 
   @override
   async create({
@@ -123,7 +99,7 @@ export default class GroupUsersStore extends Store<GroupUser> {
   };
 
   inGroup = (groupId: string) =>
-    filter(this.orderedData, (member) => member.groupId === groupId);
+    this.orderedData.filter((member) => member.groupId === groupId);
 
   /**
    * Returns the membership of a user in a group, if loaded.

--- a/app/stores/GroupUsersStore.ts
+++ b/app/stores/GroupUsersStore.ts
@@ -10,6 +10,8 @@ import Store, { type PaginatedResponse, RPCAction } from "./base/Store";
 export default class GroupUsersStore extends Store<GroupUser> {
   actions = [RPCAction.Create, RPCAction.Update, RPCAction.Delete];
 
+  responseKey = "groupMemberships";
+
   constructor(rootStore: RootStore) {
     super(rootStore, GroupUser);
     makeObservable(this);
@@ -18,10 +20,7 @@ export default class GroupUsersStore extends Store<GroupUser> {
   fetchPage = async (
     params: PaginationParams | undefined
   ): Promise<PaginatedResponse<GroupUser>> =>
-    this.fetchPaginated("/groups.memberships", params, {
-      key: "groupMemberships",
-      related: { users: this.rootStore.users },
-    });
+    this.fetchPaginated("/groups.memberships", params, [this.rootStore.users]);
 
   @override
   async create({

--- a/app/stores/GroupsStore.ts
+++ b/app/stores/GroupsStore.ts
@@ -20,10 +20,7 @@ export default class GroupsStore extends Store<Group> {
   fetchPage = async (
     params: FetchPageParams | undefined
   ): Promise<PaginatedResponse<Group>> =>
-    this.fetchPaginated("/groups.list", params, {
-      key: "groups",
-      related: { groupMemberships: this.rootStore.groupUsers },
-    });
+    this.fetchPaginated("/groups.list", params, [this.rootStore.groupUsers]);
 
   /**
    * Returns groups that are in the given collection, optionally filtered by a query.

--- a/app/stores/GroupsStore.ts
+++ b/app/stores/GroupsStore.ts
@@ -1,12 +1,9 @@
-import invariant from "invariant";
-import { filter } from "es-toolkit/compat";
-import { override, runInAction } from "mobx";
+import { override } from "mobx";
 import naturalSort from "@shared/utils/naturalSort";
 import Group from "~/models/Group";
 import type { PaginationParams } from "~/types";
-import { client } from "~/utils/ApiClient";
 import type RootStore from "./RootStore";
-import Store from "./base/Store";
+import Store, { type PaginatedResponse } from "./base/Store";
 
 type FetchPageParams = PaginationParams & { query?: string };
 
@@ -20,29 +17,13 @@ export default class GroupsStore extends Store<Group> {
     return naturalSort(Array.from(this.data.values()), "name");
   }
 
-  fetchPage = async (params: FetchPageParams | undefined): Promise<Group[]> => {
-    runInAction(() => {
-      this.isFetching = true;
+  fetchPage = async (
+    params: FetchPageParams | undefined
+  ): Promise<PaginatedResponse<Group>> =>
+    this.fetchPaginated("/groups.list", params, {
+      key: "groups",
+      related: { groupMemberships: this.rootStore.groupUsers },
     });
-
-    try {
-      const res = await client.post(`/groups.list`, params);
-      invariant(res?.data, "Data not available");
-
-      let models: Group[] = [];
-      runInAction(() => {
-        this.addPolicies(res.policies);
-        models = res.data.groups.map(this.add);
-        res.data.groupMemberships.forEach(this.rootStore.groupUsers.add);
-        this.isLoaded = true;
-      });
-      return models;
-    } finally {
-      runInAction(() => {
-        this.isFetching = false;
-      });
-    }
-  };
 
   /**
    * Returns groups that are in the given collection, optionally filtered by a query.
@@ -52,12 +33,11 @@ export default class GroupsStore extends Store<Group> {
    * @returns A list of groups that are in the given collection.
    */
   inCollection = (collectionId: string, query?: string) => {
-    const memberships = filter(
-      this.rootStore.groupMemberships.orderedData,
+    const memberships = this.rootStore.groupMemberships.orderedData.filter(
       (member) => member.collectionId === collectionId
     );
     const groupIds = memberships.map((member) => member.groupId);
-    const groups = filter(this.orderedData, (group) =>
+    const groups = this.orderedData.filter((group) =>
       groupIds.includes(group.id)
     );
 
@@ -72,13 +52,11 @@ export default class GroupsStore extends Store<Group> {
    * @returns A list of groups that are not in the given document.
    */
   notInDocument = (documentId: string, query = "") => {
-    const memberships = filter(
-      this.rootStore.groupMemberships.orderedData,
+    const memberships = this.rootStore.groupMemberships.orderedData.filter(
       (member) => member.documentId === documentId
     );
     const groupIds = memberships.map((member) => member.groupId);
-    const groups = filter(
-      this.orderedData,
+    const groups = this.orderedData.filter(
       (group) => !groupIds.includes(group.id)
     );
 
@@ -93,13 +71,11 @@ export default class GroupsStore extends Store<Group> {
    * @returns A list of groups that are not in the given collection.
    */
   notInCollection = (collectionId: string, query = "") => {
-    const memberships = filter(
-      this.rootStore.groupMemberships.orderedData,
+    const memberships = this.rootStore.groupMemberships.orderedData.filter(
       (member) => member.collectionId === collectionId
     );
     const groupIds = memberships.map((member) => member.groupId);
-    const groups = filter(
-      this.orderedData,
+    const groups = this.orderedData.filter(
       (group) => !groupIds.includes(group.id)
     );
 

--- a/app/stores/MembershipsStore.ts
+++ b/app/stores/MembershipsStore.ts
@@ -1,15 +1,11 @@
 import invariant from "invariant";
-import { action, makeObservable, override, runInAction } from "mobx";
+import { action, makeObservable, override } from "mobx";
 import type { CollectionPermission } from "@shared/types";
 import Membership from "~/models/Membership";
 import type { PaginationParams } from "~/types";
 import { client } from "~/utils/ApiClient";
 import type RootStore from "./RootStore";
-import Store, {
-  PAGINATION_SYMBOL,
-  type PaginatedResponse,
-  RPCAction,
-} from "./base/Store";
+import Store, { type PaginatedResponse, RPCAction } from "./base/Store";
 
 export default class MembershipsStore extends Store<Membership> {
   actions = [RPCAction.Create, RPCAction.Delete];
@@ -32,29 +28,11 @@ export default class MembershipsStore extends Store<Membership> {
 
   fetchPage = async (
     params: (PaginationParams & { id?: string }) | undefined
-  ): Promise<PaginatedResponse<Membership>> => {
-    runInAction(() => {
-      this.isFetching = true;
+  ): Promise<PaginatedResponse<Membership>> =>
+    this.fetchPaginated("/collections.memberships", params, {
+      key: "memberships",
+      related: { users: this.rootStore.users },
     });
-
-    try {
-      const res = await client.post(`/collections.memberships`, params);
-      invariant(res?.data, "Data not available");
-
-      let response: PaginatedResponse<Membership> = [];
-      runInAction(() => {
-        res.data.users.forEach(this.rootStore.users.add);
-        response = res.data.memberships.map(this.add);
-        this.isLoaded = true;
-      });
-      response[PAGINATION_SYMBOL] = res.pagination;
-      return response;
-    } finally {
-      runInAction(() => {
-        this.isFetching = false;
-      });
-    }
-  };
 
   @override
   async create({

--- a/app/stores/MembershipsStore.ts
+++ b/app/stores/MembershipsStore.ts
@@ -29,10 +29,9 @@ export default class MembershipsStore extends Store<Membership> {
   fetchPage = async (
     params: (PaginationParams & { id?: string }) | undefined
   ): Promise<PaginatedResponse<Membership>> =>
-    this.fetchPaginated("/collections.memberships", params, {
-      key: "memberships",
-      related: { users: this.rootStore.users },
-    });
+    this.fetchPaginated("/collections.memberships", params, [
+      this.rootStore.users,
+    ]);
 
   @override
   async create({

--- a/app/stores/NotificationsStore.ts
+++ b/app/stores/NotificationsStore.ts
@@ -1,11 +1,10 @@
-import invariant from "invariant";
 import { orderBy, sortBy } from "es-toolkit/compat";
 import { action, computed, makeObservable, override, runInAction } from "mobx";
 import Notification from "~/models/Notification";
 import type { PaginationParams } from "~/types";
 import { client } from "~/utils/ApiClient";
 import type RootStore from "./RootStore";
-import Store, { RPCAction } from "./base/Store";
+import Store, { type PaginatedResponse, RPCAction } from "./base/Store";
 
 export default class NotificationsStore extends Store<Notification> {
   actions = [RPCAction.List, RPCAction.Update];
@@ -17,28 +16,10 @@ export default class NotificationsStore extends Store<Notification> {
 
   fetchPage = async (
     options: ({ archived?: boolean } & PaginationParams) | undefined
-  ): Promise<Notification[]> => {
-    runInAction(() => {
-      this.isFetching = true;
+  ): Promise<PaginatedResponse<Notification>> =>
+    this.fetchPaginated("/notifications.list", options, {
+      key: "notifications",
     });
-
-    try {
-      const res = await client.post("/notifications.list", options);
-      invariant(res?.data, "Document revisions not available");
-
-      let models: Notification[] = [];
-      runInAction(() => {
-        models = res.data.notifications.map(this.add);
-        this.isLoaded = true;
-      });
-
-      return models;
-    } finally {
-      runInAction(() => {
-        this.isFetching = false;
-      });
-    }
-  };
 
   /**
    * Mark all notifications as read.

--- a/app/stores/NotificationsStore.ts
+++ b/app/stores/NotificationsStore.ts
@@ -17,9 +17,7 @@ export default class NotificationsStore extends Store<Notification> {
   fetchPage = async (
     options: ({ archived?: boolean } & PaginationParams) | undefined
   ): Promise<PaginatedResponse<Notification>> =>
-    this.fetchPaginated("/notifications.list", options, {
-      key: "notifications",
-    });
+    this.fetchPaginated("/notifications.list", options);
 
   /**
    * Mark all notifications as read.

--- a/app/stores/PinsStore.ts
+++ b/app/stores/PinsStore.ts
@@ -54,10 +54,7 @@ export default class PinsStore extends IndexedStore<Pin> {
   }
 
   fetchPage = async (params?: FetchParams): Promise<PaginatedResponse<Pin>> =>
-    this.fetchPaginated("/pins.list", params, {
-      key: "pins",
-      related: { documents: this.rootStore.documents },
-    });
+    this.fetchPaginated("/pins.list", params, [this.rootStore.documents]);
 
   inCollection = (collectionId: string) =>
     this.orderedData.filter((pin) => pin.collectionId === collectionId);

--- a/app/stores/PinsStore.ts
+++ b/app/stores/PinsStore.ts
@@ -1,15 +1,16 @@
 import invariant from "invariant";
-import { action, computed, override, runInAction } from "mobx";
+import { action, computed } from "mobx";
 import Pin from "~/models/Pin";
 import type { PaginationParams } from "~/types";
 import { client } from "~/utils/ApiClient";
 import { AuthorizationError, NotFoundError } from "~/utils/errors";
+import IndexedStore from "./base/IndexedStore";
 import type RootStore from "./RootStore";
-import Store from "./base/Store";
+import type { PaginatedResponse } from "./base/Store";
 
 type FetchParams = PaginationParams & { collectionId?: string };
 
-export default class PinsStore extends Store<Pin> {
+export default class PinsStore extends IndexedStore<Pin> {
   constructor(rootStore: RootStore) {
     super(rootStore, Pin);
   }
@@ -52,30 +53,11 @@ export default class PinsStore extends Store<Pin> {
     }
   }
 
-  fetchPage = async (params?: FetchParams): Promise<Pin[]> => {
-    runInAction(() => {
-      this.isFetching = true;
+  fetchPage = async (params?: FetchParams): Promise<PaginatedResponse<Pin>> =>
+    this.fetchPaginated("/pins.list", params, {
+      key: "pins",
+      related: { documents: this.rootStore.documents },
     });
-
-    try {
-      const res = await client.post(`/pins.list`, params);
-      invariant(res?.data, "Data not available");
-
-      let models: Pin[] = [];
-      runInAction(() => {
-        res.data.documents.forEach(this.rootStore.documents.add);
-        models = res.data.pins.map(this.add);
-        this.addPolicies(res.policies);
-        this.isLoaded = true;
-      });
-
-      return models;
-    } finally {
-      runInAction(() => {
-        this.isFetching = false;
-      });
-    }
-  };
 
   inCollection = (collectionId: string) =>
     this.orderedData.filter((pin) => pin.collectionId === collectionId);
@@ -83,18 +65,5 @@ export default class PinsStore extends Store<Pin> {
   @computed
   get home() {
     return this.orderedData.filter((pin) => !pin.collectionId);
-  }
-
-  @override
-  get orderedData(): Pin[] {
-    const pins = Array.from(this.data.values());
-
-    return pins.sort((a, b) => {
-      if (a.index === b.index) {
-        return a.updatedAt > b.updatedAt ? -1 : 1;
-      }
-
-      return a.index < b.index ? -1 : 1;
-    });
   }
 }

--- a/app/stores/SharesStore.ts
+++ b/app/stores/SharesStore.ts
@@ -1,5 +1,5 @@
 import invariant from "invariant";
-import { filter, find, isUndefined, orderBy } from "es-toolkit/compat";
+import { isUndefined, orderBy } from "es-toolkit/compat";
 import { action, computed, makeObservable, observable, override } from "mobx";
 import type { NavigationNode, PublicTeam } from "@shared/types";
 import type Document from "~/models/Document";
@@ -35,7 +35,7 @@ export default class SharesStore extends Store<Share> {
 
   @computed
   get published(): Share[] {
-    return filter(this.orderedData, (share) => share.published);
+    return this.orderedData.filter((share) => share.published);
   }
 
   @action
@@ -158,11 +158,11 @@ export default class SharesStore extends Store<Share> {
     return undefined;
   };
 
-  getByCollectionId = (collectionId: string): Share | null | undefined =>
-    find(this.orderedData, (share) => share.collectionId === collectionId);
+  getByCollectionId = (collectionId: string): Share | undefined =>
+    this.orderedData.find((share) => share.collectionId === collectionId);
 
-  getByDocumentId = (documentId: string): Share | null | undefined =>
-    find(this.orderedData, (share) => share.documentId === documentId);
+  getByDocumentId = (documentId: string): Share | undefined =>
+    this.orderedData.find((share) => share.documentId === documentId);
 
   get(id: string): Share | undefined {
     return id

--- a/app/stores/StarsStore.ts
+++ b/app/stores/StarsStore.ts
@@ -1,49 +1,19 @@
-import invariant from "invariant";
-import { override, runInAction } from "mobx";
 import Star from "~/models/Star";
 import type { PaginationParams } from "~/types";
-import { client } from "~/utils/ApiClient";
+import IndexedStore from "./base/IndexedStore";
 import type RootStore from "./RootStore";
-import Store from "./base/Store";
+import type { PaginatedResponse } from "./base/Store";
 
-export default class StarsStore extends Store<Star> {
+export default class StarsStore extends IndexedStore<Star> {
   constructor(rootStore: RootStore) {
     super(rootStore, Star);
   }
 
-  fetchPage = async (params?: PaginationParams): Promise<Star[]> => {
-    runInAction(() => {
-      this.isFetching = true;
+  fetchPage = async (
+    params?: PaginationParams
+  ): Promise<PaginatedResponse<Star>> =>
+    this.fetchPaginated("/stars.list", params, {
+      key: "stars",
+      related: { documents: this.rootStore.documents },
     });
-
-    try {
-      const res = await client.post(`/stars.list`, params);
-      invariant(res?.data, "Data not available");
-
-      return runInAction(() => {
-        res.data.documents.forEach(this.rootStore.documents.add);
-        const models = res.data.stars.map(this.add);
-        this.addPolicies(res.policies);
-        this.isLoaded = true;
-        return models;
-      });
-    } finally {
-      runInAction(() => {
-        this.isFetching = false;
-      });
-    }
-  };
-
-  @override
-  get orderedData(): Star[] {
-    const stars = Array.from(this.data.values());
-
-    return stars.sort((a, b) => {
-      if (a.index === b.index) {
-        return a.updatedAt > b.updatedAt ? -1 : 1;
-      }
-
-      return a.index < b.index ? -1 : 1;
-    });
-  }
 }

--- a/app/stores/StarsStore.ts
+++ b/app/stores/StarsStore.ts
@@ -12,8 +12,5 @@ export default class StarsStore extends IndexedStore<Star> {
   fetchPage = async (
     params?: PaginationParams
   ): Promise<PaginatedResponse<Star>> =>
-    this.fetchPaginated("/stars.list", params, {
-      key: "stars",
-      related: { documents: this.rootStore.documents },
-    });
+    this.fetchPaginated("/stars.list", params, [this.rootStore.documents]);
 }

--- a/app/stores/TemplatesStore.ts
+++ b/app/stores/TemplatesStore.ts
@@ -1,4 +1,4 @@
-import { filter, orderBy } from "es-toolkit/compat";
+import { orderBy } from "es-toolkit/compat";
 import { action, computed, makeObservable, override } from "mobx";
 import { invariant } from "mobx-utils";
 import naturalSort from "@shared/utils/naturalSort";
@@ -30,7 +30,7 @@ export default class TemplatesStore extends Store<Template> {
 
   @computed
   get all(): Template[] {
-    return filter(this.orderedData, (d) => !d.deletedAt);
+    return this.orderedData.filter((d) => !d.deletedAt);
   }
 
   @action

--- a/app/stores/UserMembershipsStore.ts
+++ b/app/stores/UserMembershipsStore.ts
@@ -15,6 +15,8 @@ export default class UserMembershipsStore extends IndexedStore<UserMembership> {
     RPCAction.Update,
   ];
 
+  responseKey = "memberships";
+
   constructor(rootStore: RootStore) {
     super(rootStore, UserMembership);
     makeObservable(this);
@@ -34,19 +36,17 @@ export default class UserMembershipsStore extends IndexedStore<UserMembership> {
   fetchPage = async (
     params?: PaginationParams
   ): Promise<PaginatedResponse<UserMembership>> =>
-    this.fetchPaginated("/userMemberships.list", params, {
-      key: "memberships",
-      related: { documents: this.rootStore.documents },
-    });
+    this.fetchPaginated("/userMemberships.list", params, [
+      this.rootStore.documents,
+    ]);
 
   @action
   fetchDocumentMemberships = async (
     params: (PaginationParams & { id: string }) | undefined
   ): Promise<PaginatedResponse<UserMembership>> =>
-    this.fetchPaginated("/documents.memberships", params, {
-      key: "memberships",
-      related: { users: this.rootStore.users },
-    });
+    this.fetchPaginated("/documents.memberships", params, [
+      this.rootStore.users,
+    ]);
 
   @override
   async create({ documentId, userId, permission }: Partial<UserMembership>) {

--- a/app/stores/UserMembershipsStore.ts
+++ b/app/stores/UserMembershipsStore.ts
@@ -3,10 +3,11 @@ import { action, makeObservable, override, runInAction } from "mobx";
 import UserMembership from "~/models/UserMembership";
 import type { PaginationParams } from "~/types";
 import { client } from "~/utils/ApiClient";
+import IndexedStore from "./base/IndexedStore";
 import type RootStore from "./RootStore";
-import Store, { PAGINATION_SYMBOL, RPCAction } from "./base/Store";
+import { type PaginatedResponse, RPCAction } from "./base/Store";
 
-export default class UserMembershipsStore extends Store<UserMembership> {
+export default class UserMembershipsStore extends IndexedStore<UserMembership> {
   actions = [
     RPCAction.List,
     RPCAction.Create,
@@ -30,51 +31,22 @@ export default class UserMembershipsStore extends Store<UserMembership> {
     this.rootStore.policies.removeForMembership(id);
   }
 
-  fetchPage = async (params?: PaginationParams): Promise<UserMembership[]> => {
-    runInAction(() => {
-      this.isFetching = true;
+  fetchPage = async (
+    params?: PaginationParams
+  ): Promise<PaginatedResponse<UserMembership>> =>
+    this.fetchPaginated("/userMemberships.list", params, {
+      key: "memberships",
+      related: { documents: this.rootStore.documents },
     });
-
-    try {
-      const res = await client.post(`/userMemberships.list`, params);
-      invariant(res?.data, "Data not available");
-
-      return runInAction(() => {
-        res.data.documents.forEach(this.rootStore.documents.add);
-        this.addPolicies(res.policies);
-        this.isLoaded = true;
-        return res.data.memberships.map(this.add);
-      });
-    } finally {
-      runInAction(() => {
-        this.isFetching = false;
-      });
-    }
-  };
 
   @action
   fetchDocumentMemberships = async (
     params: (PaginationParams & { id: string }) | undefined
-  ): Promise<UserMembership[]> => {
-    this.isFetching = true;
-
-    try {
-      const res = await client.post(`/documents.memberships`, params);
-      invariant(res?.data, "Data not available");
-
-      return runInAction(() => {
-        res.data.users.forEach(this.rootStore.users.add);
-
-        const response = res.data.memberships.map(this.add);
-        this.isLoaded = true;
-
-        response[PAGINATION_SYMBOL] = res.pagination;
-        return response;
-      });
-    } finally {
-      this.isFetching = false;
-    }
-  };
+  ): Promise<PaginatedResponse<UserMembership>> =>
+    this.fetchPaginated("/documents.memberships", params, {
+      key: "memberships",
+      related: { users: this.rootStore.users },
+    });
 
   @override
   async create({ documentId, userId, permission }: Partial<UserMembership>) {
@@ -100,19 +72,6 @@ export default class UserMembershipsStore extends Store<UserMembership> {
       userId,
     });
     this.removeAll({ userId, documentId });
-  }
-
-  @override
-  get orderedData(): UserMembership[] {
-    const memberships = Array.from(this.data.values());
-
-    return memberships.sort((a, b) => {
-      if (a.index === b.index) {
-        return a.updatedAt > b.updatedAt ? -1 : 1;
-      }
-
-      return a.index < b.index ? -1 : 1;
-    });
   }
 
   /**

--- a/app/stores/UsersStore.ts
+++ b/app/stores/UsersStore.ts
@@ -1,6 +1,6 @@
 import commandScore from "command-score";
 import invariant from "invariant";
-import { deburr, differenceWith, filter, orderBy } from "es-toolkit/compat";
+import { deburr, differenceWith, orderBy } from "es-toolkit/compat";
 import { action, computed, makeObservable, override, runInAction } from "mobx";
 import type { UserRole } from "@shared/types";
 import User from "~/models/User";
@@ -155,50 +155,44 @@ export default class UsersStore extends Store<User> {
    * @returns A list of users that are not in the given collection.
    */
   notInCollection = (collectionId: string, query = "") => {
-    const groupUsers = filter(
-      this.rootStore.memberships.orderedData,
+    const groupUsers = this.rootStore.memberships.orderedData.filter(
       (member) => member.collectionId === collectionId
     );
     const userIds = groupUsers.map((groupUser) => groupUser.userId);
-    const users = filter(
-      this.activeOrInvited,
+    const users = this.activeOrInvited.filter(
       (user) => !userIds.includes(user.id)
     );
     return queriedUsers(users, query);
   };
 
   inCollection = (collectionId: string, query?: string) => {
-    const groupUsers = filter(
-      this.rootStore.memberships.orderedData,
+    const groupUsers = this.rootStore.memberships.orderedData.filter(
       (member) => member.collectionId === collectionId
     );
     const userIds = groupUsers.map((groupUser) => groupUser.userId);
-    const users = filter(this.activeOrInvited, (user) =>
+    const users = this.activeOrInvited.filter((user) =>
       userIds.includes(user.id)
     );
     return queriedUsers(users, query);
   };
 
   notInGroup = (groupId: string, query = "") => {
-    const groupUsers = filter(
-      this.rootStore.groupUsers.orderedData,
+    const groupUsers = this.rootStore.groupUsers.orderedData.filter(
       (member) => member.groupId === groupId
     );
     const userIds = groupUsers.map((groupUser) => groupUser.userId);
-    const users = filter(
-      this.activeOrInvited,
+    const users = this.activeOrInvited.filter(
       (user) => !userIds.includes(user.id)
     );
     return queriedUsers(users, query);
   };
 
   inGroup = (groupId: string, query?: string) => {
-    const groupUsers = filter(
-      this.rootStore.groupUsers.orderedData,
+    const groupUsers = this.rootStore.groupUsers.orderedData.filter(
       (member) => member.groupId === groupId
     );
     const userIds = groupUsers.map((groupUser) => groupUser.userId);
-    const users = filter(this.activeOrInvited, (user) =>
+    const users = this.activeOrInvited.filter((user) =>
       userIds.includes(user.id)
     );
     return queriedUsers(users, query);
@@ -221,12 +215,12 @@ export function queriedUsers(users: User[], query?: string) {
   const normalizedQuery = deburr((query || "").toLocaleLowerCase());
 
   return normalizedQuery
-    ? filter(
-        users,
-        (user) =>
-          deburr(user.name.toLocaleLowerCase()).includes(normalizedQuery) ||
-          user.email?.includes(normalizedQuery)
-      )
+    ? users
+        .filter(
+          (user) =>
+            deburr(user.name.toLocaleLowerCase()).includes(normalizedQuery) ||
+            user.email?.includes(normalizedQuery)
+        )
         .map((user) => ({
           user,
           score: commandScore(user.name, normalizedQuery),

--- a/app/stores/ViewsStore.ts
+++ b/app/stores/ViewsStore.ts
@@ -1,4 +1,4 @@
-import { filter, find, orderBy, reduce } from "es-toolkit/compat";
+import { orderBy } from "es-toolkit/compat";
 import View from "~/models/View";
 import type RootStore from "./RootStore";
 import Store, { RPCAction } from "./base/Store";
@@ -12,7 +12,7 @@ export default class ViewsStore extends Store<View> {
 
   inDocument(documentId: string): View[] {
     return orderBy(
-      filter(this.orderedData, (view) => view.documentId === documentId),
+      this.orderedData.filter((view) => view.documentId === documentId),
       "lastViewedAt",
       "desc"
     );
@@ -20,12 +20,11 @@ export default class ViewsStore extends Store<View> {
 
   countForDocument(documentId: string): number {
     const views = this.inDocument(documentId);
-    return reduce(views, (memo, view) => memo + view.count, 0);
+    return views.reduce((memo, view) => memo + view.count, 0);
   }
 
   touch(documentId: string, userId: string) {
-    const view = find(
-      this.orderedData,
+    const view = this.orderedData.find(
       (view) => view.documentId === documentId && view.userId === userId
     );
     if (!view) {

--- a/app/stores/base/IndexedStore.ts
+++ b/app/stores/base/IndexedStore.ts
@@ -1,0 +1,22 @@
+import { override } from "mobx";
+import type Model from "~/models/base/Model";
+import Store from "./Store";
+
+/**
+ * A store for models that carry a fractional index, ordered by that index and
+ * then by the most recently updated.
+ */
+export default abstract class IndexedStore<
+  T extends Model & { index: string },
+> extends Store<T> {
+  @override
+  get orderedData(): T[] {
+    return Array.from(this.data.values()).sort((a, b) => {
+      if (a.index === b.index) {
+        return a.updatedAt > b.updatedAt ? -1 : 1;
+      }
+
+      return a.index < b.index ? -1 : 1;
+    });
+  }
+}

--- a/app/stores/base/Store.ts
+++ b/app/stores/base/Store.ts
@@ -60,6 +60,13 @@ export type PaginatedResponse<T> = T[] & {
 // oxlint-disable-next-line no-explicit-any
 export type FetchPageParams = PaginationParams & Record<string, any>;
 
+/**
+ * A store that related models found in an API response can be added to.
+ */
+interface RelatedStore {
+  add(item: PartialExcept<Model, "id">): unknown;
+}
+
 export default abstract class Store<T extends Model> {
   @observable
   data: Map<string, T> = new Map();
@@ -498,7 +505,7 @@ export default abstract class Store<T extends Model> {
   }
 
   // Not annotated: subclasses replace this field, and MobX makes an annotated
-  // field non-writable. The state changes below run in runInAction already.
+  // field non-writable. The state changes run in runInAction already.
   fetchPage = async (
     params?: FetchPageParams
   ): Promise<PaginatedResponse<T>> => {
@@ -506,29 +513,7 @@ export default abstract class Store<T extends Model> {
       throw new Error(`Cannot list ${this.modelName}`);
     }
 
-    runInAction(() => {
-      this.isFetching = true;
-    });
-
-    try {
-      const res = await client.post(`/${this.apiEndpoint}.list`, params);
-      invariant(res?.data, "Data not available");
-
-      let response: PaginatedResponse<T> = [];
-
-      runInAction(() => {
-        this.addPolicies(res.policies);
-        response = res.data.map(this.add);
-        this.isLoaded = true;
-      });
-
-      response[PAGINATION_SYMBOL] = res.pagination;
-      return response;
-    } finally {
-      runInAction(() => {
-        this.isFetching = false;
-      });
-    }
+    return this.fetchPaginated(`/${this.apiEndpoint}.list`, params);
   };
 
   @action
@@ -588,4 +573,54 @@ export default abstract class Store<T extends Model> {
   filter = (predicate: ListPredicate<T>): T[] =>
     // @ts-expect-error not sure why T is incompatible
     filter(this.orderedData, predicate);
+
+  /**
+   * Fetch a page of items from the API and add them to the store, along with
+   * any related models in the response that belong to other stores.
+   *
+   * @param endpoint the API endpoint to request.
+   * @param params the request parameters.
+   * @param options.key the key in the response data that holds the items, the
+   * response data itself is used when omitted.
+   * @param options.related a map of response data keys to the stores that the
+   * models under those keys are added to.
+   * @returns the fetched items, with pagination information attached.
+   */
+  protected async fetchPaginated(
+    endpoint: string,
+    params?: FetchPageParams,
+    options: { key?: string; related?: Record<string, RelatedStore> } = {}
+  ): Promise<PaginatedResponse<T>> {
+    runInAction(() => {
+      this.isFetching = true;
+    });
+
+    try {
+      const res = await client.post(endpoint, params);
+      invariant(res?.data, "Data not available");
+
+      let response: PaginatedResponse<T> = [];
+
+      runInAction(() => {
+        this.addPolicies(res.policies);
+
+        Object.entries(options.related ?? {}).forEach(([key, store]) => {
+          res.data[key]?.forEach((item: PartialExcept<Model, "id">) =>
+            store.add(item)
+          );
+        });
+
+        const items = options.key ? res.data[options.key] : res.data;
+        response = items.map(this.add);
+        this.isLoaded = true;
+      });
+
+      response[PAGINATION_SYMBOL] = res.pagination;
+      return response;
+    } finally {
+      runInAction(() => {
+        this.isFetching = false;
+      });
+    }
+  }
 }

--- a/app/stores/base/Store.ts
+++ b/app/stores/base/Store.ts
@@ -64,6 +64,7 @@ export type FetchPageParams = PaginationParams & Record<string, any>;
  * A store that related models found in an API response can be added to.
  */
 interface RelatedStore {
+  responseKey: string;
   add(item: PartialExcept<Model, "id">): unknown;
 }
 
@@ -90,6 +91,12 @@ export default abstract class Store<T extends Model> {
   apiEndpoint: string;
 
   /**
+   * The key under which this store's models appear in API responses that
+   * return more than one kind of model, defaults to the API endpoint name.
+   */
+  responseKey: string;
+
+  /**
    * Whether the store's data should be persisted to IndexedDB, and restored
    * at boot, once persistence is enabled for the authenticated team.
    */
@@ -114,6 +121,10 @@ export default abstract class Store<T extends Model> {
 
     if (!this.apiEndpoint) {
       this.apiEndpoint = pluralize(lowerFirst(model.modelName));
+    }
+
+    if (!this.responseKey) {
+      this.responseKey = this.apiEndpoint;
     }
 
     makeObservable(this);
@@ -576,20 +587,19 @@ export default abstract class Store<T extends Model> {
 
   /**
    * Fetch a page of items from the API and add them to the store, along with
-   * any related models in the response that belong to other stores.
+   * any related models in the response that belong to other stores. Items are
+   * read from the response data directly when it is an array, otherwise from
+   * the key of each store.
    *
    * @param endpoint the API endpoint to request.
    * @param params the request parameters.
-   * @param options.key the key in the response data that holds the items, the
-   * response data itself is used when omitted.
-   * @param options.related a map of response data keys to the stores that the
-   * models under those keys are added to.
+   * @param related the stores that related models in the response are added to.
    * @returns the fetched items, with pagination information attached.
    */
   protected async fetchPaginated(
     endpoint: string,
     params?: FetchPageParams,
-    options: { key?: string; related?: Record<string, RelatedStore> } = {}
+    related: RelatedStore[] = []
   ): Promise<PaginatedResponse<T>> {
     runInAction(() => {
       this.isFetching = true;
@@ -604,13 +614,15 @@ export default abstract class Store<T extends Model> {
       runInAction(() => {
         this.addPolicies(res.policies);
 
-        Object.entries(options.related ?? {}).forEach(([key, store]) => {
-          res.data[key]?.forEach((item: PartialExcept<Model, "id">) =>
-            store.add(item)
+        related.forEach((store) => {
+          res.data[store.responseKey]?.forEach(
+            (item: PartialExcept<Model, "id">) => store.add(item)
           );
         });
 
-        const items = options.key ? res.data[options.key] : res.data;
+        const items = Array.isArray(res.data)
+          ? res.data
+          : res.data[this.responseKey];
         response = items.map(this.add);
         this.isLoaded = true;
       });


### PR DESCRIPTION
- Add a protected `fetchPaginated` helper to the base Store that handles the fetching flags, policies, related models, and pagination data. The eight `fetchPage` overrides and the two `fetchNamedPage` helpers now call it.
- Related models are resolved through a new `responseKey` on each store, which defaults to the endpoint name. Only the group user and user membership stores override it, because their API responses use a different key.
- Add an IndexedStore base class for models ordered by fractional index, used by pins, stars, user memberships, and collections.
- Replace es-toolkit filter, find, and reduce calls in the stores with the native array methods.
- Memberships fetchPage now adds policies, and every fetchPage override attaches pagination data, matching the base behavior.