### PR TITLE
fix(editor): prevent native img drag copying selected images

### DIFF
--- a/shared/editor/components/Image.tsx
+++ b/shared/editor/components/Image.tsx
@@ -230,6 +230,7 @@ const Image = (props: Props) => {
           >
             <img
               className={EditorStyleHelper.imageHandle}
+              draggable={false}
               style={{
                 ...widthStyle,
                 display: loaded ? "block" : "none",


### PR DESCRIPTION
## Summary

Fixes an issue where dragging an already selected image in the editor results in duplicating/copying the image rather than moving it.

- Adds `draggable={false}` to the `<img>` element inside the image node component.
- Prevents the browser's default image drag behavior from hijacking the drag gesture with a copy cursor (`copy` dropEffect).
- Allows the drag event to be properly handled by ProseMirror's NodeView container, ensuring standard node move semantics.

## Why

When an image node is selected (via `NodeSelection`), subsequent dragging on the `<img>` element triggered the browser's native image drag-and-drop. This bypassed ProseMirror's internal move handling and was treated as an external image drop, resulting in a duplicate copy inserted at the destination without removing the original. Disabling native drag on the inner `<img>` lets ProseMirror handle the drag operation on the outer container as intended.

## Testing

- `npx oxlint shared/editor/components/Image.tsx`
- `npx vitest run shared/editor/nodes/Image.test.ts`
- Verified manual dragging behavior on selected images.