### PR TITLE
feat: Alt/Mod-click toggle disclosure folds nested or all toggle blocks

### DIFF
--- a/shared/editor/nodes/ToggleBlock.ts
+++ b/shared/editor/nodes/ToggleBlock.ts
@@ -52,6 +52,14 @@ export enum Action {
   UNFOLD,
 }
 
+interface FoldAction {
+  type: Action;
+  /** Position of the target block; omitted to target every toggle block. */
+  at?: number;
+  /** Whether toggle blocks nested inside the target are included. */
+  nested?: boolean;
+}
+
 interface ToggleFoldState {
   foldedIds: Set<string>;
   knownIds: Set<string>;
@@ -201,7 +209,7 @@ export default class ToggleBlock extends Node {
           const newKnownIds = new Set(pluginState.knownIds);
 
           const fold = action.type === Action.FOLD;
-          for (const { node } of this.resolveTargets(newState.doc, action.at)) {
+          for (const { node } of this.resolveTargets(newState.doc, action)) {
             if (fold) {
               newFoldedIds.add(node.attrs.id);
             } else {
@@ -254,7 +262,7 @@ export default class ToggleBlock extends Node {
 
         if (eventTr) {
           const event = eventTr.getMeta(toggleEventPluginKey);
-          const targets = this.resolveTargets(newState.doc, event.at);
+          const targets = this.resolveTargets(newState.doc, event);
 
           if (event.type === Action.FOLD) {
             tr = this.moveSelectionOutOfBody(newState, targets);
@@ -464,25 +472,42 @@ export default class ToggleBlock extends Node {
 
   /**
    * Resolve the toggle blocks an action applies to: the block at the given
-   * position, or every toggle block in the document when no position is given.
+   * position, that block and every toggle block nested inside it when
+   * `nested` is set, or every toggle block in the document when no position
+   * is given.
    *
    * @param doc The document to look in.
-   * @param at The position of a single toggle block, or undefined for all.
-   * @return The matching toggle blocks with their positions.
+   * @param action The fold action describing the target position and scope.
+   * @return The matching toggle blocks with their positions, in document order.
    */
   private resolveTargets(
     doc: ProsemirrorNode,
-    at: number | undefined
+    action: FoldAction
   ): NodeWithPos[] {
-    const blocks =
-      at === undefined
-        ? findBlockNodes(doc, true)
-        : [{ node: doc.nodeAt(at), pos: at }];
+    const isToggle = (b: {
+      node: ProsemirrorNode | null;
+      pos: number;
+    }): b is NodeWithPos =>
+      b.node !== null && b.node.type.name === this.name && !!b.node.attrs.id;
 
-    return blocks.filter(
-      (b): b is NodeWithPos =>
-        b.node !== null && b.node.type.name === this.name && !!b.node.attrs.id
-    );
+    if (action.at === undefined) {
+      return findBlockNodes(doc, true).filter(isToggle);
+    }
+
+    const at = action.at;
+    const root = { node: doc.nodeAt(at), pos: at };
+    if (!isToggle(root)) {
+      return [];
+    }
+
+    if (!action.nested) {
+      return [root];
+    }
+
+    const descendants = findBlockNodes(root.node, true)
+      .map((b) => ({ node: b.node, pos: at + 1 + b.pos }))
+      .filter(isToggle);
+    return [root, ...descendants];
   }
 
   /**

--- a/shared/editor/nodes/ToggleBlock.ts
+++ b/shared/editor/nodes/ToggleBlock.ts
@@ -8,7 +8,7 @@ import type {
   Node as ProsemirrorNode,
   Schema,
 } from "prosemirror-model";
-import type { Command, Transaction } from "prosemirror-state";
+import type { Command, EditorState, Transaction } from "prosemirror-state";
 import { Plugin, PluginKey, TextSelection } from "prosemirror-state";
 import { findWrapping } from "prosemirror-transform";
 import { Decoration, DecorationSet } from "prosemirror-view";
@@ -168,16 +168,13 @@ export default class ToggleBlock extends Node {
 
       state: {
         init: (_config, state) => {
-          const { foldedIds, knownIds, blocks } =
-            this.collectFoldState(state.doc);
+          const { foldedIds, knownIds, blocks } = this.collectFoldState(
+            state.doc
+          );
           return {
             foldedIds,
             knownIds,
-            decorations: this.createDecorations(
-              state.doc,
-              foldedIds,
-              blocks
-            ),
+            decorations: this.createDecorations(state.doc, foldedIds, blocks),
           };
         },
 
@@ -203,26 +200,15 @@ export default class ToggleBlock extends Node {
           const newFoldedIds = new Set(pluginState.foldedIds);
           const newKnownIds = new Set(pluginState.knownIds);
 
-          switch (action.type) {
-            case Action.FOLD: {
-              const node = newState.doc.nodeAt(action.at);
-              if (node?.attrs.id) {
-                newFoldedIds.add(node.attrs.id);
-                newKnownIds.add(node.attrs.id);
-                foldStateCache.set(node.attrs.id, { fold: true });
-              }
-              break;
+          const fold = action.type === Action.FOLD;
+          for (const { node } of this.resolveTargets(newState.doc, action.at)) {
+            if (fold) {
+              newFoldedIds.add(node.attrs.id);
+            } else {
+              newFoldedIds.delete(node.attrs.id);
             }
-
-            case Action.UNFOLD: {
-              const node = newState.doc.nodeAt(action.at);
-              if (node?.attrs.id) {
-                newFoldedIds.delete(node.attrs.id);
-                newKnownIds.add(node.attrs.id);
-                foldStateCache.set(node.attrs.id, { fold: false });
-              }
-              break;
-            }
+            newKnownIds.add(node.attrs.id);
+            foldStateCache.set(node.attrs.id, { fold });
           }
 
           return {
@@ -268,31 +254,12 @@ export default class ToggleBlock extends Node {
 
         if (eventTr) {
           const event = eventTr.getMeta(toggleEventPluginKey);
-          const node = newState.doc.nodeAt(event.at);
+          const targets = this.resolveTargets(newState.doc, event.at);
 
-          if (node) {
-            if (event.type === Action.FOLD) {
-              // Move cursor out of body if folding
-              const { $anchor } = newState.selection;
-              const startOfNode = event.at + 1;
-              const endOfFirstChild = startOfNode + node.firstChild!.nodeSize;
-              const endOfNode = startOfNode + node.nodeSize - 1;
-
-              if ($anchor.pos > endOfFirstChild && $anchor.pos < endOfNode) {
-                const $endOfFirstChild = newState.doc.resolve(endOfFirstChild);
-                tr = newState.tr.setSelection(
-                  TextSelection.near($endOfFirstChild, -1)
-                );
-              }
-            } else if (event.type === Action.UNFOLD) {
-              // Insert empty paragraph if body is empty (for placeholder visibility)
-              if (node.childCount === 1) {
-                tr = newState.tr.insert(
-                  event.at + 1 + node.content.size,
-                  newState.schema.nodes.paragraph.create({})
-                );
-              }
-            }
+          if (event.type === Action.FOLD) {
+            tr = this.moveSelectionOutOfBody(newState, targets);
+          } else if (event.type === Action.UNFOLD) {
+            tr = this.insertParagraphIntoEmptyBodies(newState, targets);
           }
         }
 
@@ -496,6 +463,86 @@ export default class ToggleBlock extends Node {
   }
 
   /**
+   * Resolve the toggle blocks an action applies to: the block at the given
+   * position, or every toggle block in the document when no position is given.
+   *
+   * @param doc The document to look in.
+   * @param at The position of a single toggle block, or undefined for all.
+   * @return The matching toggle blocks with their positions.
+   */
+  private resolveTargets(
+    doc: ProsemirrorNode,
+    at: number | undefined
+  ): NodeWithPos[] {
+    const blocks =
+      at === undefined
+        ? findBlockNodes(doc, true)
+        : [{ node: doc.nodeAt(at), pos: at }];
+
+    return blocks.filter(
+      (b): b is NodeWithPos =>
+        b.node !== null && b.node.type.name === this.name && !!b.node.attrs.id
+    );
+  }
+
+  /**
+   * Move the selection to the end of the title of the outermost target whose
+   * body contains it, so that folding does not hide the cursor.
+   *
+   * @param state The editor state after the fold.
+   * @param targets The toggle blocks being folded, in document order.
+   * @return A transaction moving the selection, or null if none is needed.
+   */
+  private moveSelectionOutOfBody(
+    state: EditorState,
+    targets: NodeWithPos[]
+  ): Transaction | null {
+    const { $anchor } = state.selection;
+
+    for (const { node, pos } of targets) {
+      const startOfNode = pos + 1;
+      const endOfFirstChild = startOfNode + node.firstChild!.nodeSize;
+      const endOfNode = startOfNode + node.nodeSize - 1;
+
+      if ($anchor.pos > endOfFirstChild && $anchor.pos < endOfNode) {
+        return state.tr.setSelection(
+          TextSelection.near(state.doc.resolve(endOfFirstChild), -1)
+        );
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Insert an empty paragraph into every target with an empty body so that
+   * the placeholder is visible after unfolding.
+   *
+   * @param state The editor state after the unfold.
+   * @param targets The toggle blocks being unfolded, in document order.
+   * @return A transaction inserting paragraphs, or null if none is needed.
+   */
+  private insertParagraphIntoEmptyBodies(
+    state: EditorState,
+    targets: NodeWithPos[]
+  ): Transaction | null {
+    const emptyBlocks = targets.filter((b) => b.node.childCount === 1);
+    if (emptyBlocks.length === 0) {
+      return null;
+    }
+
+    const tr = state.tr;
+    // Insert from the end so earlier positions stay valid.
+    for (const { node, pos } of emptyBlocks.reverse()) {
+      tr.insert(
+        pos + 1 + node.content.size,
+        state.schema.nodes.paragraph.create({})
+      );
+    }
+    return tr;
+  }
+
+  /**
    * Collect initial fold state for every toggle block in the document.
    *
    * Used on plugin initialization, where every block is treated as new: the
@@ -605,7 +652,11 @@ export default class ToggleBlock extends Node {
     return {
       foldedIds,
       knownIds,
-      decorations: this.buildDecorationsFromBlocks(doc, toggleBlocks, foldedIds),
+      decorations: this.buildDecorationsFromBlocks(
+        doc,
+        toggleBlocks,
+        foldedIds
+      ),
     };
   }
 

--- a/shared/editor/nodes/ToggleBlockView.ts
+++ b/shared/editor/nodes/ToggleBlockView.ts
@@ -1,6 +1,7 @@
 import type { Node as ProsemirrorNode } from "prosemirror-model";
 import type { EditorView, NodeView, DecorationSource } from "prosemirror-view";
 import type { Decoration } from "prosemirror-view";
+import { isModKey } from "../../utils/keyboard";
 import { EditorStyleHelper } from "../styles/EditorStyleHelper";
 import {
   Action,
@@ -64,7 +65,7 @@ export class ToggleBlockView implements NodeView {
       return;
     }
 
-    this.handleToggle(event.altKey);
+    this.handleToggle(event);
   };
 
   private handleToggleHeadClick = (event: MouseEvent) => {
@@ -93,14 +94,15 @@ export class ToggleBlockView implements NodeView {
     }
 
     event.preventDefault();
-    this.handleToggle(event.altKey);
+    this.handleToggle(event);
   };
 
   /**
-   * Fold or unfold this block, or every toggle block in the document when
-   * `all` is true.
+   * Fold or unfold this block. With Alt held the block and every toggle block
+   * nested inside it are toggled; with the Mod key held every toggle block in
+   * the document is toggled.
    */
-  private handleToggle = (all = false) => {
+  private handleToggle = (event: MouseEvent) => {
     const pos = this.getPos();
     if (pos === undefined) {
       return;
@@ -112,12 +114,14 @@ export class ToggleBlockView implements NodeView {
 
     const type = isFolded ? Action.UNFOLD : Action.FOLD;
     // Omitting the position applies the action to every toggle block.
-    const at = all ? undefined : pos;
+    const action = isModKey(event)
+      ? { type }
+      : { type, at: pos, nested: event.altKey };
 
     this.view.dispatch(
       this.view.state.tr
-        .setMeta(toggleFoldPluginKey, { type, at })
-        .setMeta(toggleEventPluginKey, { type, at })
+        .setMeta(toggleFoldPluginKey, action)
+        .setMeta(toggleEventPluginKey, action)
     );
   };
 

--- a/shared/editor/nodes/ToggleBlockView.ts
+++ b/shared/editor/nodes/ToggleBlockView.ts
@@ -64,7 +64,7 @@ export class ToggleBlockView implements NodeView {
       return;
     }
 
-    this.handleToggle();
+    this.handleToggle(event.altKey);
   };
 
   private handleToggleHeadClick = (event: MouseEvent) => {
@@ -93,10 +93,14 @@ export class ToggleBlockView implements NodeView {
     }
 
     event.preventDefault();
-    this.handleToggle();
+    this.handleToggle(event.altKey);
   };
 
-  private handleToggle = () => {
+  /**
+   * Fold or unfold this block, or every toggle block in the document when
+   * `all` is true.
+   */
+  private handleToggle = (all = false) => {
     const pos = this.getPos();
     if (pos === undefined) {
       return;
@@ -106,16 +110,14 @@ export class ToggleBlockView implements NodeView {
       EditorStyleHelper.toggleBlockFolded
     );
 
+    const type = isFolded ? Action.UNFOLD : Action.FOLD;
+    // Omitting the position applies the action to every toggle block.
+    const at = all ? undefined : pos;
+
     this.view.dispatch(
       this.view.state.tr
-        .setMeta(toggleFoldPluginKey, {
-          type: isFolded ? Action.UNFOLD : Action.FOLD,
-          at: pos,
-        })
-        .setMeta(toggleEventPluginKey, {
-          type: isFolded ? Action.UNFOLD : Action.FOLD,
-          at: pos,
-        })
+        .setMeta(toggleFoldPluginKey, { type, at })
+        .setMeta(toggleEventPluginKey, { type, at })
     );
   };
 


### PR DESCRIPTION
Modifier-clicking a toggle block's disclosure arrow (or its title in read-only mode) now affects more than the clicked block. Alt folds or unfolds the block and every toggle block nested inside it; Mod (Cmd on Mac, Ctrl elsewhere) folds or unfolds every toggle block in the document.

- Fold and unfold actions carry an optional position and a nested flag; no position means every toggle block. Each block's state is persisted as before.
- Cursor relocation on fold and empty-body paragraph insertion on unfold are shared between the single, nested and all-blocks paths.