### PR TITLE
fix: previous() on UserMembership and Star returned the next item

### DIFF
--- a/app/models/Star.ts
+++ b/app/models/Star.ts
@@ -48,7 +48,7 @@ class Star extends Model {
    */
   previous(): Star | undefined {
     const index = this.store.orderedData.indexOf(this);
-    return this.store.orderedData[index + 1];
+    return this.store.orderedData[index - 1];
   }
 }
 

--- a/app/models/UserMembership.ts
+++ b/app/models/UserMembership.ts
@@ -87,7 +87,7 @@ class UserMembership extends NavigableModel {
       userId: this.userId,
     });
     const index = memberships.indexOf(this);
-    return memberships[index + 1];
+    return memberships[index - 1];
   }
 }
 


### PR DESCRIPTION
The previous() helpers on the UserMembership and Star models used the same index arithmetic as next(), so both methods returned the item after the current one.

- UserMembership.previous() now returns the membership before the current one for the same user
- Star.previous() now returns the star before the current one in the list