### PR TITLE
fix: Align attachment upload permissions

### DIFF
--- a/server/routes/api/attachments/attachments.test.ts
+++ b/server/routes/api/attachments/attachments.test.ts
@@ -226,24 +226,21 @@ describe("#attachments.create", () => {
       }
     });
 
-    it("should create expiring attachment using import preset", async () => {
-      const user = await buildUser();
-      const res = await server.post("/api/attachments.create", user, {
-        body: {
-          name: "test.zip",
-          contentType: "application/zip",
-          size: 10000,
-          preset: AttachmentPreset.WorkspaceImport,
-        },
-      });
-      expect(res.status).toEqual(200);
-
-      const body = await res.json();
-      const attachment = await Attachment.findByPk(body.data.attachment.id, {
-        rejectOnEmpty: true,
-      });
-      expect(attachment.expiresAt).toBeTruthy();
-    });
+    it.each([AttachmentPreset.Import, AttachmentPreset.WorkspaceImport])(
+      "should not allow upload using %s preset",
+      async (preset) => {
+        const user = await buildUser();
+        const res = await server.post("/api/attachments.create", user, {
+          body: {
+            name: "test.zip",
+            contentType: "application/zip",
+            size: 10000,
+            preset,
+          },
+        });
+        expect(res.status).toEqual(403);
+      }
+    );
 
     it("should not allow attachment creation for other documents", async () => {
       const user = await buildUser();
@@ -360,6 +357,49 @@ describe("#attachments.create", () => {
       });
       expect(res.status).toEqual(200);
     });
+  });
+
+  describe("admin", () => {
+    it.each([AttachmentPreset.Import, AttachmentPreset.WorkspaceImport])(
+      "should create expiring attachment using %s preset",
+      async (preset) => {
+        const user = await buildAdmin();
+        const res = await server.post("/api/attachments.create", user, {
+          body: {
+            name: "test.zip",
+            contentType: "application/zip",
+            size: 10000,
+            preset,
+          },
+        });
+        expect(res.status).toEqual(200);
+
+        const body = await res.json();
+        const attachment = await Attachment.findByPk(body.data.attachment.id, {
+          rejectOnEmpty: true,
+        });
+        expect(attachment.expiresAt).toBeTruthy();
+      }
+    );
+
+    it.each([AttachmentPreset.Import, AttachmentPreset.WorkspaceImport])(
+      "should not allow upload using %s preset for another team's document",
+      async (preset) => {
+        const user = await buildAdmin();
+        const document = await buildDocument();
+
+        const res = await server.post("/api/attachments.create", user, {
+          body: {
+            name: "test.zip",
+            contentType: "application/zip",
+            size: 10000,
+            documentId: document.id,
+            preset,
+          },
+        });
+        expect(res.status).toEqual(403);
+      }
+    );
   });
 });
 

--- a/server/routes/api/attachments/attachments.ts
+++ b/server/routes/api/attachments/attachments.ts
@@ -91,16 +91,23 @@ router.post(
     const { auth, transaction } = ctx.state;
     const { user } = auth;
 
+    if (documentId) {
+      const document = await Document.findByPk(documentId, {
+        userId: user.id,
+        transaction,
+      });
+      authorize(user, "update", document);
+    }
+
     // All user types can upload an avatar so no additional authorization is needed.
     if (preset === AttachmentPreset.Avatar) {
       assertIn(contentType, AttachmentValidation.avatarContentTypes);
     } else {
-      if (preset === AttachmentPreset.DocumentAttachment && documentId) {
-        const document = await Document.findByPk(documentId, {
-          userId: user.id,
-          transaction,
-        });
-        authorize(user, "update", document);
+      if (
+        preset === AttachmentPreset.Import ||
+        preset === AttachmentPreset.WorkspaceImport
+      ) {
+        authorize(user, "createImport", user.team);
       }
       if (preset === AttachmentPreset.Emoji) {
         assertIn(contentType, AttachmentValidation.emojiContentTypes);


### PR DESCRIPTION
- Apply preset-specific permission checks during attachment creation.
- Validate access when uploads include a document reference.