### PR TITLE
chore: upgrade Zod and enable compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -279,7 +279,7 @@
     "yauzl": "^3.3.1",
     "yazl": "^3.3.1",
     "yjs": "^13.6.31",
-    "zod": "^4.4.3"
+    "zod": "^4.5.4"
   },
   "devDependencies": {
     "@faker-js/faker": "^10.5.0",
@@ -378,7 +378,7 @@
     "@types/koa": "2.15.1",
     "prosemirror-transform": "1.10.5",
     "prismjs": "1.30.0",
-    "zod": "^4.4.3",
+    "zod": "^4.5.4",
     "@types/markdown-it": "14.1.2",
     "ip-address@npm:10.1.0": "^10.2.0",
     "minimatch@npm:9.0.1": "9.0.9",

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,5 +1,6 @@
 /* oxlint-disable @typescript-eslint/no-misused-promises */
 /* oxlint-disable import/order */
+import "zod/compile";
 import "./logging/tracer"; // must come before importing any instrumented module
 
 import os from "node:os";

--- a/yarn.lock
+++ b/yarn.lock
@@ -15820,7 +15820,7 @@ __metadata:
     yauzl: "npm:^3.3.1"
     yazl: "npm:^3.3.1"
     yjs: "npm:^13.6.31"
-    zod: "npm:^4.4.3"
+    zod: "npm:^4.5.4"
   languageName: unknown
   linkType: soft
 
@@ -21533,9 +21533,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^4.4.3":
-  version: 4.4.3
-  resolution: "zod@npm:4.4.3"
-  checksum: 10c0/7ea31b558e88f9faf44f31dd185e2e1cbf51fed3081787fb96cc2534749b50c0acfc6da7f0922a7353ed092dd358c7d50c28ea96c94d04af64191bd33152eca3
+"zod@npm:^4.5.4":
+  version: 4.5.4
+  resolution: "zod@npm:4.5.4"
+  checksum: 10c0/511a2a4d1a6f875dfdd70a1586989a8b14ef126776cd6218a2c760b9f65f14ef389ec20d92ee1aa4fcb4566d4ff3fa012956044f9dc503510d82e4c756a8ba92
   languageName: node
   linkType: hard


### PR DESCRIPTION
- Upgrade Zod to 4.5.4.
- Enable global lazy schema compilation for server processes.