### PR TITLE
fix: Persist comment sidebar open/close state across reloads

### DIFF
--- a/app/stores/UiStore.ts
+++ b/app/stores/UiStore.ts
@@ -410,6 +410,7 @@ class UiStore {
       this.secondaryRightSidebar = panel;
     } else {
       this.rightSidebar = panel;
+      this.persist();
     }
   };
 


### PR DESCRIPTION
The comment sidebar open/close state stopped persisting after the split view refactor, so it always reappeared open on reload.

- Persist the primary right sidebar state when it is toggled, restoring the pre-refactor behavior
- The secondary pane stays session-only, as before