### PR TITLE
fix: Markdown list dropped when a plain item precedes a checkbox item

### DIFF
--- a/shared/editor/rules/checkboxes.test.ts
+++ b/shared/editor/rules/checkboxes.test.ts
@@ -48,3 +48,49 @@ it("does not convert nested bullet list items inside checkbox lists", () => {
   expect(nestedList).toBeDefined();
   expect(nestedList?.content?.[0].type).toBe("list_item");
 });
+
+it("converts a list where a plain item precedes a checkbox item", () => {
+  const markdown = `- Item one
+- [ ] Item two`;
+
+  const ast = parser.parse(markdown);
+  const [checkboxList] = findNodes(ast?.toJSON(), "checkbox_list");
+
+  expect(checkboxList).toBeDefined();
+  expect(checkboxList?.content).toHaveLength(2);
+  expect(checkboxList?.content?.[0].type).toBe("checkbox_item");
+  expect(checkboxList?.content?.[1].type).toBe("checkbox_item");
+  expect(serializer.serialize(ast)).toBe(`- [ ] Item one
+- [ ] Item two`);
+});
+
+it("converts a nested list where a plain item precedes a checkbox item", () => {
+  const markdown = `- Parent
+    - Nested plain
+    - [x] Nested checkbox
+- Sibling`;
+
+  const ast = parser.parse(markdown);
+  const [bulletList] = findNodes(ast?.toJSON(), "bullet_list");
+  const [checkboxList] = findNodes(ast?.toJSON(), "checkbox_list");
+
+  expect(bulletList?.content).toHaveLength(2);
+  expect(checkboxList).toBeDefined();
+  expect(checkboxList?.content).toHaveLength(2);
+  expect(checkboxList?.content?.[0].type).toBe("checkbox_item");
+  expect(checkboxList?.content?.[1].type).toBe("checkbox_item");
+  expect(checkboxList?.content?.[1].attrs?.checked).toBe(true);
+});
+
+it("converts an ordered list containing a checkbox item", () => {
+  const markdown = `1. Item one
+2. [ ] Item two`;
+
+  const ast = parser.parse(markdown);
+  const [checkboxList] = findNodes(ast?.toJSON(), "checkbox_list");
+
+  expect(checkboxList).toBeDefined();
+  expect(checkboxList?.content).toHaveLength(2);
+  expect(checkboxList?.content?.[0].type).toBe("checkbox_item");
+  expect(checkboxList?.content?.[1].type).toBe("checkbox_item");
+});

--- a/shared/editor/rules/checkboxes.ts
+++ b/shared/editor/rules/checkboxes.ts
@@ -22,6 +22,18 @@ function isListItem(token: Token): boolean {
   return !!token && token.type === "list_item_open";
 }
 
+function isListOpen(token: Token): boolean {
+  return (
+    token.type === "bullet_list_open" || token.type === "ordered_list_open"
+  );
+}
+
+function isListClose(token: Token): boolean {
+  return (
+    token.type === "bullet_list_close" || token.type === "ordered_list_close"
+  );
+}
+
 function looksLikeChecklist(tokens: Token[], index: number) {
   return (
     isInline(tokens[index]) &&
@@ -61,13 +73,20 @@ export default function markdownItCheckbox(md: MarkdownIt): void {
         const value = matchesChecklist[1];
         const checked = value.toLowerCase() === "x";
 
-        // convert surrounding list tokens
-        if (tokens[i - 3].type === "bullet_list_open") {
-          tokens[i - 3].type = "checkbox_list_open";
+        // convert the enclosing list tokens, which may not be adjacent when
+        // the checkbox item is preceded by plain items or contains nested lists.
+        const listLevel = tokens[i - 2].level - 1;
+        for (let k = i - 3; k >= 0; k--) {
+          if (tokens[k].level === listLevel && isListOpen(tokens[k])) {
+            tokens[k].type = "checkbox_list_open";
+            break;
+          }
         }
-
-        if (tokens[i + 3].type === "bullet_list_close") {
-          tokens[i + 3].type = "checkbox_list_close";
+        for (let k = i + 1; k < tokens.length; k++) {
+          if (tokens[k].level === listLevel && isListClose(tokens[k])) {
+            tokens[k].type = "checkbox_list_close";
+            break;
+          }
         }
 
         // remove [ ] [x] from list item label – must use the content from the


### PR DESCRIPTION
Parsing a Markdown list where a plain item is followed by a checkbox item silently dropped the whole list.

- The checkbox `markdown-it` rule used fixed token offsets to find the enclosing list, which broke when the checkbox item was not first or contained a nested list
- The rule now walks the token stream by nesting level to convert the enclosing list open and close tokens
- Ordered lists containing a checkbox item are now converted instead of dropped (we don't support mixed lists)

closes #13661