### PR TITLE
fix: Suppress WebMCP registration warning on abort teardown

### DIFF
--- a/app/utils/ModelContext.test.ts
+++ b/app/utils/ModelContext.test.ts
@@ -1,4 +1,5 @@
 import { vi } from "vitest";
+import Logger from "~/utils/Logger";
 import {
   isModelContextSupported,
   registerModelContextTool,
@@ -86,6 +87,26 @@ describe("ModelContext", () => {
       );
 
       second.abort();
+    });
+
+    it("should not warn when a pending registration is aborted", async () => {
+      const warn = vi.spyOn(Logger, "warn").mockImplementation(() => {});
+      const registerTool = vi
+        .fn()
+        .mockRejectedValue(
+          new DOMException("signal is aborted without reason", "AbortError")
+        );
+      window.document.modelContext = { registerTool };
+
+      const controller = new AbortController();
+      expect(registerModelContextTool(makeTool("six"), controller.signal)).toBe(
+        true
+      );
+      controller.abort();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(warn).not.toHaveBeenCalled();
+      warn.mockRestore();
     });
 
     it("should not register when the signal is already aborted", () => {

--- a/app/utils/ModelContext.ts
+++ b/app/utils/ModelContext.ts
@@ -84,15 +84,16 @@ export function registerModelContextTool(
       signal,
     });
     if (result instanceof Promise) {
-      result.catch((err: DOMException) => {
+      result.catch((err: unknown) => {
         // An aborted signal rejects a pending registration; this is normal
         // teardown, not a failure.
-        if (signal.aborted || err?.name === "AbortError") {
+        const error = toError(err);
+        if (signal.aborted || error.name === "AbortError") {
           return;
         }
         Logger.warn("Failed to register WebMCP tool", {
           name: tool.name,
-          error: err?.message,
+          error: error.message,
         });
         registeredToolNames.delete(tool.name);
       });

--- a/app/utils/ModelContext.ts
+++ b/app/utils/ModelContext.ts
@@ -1,3 +1,4 @@
+import { toError } from "@shared/utils/error";
 import Logger from "~/utils/Logger";
 
 /** A content block returned from a WebMCP tool execution. */
@@ -83,13 +84,24 @@ export function registerModelContextTool(
       signal,
     });
     if (result instanceof Promise) {
-      result.catch(() => {
-        Logger.warn("Failed to register WebMCP tool", { name: tool.name });
+      result.catch((err: DOMException) => {
+        // An aborted signal rejects a pending registration; this is normal
+        // teardown, not a failure.
+        if (signal.aborted || err?.name === "AbortError") {
+          return;
+        }
+        Logger.warn("Failed to register WebMCP tool", {
+          name: tool.name,
+          error: err?.message,
+        });
         registeredToolNames.delete(tool.name);
       });
     }
-  } catch (_err) {
-    Logger.warn("Failed to register WebMCP tool", { name: tool.name });
+  } catch (err) {
+    Logger.warn("Failed to register WebMCP tool", {
+      name: tool.name,
+      error: toError(err).message,
+    });
     registeredToolNames.delete(tool.name);
     return false;
   }


### PR DESCRIPTION
- Chrome rejects a pending `registerTool()` promise with `AbortError` when its signal aborts; StrictMode double-mounts and route changes triggered this for every tool, flooding the console with "Failed to register WebMCP tool" warnings
- Skip the warning when the rejection is abort-driven teardown; tools re-register correctly afterwards
- Include the error message in the warning for genuine registration failures