### PR TITLE
fix: re-render revision viewer when late-loaded content arrives

### DIFF
--- a/app/scenes/Document/components/History/History.tsx
+++ b/app/scenes/Document/components/History/History.tsx
@@ -185,18 +185,27 @@ function History() {
     ? revisions.get(latestRevisionEvent.id)
     : undefined;
 
+  // Revision content arrives via a separate fetch, and models only annotate a
+  // field once it is first written, so reads of not-yet-loaded content are not
+  // tracked by `observer` — bump a local version when it lands so the
+  // `isDocUpdated` check below re-evaluates.
+  const [, bumpContentLoaded] = React.useReducer((v: number) => v + 1, 0);
+
   React.useEffect(() => {
     if (latestRevision && !latestRevision.data) {
-      void revisions.fetch(latestRevision.id);
+      revisions.fetch(latestRevision.id).then(
+        () => bumpContentLoaded(),
+        () => {}
+      );
     }
   }, [revisions, latestRevision]);
 
   // Whether the current document has unsaved changes beyond its latest
   // revision, in which case a "Current version" entry is shown. Computed in the
-  // render body (rather than the memo below) so the observer re-evaluates it
-  // once the lazily-loaded revision content arrives. The content-aware check is
-  // deferred until the content has loaded to avoid showing an entry that would
-  // then vanish.
+  // render body (rather than the memo below) so it re-evaluates once the
+  // lazily-loaded revision content arrives (the version bump above). The
+  // content-aware check is deferred until the content has loaded to avoid
+  // showing an entry that would then vanish.
   const isDocUpdated =
     !!latestRevision &&
     !!document &&

--- a/app/scenes/Document/components/RevisionViewer.tsx
+++ b/app/scenes/Document/components/RevisionViewer.tsx
@@ -72,11 +72,47 @@ function RevisionViewer(props: Props, ref: React.Ref<TEditor>) {
   const beforeRevisionId = compareToRevisionId
     ? undefined
     : revision.before?.id;
+
+  // Revision content is fetched separately and arrives after this component
+  // has mounted. Outline models only annotate a field once it is first
+  // written, so reads of not-yet-loaded content are not tracked by `observer`
+  // and its arrival alone will not re-render this component. Bump a local
+  // version once the fetch resolves so the editor, and its diff
+  // configuration, refresh when the content lands.
+  const [, bumpContentLoaded] = React.useReducer((v: number) => v + 1, 0);
+
   React.useEffect(() => {
-    if (showChanges && beforeRevisionId) {
-      void revisions.fetch(beforeRevisionId);
+    if (revision.data) {
+      return;
     }
+    revisions.fetch(revision.id).then(
+      () => bumpContentLoaded(),
+      () => {}
+    );
+  }, [revision.id, revision.data, revisions]);
+
+  React.useEffect(() => {
+    if (!showChanges || !beforeRevisionId) {
+      return;
+    }
+    revisions.fetch(beforeRevisionId).then(
+      () => bumpContentLoaded(),
+      () => {}
+    );
   }, [showChanges, beforeRevisionId, revisions]);
+
+  React.useEffect(() => {
+    if (!compareToRevisionId || comparisonData) {
+      return;
+    }
+    // The `compareTo` revision is fetched by the document DataLoader, but its
+    // content may still arrive after this component has rendered — same as
+    // above, bump the version once it has so the Diff extension can be built.
+    revisions.fetch(compareToRevisionId).then(
+      () => bumpContentLoaded(),
+      () => {}
+    );
+  }, [compareToRevisionId, comparisonData, revisions]);
 
   /**
    * Create editor extensions with the Diff extension configured to render


### PR DESCRIPTION
## Description

Fixes #13674.

Revisions are listed without their content, so the content of the viewed revision, of the `before` revision and of the `compareTo` revision is fetched separately and usually arrives **after** the revision viewer has rendered. Because models only annotate a field once it is first written, reads of not-yet-loaded content in the render are not tracked by `observer` — when the content lands, nothing re-renders, so the `editorKey` remount (from #13140 / #13656) never re-evaluates and the editor is not rebuilt with the completed diff configuration. The view stays blank or without highlights until an unrelated re-render happens.

- `RevisionViewer`: bump a local version (`useReducer`) once each of the three fetches resolves, so the component re-renders and the editor remounts with the diff when late content lands. The revision's own content is also fetched when missing (direct links to a revision rely on the document DataLoader, which may resolve after this component has mounted).
- `History`: the same bump for the latest-revision fetch added in #13669, so the `isDocUpdated` "Current version" comparison re-evaluates when its content arrives.

## Test plan

Verified manually on a self-hosted instance running essentially this code:

- Reloaded the page, then opened History and a revision with `?changes=true`: content and diff highlights now appear on the first render without toggling anything.
- Direct navigation to `/doc/<slug>/history/<id>?changes=true` for revisions whose content was not yet in the store: the revision renders with highlights once the fetch resolves.
- `?compareTo=latest`: comparison content arriving late now builds the diff and the change count.
- The History sidebar "Current version" entry appears/disappears correctly when the latest revision's content arrives late.
- Regression-checked: switching between revisions, toggling highlights off/on, and returning to the live document all behave as before.
