### PR TITLE
fix: History changes indicator missing on load and stuck on "N changes"

### DIFF
--- a/app/components/DocumentContext.tsx
+++ b/app/components/DocumentContext.tsx
@@ -14,7 +14,12 @@ class DocumentContext {
   document?: Document;
 
   /** The editor instance for this document */
-  editor?: Editor;
+  @observable.ref
+  editor: Editor | undefined = undefined;
+
+  /** The total number of changes in the currently viewed revision diff */
+  @observable
+  totalChanges: number = 0;
 
   /** The ID of the currently focused comment, or null if no comment is focused */
   @observable
@@ -65,6 +70,11 @@ class DocumentContext {
   @action
   setEditorInitialized = (initialized: boolean) => {
     this.isEditorInitialized = initialized;
+  };
+
+  @action
+  setTotalChanges = (totalChanges: number) => {
+    this.totalChanges = totalChanges;
   };
 
   @action

--- a/app/scenes/Document/components/ChangesNavigation.tsx
+++ b/app/scenes/Document/components/ChangesNavigation.tsx
@@ -13,7 +13,7 @@ import useQuery from "~/hooks/useQuery";
 export const ChangesNavigation = observer(function ChangesNavigation_() {
   const { t } = useTranslation();
   const query = useQuery();
-  const showChanges = query.get("changes");
+  const showChanges = query.has("changes");
   const { editor, totalChanges } = useDocumentContext();
 
   if (!showChanges) {

--- a/app/scenes/Document/components/ChangesNavigation.tsx
+++ b/app/scenes/Document/components/ChangesNavigation.tsx
@@ -43,6 +43,7 @@ export const ChangesNavigation = observer(function ChangesNavigation_() {
             <NavigationButton
               icon={<CaretUpIcon />}
               onClick={() => editor?.commands.prevChange()}
+              disabled={!diffExtension}
               aria-label={t("Previous change")}
             />
           </Tooltip>
@@ -50,6 +51,7 @@ export const ChangesNavigation = observer(function ChangesNavigation_() {
             <NavigationButton
               icon={<CaretDownIcon />}
               onClick={() => editor?.commands.nextChange()}
+              disabled={!diffExtension}
               aria-label={t("Next change")}
             />
           </Tooltip>

--- a/app/scenes/Document/components/ChangesNavigation.tsx
+++ b/app/scenes/Document/components/ChangesNavigation.tsx
@@ -6,32 +6,24 @@ import { CaretDownIcon, CaretUpIcon } from "outline-icons";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import Button from "~/components/Button";
+import { useDocumentContext } from "~/components/DocumentContext";
 import Tooltip from "~/components/Tooltip";
-import { type Editor } from "~/editor";
 import useQuery from "~/hooks/useQuery";
-import type Revision from "~/models/Revision";
 
-type Props = {
-  revision: Revision;
-  editorRef: React.RefObject<Editor>;
-};
-
-export const ChangesNavigation = observer(function ChangesNavigation_({
-  editorRef,
-}: Props) {
+export const ChangesNavigation = observer(function ChangesNavigation_() {
   const { t } = useTranslation();
   const query = useQuery();
   const showChanges = query.get("changes");
+  const { editor, totalChanges } = useDocumentContext();
 
   if (!showChanges) {
     return null;
   }
 
-  const diffExtension = editorRef.current?.extensions.extensions.find(
+  const diffExtension = editor?.extensions.extensions.find(
     (ext) => ext instanceof Diff
   ) as Diff | undefined;
   const currentChangeIndex = diffExtension?.getCurrentChangeIndex() ?? -1;
-  const totalChanges = diffExtension?.getTotalChangesCount() ?? 0;
 
   return (
     <>
@@ -50,14 +42,14 @@ export const ChangesNavigation = observer(function ChangesNavigation_({
           <Tooltip content={t("Previous change")} placement="bottom">
             <NavigationButton
               icon={<CaretUpIcon />}
-              onClick={() => editorRef.current?.commands.prevChange()}
+              onClick={() => editor?.commands.prevChange()}
               aria-label={t("Previous change")}
             />
           </Tooltip>
           <Tooltip content={t("Next change")} placement="bottom">
             <NavigationButton
               icon={<CaretDownIcon />}
-              onClick={() => editorRef.current?.commands.nextChange()}
+              onClick={() => editor?.commands.nextChange()}
               aria-label={t("Next change")}
             />
           </Tooltip>

--- a/app/scenes/Document/components/Document.tsx
+++ b/app/scenes/Document/components/Document.tsx
@@ -365,7 +365,6 @@ function DocumentScene({
             <SharedHeader document={document} />
           ) : (
             <Header
-              editorRef={editorRef}
               document={document}
               revision={revision}
               isDraft={document.isDraft}

--- a/app/scenes/Document/components/Header.tsx
+++ b/app/scenes/Document/components/Header.tsx
@@ -21,7 +21,6 @@ import Flex from "~/components/Flex";
 import Header from "~/components/Header";
 import Star from "~/components/Star";
 import Tooltip from "~/components/Tooltip";
-import { type Editor } from "~/editor";
 import useCurrentTeam from "~/hooks/useCurrentTeam";
 import useCurrentUser from "~/hooks/useCurrentUser";
 import useEditingFocus from "~/hooks/useEditingFocus";
@@ -44,7 +43,6 @@ import { SearchHighlightChip } from "./SearchHighlightChip";
 import ShareButton from "./ShareButton";
 
 type Props = {
-  editorRef: React.RefObject<Editor>;
   document: Document;
   revision: Revision | undefined;
   isDraft: boolean;
@@ -62,7 +60,6 @@ type Props = {
 };
 
 function DocumentHeader({
-  editorRef,
   document,
   revision,
   isEditing,
@@ -263,7 +260,7 @@ function DocumentHeader({
           {revision && (
             <>
               <Action>
-                <ChangesNavigation revision={revision} editorRef={editorRef} />
+                <ChangesNavigation />
               </Action>
               <Action>
                 <Tooltip content={t("Restore version")} placement="bottom">

--- a/app/scenes/Document/components/RevisionViewer.tsx
+++ b/app/scenes/Document/components/RevisionViewer.tsx
@@ -44,7 +44,7 @@ type Props = Omit<EditorProps, "extensions"> & {
 function RevisionViewer(props: Props, ref: React.Ref<TEditor>) {
   const { document, children, revision } = props;
   const { revisions } = useStores();
-  const { setEditor } = useDocumentContext();
+  const { setEditor, setTotalChanges } = useDocumentContext();
   const query = useQuery();
   const showChanges = props.showChanges ?? query.has("changes");
   const compareToParam = query.get("compareTo");
@@ -80,21 +80,35 @@ function RevisionViewer(props: Props, ref: React.Ref<TEditor>) {
 
   /**
    * Create editor extensions with the Diff extension configured to render
-   * the calculated changes as decorations in the editor.
+   * the calculated changes as decorations in the editor. The change count is
+   * derived from the same changeset so the indicator can render before the
+   * editor and its Diff extension have finished mounting.
    */
-  const extensions = React.useMemo(() => {
+  const { extensions, totalChanges } = React.useMemo(() => {
     const changeset = ChangesetHelper.getChangeset(
       revision.data,
       comparisonData
     );
-    return [
-      CodeWordBreak,
-      ...withComments(richExtensions),
-      ...(showChanges && changeset?.changes
-        ? [new Diff({ changes: changeset?.changes })]
-        : []),
-    ];
+    return {
+      extensions: [
+        CodeWordBreak,
+        ...withComments(richExtensions),
+        ...(showChanges && changeset?.changes
+          ? [new Diff({ changes: changeset?.changes })]
+          : []),
+      ],
+      totalChanges: showChanges
+        ? Diff.countChanges(changeset?.changes ?? null)
+        : 0,
+    };
   }, [revision.data, comparisonData, showChanges]);
+
+  // Publish the change count so the header indicator can render immediately,
+  // without waiting for the lazily-loaded editor to mount.
+  React.useEffect(() => {
+    setTotalChanges(totalChanges);
+    return () => setTotalChanges(0);
+  }, [totalChanges, setTotalChanges]);
 
   // The editor builds its extensions once, on mount, so it has to be remounted
   // whenever the diff configuration changes. Revisions are listed without their

--- a/app/scenes/Document/components/RevisionViewer.tsx
+++ b/app/scenes/Document/components/RevisionViewer.tsx
@@ -107,8 +107,10 @@ function RevisionViewer(props: Props, ref: React.Ref<TEditor>) {
   // without waiting for the lazily-loaded editor to mount.
   React.useEffect(() => {
     setTotalChanges(totalChanges);
-    return () => setTotalChanges(0);
   }, [totalChanges, setTotalChanges]);
+
+  // Reset the count on unmount so it does not linger on the live document.
+  React.useEffect(() => () => setTotalChanges(0), [setTotalChanges]);
 
   // The editor builds its extensions once, on mount, so it has to be remounted
   // whenever the diff configuration changes. Revisions are listed without their

--- a/shared/editor/extensions/Diff.ts
+++ b/shared/editor/extensions/Diff.ts
@@ -36,6 +36,29 @@ type DiffOptions = {
 };
 
 export default class Diff extends Extension<DiffOptions> {
+  /**
+   * Count the total number of individual changes in a changeset.
+   *
+   * @param changes the set of changes, or null.
+   * @returns the total count of all inserted, deleted, and modified items.
+   */
+  public static countChanges(
+    changes: readonly ExtendedChange[] | null
+  ): number {
+    if (!changes) {
+      return 0;
+    }
+
+    return changes.reduce(
+      (total, change) =>
+        total +
+        change.inserted.length +
+        change.deleted.length +
+        change.modified.length,
+      0
+    );
+  }
+
   get name() {
     return "diff";
   }
@@ -82,19 +105,7 @@ export default class Diff extends Extension<DiffOptions> {
    * @returns the total count of all inserted, deleted, and modified items.
    */
   public getTotalChangesCount(): number {
-    const { changes } = this.options;
-    if (!changes) {
-      return 0;
-    }
-
-    return changes.reduce(
-      (total, change) =>
-        total +
-        change.inserted.length +
-        change.deleted.length +
-        change.modified.length,
-      0
-    );
+    return Diff.countChanges(this.options.changes);
   }
 
   private goToChange(direction: number): Command {


### PR DESCRIPTION
In document history, the changes indicator with prev/next navigation was unreliable: on a fresh load it was usually missing, and once visible the label never switched to "current of N" when navigating. The component read the editor through a plain React ref, so it never re-rendered when the lazily-mounted editor arrived or when the current change moved.

- Make the editor arrival observable on DocumentContext and publish the change count through it, so the indicator can render before the editor mounts
- Have ChangesNavigation read the editor and change count from context during render, so the observer tracks the editor arriving, the count settling, and the current change moving
- Extract the change counting into a shared helper on the Diff extension

closes #13670