### PR TITLE
fix: Signed file downloads rejected when an API key lacks scope for the route

### DIFF
--- a/plugins/storage/server/api/files.test.ts
+++ b/plugins/storage/server/api/files.test.ts
@@ -11,6 +11,7 @@ import AttachmentHelper, {
 } from "@server/models/helpers/AttachmentHelper";
 import FileStorage from "@server/storage/files";
 import {
+  buildApiKey,
   buildAttachment,
   buildFileOperation,
   buildUser,
@@ -594,5 +595,40 @@ describe("#files.get", () => {
     expect(res.headers.get("Content-Disposition")).toEqual(
       'attachment; filename="export-markdown.zip"'
     );
+  });
+  it("should succeed with status 200 ok when signed file is requested with an API key lacking scope", async () => {
+    const user = await buildUser();
+    const apiKey = await buildApiKey({
+      userId: user.id,
+      scope: ["/api/fileOperations.redirect"],
+    });
+    const fileName = "export-markdown.zip";
+    const key = `${Buckets.uploads}/${user.teamId}/${crypto.randomUUID()}/${fileName}`;
+
+    await buildFileOperation({
+      userId: user.id,
+      teamId: user.teamId,
+      type: FileOperationType.Export,
+      state: FileOperationState.Complete,
+      key,
+    });
+
+    ensureDirSync(
+      path.dirname(path.join(env.FILE_STORAGE_LOCAL_ROOT_DIR, key))
+    );
+
+    copyFileSync(
+      path.resolve(__dirname, "..", "test", "fixtures", fileName),
+      path.join(env.FILE_STORAGE_LOCAL_ROOT_DIR, key)
+    );
+
+    const signedUrl = await FileStorage.getSignedUrl(key);
+    const url = new URL(signedUrl);
+    const res = await server.get(url.pathname + url.search, {
+      headers: { authorization: `Bearer ${apiKey.value}` },
+    });
+
+    expect(res.status).toEqual(200);
+    expect(res.headers.get("Content-Type")).toEqual("application/zip");
   });
 });

--- a/plugins/storage/server/api/files.ts
+++ b/plugins/storage/server/api/files.ts
@@ -98,7 +98,8 @@ router.post(
 
 router.get(
   "files.get",
-  auth({ optional: true }),
+  // Signed requests are authorized by their signature alone.
+  auth({ optional: true, skip: (ctx) => !!ctx.query.sig }),
   validate(T.FilesGetSchema),
   async (ctx: APIContext<T.FilesGetReq>) => {
     const actor = ctx.state.auth.user;

--- a/server/middlewares/authentication.test.ts
+++ b/server/middlewares/authentication.test.ts
@@ -441,4 +441,58 @@ describe("Authentication middleware", () => {
 
     expect(errToString(error)).toEqual("Invalid token");
   });
+  describe("with skip", () => {
+    it("should ignore credentials when skip returns true", async () => {
+      const state = {} as DefaultState;
+      const user = await buildUser();
+      const apiKey = await buildApiKey({
+        userId: user.id,
+        scope: ["/api/documents.info"],
+      });
+      const next = vi.fn();
+      const authMiddleware = auth({
+        optional: true,
+        skip: (ctx) => !!ctx.query.sig,
+      });
+      await authMiddleware(
+        {
+          // @ts-expect-error mock request
+          request: {
+            get: vi.fn(() => `Bearer ${apiKey.value}`),
+          },
+          query: { sig: "signature" },
+          originalUrl: "/api/files.get?sig=signature",
+          state,
+          cache: {},
+        },
+        next
+      );
+      expect(next).toHaveBeenCalled();
+      expect(state.auth).toEqual({});
+    });
+
+    it("should authenticate when skip returns false", async () => {
+      const state = {} as DefaultState;
+      const user = await buildUser();
+      const next = vi.fn();
+      const authMiddleware = auth({
+        optional: true,
+        skip: (ctx) => !!ctx.query.sig,
+      });
+      await authMiddleware(
+        {
+          // @ts-expect-error mock request
+          request: {
+            get: vi.fn(() => `Bearer ${user.getSessionToken()}`),
+          },
+          query: {},
+          state,
+          cache: {},
+        },
+        next
+      );
+      expect(next).toHaveBeenCalled();
+      expect(state.auth.user.id).toEqual(user.id);
+    });
+  });
 });

--- a/server/middlewares/authentication.ts
+++ b/server/middlewares/authentication.ts
@@ -24,6 +24,11 @@ type AuthenticationOptions = {
   type?: AuthenticationType | AuthenticationType[];
   /** Authentication is parsed, but optional. */
   optional?: boolean;
+  /**
+   * Returns true when the request is authorized by other means, in which case
+   * any credentials on the request are ignored rather than parsed.
+   */
+  skip?: (ctx: AppContext) => boolean;
 };
 
 type AuthTransport = "cookie" | "header" | "body" | "query";
@@ -37,6 +42,11 @@ type AuthInput = {
 
 export default function auth(options: AuthenticationOptions = {}) {
   return async function authMiddleware(ctx: AppContext, next: Next) {
+    if (options.skip?.(ctx)) {
+      ctx.state.auth = {};
+      return next();
+    }
+
     try {
       const { type, token, user, service, scope } =
         await validateAuthentication(ctx, options);

--- a/server/middlewares/authentication.ts
+++ b/server/middlewares/authentication.ts
@@ -17,19 +17,28 @@ import {
   UserSuspendedError,
 } from "../errors";
 
-type AuthenticationOptions = {
+type BaseAuthenticationOptions = {
   /** Role required to access the route. */
   role?: UserRole;
   /** Type of authentication required to access the route. */
   type?: AuthenticationType | AuthenticationType[];
-  /** Authentication is parsed, but optional. */
-  optional?: boolean;
-  /**
-   * Returns true when the request is authorized by other means, in which case
-   * any credentials on the request are ignored rather than parsed.
-   */
-  skip?: (ctx: AppContext) => boolean;
 };
+
+type AuthenticationOptions =
+  | (BaseAuthenticationOptions & {
+      /** Authentication is required. */
+      optional?: false;
+      skip?: never;
+    })
+  | (BaseAuthenticationOptions & {
+      /** Authentication is parsed, but optional. */
+      optional: true;
+      /**
+       * Returns true when the request is authorized by other means, in which
+       * case any credentials on the request are ignored rather than parsed.
+       */
+      skip?: (ctx: AppContext) => boolean;
+    });
 
 type AuthTransport = "cookie" | "header" | "body" | "query";
 

--- a/shared/helpers/AuthenticationHelper.test.ts
+++ b/shared/helpers/AuthenticationHelper.test.ts
@@ -102,6 +102,14 @@ describe("AuthenticationHelper", () => {
         expect(canAccess("/api/attachments.delete", scopes)).toBe(false);
       });
 
+      it("files read scope grants access to get", async () => {
+        const scopes = ["files:read"];
+
+        expect(canAccess("/api/files.get", scopes)).toBe(true);
+        expect(canAccess("/api/files.get?sig=abc", scopes)).toBe(true);
+        expect(canAccess("/api/files.create", scopes)).toBe(false);
+      });
+
       it("write", async () => {
         const scopes = ["documents:write"];
 
@@ -142,6 +150,7 @@ describe("AuthenticationHelper", () => {
           true
         );
         expect(canAccess("/api/attachments.redirect", scopes)).toBe(true);
+        expect(canAccess("/api/files.get", scopes)).toBe(true);
         expect(canAccess("/api/documents.create", scopes)).toBe(false);
         expect(canAccess("/api/documents.update", scopes)).toBe(false);
         expect(canAccess("/api/users.create", scopes)).toBe(false);

--- a/shared/helpers/AuthenticationHelper.ts
+++ b/shared/helpers/AuthenticationHelper.ts
@@ -11,6 +11,7 @@ export default class AuthenticationHelper {
    * - `collections.memberships` -> `Scope.Read`
    * - `collections.group_memberships` -> `Scope.Read`
    * - `attachments.redirect` -> `Scope.Read`
+   * - `files.get` -> `Scope.Read`
    */
   private static methodToScope = {
     create: Scope.Create,
@@ -23,6 +24,7 @@ export default class AuthenticationHelper {
     viewed: Scope.Read,
     export: Scope.Read,
     redirect: Scope.Read,
+    get: Scope.Read,
     memberships: Scope.Read,
     group_memberships: Scope.Read,
   };


### PR DESCRIPTION
Since v1.10.0, downloading a completed export with a scoped API key on local storage fails with 403. The redirect lands on the signed file route with the key still attached, and optional auth now surfaces the scope failure instead of ignoring it.

- Adds a `skip` predicate to the auth middleware so routes that are authorized by other means can ignore credentials on the request
- Applies it to signed file requests, which are authorized by their signature alone
- Maps the `get` method to the read scope so `files:read` and the global read scope cover the file route

closes #13679