### PR TITLE
fix: Allow manual sizing of embedded PDFs

### DIFF
--- a/app/editor/components/MediaDimension.tsx
+++ b/app/editor/components/MediaDimension.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import Flex from "@shared/components/Flex";
 import Text from "@shared/components/Text";
+import { resolvePDFDimensions } from "@shared/editor/lib/pdf";
 import { EditorStyleHelper } from "@shared/editor/styles/EditorStyleHelper";
 import { extraArea } from "@shared/styles";
 import Input, { NativeInput, Outline } from "~/components/Input";
@@ -29,9 +30,13 @@ export function MediaDimension() {
 
   // This component will be rendered for specific media nodes like image, video or pdfs (NodeSelection types).
   const node = (selection as NodeSelection).node;
-  const nodeType = node.type.name,
-    width = node.attrs.width as number,
-    height = node.attrs.height as number;
+  const nodeType = node.type.name;
+  const nodeWidth = node.attrs.width as number | null | undefined;
+  const nodeHeight = node.attrs.height as number | null | undefined;
+  const { width, height } =
+    nodeType === "attachment"
+      ? resolvePDFDimensions(nodeWidth, nodeHeight)
+      : { width: nodeWidth ?? 0, height: nodeHeight ?? 0 };
 
   const [localDimension, setLocalDimension] = useState<Dimension>(() => ({
     width: width ? String(width) : "",
@@ -222,9 +227,14 @@ export function MediaDimension() {
         isDraggingRef.current = isDragging;
       }
 
+      const dimensions =
+        nodeType === "attachment"
+          ? resolvePDFDimensions(newWidth)
+          : { width: newWidth, height: newHeight };
+
       setLocalDimension({
-        width: newWidth ? String(newWidth) : "",
-        height: newHeight ? String(newHeight) : "",
+        width: dimensions.width ? String(dimensions.width) : "",
+        height: dimensions.height ? String(dimensions.height) : "",
         changed: "none",
       });
     };
@@ -233,7 +243,7 @@ export function MediaDimension() {
     return () => {
       window.removeEventListener("media-drag-resize", handleDragResize);
     };
-  }, []);
+  }, [nodeType]);
 
   // hacky debounce for checking error.
   useEffect(() => {

--- a/shared/editor/components/PDF.tsx
+++ b/shared/editor/components/PDF.tsx
@@ -9,13 +9,7 @@ import Flex from "../../components/Flex";
 import { s } from "../../styles";
 import { Preview, Subtitle, Title } from "./Widget";
 import { EditorStyleHelper } from "../styles/EditorStyleHelper";
-
-/**
- * Default dimensions for the PDF preview – approximately the width of a standard
- * document with an A4 portrait aspect ratio.
- */
-const naturalWidth = 768;
-const naturalHeight = 1086;
+import { pdfNaturalHeight, pdfNaturalWidth } from "../lib/pdf";
 
 type Props = ComponentProps & {
   /** Icon to display on the left side of the widget */
@@ -38,8 +32,8 @@ export default function PdfViewer(props: Props) {
   const { width, handlePointerDown, dragging } = useDragResize({
     width: node.attrs.width,
     height: node.attrs.height,
-    naturalWidth,
-    naturalHeight,
+    naturalWidth: pdfNaturalWidth,
+    naturalHeight: pdfNaturalHeight,
     onChangeSize,
     ref,
   });
@@ -109,7 +103,7 @@ export default function PdfViewer(props: Props) {
         style={{
           width: "100%",
           height: "auto",
-          aspectRatio: `${naturalWidth} / ${naturalHeight}`,
+          aspectRatio: `${pdfNaturalWidth} / ${pdfNaturalHeight}`,
           pointerEvents:
             !isEditable || (isSelected && !dragging) ? "initial" : "none",
           marginTop: 6,

--- a/shared/editor/lib/pdf.ts
+++ b/shared/editor/lib/pdf.ts
@@ -1,0 +1,45 @@
+interface PDFDimensions {
+  width: number;
+  height: number;
+}
+
+/** The natural width of an embedded PDF preview. */
+export const pdfNaturalWidth = 768;
+
+/** The natural height of an embedded PDF preview. */
+export const pdfNaturalHeight = 1086;
+
+/**
+ * Resolves missing PDF dimensions using the default preview aspect ratio.
+ *
+ * @param width - the stored preview width.
+ * @param height - the stored preview height.
+ * @returns the complete PDF preview dimensions.
+ */
+export function resolvePDFDimensions(
+  width?: number | null,
+  height?: number | null
+): PDFDimensions {
+  if (width && height) {
+    return { width, height };
+  }
+
+  if (width) {
+    return {
+      width,
+      height: Math.round((width * pdfNaturalHeight) / pdfNaturalWidth),
+    };
+  }
+
+  if (height) {
+    return {
+      width: Math.round((height * pdfNaturalWidth) / pdfNaturalHeight),
+      height,
+    };
+  }
+
+  return {
+    width: pdfNaturalWidth,
+    height: pdfNaturalHeight,
+  };
+}

--- a/shared/editor/nodes/Attachment.tsx
+++ b/shared/editor/nodes/Attachment.tsx
@@ -16,6 +16,7 @@ import toggleWrap from "../commands/toggleWrap";
 import FileExtension from "../components/FileExtension";
 import Widget from "../components/Widget";
 import type { MarkdownSerializerState } from "../lib/markdown/serializer";
+import { resolvePDFDimensions } from "../lib/pdf";
 import { isPDFAttachment } from "../queries/isPDFAttachment";
 import attachmentsRule from "../rules/links";
 import type { ComponentProps } from "../types";
@@ -99,7 +100,7 @@ export default class Attachment extends Node {
 
   handleChangeSize =
     ({ node, getPos }: { node: ProsemirrorNode; getPos: () => number }) =>
-    ({ width, height }: { width: number; height?: number }) => {
+    ({ width }: { width: number; height?: number }) => {
       if (!node.attrs.preview) {
         return;
       }
@@ -109,12 +110,10 @@ export default class Attachment extends Node {
 
       const pos = getPos();
       const $pos = doc.resolve(pos);
+      const dimensions = resolvePDFDimensions(width);
 
       view.dispatch(tr.setSelection(new NodeSelection($pos)));
-      commands["resizeAttachment"]({
-        width,
-        height: height || node.attrs.height,
-      });
+      commands["resizeAttachment"](dimensions);
     };
 
   component = (props: ComponentProps) => {


### PR DESCRIPTION
- Provide fallback dimensions when embedded PDFs have no stored size.
- Keep toolbar values and saved dimensions synchronized during handle resizing.
- Closes #13634