### PR TITLE
fix: Handle unavailable response in error handler

### DIFF
--- a/server/onerror.test.ts
+++ b/server/onerror.test.ts
@@ -150,6 +150,15 @@ describe("onerror", () => {
     expect(ctx.res.end).not.toHaveBeenCalled();
   });
 
+  it("should not throw when the response is unavailable", () => {
+    ctx.writable = false;
+    Reflect.deleteProperty(ctx, "res");
+
+    expect(() =>
+      app.context.onerror.call(ctx, InternalError("Test internal error"))
+    ).not.toThrow();
+  });
+
   it("should report errors explicitly marked with isReportable: true", () => {
     const error = new Error("Custom error") as ReportableError;
     error.status = 400;

--- a/server/onerror.ts
+++ b/server/onerror.ts
@@ -81,7 +81,7 @@ export default function onerror(app: Koa) {
 
       // Nothing was written, so the status code is still Koa's placeholder 404 –
       // correct it so that logging and tracing report the real outcome.
-      if (!this.headerSent && typeof err.status === "number") {
+      if (!this.headerSent && this.res && typeof err.status === "number") {
         this.res.statusCode = err.status;
       }
 


### PR DESCRIPTION
- Guard the status-code update when the response is no longer available.
- Prevent an error during a client disconnect from stopping the process.
- closes #13636