### PR TITLE
fix: AuthStore.fetchConfig updates config outside a MobX action

### DIFF
--- a/app/stores/AuthStore.ts
+++ b/app/stores/AuthStore.ts
@@ -195,11 +195,12 @@ export default class AuthStore extends Store<Team> {
     };
   }
 
-  @action
   fetchConfig = async () => {
     const res = await client.post("/auth.config");
     invariant(res?.data, "Config not available");
-    this.config = res.data;
+    runInAction(() => {
+      this.config = res.data;
+    });
   };
 
   @action


### PR DESCRIPTION
Profiling the client after the MobX and React upgrades showed the model layer is cheap and the extra dev-mode render cost comes from React 18 StrictMode double-mounting effects. One real MobX issue surfaced along the way: the auth config was written after an await, outside any action, which logs strict-mode warnings on every page load in development.

- Wrap the post-await write in AuthStore.fetchConfig in runInAction and drop the now-redundant action decorator