### PR TITLE
fix: Editor crash when upload placeholder targets a position with no node

### DIFF
--- a/shared/editor/lib/uploadPlaceholder.tsx
+++ b/shared/editor/lib/uploadPlaceholder.tsx
@@ -22,7 +22,7 @@ const uploadPlaceholder = new Plugin({
           const $pos = tr.doc.resolve(action.add.pos);
           const nodeAfter = $pos.nodeAfter;
           if (!nodeAfter) {
-            return;
+            return set;
           }
 
           const deco = Decoration.node(


### PR DESCRIPTION
- The upload placeholder plugin returned `undefined` as its state when a replacement placeholder targeted a position with no node after it.
- On the next transaction the decoration mapper received undefined and threw, crashing the editor.
- Now returns the current decoration set so the plugin state stays valid.