### PR TITLE
fix: Load revision content in document history

### DIFF
--- a/app/scenes/Document/components/RevisionViewer.tsx
+++ b/app/scenes/Document/components/RevisionViewer.tsx
@@ -102,6 +102,7 @@ function RevisionViewer(props: Props, ref: React.Ref<TEditor>) {
     showChanges ? "changes" : "no-changes",
     compareToRevisionId ?? revision.before?.id ?? "none",
     comparisonData ? "loaded" : "pending",
+    revision.data ? "loaded" : "pending",
   ].join("-");
 
   return (


### PR DESCRIPTION
- Remounts the revision editor when the viewed revision content finishes loading.
- Prevents revisions from remaining blank after the content request completes.
- closes #13655