### PR TITLE
feat: Add Open Knowledge Format (OKF) export

### DIFF
--- a/app/components/Export/ExportDialog.tsx
+++ b/app/components/Export/ExportDialog.tsx
@@ -1,12 +1,10 @@
 import { observer } from "mobx-react";
-import { ArchiveIcon, CodeIcon } from "outline-icons";
+import { ArchiveIcon, CodeIcon, GlobeIcon } from "outline-icons";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { FileOperationFormat, NotificationEventType } from "@shared/types";
 import type Collection from "~/models/Collection";
-import { AvatarSize } from "~/components/Avatar";
-import Initials from "~/components/Avatar/Initials";
 import ConfirmationDialog from "~/components/ConfirmationDialog";
 import Flex from "~/components/Flex";
 import { FileFormatSelector } from "~/components/Export/FileFormatSelector";
@@ -78,11 +76,7 @@ export const ExportDialog = observer(({ collection, onSubmit }: Props) => {
       title: "Open Knowledge Format",
       extension: ".okf.zip",
       value: FileOperationFormat.OKFZip,
-      icon: (
-        <InitialsIcon size={AvatarSize.Medium} content="OKF">
-          OKF
-        </InitialsIcon>
-      ),
+      icon: <GlobeIcon />,
     },
     {
       title: "HTML",
@@ -161,10 +155,6 @@ export const ExportDialog = observer(({ collection, onSubmit }: Props) => {
     </ConfirmationDialog>
   );
 });
-
-const InitialsIcon = styled(Initials)`
-  border-radius: ${AvatarSize.Medium / 8}px;
-`;
 
 const HR = styled.hr`
   margin: 16px 0;

--- a/app/components/Export/ExportDialog.tsx
+++ b/app/components/Export/ExportDialog.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import { ArchiveIcon, CodeIcon } from "outline-icons";
+import { ArchiveIcon, CodeIcon, GraphIcon } from "outline-icons";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
@@ -71,6 +71,12 @@ export const ExportDialog = observer(({ collection, onSubmit }: Props) => {
       extension: ".markdown.zip",
       value: FileOperationFormat.MarkdownZip,
       icon: <MarkdownIcon />,
+    },
+    {
+      title: "Open Knowledge Format",
+      extension: ".okf.zip",
+      value: FileOperationFormat.OKFZip,
+      icon: <GraphIcon />,
     },
     {
       title: "HTML",

--- a/app/components/Export/ExportDialog.tsx
+++ b/app/components/Export/ExportDialog.tsx
@@ -1,10 +1,12 @@
 import { observer } from "mobx-react";
-import { ArchiveIcon, CodeIcon, GraphIcon } from "outline-icons";
+import { ArchiveIcon, CodeIcon } from "outline-icons";
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { FileOperationFormat, NotificationEventType } from "@shared/types";
 import type Collection from "~/models/Collection";
+import { AvatarSize } from "~/components/Avatar";
+import Initials from "~/components/Avatar/Initials";
 import ConfirmationDialog from "~/components/ConfirmationDialog";
 import Flex from "~/components/Flex";
 import { FileFormatSelector } from "~/components/Export/FileFormatSelector";
@@ -76,7 +78,11 @@ export const ExportDialog = observer(({ collection, onSubmit }: Props) => {
       title: "Open Knowledge Format",
       extension: ".okf.zip",
       value: FileOperationFormat.OKFZip,
-      icon: <GraphIcon />,
+      icon: (
+        <InitialsIcon size={AvatarSize.Medium} content="OKF">
+          OKF
+        </InitialsIcon>
+      ),
     },
     {
       title: "HTML",
@@ -155,6 +161,10 @@ export const ExportDialog = observer(({ collection, onSubmit }: Props) => {
     </ConfirmationDialog>
   );
 });
+
+const InitialsIcon = styled(Initials)`
+  border-radius: ${AvatarSize.Medium / 8}px;
+`;
 
 const HR = styled.hr`
   margin: 16px 0;

--- a/app/scenes/Settings/components/FileOperationListItem.tsx
+++ b/app/scenes/Settings/components/FileOperationListItem.tsx
@@ -57,6 +57,7 @@ const FileOperationListItem = ({ fileOperation }: Props) => {
     [FileOperationFormat.JSON]: "JSON",
     [FileOperationFormat.Notion]: "Notion",
     [FileOperationFormat.MarkdownZip]: "Markdown",
+    [FileOperationFormat.OKFZip]: "OKF",
     [FileOperationFormat.HTMLZip]: "HTML",
     [FileOperationFormat.TextBundleZip]: "TextBundle",
     [FileOperationFormat.PDF]: "PDF",

--- a/server/models/helpers/OKFHelper.ts
+++ b/server/models/helpers/OKFHelper.ts
@@ -1,5 +1,4 @@
 import yaml from "js-yaml";
-import env from "@server/env";
 import type Document from "@server/models/Document";
 
 interface Frontmatter {
@@ -53,9 +52,12 @@ export default class OKFHelper {
    * Builds the frontmatter block that precedes a document's markdown body.
    *
    * @param document The document being exported.
-   * @returns The YAML frontmatter, including delimiters and a trailing newline.
+   * @param origin The origin of the team's URL, used to build the canonical
+   * URL of the document.
+   * @returns The YAML frontmatter, including delimiters and a trailing blank
+   * line that separates it from the body.
    */
-  public static frontmatter(document: Document): string {
+  public static frontmatter(document: Document, origin: string): string {
     const description = this.singleLine(document.getSummary());
     const actor = document.updatedBy ?? document.createdBy;
 
@@ -63,7 +65,7 @@ export default class OKFHelper {
       type: this.conceptType,
       title: document.titleWithDefault,
       ...(description ? { description } : {}),
-      resource: `${env.URL}${document.path}`,
+      resource: `${origin}${document.path}`,
       status: this.status(document),
       generated: {
         by: `human:${actor.email ?? actor.id}`,
@@ -89,7 +91,7 @@ export default class OKFHelper {
       return description ? `* ${link} - ${description}` : `* ${link}`;
     });
 
-    return `${this.serialize({ okf_version: this.version })}\n# ${heading}\n\n${lines.join("\n")}\n`;
+    return `${this.serialize({ okf_version: this.version })}# ${heading}\n\n${lines.join("\n")}\n`;
   }
 
   private static status(document: Document): "draft" | "stable" | "deprecated" {
@@ -107,6 +109,6 @@ export default class OKFHelper {
   }
 
   private static serialize(data: object): string {
-    return `---\n${yaml.dump(data, { lineWidth: -1, noRefs: true })}---\n`;
+    return `---\n${yaml.dump(data, { lineWidth: -1, noRefs: true })}---\n\n`;
   }
 }

--- a/server/models/helpers/OKFHelper.ts
+++ b/server/models/helpers/OKFHelper.ts
@@ -1,0 +1,112 @@
+import yaml from "js-yaml";
+import env from "@server/env";
+import type Document from "@server/models/Document";
+
+interface Frontmatter {
+  type: string;
+  title: string;
+  description?: string;
+  resource: string;
+  status: "draft" | "stable" | "deprecated";
+  generated: { by: string; at: string };
+}
+
+interface IndexEntry {
+  /** The display name of the entry. */
+  title: string;
+  /** The path of the entry relative to the index file. */
+  path: string;
+  /** A short description of the entry, if any. */
+  description?: string | null;
+}
+
+/**
+ * Helpers for writing documents in the Open Knowledge Format (OKF), a bundle
+ * of markdown files with YAML frontmatter.
+ *
+ * @see https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md
+ */
+export default class OKFHelper {
+  /** The version of the specification the exported bundle targets. */
+  public static readonly version = "0.2";
+
+  /** Name of the directory listing entry. */
+  public static readonly indexFileName = "index.md";
+
+  /** File names that may not be used for a concept document. */
+  public static readonly reservedFileNames = ["index.md", "log.md"];
+
+  /** The concept type written to every exported document. */
+  public static readonly conceptType = "Document";
+
+  /**
+   * Whether a file name is reserved by the format and cannot hold a document.
+   *
+   * @param fileName The file name, without any directory.
+   * @returns true if the name is reserved.
+   */
+  public static isReservedFileName(fileName: string): boolean {
+    return this.reservedFileNames.includes(fileName.toLowerCase());
+  }
+
+  /**
+   * Builds the frontmatter block that precedes a document's markdown body.
+   *
+   * @param document The document being exported.
+   * @returns The YAML frontmatter, including delimiters and a trailing newline.
+   */
+  public static frontmatter(document: Document): string {
+    const description = this.singleLine(document.getSummary());
+    const actor = document.updatedBy ?? document.createdBy;
+
+    const data: Frontmatter = {
+      type: this.conceptType,
+      title: document.titleWithDefault,
+      ...(description ? { description } : {}),
+      resource: `${env.URL}${document.path}`,
+      status: this.status(document),
+      generated: {
+        by: `human:${actor.email ?? actor.id}`,
+        at: document.updatedAt.toISOString(),
+      },
+    };
+
+    return this.serialize(data);
+  }
+
+  /**
+   * Builds the bundle-root index that declares the format version and lists
+   * the top-level entries of the bundle.
+   *
+   * @param heading The heading the entries are grouped under.
+   * @param entries The entries to list.
+   * @returns The contents of the root index.md.
+   */
+  public static rootIndex(heading: string, entries: IndexEntry[]): string {
+    const lines = entries.map((entry) => {
+      const description = this.singleLine(entry.description);
+      const link = `[${entry.title}](${encodeURI(entry.path)})`;
+      return description ? `* ${link} - ${description}` : `* ${link}`;
+    });
+
+    return `${this.serialize({ okf_version: this.version })}\n# ${heading}\n\n${lines.join("\n")}\n`;
+  }
+
+  private static status(document: Document): "draft" | "stable" | "deprecated" {
+    if (document.archivedAt) {
+      return "deprecated";
+    }
+    if (!document.publishedAt) {
+      return "draft";
+    }
+    return "stable";
+  }
+
+  private static singleLine(value?: string | null): string {
+    return (value ?? "").replace(/\s+/g, " ").trim();
+  }
+
+  private static serialize(data: object): string {
+    return `---\n${yaml.dump(data, { lineWidth: -1, noRefs: true })}---\n`;
+  }
+}

--- a/server/queues/processors/FileOperationCreatedProcessor.ts
+++ b/server/queues/processors/FileOperationCreatedProcessor.ts
@@ -4,6 +4,7 @@ import type { Event as TEvent, FileOperationEvent } from "@server/types";
 import ExportHTMLZipTask from "../tasks/ExportHTMLZipTask";
 import ExportJSONTask from "../tasks/ExportJSONTask";
 import ExportMarkdownZipTask from "../tasks/ExportMarkdownZipTask";
+import ExportOKFZipTask from "../tasks/ExportOKFZipTask";
 import ExportTextBundleZipTask from "../tasks/ExportTextBundleZipTask";
 import BaseProcessor from "./BaseProcessor";
 
@@ -30,6 +31,11 @@ export default class FileOperationCreatedProcessor extends BaseProcessor {
           break;
         case FileOperationFormat.MarkdownZip:
           await new ExportMarkdownZipTask().schedule({
+            fileOperationId: event.modelId,
+          });
+          break;
+        case FileOperationFormat.OKFZip:
+          await new ExportOKFZipTask().schedule({
             fileOperationId: event.modelId,
           });
           break;

--- a/server/queues/tasks/ExportDocumentTreeTask.ts
+++ b/server/queues/tasks/ExportDocumentTreeTask.ts
@@ -8,6 +8,7 @@ import Logger from "@server/logging/Logger";
 import type { Collection } from "@server/models";
 import Attachment from "@server/models/Attachment";
 import Document from "@server/models/Document";
+import Team from "@server/models/Team";
 import { DocumentHelper } from "@server/models/helpers/DocumentHelper";
 import HTMLHelper from "@server/models/helpers/HTMLHelper";
 import OKFHelper from "@server/models/helpers/OKFHelper";
@@ -53,6 +54,7 @@ export default abstract class ExportDocumentTreeTask extends ExportTask {
     format,
     includeAttachments,
     pathMap,
+    origin,
   }: {
     zip: ZipFile;
     pathInZip: string;
@@ -60,6 +62,7 @@ export default abstract class ExportDocumentTreeTask extends ExportTask {
     format: FileOperationFormat;
     includeAttachments: boolean;
     pathMap: Map<string, string>;
+    origin?: string;
   }) {
     Logger.debug("task", `Adding document to archive`, { documentId });
     const result = await sequelizeReadOnly.transaction(async (transaction) => {
@@ -214,8 +217,8 @@ export default abstract class ExportDocumentTreeTask extends ExportTask {
 
     // OKF frontmatter carries the document's canonical URL, so it is added
     // only after internal links have been rewritten to relative paths.
-    if (format === FileOperationFormat.OKFZip) {
-      text = OKFHelper.frontmatter(document) + text;
+    if (format === FileOperationFormat.OKFZip && origin) {
+      text = OKFHelper.frontmatter(document, origin) + text;
     }
 
     // Finally, add the document to the zip file
@@ -245,12 +248,14 @@ export default abstract class ExportDocumentTreeTask extends ExportTask {
     includeAttachments = true
   ) {
     const { pathMap, roots } = this.createPathMap(collections, format);
+    const origin = await this.originForFormat(format, collections[0]?.teamId);
     return await ZipHelper.toTmpFile(async (zip) => {
       await this.addDocumentsToArchive({
         zip,
         pathMap,
         format,
         includeAttachments,
+        origin,
       });
 
       if (format === FileOperationFormat.OKFZip) {
@@ -297,12 +302,14 @@ export default abstract class ExportDocumentTreeTask extends ExportTask {
       format
     );
 
+    const origin = await this.originForFormat(format, document.teamId);
     return await ZipHelper.toTmpFile(async (zip) => {
       await this.addDocumentsToArchive({
         zip,
         pathMap,
         format,
         includeAttachments,
+        origin,
       });
 
       if (format === FileOperationFormat.OKFZip) {
@@ -323,23 +330,46 @@ export default abstract class ExportDocumentTreeTask extends ExportTask {
   }
 
   /**
+   * Resolves the origin used for canonical document URLs, which only the OKF
+   * format writes into its output.
+   *
+   * @param format The format to export in
+   * @param teamId The team that owns the exported documents
+   * @returns The team's URL origin, or undefined when the format has no use for it.
+   */
+  private async originForFormat(
+    format: FileOperationFormat,
+    teamId?: string
+  ): Promise<string | undefined> {
+    if (format !== FileOperationFormat.OKFZip || !teamId) {
+      return undefined;
+    }
+
+    const team = await Team.findByPk(teamId, { rejectOnEmpty: true });
+    return team.url;
+  }
+
+  /**
    * Processes each unique document in the path map and adds it to the zip.
    *
    * @param zip The yazl ZipFile to add files to
    * @param pathMap Map of document urls to their path in the zip
    * @param format The format to export in
    * @param includeAttachments Whether to include attachments in the export
+   * @param origin The origin for canonical document URLs, when the format needs one
    */
   private async addDocumentsToArchive({
     zip,
     pathMap,
     format,
     includeAttachments,
+    origin,
   }: {
     zip: ZipFile;
     pathMap: Map<string, string>;
     format: FileOperationFormat;
     includeAttachments: boolean;
+    origin?: string;
   }) {
     const processedPaths = new Set<string>();
 
@@ -360,6 +390,7 @@ export default abstract class ExportDocumentTreeTask extends ExportTask {
         includeAttachments,
         format,
         pathMap,
+        origin,
       });
     }
 

--- a/server/queues/tasks/ExportDocumentTreeTask.ts
+++ b/server/queues/tasks/ExportDocumentTreeTask.ts
@@ -10,6 +10,7 @@ import Attachment from "@server/models/Attachment";
 import Document from "@server/models/Document";
 import { DocumentHelper } from "@server/models/helpers/DocumentHelper";
 import HTMLHelper from "@server/models/helpers/HTMLHelper";
+import OKFHelper from "@server/models/helpers/OKFHelper";
 import { ProsemirrorHelper } from "@server/models/helpers/ProsemirrorHelper";
 import TextBundleHelper from "@server/models/helpers/TextBundleHelper";
 import { sequelizeReadOnly } from "@server/storage/database";
@@ -211,6 +212,12 @@ export default abstract class ExportDocumentTreeTask extends ExportTask {
       );
     }
 
+    // OKF frontmatter carries the document's canonical URL, so it is added
+    // only after internal links have been rewritten to relative paths.
+    if (format === FileOperationFormat.OKFZip) {
+      text = OKFHelper.frontmatter(document) + text;
+    }
+
     // Finally, add the document to the zip file
     zip.addBuffer(Buffer.from(text), textPathInZip, {
       mtime: document.updatedAt,
@@ -237,15 +244,31 @@ export default abstract class ExportDocumentTreeTask extends ExportTask {
     format: FileOperationFormat,
     includeAttachments = true
   ) {
-    const pathMap = this.createPathMap(collections, format);
-    return await ZipHelper.toTmpFile((zip) =>
-      this.addDocumentsToArchive({
+    const { pathMap, roots } = this.createPathMap(collections, format);
+    return await ZipHelper.toTmpFile(async (zip) => {
+      await this.addDocumentsToArchive({
         zip,
         pathMap,
         format,
         includeAttachments,
-      })
-    );
+      });
+
+      if (format === FileOperationFormat.OKFZip) {
+        zip.addBuffer(
+          Buffer.from(
+            OKFHelper.rootIndex(
+              "Collections",
+              roots.map(({ root, collection }) => ({
+                title: collection.name,
+                path: `${root}/`,
+                description: collection.description,
+              }))
+            )
+          ),
+          OKFHelper.indexFileName
+        );
+      }
+    });
   }
 
   protected async addDocumentToArchive({
@@ -262,28 +285,41 @@ export default abstract class ExportDocumentTreeTask extends ExportTask {
     const pathMap = new Map<string, string>();
 
     const rootFolderName = serializeFilename(document.titleWithDefault);
+    const rootPath = `${rootFolderName}.${ExportDocumentTreeTask.extensionForFormat(format)}`;
 
     // entry for root document
-    pathMap.set(
-      document.path,
-      `${rootFolderName}.${ExportDocumentTreeTask.extensionForFormat(format)}`
-    );
+    pathMap.set(document.path, rootPath);
 
     this.addDocumentTreeToPathMap(
       pathMap,
       documentStructure,
-      serializeFilename(document.titleWithDefault),
+      rootFolderName,
       format
     );
 
-    return await ZipHelper.toTmpFile((zip) =>
-      this.addDocumentsToArchive({
+    return await ZipHelper.toTmpFile(async (zip) => {
+      await this.addDocumentsToArchive({
         zip,
         pathMap,
         format,
         includeAttachments,
-      })
-    );
+      });
+
+      if (format === FileOperationFormat.OKFZip) {
+        zip.addBuffer(
+          Buffer.from(
+            OKFHelper.rootIndex("Documents", [
+              {
+                title: document.titleWithDefault,
+                path: rootPath,
+                description: document.getSummary(),
+              },
+            ])
+          ),
+          OKFHelper.indexFileName
+        );
+      }
+    });
   }
 
   /**
@@ -335,25 +371,26 @@ export default abstract class ExportDocumentTreeTask extends ExportTask {
    *
    * @param collections The collections to generate the path map for.
    * @param format The format of the exported documents.
+   * @returns The path map and the root directory chosen for each collection.
    */
   private createPathMap(
     collections: Collection[],
     format: FileOperationFormat
   ) {
-    const map = new Map<string, string>();
-    const usedRoots = new Set<string>();
+    const pathMap = new Map<string, string>();
+    const roots: { root: string; collection: Collection }[] = [];
 
     for (const collection of collections) {
       if (collection.documentStructure) {
         let root = serializeFilename(collection.name);
         let i = 0;
-        while (usedRoots.has(root)) {
+        while (roots.some((entry) => entry.root === root)) {
           root = `${serializeFilename(collection.name)} (${++i})`;
         }
-        usedRoots.add(root);
+        roots.push({ root, collection });
 
         this.addDocumentTreeToPathMap(
-          map,
+          pathMap,
           collection.documentStructure,
           root,
           format
@@ -361,7 +398,7 @@ export default abstract class ExportDocumentTreeTask extends ExportTask {
       }
     }
 
-    return map;
+    return { pathMap, roots };
   }
 
   private addDocumentTreeToPathMap(
@@ -375,10 +412,15 @@ export default abstract class ExportDocumentTreeTask extends ExportTask {
       const extension = ExportDocumentTreeTask.extensionForFormat(format);
 
       // Ensure the document is given a unique path in zip, even if it has
-      // the same title as another document in the same collection.
+      // the same title as another document in the same collection. OKF also
+      // reserves some file names, which a document may not take.
       let i = 0;
       let filePath = path.join(root, `${title}.${extension}`);
-      while (Array.from(map.values()).includes(filePath)) {
+      while (
+        Array.from(map.values()).includes(filePath) ||
+        (format === FileOperationFormat.OKFZip &&
+          OKFHelper.isReservedFileName(path.basename(filePath)))
+      ) {
         filePath = path.join(root, `${title} (${++i}).${extension}`);
       }
 

--- a/server/queues/tasks/ExportOKFZipTask.test.ts
+++ b/server/queues/tasks/ExportOKFZipTask.test.ts
@@ -1,0 +1,174 @@
+import fs from "fs-extra";
+import yaml from "js-yaml";
+import ZipHelper from "@server/utils/ZipHelper";
+import {
+  buildCollection,
+  buildDocument,
+  buildFileOperation,
+  buildTeam,
+  buildUser,
+} from "@server/test/factories";
+import ExportOKFZipTask from "./ExportOKFZipTask";
+
+describe("ExportOKFZipTask", () => {
+  it("should write frontmatter and a root index", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const collection = await buildCollection({
+      teamId: team.id,
+      createdById: user.id,
+      description: "About the collection",
+    });
+    const document = await buildDocument({
+      teamId: team.id,
+      userId: user.id,
+      collectionId: collection.id,
+      title: "Test1",
+      text: "First line of body",
+    });
+    await collection.addDocumentToStructure(document);
+    const fileOperation = await buildFileOperation({
+      teamId: team.id,
+      userId: user.id,
+    });
+
+    const task = new ExportOKFZipTask();
+    const filePath = await task.exportCollections([collection], fileOperation);
+
+    try {
+      const contents = await readZipContents(filePath);
+      expect(Object.keys(contents).sort()).toEqual([
+        `${collection.name}/Test1.md`,
+        "index.md",
+      ]);
+
+      const [frontmatter, body] = splitFrontmatter(
+        contents[`${collection.name}/Test1.md`]
+      );
+      expect(frontmatter).toMatchObject({
+        type: "Document",
+        title: "Test1",
+        description: "First line of body",
+        status: "stable",
+        generated: {
+          by: `human:${user.email}`,
+          at: document.updatedAt.toISOString(),
+        },
+      });
+      expect(frontmatter.resource).toContain(document.path);
+      expect(body).toContain("First line of body");
+
+      const [indexFrontmatter, indexBody] = splitFrontmatter(
+        contents["index.md"]
+      );
+      expect(indexFrontmatter).toEqual({ okf_version: "0.2" });
+      expect(indexBody).toContain(
+        `* [${collection.name}](${encodeURI(collection.name)}/) - About the collection`
+      );
+    } finally {
+      await fs.remove(filePath);
+    }
+  });
+
+  it("should not use reserved file names for documents", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const collection = await buildCollection({
+      teamId: team.id,
+      createdById: user.id,
+    });
+    const document = await buildDocument({
+      teamId: team.id,
+      userId: user.id,
+      collectionId: collection.id,
+      title: "index",
+    });
+    await collection.addDocumentToStructure(document);
+    const fileOperation = await buildFileOperation({
+      teamId: team.id,
+      userId: user.id,
+    });
+
+    const task = new ExportOKFZipTask();
+    const filePath = await task.exportCollections([collection], fileOperation);
+
+    try {
+      const contents = await readZipContents(filePath);
+      expect(Object.keys(contents).sort()).toEqual([
+        `${collection.name}/index (1).md`,
+        "index.md",
+      ]);
+    } finally {
+      await fs.remove(filePath);
+    }
+  });
+
+  it("should rewrite internal links but keep the resource URL", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const collection = await buildCollection({
+      teamId: team.id,
+      createdById: user.id,
+    });
+    const target = await buildDocument({
+      teamId: team.id,
+      userId: user.id,
+      collectionId: collection.id,
+      title: "Target",
+    });
+    const source = await buildDocument({
+      teamId: team.id,
+      userId: user.id,
+      collectionId: collection.id,
+      title: "Source",
+      text: `See [Target](${target.path})`,
+    });
+    await collection.addDocumentToStructure(target);
+    await collection.addDocumentToStructure(source);
+    const fileOperation = await buildFileOperation({
+      teamId: team.id,
+      userId: user.id,
+    });
+
+    const task = new ExportOKFZipTask();
+    const filePath = await task.exportCollections([collection], fileOperation);
+
+    try {
+      const contents = await readZipContents(filePath);
+      const [frontmatter, body] = splitFrontmatter(
+        contents[`${collection.name}/Source.md`]
+      );
+      expect(frontmatter.resource).toContain(source.path);
+      expect(body).toContain("(./Target.md)");
+      expect(body).not.toContain(target.path);
+    } finally {
+      await fs.remove(filePath);
+    }
+  });
+});
+
+function splitFrontmatter(content: string): [Record<string, unknown>, string] {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) {
+    throw new Error("No frontmatter found");
+  }
+  const data = yaml.load(match[1]);
+  if (typeof data !== "object" || data === null) {
+    throw new Error("Frontmatter is not a mapping");
+  }
+  return [data as Record<string, unknown>, match[2]];
+}
+
+async function readZipContents(
+  filePath: string
+): Promise<Record<string, string>> {
+  const contents: Record<string, string> = {};
+  await ZipHelper.walk(filePath, async (entry) => {
+    if (!entry.isDirectory) {
+      contents[entry.fileName] = (await entry.readBuffer(1024 * 1024)).toString(
+        "utf8"
+      );
+    }
+  });
+  return contents;
+}

--- a/server/queues/tasks/ExportOKFZipTask.test.ts
+++ b/server/queues/tasks/ExportOKFZipTask.test.ts
@@ -37,10 +37,9 @@ describe("ExportOKFZipTask", () => {
 
     try {
       const contents = await readZipContents(filePath);
-      expect(Object.keys(contents).sort()).toEqual([
-        `${collection.name}/Test1.md`,
-        "index.md",
-      ]);
+      expect(Object.keys(contents).sort()).toEqual(
+        [`${collection.name}/Test1.md`, "index.md"].sort()
+      );
 
       const [frontmatter, body] = splitFrontmatter(
         contents[`${collection.name}/Test1.md`]
@@ -55,13 +54,15 @@ describe("ExportOKFZipTask", () => {
           at: document.updatedAt.toISOString(),
         },
       });
-      expect(frontmatter.resource).toContain(document.path);
+      expect(frontmatter.resource).toBe(`${team.url}${document.path}`);
+      expect(body.startsWith("\n")).toBe(true);
       expect(body).toContain("First line of body");
 
       const [indexFrontmatter, indexBody] = splitFrontmatter(
         contents["index.md"]
       );
       expect(indexFrontmatter).toEqual({ okf_version: "0.2" });
+      expect(indexBody.startsWith("\n# Collections\n")).toBe(true);
       expect(indexBody).toContain(
         `* [${collection.name}](${encodeURI(collection.name)}/) - About the collection`
       );
@@ -94,10 +95,9 @@ describe("ExportOKFZipTask", () => {
 
     try {
       const contents = await readZipContents(filePath);
-      expect(Object.keys(contents).sort()).toEqual([
-        `${collection.name}/index (1).md`,
-        "index.md",
-      ]);
+      expect(Object.keys(contents).sort()).toEqual(
+        [`${collection.name}/index (1).md`, "index.md"].sort()
+      );
     } finally {
       await fs.remove(filePath);
     }

--- a/server/queues/tasks/ExportOKFZipTask.ts
+++ b/server/queues/tasks/ExportOKFZipTask.ts
@@ -1,0 +1,31 @@
+import type { NavigationNode } from "@shared/types";
+import { FileOperationFormat } from "@shared/types";
+import type { Collection, FileOperation } from "@server/models";
+import type { Document } from "@server/models";
+import ExportDocumentTreeTask from "./ExportDocumentTreeTask";
+
+export default class ExportOKFZipTask extends ExportDocumentTreeTask {
+  public async exportCollections(
+    collections: Collection[],
+    fileOperation: FileOperation
+  ) {
+    return await this.addCollectionsToArchive(
+      collections,
+      FileOperationFormat.OKFZip,
+      fileOperation.options?.includeAttachments
+    );
+  }
+
+  public async exportDocument(
+    document: Document,
+    documentStructure: NavigationNode[],
+    includeAttachments: boolean
+  ): Promise<string> {
+    return await this.addDocumentToArchive({
+      document,
+      documentStructure,
+      format: FileOperationFormat.OKFZip,
+      includeAttachments,
+    });
+  }
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -71,6 +71,7 @@ export enum ExportContentType {
 export enum FileOperationFormat {
   JSON = "json",
   MarkdownZip = "outline-markdown",
+  OKFZip = "okf",
   HTMLZip = "html",
   TextBundleZip = "textbundle",
   PDF = "pdf",


### PR DESCRIPTION
Adds an export option for the [Open Knowledge Format (OKF)](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md), a markdown bundle with YAML frontmatter.

- New `okf` file operation format, selectable in the collection and workspace export dialog
- Reuses the markdown export path and prepends frontmatter to each document (type, title, description, resource, status, generated)
- Writes a bundle-root `index.md` declaring the OKF version and listing the top-level entries
- Avoids the reserved `index.md` and `log.md` names for document files
