### PR TITLE
Keep editor "find and replace" panel open

### DIFF
--- a/app/editor/components/FindAndReplace.tsx
+++ b/app/editor/components/FindAndReplace.tsx
@@ -30,6 +30,7 @@ import { HStack } from "~/components/primitives/HStack";
 
 type KeyboardShortcutsProps = {
   open: boolean;
+  inputRef: React.RefObject<HTMLInputElement>;
   handleOpen: ({ withReplace }: { withReplace: boolean }) => void;
   handleCaseSensitive: () => void;
   handleRegex: () => void;
@@ -37,6 +38,7 @@ type KeyboardShortcutsProps = {
 
 function useKeyboardShortcuts({
   open,
+  inputRef,
   handleOpen,
   handleCaseSensitive,
   handleRegex,
@@ -45,8 +47,8 @@ function useKeyboardShortcuts({
   useKeyDown(
     (ev) =>
       isModKey(ev) &&
-      !open &&
       ev.code === "KeyF" &&
+      (!open || ev.altKey || document.activeElement !== inputRef.current) &&
       // Keyboard handler is through the AppMenu on Desktop v1.2.0+
       !(Desktop.bridge && "onFindInPage" in Desktop.bridge),
     (ev) => {
@@ -318,8 +320,23 @@ export default function FindAndReplace({
     [handleReplace]
   );
 
+  const handleEscape = React.useCallback(
+    (ev: KeyboardEvent) => {
+      if (!searchTerm) {
+        return;
+      }
+
+      ev.preventDefault();
+      debouncedFind.cancel();
+      setSearchTerm("");
+      editor.commands.clearSearch();
+    },
+    [debouncedFind, editor.commands, searchTerm]
+  );
+
   useKeyboardShortcuts({
     open: localOpen,
+    inputRef,
     handleOpen,
     handleCaseSensitive,
     handleRegex,
@@ -414,11 +431,9 @@ export default function FindAndReplace({
         width={0}
         minWidth={420}
         scrollable={false}
-        onPointerDownOutside={() => setLocalOpen(false)}
-        onFocusOutside={(event) => {
-          event.preventDefault();
-          inputRef.current?.focus();
-        }}
+        onEscapeKeyDown={handleEscape}
+        onPointerDownOutside={(ev) => ev.preventDefault()}
+        onFocusOutside={(ev) => ev.preventDefault()}
         style={{ marginRight: 16, marginTop: 60 }}
       >
         <Content column>

--- a/app/editor/extensions/FindAndReplace.tsx
+++ b/app/editor/extensions/FindAndReplace.tsx
@@ -7,6 +7,7 @@ import { Decoration, DecorationSet } from "prosemirror-view";
 import scrollIntoView from "scroll-into-view-if-needed";
 import type { WidgetProps } from "@shared/editor/lib/Extension";
 import Extension from "@shared/editor/lib/Extension";
+import { expandCodeBlockAt } from "@shared/editor/nodes/CodeFence";
 import { Action, toggleFoldPluginKey } from "@shared/editor/nodes/ToggleBlock";
 import { isToggleBlock } from "@shared/editor/queries/toggleBlock";
 import { ancestors } from "@shared/editor/utils";
@@ -43,7 +44,7 @@ export default class FindAndReplaceExtension extends Extension<FindAndReplaceOpt
   keys(): Record<string, Command> {
     return {
       Escape: () => {
-        if (!this.searchTerm) {
+        if (!this.searchTerm || this.open) {
           return false;
         }
         this.handleEscape();
@@ -316,7 +317,8 @@ export default class FindAndReplaceExtension extends Extension<FindAndReplaceOpt
       return;
     }
 
-    this.editor.commands.expandCodeBlockAt(result.from);
+    const view = this.editor.view;
+    expandCodeBlockAt(result.from)(view.state, view.dispatch, view);
   }
 
   private rebaseNextResult(replace: string, index: number, lastOffset = 0) {
@@ -584,7 +586,7 @@ export default class FindAndReplaceExtension extends Extension<FindAndReplaceOpt
   };
 
   private handleDocumentKeyDown = (event: KeyboardEvent) => {
-    if (event.key !== "Escape" || !this.searchTerm) {
+    if (event.key !== "Escape" || !this.searchTerm || this.open) {
       return;
     }
     if (event.defaultPrevented) {

--- a/shared/editor/nodes/CodeFence.ts
+++ b/shared/editor/nodes/CodeFence.ts
@@ -64,6 +64,8 @@ const COLLAPSE_HEIGHT_RATIO = 0.5;
 /** Approximate rendered line height of a code block, in pixels. */
 const CODE_LINE_HEIGHT = 20;
 
+const collapseKey = new PluginKey<CollapseState>("collapse-code-block");
+
 /**
  * Reduce a language attribute or fence info string to a single safe token, so
  * it cannot break the fence line when written back to markdown.
@@ -85,6 +87,34 @@ interface CollapseState {
   collapsedBlocks: Set<number>;
   /** Node decorations that add the `collapsed` CSS class. */
   decorations: DecorationSet;
+}
+
+/**
+ * Expand the collapsed code block that contains a document position.
+ *
+ * @param pos - the document position inside the code block.
+ * @returns a command that expands the code block when it is collapsed.
+ */
+export function expandCodeBlockAt(pos: number): Command {
+  return (state, dispatch) => {
+    const $pos = state.doc.resolve(pos);
+    const codeBlock = findParentNodeClosestToPos($pos, isCode);
+    if (!codeBlock) {
+      return false;
+    }
+
+    const collapseState = collapseKey.getState(state);
+    if (!collapseState?.collapsedBlocks.has(codeBlock.pos)) {
+      return false;
+    }
+
+    dispatch?.(
+      state.tr
+        .setMeta(collapseKey, { expand: codeBlock.pos })
+        .setMeta("addToHistory", false)
+    );
+    return true;
+  };
 }
 
 /**
@@ -181,11 +211,6 @@ type CodeFenceOptions = {
 };
 
 export default class CodeFence extends Node<CodeFenceOptions> {
-  /** Plugin key for the collapse state, shared with the command. */
-  private static readonly collapseKey = new PluginKey<CollapseState>(
-    "collapse-code-block"
-  );
-
   get showLineNumbers(): boolean {
     return this.options.userPreferences?.codeBlockLineNumbers ?? true;
   }
@@ -273,29 +298,7 @@ export default class CodeFence extends Node<CodeFenceOptions> {
           ...attrs,
         });
       },
-      expandCodeBlockAt:
-        (pos: number): Command =>
-        (state, dispatch) => {
-          const $pos = state.doc.resolve(pos);
-          const codeBlock = findParentNodeClosestToPos($pos, isCode);
-          if (!codeBlock) {
-            return false;
-          }
-
-          const collapseState = CodeFence.collapseKey.getState(state);
-          if (!collapseState?.collapsedBlocks.has(codeBlock.pos)) {
-            return false;
-          }
-
-          if (dispatch) {
-            dispatch(
-              state.tr
-                .setMeta(CodeFence.collapseKey, { expand: codeBlock.pos })
-                .setMeta("addToHistory", false)
-            );
-          }
-          return true;
-        },
+      expandCodeBlockAt: (pos: number) => expandCodeBlockAt(pos),
       toggleCodeBlockCollapse: (): Command => (state, dispatch) => {
         const codeBlock = findParentNode(isCode)(state.selection);
         if (!codeBlock) {
@@ -305,7 +308,7 @@ export default class CodeFence extends Node<CodeFenceOptions> {
         if (dispatch) {
           dispatch(
             state.tr
-              .setMeta(CodeFence.collapseKey, {
+              .setMeta(collapseKey, {
                 toggle: codeBlock.pos,
               })
               .setMeta("addToHistory", false)
@@ -429,7 +432,6 @@ export default class CodeFence extends Node<CodeFenceOptions> {
 
   /** Plugins for collapsible code block behavior. */
   private collapsePlugins(): Plugin[] {
-    const collapseKey = CodeFence.collapseKey;
     const build = (
       doc: ProsemirrorNode,
       tall: Set<number>,


### PR DESCRIPTION
- Keep the editor find panel open while users read, select, or edit document content.
- Clear the search on the first Escape and close the panel on the second; allow native find only when the Outline find input has focus.
- Expand collapsed code blocks without moving focus away from the find input.
- closes #13612