### PR TITLE
fix: Child documents list empty until sidebar renders the collection

### DIFF
--- a/app/scenes/Document/components/DataLoader.tsx
+++ b/app/scenes/Document/components/DataLoader.tsx
@@ -67,7 +67,8 @@ type Props = RouteComponentProps<Params, StaticContext, LocationState> & {
 };
 
 function DataLoader({ match, children }: Props) {
-  const { ui, views, shares, comments, documents, revisions } = useStores();
+  const { ui, views, shares, comments, documents, revisions, collections } =
+    useStores();
   const team = useCurrentTeam();
   const user = useCurrentUser();
   const { setDocument } = useDocumentContext();
@@ -170,6 +171,21 @@ function DataLoader({ match, children }: Props) {
     }
     void fetchViews();
   }, [document?.id, document?.isDeleted, revisionId, views, isJustCreated]);
+
+  // The collection tree provides the child documents list, so load it here
+  // rather than relying on the sidebar having rendered the collection.
+  const collectionId = document?.collectionId;
+  React.useEffect(() => {
+    if (!collectionId) {
+      return;
+    }
+    void collections
+      .fetch(collectionId)
+      .then((collection) => collection.fetchDocuments())
+      .catch((err) =>
+        Logger.error("Failed to fetch collection documents", toError(err))
+      );
+  }, [collections, collectionId]);
 
   const onCreateLink = React.useCallback(
     async (params: Properties<Document>, nested?: boolean) => {


### PR DESCRIPTION
The Documents tab on a document reads its children from the collection navigation tree, but only the sidebar requested that tree and only once it rendered the collection row. Collections below the first sidebar page never triggered the request, so the tab stayed empty after a refresh.

- Fetch the collection and its tree from the document DataLoader when the document loads
- No duplicate request when the sidebar already loaded the tree

closes #13659