### PR TITLE
fix: Tighten authentication on views.create endpoint

### DIFF
--- a/server/routes/api/views/views.ts
+++ b/server/routes/api/views/views.ts
@@ -6,6 +6,7 @@ import validate from "@server/middlewares/validate";
 import { View, Document } from "@server/models";
 import { authorize } from "@server/policies";
 import { presentView } from "@server/presenters";
+import { AuthenticationType } from "@server/types";
 import type { APIContext } from "@server/types";
 import { RateLimiterStrategy } from "@server/utils/RateLimiter";
 import * as T from "./schema";
@@ -41,7 +42,7 @@ router.post(
 router.post(
   "views.create",
   rateLimiter(RateLimiterStrategy.OneThousandPerHour),
-  auth(),
+  auth({ type: AuthenticationType.APP }),
   validate(T.ViewsCreateSchema),
   transaction(),
   async (ctx: APIContext<T.ViewsCreateReq>) => {


### PR DESCRIPTION
- Restricts the `views.create` endpoint to session authentication only, in line with other app-only endpoints.
- View recording is a first-party client action and should not be reachable via other token types.