### PR TITLE
fix: Allow dropping a document after an expanded subtree in the sidebar

### DIFF
--- a/app/components/DocumentListItem.tsx
+++ b/app/components/DocumentListItem.tsx
@@ -135,7 +135,6 @@ function DocumentListItem(
     document.asNavigationNode,
     0,
     document,
-    false,
     false
   );
 

--- a/app/components/Sidebar/components/DocumentLink.tsx
+++ b/app/components/Sidebar/components/DocumentLink.tsx
@@ -36,6 +36,7 @@ import { useSidebarExpansion } from "./SidebarExpansionContext";
 import DocumentRow from "./DocumentRow";
 import DropCursor from "./DropCursor";
 import Folder from "./Folder";
+import { indentForDepth } from "./SidebarLink";
 import type { SidebarContextType } from "./SidebarContext";
 import { useSidebarContext } from "./SidebarContext";
 
@@ -49,6 +50,19 @@ type Props = {
   depth: number;
   index: number;
   parentId?: string;
+  /**
+   * Positions directly after each ancestor whose subtree ends with this node,
+   * nearest first. They let a drop at the end of an expanded subtree land
+   * beside an ancestor instead of inside it.
+   */
+  ancestorDropTargets?: DropTarget[];
+};
+
+/** A position in the document tree that a dragged document can be dropped at. */
+type DropTarget = {
+  parentDocumentId: string | undefined;
+  index: number;
+  depth: number;
 };
 
 // Approximate rendered row height; used to reserve space for unmounted rows so
@@ -117,6 +131,20 @@ const DocumentLink = observer(function DocumentLink(props: Props) {
     [draftNavNode, collection, node.children]
   );
 
+  // The last child shares its bottom edge with this node's subtree, so a drop
+  // there may also target the position after this node or its ancestors.
+  const lastChildDropTargets = React.useMemo<DropTarget[]>(
+    () => [
+      {
+        parentDocumentId: props.parentId,
+        index: props.index + 1,
+        depth: props.depth,
+      },
+      ...(props.ancestorDropTargets ?? []),
+    ],
+    [props.parentId, props.index, props.depth, props.ancestorDropTargets]
+  );
+
   // Visibility gate: only mount the heavy inner content when scrolled near the
   // viewport, but keep it mounted while a drag is in progress so the dragged
   // source (or a drop target the user is heading toward) isn't yanked.
@@ -179,6 +207,11 @@ const DocumentLink = observer(function DocumentLink(props: Props) {
             depth={props.depth + 1}
             index={childIndex}
             parentId={node.id}
+            ancestorDropTargets={
+              childIndex === nodeChildren.length - 1
+                ? lastChildDropTargets
+                : undefined
+            }
           />
         ))}
       </Folder>
@@ -200,6 +233,7 @@ const DocumentLinkInner = observer(function DocumentLinkInner({
   index,
   parentId,
   hasChildren,
+  ancestorDropTargets,
 }: InnerProps) {
   const { documents } = useStores();
   const { t } = useTranslation();
@@ -325,42 +359,33 @@ const DocumentLinkInner = observer(function DocumentLinkInner({
   // Fall back so document-only access (e.g. "Manage" on a parent) can reorder.
   const moveCollectionId = collection?.id ?? document?.collectionId;
 
-  const [{ isOverReorder: isOverReorderAbove }, dropToReorderAbove] =
-    useDropToReorderDocument(node, collection, (item) => {
-      if (!moveCollectionId) {
-        return;
-      }
-      return {
-        documentId: item.id,
-        collectionId: moveCollectionId,
-        parentDocumentId: parentId,
-        index,
-      };
-    });
-
-  const [{ isOverReorder }, dropToReorder] = useDropToReorderDocument(
-    node,
-    collection,
-    (item) => {
-      if (!moveCollectionId) {
-        return;
-      }
-      if (expansion.isExpanded(node.id)) {
-        return {
-          documentId: item.id,
-          collectionId: moveCollectionId,
-          parentDocumentId: node.id,
-          index: 0,
-        };
-      }
-      return {
-        documentId: item.id,
-        collectionId: moveCollectionId,
-        parentDocumentId: parentId,
-        index: index + 1,
-      };
-    }
+  const targetAbove = React.useMemo<DropTarget>(
+    () => ({ parentDocumentId: parentId, index, depth }),
+    [parentId, index, depth]
   );
+
+  // Below an expanded node the only position is its first child. Otherwise the
+  // position after the node comes first, then any ancestor positions that end
+  // here, so the pointer's horizontal position picks the depth. The node being
+  // dragged skips the position after itself, which would be a no-op.
+  const targetsBelow = React.useMemo<DropTarget[]>(() => {
+    if (expanded && hasChildren) {
+      return [{ parentDocumentId: node.id, index: 0, depth: depth + 1 }];
+    }
+    const afterSelf = isDragging
+      ? []
+      : [{ parentDocumentId: parentId, index: index + 1, depth }];
+    return [...afterSelf, ...(ancestorDropTargets ?? [])];
+  }, [
+    expanded,
+    hasChildren,
+    isDragging,
+    node.id,
+    parentId,
+    index,
+    depth,
+    ancestorDropTargets,
+  ]);
 
   const title = document?.title || node.title || t("Untitled");
 
@@ -422,16 +447,33 @@ const DocumentLinkInner = observer(function DocumentLinkInner({
   // the tree for every row.
   const cursorBefore =
     canReorderHere && index === 0 ? (
-      <DropCursor
-        isActiveDrop={isOverReorderAbove}
-        innerRef={dropToReorderAbove}
+      <ReorderDropCursor
+        node={node}
+        collection={collection}
+        collectionId={moveCollectionId}
+        target={targetAbove}
         position="top"
       />
     ) : undefined;
 
-  const cursorAfter = canReorderHere ? (
-    <DropCursor isActiveDrop={isOverReorder} innerRef={dropToReorder} />
-  ) : undefined;
+  // Later cursors render on top, so each outer level's narrower hit area wins
+  // when the pointer is left of the previous level's indent.
+  const cursorAfter = canReorderHere
+    ? targetsBelow.map((target, level) => (
+        <ReorderDropCursor
+          key={level}
+          node={node}
+          collection={collection}
+          collectionId={moveCollectionId}
+          target={target}
+          hitWidth={
+            level > 0
+              ? indentForDepth(targetsBelow[level - 1].depth)
+              : undefined
+          }
+        />
+      ))
+    : undefined;
 
   return (
     <DocumentRow
@@ -467,6 +509,50 @@ const DocumentLinkInner = observer(function DocumentLinkInner({
       contextAction={contextMenuAction}
       isActiveOverride={isActiveCheck}
       onClickIntent={handlePrefetch}
+    />
+  );
+});
+
+type ReorderDropCursorProps = {
+  node: NavigationNode;
+  collection?: Collection;
+  collectionId?: string | null;
+  target: DropTarget;
+  position?: "top";
+  hitWidth?: number;
+};
+
+const ReorderDropCursor = observer(function ReorderDropCursor({
+  node,
+  collection,
+  collectionId,
+  target,
+  position,
+  hitWidth,
+}: ReorderDropCursorProps) {
+  const [{ isOverReorder }, dropToReorder] = useDropToReorderDocument(
+    node,
+    collection,
+    (item) => {
+      if (!collectionId) {
+        return;
+      }
+      return {
+        documentId: item.id,
+        collectionId,
+        parentDocumentId: target.parentDocumentId,
+        index: target.index,
+      };
+    }
+  );
+
+  return (
+    <DropCursor
+      isActiveDrop={isOverReorder}
+      innerRef={dropToReorder}
+      position={position}
+      indent={indentForDepth(target.depth)}
+      hitWidth={hitWidth}
     />
   );
 });

--- a/app/components/Sidebar/components/DragPlaceholder.tsx
+++ b/app/components/Sidebar/components/DragPlaceholder.tsx
@@ -16,26 +16,18 @@ const layerStyles: React.CSSProperties = {
   height: "100%",
 };
 
-function getItemStyles(
-  initialOffset: XYCoord | null,
-  currentOffset: XYCoord | null,
-  sidebarWidth: number,
-  constrainToSidebar: boolean
-) {
-  if (!initialOffset || !currentOffset) {
+// Keep the ghost beside the pointer so it never covers the drop cursor.
+const POINTER_OFFSET_X = 12;
+const POINTER_OFFSET_Y = 14;
+
+function getItemStyles(pointerOffset: XYCoord | null, sidebarWidth: number) {
+  if (!pointerOffset) {
     return {
       display: "none",
     };
   }
-  const { y } = currentOffset;
-  // Sidebar drags keep the ghost tethered near its origin, but drags from
-  // outside the sidebar should follow the cursor freely.
-  const x = constrainToSidebar
-    ? Math.max(
-        initialOffset.x,
-        Math.min(initialOffset.x + sidebarWidth / 4, currentOffset.x)
-      )
-    : currentOffset.x;
+  const x = pointerOffset.x + POINTER_OFFSET_X;
+  const y = pointerOffset.y - POINTER_OFFSET_Y;
 
   const transform = `translate(${x}px, ${y}px)`;
   return {
@@ -49,35 +41,25 @@ const DragPlaceholder = () => {
   const { t } = useTranslation();
   const { ui } = useStores();
 
-  const { isDragging, item, initialOffset, currentOffset } = useDragLayer(
-    (monitor) => ({
-      item: monitor.getItem(),
-      itemType: monitor.getItemType(),
-      initialOffset: monitor.getInitialSourceClientOffset(),
-      currentOffset: monitor.getSourceClientOffset(),
-      isDragging: monitor.isDragging(),
-    })
-  );
+  const { isDragging, item, pointerOffset } = useDragLayer((monitor) => ({
+    item: monitor.getItem(),
+    itemType: monitor.getItemType(),
+    pointerOffset: monitor.getClientOffset(),
+    isDragging: monitor.isDragging(),
+  }));
 
-  if (!isDragging || !currentOffset) {
+  if (!isDragging || !pointerOffset) {
     return null;
   }
 
   return (
     <div style={layerStyles}>
-      <div
-        style={getItemStyles(
-          initialOffset,
-          currentOffset,
-          ui.sidebarWidth,
-          item.constrainToSidebar !== false
-        )}
-      >
+      <div style={getItemStyles(pointerOffset, ui.sidebarWidth)}>
         <GhostLink
           icon={item.icon}
           label={item.title || t("Untitled")}
           isDraft={item.isDraft}
-          depth={item.depth}
+          depth={0}
           active
         />
       </div>

--- a/app/components/Sidebar/components/DropCursor.tsx
+++ b/app/components/Sidebar/components/DropCursor.tsx
@@ -5,17 +5,35 @@ type Props = {
   isActiveDrop: boolean;
   innerRef: React.Ref<HTMLDivElement>;
   position?: "top";
+  /** Inline-start offset of the visible line in pixels, to match a tree depth. */
+  indent?: number;
+  /** Width of the area that accepts a drop in pixels, defaults to the full row. */
+  hitWidth?: number;
   className?: string;
 };
 
-function DropCursor({ isActiveDrop, innerRef, position, className }: Props) {
+function DropCursor({
+  isActiveDrop,
+  innerRef,
+  position,
+  indent = 0,
+  hitWidth,
+  className,
+}: Props) {
+  const hitStyle = React.useMemo(
+    () => (hitWidth === undefined ? undefined : { width: hitWidth }),
+    [hitWidth]
+  );
+
   return (
     <Cursor
       isOver={isActiveDrop}
-      ref={innerRef}
       position={position}
+      $indent={indent}
       className={className}
-    />
+    >
+      <HitArea ref={innerRef} style={hitStyle} />
+    </Cursor>
   );
 }
 
@@ -23,30 +41,40 @@ function DropCursor({ isActiveDrop, innerRef, position, className }: Props) {
 const Cursor = styled.div<{
   isOver?: boolean;
   position?: "top";
+  $indent: number;
 }>`
   opacity: ${(props) => (props.isOver ? 1 : 0)};
   transition: opacity 150ms;
   position: absolute;
   z-index: 1;
   pointer-events: none;
-
-  [data-drag-active] & {
-    pointer-events: auto;
-  }
-
   width: 100%;
   height: 14px;
   background: transparent;
   ${(props) => (props.position === "top" ? "top: -7px;" : "bottom: -7px;")}
 
   ::after {
-    background: ${(props) => props.theme.slateDark};
+    background: ${(props) => props.theme.accent};
     position: absolute;
     top: 6px;
+    inset-inline: ${(props) => props.$indent}px 0;
     content: "";
     height: 2px;
     border-radius: 2px;
-    width: 100%;
+  }
+`;
+
+// The drop target. Narrower than the line when several cursors share a band so
+// that the pointer's horizontal position picks between them.
+const HitArea = styled.div`
+  position: absolute;
+  inset-block: 0;
+  inset-inline-start: 0;
+  width: 100%;
+  pointer-events: none;
+
+  [data-drag-active] & {
+    pointer-events: auto;
   }
 `;
 

--- a/app/components/Sidebar/components/SidebarLink.tsx
+++ b/app/components/Sidebar/components/SidebarLink.tsx
@@ -17,6 +17,17 @@ import { ContextMenu } from "~/components/Menu/ContextMenu";
 import { useTranslation } from "react-i18next";
 
 /**
+ * Returns the inline-start offset in pixels of a sidebar row's content at the
+ * given nesting depth.
+ *
+ * @param depth The nesting depth of the row, 0-based.
+ * @returns the offset in pixels.
+ */
+export function indentForDepth(depth: number): number {
+  return depth * 16 + 12;
+}
+
+/**
  * Props for the SidebarLink component.
  * Extends NavLink props with additional sidebar-specific functionality.
  */
@@ -104,7 +115,7 @@ function SidebarLink(
   const { handleMouseEnter, handleMouseLeave } = useClickIntent(onClickIntent);
   const style = React.useMemo(
     () => ({
-      paddingInlineStart: `${(depth || 0) * 16 + (icon ? -8 : 12)}px`,
+      paddingInlineStart: `${indentForDepth(depth || 0) - (icon ? 20 : 0)}px`,
       paddingInlineEnd: unreadBadge ? "32px" : undefined,
     }),
     [depth, icon, unreadBadge]

--- a/app/components/Sidebar/hooks/useDragAndDrop.tsx
+++ b/app/components/Sidebar/hooks/useDragAndDrop.tsx
@@ -27,12 +27,6 @@ import { useSidebarLabelAndIcon } from "./useSidebarLabelAndIcon";
 export type DragObject = NavigationNode & {
   depth: number;
   collectionId: string;
-  /**
-   * Whether the drag ghost should stay tethered to the sidebar. Defaults to
-   * tethered when unset — the placeholder only lets the ghost follow the
-   * cursor when this is explicitly `false` (e.g. drags from a document list).
-   */
-  constrainToSidebar?: boolean;
 };
 
 function useHover(
@@ -237,16 +231,12 @@ export function useDropToReorderSidebarSection(
  * @param depth The depth of the node in the sidebar.
  * @param document The related Document model.
  * @param isEditing Whether the sidebar item is currently being edited.
- * @param constrainToSidebar Whether the drag ghost should stay tethered to the
- * sidebar. Defaults to true; pass false when dragging from outside the sidebar
- * (e.g. a document list) so the ghost follows the cursor.
  */
 export function useDragDocument(
   node: NavigationNode,
   depth: number,
   document?: Document,
-  isEditing?: boolean,
-  constrainToSidebar = true
+  isEditing?: boolean
 ) {
   const icon = document?.icon || node.icon || node.emoji;
   const color = document?.color || node.color;
@@ -266,7 +256,6 @@ export function useDragDocument(
           <Icon initial={initial} value={icon} color={color} />
         ) : undefined,
         collectionId: document?.collectionId || "",
-        constrainToSidebar,
       }) as DragObject,
     canDrag: () => !!document?.isActive && !isEditing,
     collect: (monitor) => ({
@@ -493,10 +482,24 @@ export function useDropToReorderDocument(
   return useDrop<DragObject, Promise<void>, { isOverReorder: boolean }>({
     accept: "document",
     canDrop: (item: DragObject) => {
-      if (item.id === node.id || (document && !document.isActive)) {
+      if (
+        (document && !document.isActive) ||
+        !policies.abilities(item.id).move
+      ) {
         return false;
       }
-      return !!policies.abilities(item.id).move;
+      if (item.id !== node.id) {
+        return true;
+      }
+      // A document can only be dropped on its own cursor when that moves it to
+      // a different parent, e.g. out of the end of an expanded subtree.
+      const params = getMoveParams(item);
+      return (
+        !!params &&
+        params.parentDocumentId !== item.id &&
+        (params.parentDocumentId ?? null) !==
+          (document?.parentDocumentId ?? null)
+      );
     },
     drop: async (item) => {
       if (!collection?.isManualSort && item.collectionId === collection?.id) {


### PR DESCRIPTION
In a manually sorted collection there was no drop position after an expanded subtree, so dropping a document at the bottom of a parent's children always nested it inside that parent. The end of a subtree now offers one drop cursor per ancestor level, and the pointer's horizontal position picks the depth.

- Each parent passes its "after me" position down to its last child, which renders a stacked cursor for every level with a narrower hit area per outer level
- The drop line indents to the depth it targets and uses the accent color so the target is visible
- A document can be dropped on its own cursor when that moves it out to a different parent, and the no-op position after itself is skipped while it is dragged
- The drag ghost now follows the pointer and sits just to its right instead of covering the row and the cursor

closes #10685