### PR TITLE
fix: History "Current version" entry never finishes loading

### DIFF
--- a/app/stores/RevisionsStore.ts
+++ b/app/stores/RevisionsStore.ts
@@ -1,4 +1,5 @@
 import { type JSONObject } from "@shared/types";
+import { RevisionHelper } from "@shared/utils/RevisionHelper";
 import type RootStore from "~/stores/RootStore";
 import Store from "~/stores/base/Store";
 import Revision from "~/models/Revision";
@@ -17,6 +18,11 @@ export default class RevisionsStore extends Store<Revision> {
    * @returns A promise that resolves to the fetched revision.
    */
   async fetch(id: string, options: JSONObject = {}): Promise<Revision> {
+    const documentId = RevisionHelper.documentIdFromLatestId(id);
+    if (documentId) {
+      return this.fetchLatest(documentId);
+    }
+
     const item = this.get(id);
     const force = Boolean(options.force) || (!!item && !item.data);
     return super.fetch(id, { ...options, force });

--- a/app/stores/RevisionsStore.ts
+++ b/app/stores/RevisionsStore.ts
@@ -45,6 +45,7 @@ export default class RevisionsStore extends Store<Revision> {
    */
   fetchLatest = async (documentId: string) => {
     const res = await client.post(`/revisions.info`, { documentId });
+    this.addPolicies(res.policies);
     return this.add(res.data);
   };
 }

--- a/server/routes/api/revisions/revisions.test.ts
+++ b/server/routes/api/revisions/revisions.test.ts
@@ -3,6 +3,7 @@ import {
   ExportContentType,
   TeamPreference,
 } from "@shared/types";
+import { RevisionHelper } from "@shared/utils/RevisionHelper";
 import { createContext } from "@server/context";
 import { UserMembership, Revision } from "@server/models";
 import FileStorage from "@server/storage/files";
@@ -42,6 +43,25 @@ describe("#revisions.info", () => {
     // The single revision endpoint includes the full document content.
     expect(body.data.data).toBeDefined();
     expect(body.data.text).toBeDefined();
+  });
+
+  it("should return the latest revision by documentId with a stable id", async () => {
+    const user = await buildUser();
+    const document = await buildDocument({
+      userId: user.id,
+      teamId: user.teamId,
+    });
+    const res = await server.post("/api/revisions.info", user, {
+      body: {
+        documentId: document.id,
+      },
+    });
+    const body = await res.json();
+    expect(res.status).toEqual(200);
+    expect(body.data.id).toEqual(RevisionHelper.latestId(document.id));
+    expect(body.data.documentId).toEqual(document.id);
+    expect(body.data.title).toEqual(document.title);
+    expect(body.data.data).toBeDefined();
   });
 
   it("should require authorization", async () => {

--- a/server/routes/api/revisions/revisions.ts
+++ b/server/routes/api/revisions/revisions.ts
@@ -53,7 +53,8 @@ router.post(
       });
       authorize(user, "listRevisions", document);
       revision = Revision.buildFromDocument(document);
-      revision.id = RevisionHelper.latestId(document.id);
+      // Sequelize ignores primary key assignment on built instances.
+      revision.setDataValue("id", RevisionHelper.latestId(document.id));
       revision.user = document.updatedBy;
     } else {
       throw ValidationError("Either id or documentId must be provided");

--- a/shared/utils/RevisionHelper.ts
+++ b/shared/utils/RevisionHelper.ts
@@ -8,4 +8,14 @@ export class RevisionHelper {
   static latestId(documentId?: string) {
     return documentId ? `latest-${documentId}` : "";
   }
+
+  /**
+   * Extract the document id from a latest revision id.
+   *
+   * @param id The revision id to inspect.
+   * @returns The document id if the id is a latest revision id, otherwise undefined.
+   */
+  static documentIdFromLatestId(id: string) {
+    return id.startsWith("latest-") ? id.slice("latest-".length) : undefined;
+  }
 }


### PR DESCRIPTION
When a document has changes beyond its latest revision, opening the "Current version" entry in the History panel showed the loading skeleton forever. Assigning the primary key on a built, unsaved Sequelize instance is a silent no-op, so `revisions.info` returned a random UUID instead of the stable latest id the client waits for. This has been broken since the Fix decorator was removed in #13100, which previously bypassed that guard.

- Write the synthetic latest id with `setDataValue` in the documentId branch of revisions.info
- Route synthetic latest ids in the client RevisionsStore through fetchLatest instead of sending them to the API
- Add a RevisionHelper method to extract the document id from a latest revision id

closes #13666