### PR TITLE
fix: make revision change count indicator and current-of-N navigation reliable

### DIFF
--- a/app/components/DocumentContext.tsx
+++ b/app/components/DocumentContext.tsx
@@ -28,6 +28,14 @@ class DocumentContext {
   @observable
   headings: Heading[] = [];
 
+  /**
+   * The total number of changes highlighted in the revision viewer. Written
+   * after the revision editor is (re)built, because the header's changes
+   * navigation cannot observe the editor instance through a ref alone.
+   */
+  @observable
+  totalChanges: number = 0;
+
   constructor() {
     makeObservable(this);
   }
@@ -70,6 +78,16 @@ class DocumentContext {
   @action
   setFocusedCommentId = (commentId: string | null) => {
     this.focusedCommentId = commentId;
+  };
+
+  /**
+   * Set the total number of changes highlighted in the revision viewer.
+   *
+   * @param total - The number of changes, or 0 when none are highlighted.
+   */
+  @action
+  setTotalChanges = (total: number) => {
+    this.totalChanges = total;
   };
 
   @action

--- a/app/components/DocumentContext.tsx
+++ b/app/components/DocumentContext.tsx
@@ -13,7 +13,12 @@ class DocumentContext {
   /** The current document */
   document?: Document;
 
-  /** The editor instance for this document */
+  /**
+   * The editor instance for this document. Observable so that components
+   * reading it re-render when the (lazily loaded) editor finally mounts —
+   * a plain ref cannot notify them.
+   */
+  @observable.ref
   editor?: Editor;
 
   /** The ID of the currently focused comment, or null if no comment is focused */

--- a/app/components/DocumentContext.tsx
+++ b/app/components/DocumentContext.tsx
@@ -17,9 +17,13 @@ class DocumentContext {
    * The editor instance for this document. Observable so that components
    * reading it re-render when the (lazily loaded) editor finally mounts —
    * a plain ref cannot notify them.
+   *
+   * The initializer is required: without an own property at the time
+   * `makeObservable` runs, mobx silently skips the annotation (assuming a
+   * subclass constructor will apply it later) and the field stays plain.
    */
   @observable.ref
-  editor?: Editor;
+  editor: Editor | undefined = undefined;
 
   /** The ID of the currently focused comment, or null if no comment is focused */
   @observable

--- a/app/scenes/Document/components/ChangesNavigation.tsx
+++ b/app/scenes/Document/components/ChangesNavigation.tsx
@@ -23,13 +23,16 @@ export const ChangesNavigation = observer(function ChangesNavigation_({
   const { t } = useTranslation();
   const query = useQuery();
   const showChanges = query.get("changes");
-  const { totalChanges } = useDocumentContext();
+  // The editor mounts from a lazy chunk, and a ref update alone cannot
+  // re-render this component — read the instance through the document
+  // context so its arrival and any change of the current index are tracked.
+  const { editor, totalChanges } = useDocumentContext();
 
   if (!showChanges) {
     return null;
   }
 
-  const diffExtension = editorRef.current?.extensions.extensions.find(
+  const diffExtension = editor?.extensions.extensions.find(
     (ext) => ext instanceof Diff
   ) as Diff | undefined;
   const currentChangeIndex = diffExtension?.getCurrentChangeIndex() ?? -1;

--- a/app/scenes/Document/components/ChangesNavigation.tsx
+++ b/app/scenes/Document/components/ChangesNavigation.tsx
@@ -6,6 +6,7 @@ import { CaretDownIcon, CaretUpIcon } from "outline-icons";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import Button from "~/components/Button";
+import { useDocumentContext } from "~/components/DocumentContext";
 import Tooltip from "~/components/Tooltip";
 import { type Editor } from "~/editor";
 import useQuery from "~/hooks/useQuery";
@@ -22,6 +23,7 @@ export const ChangesNavigation = observer(function ChangesNavigation_({
   const { t } = useTranslation();
   const query = useQuery();
   const showChanges = query.get("changes");
+  const { totalChanges } = useDocumentContext();
 
   if (!showChanges) {
     return null;
@@ -31,7 +33,6 @@ export const ChangesNavigation = observer(function ChangesNavigation_({
     (ext) => ext instanceof Diff
   ) as Diff | undefined;
   const currentChangeIndex = diffExtension?.getCurrentChangeIndex() ?? -1;
-  const totalChanges = diffExtension?.getTotalChangesCount() ?? 0;
 
   return (
     <>

--- a/app/scenes/Document/components/RevisionViewer.tsx
+++ b/app/scenes/Document/components/RevisionViewer.tsx
@@ -44,7 +44,7 @@ type Props = Omit<EditorProps, "extensions"> & {
 function RevisionViewer(props: Props, ref: React.Ref<TEditor>) {
   const { document, children, revision } = props;
   const { revisions } = useStores();
-  const { setEditor } = useDocumentContext();
+  const { setEditor, setTotalChanges } = useDocumentContext();
   const query = useQuery();
   const showChanges = props.showChanges ?? query.has("changes");
   const compareToParam = query.get("compareTo");
@@ -80,21 +80,35 @@ function RevisionViewer(props: Props, ref: React.Ref<TEditor>) {
 
   /**
    * Create editor extensions with the Diff extension configured to render
-   * the calculated changes as decorations in the editor.
+   * the calculated changes as decorations in the editor, along with the
+   * total change count published to the document context.
    */
-  const extensions = React.useMemo(() => {
+  const { extensions, totalChanges } = React.useMemo(() => {
     const changeset = ChangesetHelper.getChangeset(
       revision.data,
       comparisonData
     );
-    return [
-      CodeWordBreak,
-      ...withComments(richExtensions),
-      ...(showChanges && changeset?.changes
-        ? [new Diff({ changes: changeset?.changes })]
-        : []),
-    ];
+    return {
+      extensions: [
+        CodeWordBreak,
+        ...withComments(richExtensions),
+        ...(showChanges && changeset?.changes
+          ? [new Diff({ changes: changeset?.changes })]
+          : []),
+      ],
+      totalChanges: showChanges
+        ? Diff.countChanges(changeset?.changes ?? null)
+        : 0,
+    };
   }, [revision.data, comparisonData, showChanges]);
+
+  // The header's changes navigation lives outside this component and cannot
+  // observe the rebuilt editor through a ref, so publish the change count
+  // through the document context once the diff configuration settles.
+  React.useEffect(() => {
+    setTotalChanges(totalChanges);
+    return () => setTotalChanges(0);
+  }, [totalChanges, setTotalChanges]);
 
   // The editor builds its extensions once, on mount, so it has to be remounted
   // whenever the diff configuration changes. Revisions are listed without their

--- a/shared/editor/extensions/Diff.ts
+++ b/shared/editor/extensions/Diff.ts
@@ -77,12 +77,14 @@ export default class Diff extends Extension<DiffOptions> {
   }
 
   /**
-   * Get the total number of individual changes.
+   * Count the total number of individual changes in a changeset.
    *
+   * @param changes - The changes to count, or null.
    * @returns the total count of all inserted, deleted, and modified items.
    */
-  public getTotalChangesCount(): number {
-    const { changes } = this.options;
+  public static countChanges(
+    changes: readonly ExtendedChange[] | null
+  ): number {
     if (!changes) {
       return 0;
     }
@@ -95,6 +97,15 @@ export default class Diff extends Extension<DiffOptions> {
         change.modified.length,
       0
     );
+  }
+
+  /**
+   * Get the total number of individual changes.
+   *
+   * @returns the total count of all inserted, deleted, and modified items.
+   */
+  public getTotalChangesCount(): number {
+    return Diff.countChanges(this.options.changes);
   }
 
   private goToChange(direction: number): Command {


### PR DESCRIPTION
## Description

Fixes #13670.

`ChangesNavigation` reads the editor through a plain React ref during render (`editorRef.current`), but a ref mutation never re-renders a component and the editor mounts asynchronously from a lazy chunk — so on first render the ref is still `null` and nothing notifies the component when the editor (and its `Diff` extension with the computed changeset) arrives. The `observer` wrapper has nothing tracked, so even though `Diff.currentChangeIndex` is observable, mutations to it cannot re-render this component.

Three changes:

- Mark `DocumentContext.editor` as `@observable.ref` **with an initializer**. The initializer matters: without an own property at the time `makeObservable` runs, mobx silently skips the annotation (assuming a subclass constructor will apply it later) and the field stays plain — no error, no atom, no re-renders. Every other field in the class works because it has an initializer.
- Publish the change count through the same context (`totalChanges`, written by `RevisionViewer` once the changeset settles) so the indicator can render before the editor chunk has even loaded.
- Have `ChangesNavigation` read `editor` and `totalChanges` from `useDocumentContext()` during render. Now the observer tracks the editor arriving, the count settling, and `currentChangeIndex` changes (read transitively through the observable editor reference), so the label updates to "current of N" while navigating.

Also extracts `Diff.countChanges()` as a static so the count can be computed from the changeset before the editor exists.

Touches the same file as #13675 (different hunks; should merge independently).

## Test plan

Verified manually on a self-hosted instance across a full matrix:

- Cold load of five revisions covering insertions, deletions, node insertions, attribute modifications (checkbox toggle) and `compareTo=latest`: the "N changes" count matched the changeset in every case, and stripping the rendered `diff-insertion` / `diff-deletion` marks from the DOM reproduced the before/after revision texts fetched from the API exactly.
- The indicator now appears on first load, without needing an unrelated re-render.
- Clicking prev/next switches the label to "current of N" and wraps around in both directions; `Diff.currentChangeIndex` changes re-render the header.
- Survives toggling the highlight off and on, updates when switching revisions, and disappears when returning to the live document.
