### PR TITLE
fix: Revision view does not re-render when late-loaded content arrives

### DIFF
--- a/app/models/base/Model.test.ts
+++ b/app/models/base/Model.test.ts
@@ -45,6 +45,17 @@ describe("Model observability", () => {
     expect(seen).toEqual([undefined, false, true]);
   });
 
+  it("annotates fields inherited from base classes and omitted from the payload", () => {
+    const doc = stores.documents.add({
+      id: "aaaaaaaa-6666-6666-6666-666666666666",
+      title: "partial",
+    });
+
+    expect(isObservableProp(doc, "createdAt")).toBe(true); // Model
+    expect(isObservableProp(doc, "deletedAt")).toBe(true); // ParanoidModel
+    expect(isObservableProp(doc, "archivedAt")).toBe(true); // ArchivableModel
+  });
+
   it("annotates observable fields that are not serializable fields", () => {
     // Revision content is observable but not a @Field, and list responses
     // omit it entirely.

--- a/app/models/base/Model.test.ts
+++ b/app/models/base/Model.test.ts
@@ -45,6 +45,38 @@ describe("Model observability", () => {
     expect(seen).toEqual([undefined, false, true]);
   });
 
+  it("annotates observable fields that are not serializable fields", () => {
+    // Revision content is observable but not a @Field, and list responses
+    // omit it entirely.
+    const revision = stores.revisions.add({
+      id: "bbbbbbbb-1111-1111-1111-111111111111",
+      documentId: "aaaaaaaa-1111-1111-1111-111111111111",
+      title: "partial",
+    });
+
+    expect(isObservableProp(revision, "data")).toBe(true);
+  });
+
+  it("tracks reads of an omitted field made before it is populated", () => {
+    const revision = stores.revisions.add({
+      id: "bbbbbbbb-2222-2222-2222-222222222222",
+      documentId: "aaaaaaaa-1111-1111-1111-111111111111",
+      title: "partial",
+    });
+    const seen: Array<string | undefined> = [];
+    const dispose = autorun(() => seen.push(revision.data?.type));
+
+    stores.revisions.add({
+      id: "bbbbbbbb-2222-2222-2222-222222222222",
+      documentId: "aaaaaaaa-1111-1111-1111-111111111111",
+      title: "partial",
+      data: { type: "doc", content: [] },
+    });
+
+    dispose();
+    expect(seen).toEqual([undefined, "doc"]);
+  });
+
   it("reacts to changes", () => {
     const doc = stores.documents.add({
       id: "aaaaaaaa-2222-2222-2222-222222222222",

--- a/app/models/base/Model.ts
+++ b/app/models/base/Model.ts
@@ -8,6 +8,44 @@ import { getFieldsForModel, getFieldsForModelClass } from "../decorators/Field";
 import { LifecycleManager } from "../decorators/Lifecycle";
 import { getRelationsForModelClass } from "../decorators/Relation";
 
+/**
+ * MobX records decorator annotations on the prototype under a symbol with this
+ * description.
+ */
+const storedAnnotationsDescription = "mobx-stored-annotations";
+
+/**
+ * Returns the keys of every decorated member on a model, collected across its
+ * prototype chain.
+ *
+ * With `useDefineForClassFields: false` a field declared without an initializer
+ * never exists on the instance, so MobX cannot annotate it. This helper, and
+ * the pre-definition in `initialize`, can be removed if that compiler option
+ * is enabled.
+ *
+ * @param target the model to inspect.
+ * @returns the keys annotated with a MobX decorator.
+ */
+function getAnnotatedKeysForModel(target: Model): (string | symbol)[] {
+  let prototype = Object.getPrototypeOf(target);
+
+  while (prototype && prototype !== Object.prototype) {
+    const symbol = Object.getOwnPropertySymbols(prototype).find(
+      (candidate) => candidate.description === storedAnnotationsDescription
+    );
+    if (symbol) {
+      const annotations: Record<string | symbol, unknown> = Reflect.get(
+        prototype,
+        symbol
+      );
+      return Reflect.ownKeys(annotations);
+    }
+    prototype = Object.getPrototypeOf(prototype);
+  }
+
+  return [];
+}
+
 export default abstract class Model {
   static modelName: string;
 
@@ -57,7 +95,11 @@ export default abstract class Model {
    * @param fields the data to construct the model with.
    */
   protected initialize(fields: Record<string, unknown>) {
-    for (const field of getFieldsForModel(this)) {
+    const declared = [
+      ...getFieldsForModel(this),
+      ...getAnnotatedKeysForModel(this),
+    ];
+    for (const field of declared) {
       if (field in this) {
         continue;
       }

--- a/app/models/base/Model.ts
+++ b/app/models/base/Model.ts
@@ -15,8 +15,9 @@ import { getRelationsForModelClass } from "../decorators/Relation";
 const storedAnnotationsDescription = "mobx-stored-annotations";
 
 /**
- * Returns the keys of every decorated member on a model, collected across its
- * prototype chain.
+ * Returns the keys of every decorated member on a model, including those
+ * inherited from base classes. The nearest record on the prototype chain
+ * already includes the parents' annotations, so the search stops there.
  *
  * With `useDefineForClassFields: false` a field declared without an initializer
  * never exists on the instance, so MobX cannot annotate it. This helper, and


### PR DESCRIPTION
Opening a revision, a comparison, or the history sidebar shortly after page load could show stale content without diff highlights or a change count, because the view never re-rendered when the revision content arrived. Revisions are listed without content, and a field that is observable but not a serializable field did not exist on the model instance until first written, so reads made before the fetch completed were never tracked by MobX.

- Pre-define every decorated field on model instances in `Model.initialize` so reads of not-yet-loaded data are tracked and re-run once the data lands.
- Collect the decorated keys from the annotation record MobX stores on the prototype chain, covering fields inherited from parent classes.
- Document that this step can be removed if `useDefineForClassFields` is enabled, as the class field would then create the property itself.

closes #13674