### PR TITLE
fix(editor): restore comments panel initialization after React upgrade

### DIFF
--- a/app/editor/index.tsx
+++ b/app/editor/index.tsx
@@ -274,6 +274,7 @@ export class Editor extends React.PureComponent<
    */
   public componentDidMount() {
     this.init();
+    this.handleEditorInit();
     window.addEventListener("theme-changed", this.dispatchThemeChanged);
 
     if (this.props.scrollTo) {
@@ -985,6 +986,8 @@ export class Editor extends React.PureComponent<
   };
 
   private handleEditorDestroy = () => {
+    this.isInitialized = false;
+
     if (!this.props.onDestroy) {
       return;
     }


### PR DESCRIPTION
## Summary

Fixes a regression where the document comments panel does not render after the React version upgrade.

The editor now reports its initialized state immediately after mounting, so the document scene can enable the comments UI as soon as the editor is ready. The editor lifecycle state is also reset during teardown so a recreated editor can initialize cleanly.

## Why

The comments panel is gated by the document editor initialization state. `DocumentEditor` sets that state through the editor `onInit` callback, while the comments component renders nothing until `isEditorInitialized` is true.

After the React upgrade, relying only on the later editor transaction path to invoke the initialization callback could leave the mounted editor in an uninitialized state. As a result, the comments panel remained hidden even though the editor itself had mounted.

## Fix

- Invoke `handleEditorInit` from `componentDidMount` immediately after the editor instance is initialized.
- Reset `isInitialized` in `handleEditorDestroy` so the callback can run again when the editor lifecycle is recreated.
- Preserve the existing idempotency guard, callback contract, and teardown behavior.

This is intentionally limited to the shared editor lifecycle. It does not change comment data loading, permissions, sidebar routing, or comment rendering logic.

## Testing

- `yarn oxlint --type-aware app/editor/index.tsx`
- `git diff --check upstream/main...HEAD`

## Urgency

This is a production-facing regression introduced by the React upgrade and directly prevents users from accessing the comments panel. Please prioritize a quick review and merge so the fix can be released as soon as possible.