### PR TITLE
fix: Allow document mentions to wrap

### DIFF
--- a/shared/editor/components/Mentions.tsx
+++ b/shared/editor/components/Mentions.tsx
@@ -72,7 +72,7 @@ export const MentionUser = observer(function MentionUser_(
         "ProseMirror-selectednode": isSelected,
       })}
     >
-      <EmailIcon size={18} />
+      <EmailIcon className="mention-icon" size={18} />
       <span>{user?.name || node.attrs.label}</span>
     </span>
   );
@@ -93,7 +93,7 @@ export const MentionGroup = observer(function MentionGroup_(
         "ProseMirror-selectednode": isSelected,
       })}
     >
-      <EmailIcon size={18} />
+      <EmailIcon className="mention-icon" size={18} />
       <span>{group?.name || node.attrs.label}</span>
     </span>
   );
@@ -127,13 +127,14 @@ export const MentionDocument = observer(function MentionDocument_(
     >
       {doc?.icon ? (
         <Icon
+          className="mention-icon"
           value={doc.icon}
           initial={doc.initial}
           color={doc.color}
           size={18}
         />
       ) : (
-        <DocumentIcon size={18} />
+        <DocumentIcon className="mention-icon" size={18} />
       )}
       <span>{doc?.title || node.attrs.label}</span>
     </Link>
@@ -165,13 +166,14 @@ export const MentionCollection = observer(function MentionCollection_(
     >
       {collection?.icon ? (
         <Icon
+          className="mention-icon"
           value={collection.icon}
           initial={collection.initial}
           color={collection.color}
           size={18}
         />
       ) : (
-        <CollectionIcon size={18} />
+        <CollectionIcon className="mention-icon" size={18} />
       )}
       <span>{collection?.title || node.attrs.label}</span>
     </Link>

--- a/shared/editor/components/Mentions.tsx
+++ b/shared/editor/components/Mentions.tsx
@@ -72,7 +72,7 @@ export const MentionUser = observer(function MentionUser_(
         "ProseMirror-selectednode": isSelected,
       })}
     >
-      <EmailIcon className="mention-icon" size={18} />
+      <EmailIcon size={18} />
       <span>{user?.name || node.attrs.label}</span>
     </span>
   );
@@ -93,7 +93,7 @@ export const MentionGroup = observer(function MentionGroup_(
         "ProseMirror-selectednode": isSelected,
       })}
     >
-      <EmailIcon className="mention-icon" size={18} />
+      <EmailIcon size={18} />
       <span>{group?.name || node.attrs.label}</span>
     </span>
   );
@@ -127,14 +127,13 @@ export const MentionDocument = observer(function MentionDocument_(
     >
       {doc?.icon ? (
         <Icon
-          className="mention-icon"
           value={doc.icon}
           initial={doc.initial}
           color={doc.color}
           size={18}
         />
       ) : (
-        <DocumentIcon className="mention-icon" size={18} />
+        <DocumentIcon size={18} />
       )}
       <span>{doc?.title || node.attrs.label}</span>
     </Link>
@@ -166,14 +165,13 @@ export const MentionCollection = observer(function MentionCollection_(
     >
       {collection?.icon ? (
         <Icon
-          className="mention-icon"
           value={collection.icon}
           initial={collection.initial}
           color={collection.color}
           size={18}
         />
       ) : (
-        <CollectionIcon className="mention-icon" size={18} />
+        <CollectionIcon size={18} />
       )}
       <span>{collection?.title || node.attrs.label}</span>
     </Link>

--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -560,25 +560,31 @@ width: 100%;
   gap: 4px;
   vertical-align: bottom;
 
-  /* Long labels are truncated so a mention never wraps onto a second line. */
-  max-width: 100%;
-  white-space: nowrap;
-  overflow: hidden;
-
-  span {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    /* Text sets white-space: normal, so nowrap cannot simply be inherited. */
+  /* External resource titles stay on one line, while internal mentions can
+     wrap to fit constrained containers such as table cells. */
+  &[data-type="issue"],
+  &[data-type="pull_request"],
+  &[data-type="project"],
+  &[data-type="url"] {
+    max-width: 100%;
     white-space: nowrap;
-  }
+    overflow: hidden;
 
-  /* Only the label truncates; icons and trailing identifiers stay whole. */
-  &::before,
-  svg,
-  img,
-  span ~ span {
-    flex-shrink: 0;
+    span {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      /* Text sets white-space: normal, so nowrap cannot simply be inherited. */
+      white-space: nowrap;
+    }
+
+    /* Only the label truncates; icons and trailing identifiers stay whole. */
+    &::before,
+    svg,
+    img,
+    span ~ span {
+      flex-shrink: 0;
+    }
   }
 
   &:${hover} {

--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -560,6 +560,13 @@ width: 100%;
   gap: 4px;
   vertical-align: bottom;
 
+  /* Keep icons at their intended size when the mention wraps. */
+  &::before,
+  svg,
+  img {
+    flex-shrink: 0;
+  }
+
   /* External resource titles stay on one line, while internal mentions can
      wrap to fit constrained containers such as table cells. */
   &[data-type="issue"],
@@ -578,10 +585,7 @@ width: 100%;
       white-space: nowrap;
     }
 
-    /* Only the label truncates; icons and trailing identifiers stay whole. */
-    &::before,
-    svg,
-    img,
+    /* Only the label truncates; trailing identifiers stay whole. */
     span ~ span {
       flex-shrink: 0;
     }

--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -545,6 +545,7 @@ width: 100%;
 
 .mention {
   background: ${props.theme.mentionBackground};
+  color: ${props.theme.text};
   border-radius: 8px;
   padding-top: 1px;
   padding-bottom: 1px;
@@ -562,6 +563,7 @@ width: 100%;
 
   /* Keep icons at their intended size when the mention wraps. */
   &::before,
+  .mention-icon,
   svg,
   img {
     flex-shrink: 0;

--- a/shared/editor/components/Styles.ts
+++ b/shared/editor/components/Styles.ts
@@ -563,7 +563,6 @@ width: 100%;
 
   /* Keep icons at their intended size when the mention wraps. */
   &::before,
-  .mention-icon,
   svg,
   img {
     flex-shrink: 0;

--- a/shared/utils/IconLibrary.tsx
+++ b/shared/utils/IconLibrary.tsx
@@ -607,6 +607,7 @@ export class IconLibrary {
 
 const FontAwesomeWrapper = styled.span<{ size: number }>`
   display: flex;
+  flex-shrink: 0;
   align-items: center;
   justify-content: center;
   width: ${(props) => props.size}px;


### PR DESCRIPTION
- Allow internal document and collection mentions to wrap in constrained containers.
- Keep single-line truncation for external resource mentions.
- closes #13619