### PR TITLE
perf: Prefetch revision content on hover in history sidebar

### DIFF
--- a/app/scenes/Document/components/History/RevisionListItem.tsx
+++ b/app/scenes/Document/components/History/RevisionListItem.tsx
@@ -61,7 +61,7 @@ const RevisionListItem = ({ item, document, ...rest }: Props) => {
   const contextMenuAction = useMenuAction(actions);
 
   const handleClickIntent = useCallback(() => {
-    void revisions.prefetch(item.id);
+    void revisions.fetch(item.id);
   }, [revisions, item.id]);
   const { handleMouseEnter, handleMouseLeave } =
     useClickIntent(handleClickIntent);

--- a/app/scenes/Document/components/History/RevisionListItem.tsx
+++ b/app/scenes/Document/components/History/RevisionListItem.tsx
@@ -1,7 +1,7 @@
 import type { LocationDescriptor } from "history";
 import { observer } from "mobx-react";
 import { EditIcon, TrashIcon } from "outline-icons";
-import { useMemo, useRef } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation } from "react-router-dom";
 import styled, { css } from "styled-components";
@@ -22,8 +22,10 @@ import { ContextMenu } from "~/components/Menu/ContextMenu";
 import Time from "~/components/Time";
 import { ActionContextProvider } from "~/hooks/useActionContext";
 import useBoolean from "~/hooks/useBoolean";
+import useClickIntent from "~/hooks/useClickIntent";
 import { useLocationSidebarContext } from "~/hooks/useLocationSidebarContext";
 import { useMenuAction } from "~/hooks/useMenuAction";
+import useStores from "~/hooks/useStores";
 import RevisionMenu from "~/menus/RevisionMenu";
 import { documentHistoryPath } from "~/utils/routeHelpers";
 import { EventItem, lineStyle } from "./EventListItem";
@@ -38,6 +40,7 @@ type Props = {
 
 const RevisionListItem = ({ item, document, ...rest }: Props) => {
   const { t } = useTranslation();
+  const { revisions } = useStores();
   const location = useLocation();
   const sidebarContext = useLocationSidebarContext();
   const [menuOpen, handleMenuOpen, handleMenuClose] = useBoolean();
@@ -56,6 +59,12 @@ const RevisionListItem = ({ item, document, ...rest }: Props) => {
     [item.id]
   );
   const contextMenuAction = useMenuAction(actions);
+
+  const handleClickIntent = useCallback(() => {
+    void revisions.prefetch(item.id);
+  }, [revisions, item.id]);
+  const { handleMouseEnter, handleMouseLeave } =
+    useClickIntent(handleClickIntent);
 
   // the time component tends to steal focus when clicked
   // ...so forward the focus back to the parent item
@@ -149,6 +158,8 @@ const RevisionListItem = ({ item, document, ...rest }: Props) => {
               <RevisionMenu document={document} revisionId={item.id} />
             </StyledEventBoundary>
           }
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
           ref={ref}
           $menuOpen={menuOpen}
           {...rest}

--- a/app/stores/RevisionsStore.ts
+++ b/app/stores/RevisionsStore.ts
@@ -52,19 +52,22 @@ export default class RevisionsStore extends Store<Revision> {
       return inflight;
     }
 
-    const promise = client
-      .post(`/revisions.info`, { documentId })
-      .then((res) =>
-        runInAction(() => {
-          this.addPolicies(res.policies);
-          return this.add(res.data);
-        })
-      )
-      .finally(() => {
-        this.requests.delete(id);
-      });
-
+    const promise = this.requestLatest(documentId);
     this.requests.set(id, promise);
-    return promise;
+
+    try {
+      return await promise;
+    } finally {
+      this.requests.delete(id);
+    }
   };
+
+  private async requestLatest(documentId: string): Promise<Revision> {
+    const res = await client.post(`/revisions.info`, { documentId });
+
+    return runInAction(() => {
+      this.addPolicies(res.policies);
+      return this.add(res.data);
+    });
+  }
 }

--- a/app/stores/RevisionsStore.ts
+++ b/app/stores/RevisionsStore.ts
@@ -29,6 +29,21 @@ export default class RevisionsStore extends Store<Revision> {
   }
 
   /**
+   * Loads the full content of a revision ahead of time when the user is
+   * likely to view it. Does nothing if the content is already loaded.
+   *
+   * @param id - The ID of the revision to prefetch.
+   * @returns A promise that resolves to the revision, or nothing if it was already loaded.
+   */
+  prefetch = async (id: string): Promise<Revision | void> => {
+    if (this.get(id)?.data) {
+      return;
+    }
+
+    return this.fetch(id);
+  };
+
+  /**
    * Retrieves all revisions for a given document ID
    *
    * @param documentId - The ID of the document to retrieve revisions for

--- a/app/stores/RevisionsStore.ts
+++ b/app/stores/RevisionsStore.ts
@@ -1,3 +1,4 @@
+import { runInAction } from "mobx";
 import { type JSONObject } from "@shared/types";
 import { RevisionHelper } from "@shared/utils/RevisionHelper";
 import type RootStore from "~/stores/RootStore";
@@ -18,30 +19,16 @@ export default class RevisionsStore extends Store<Revision> {
    * @returns A promise that resolves to the fetched revision.
    */
   async fetch(id: string, options: JSONObject = {}): Promise<Revision> {
-    const documentId = RevisionHelper.documentIdFromLatestId(id);
-    if (documentId) {
-      return this.fetchLatest(documentId);
-    }
-
     const item = this.get(id);
     const force = Boolean(options.force) || (!!item && !item.data);
-    return super.fetch(id, { ...options, force });
-  }
 
-  /**
-   * Loads the full content of a revision ahead of time when the user is
-   * likely to view it. Does nothing if the content is already loaded.
-   *
-   * @param id - The ID of the revision to prefetch.
-   * @returns A promise that resolves to the revision, or nothing if it was already loaded.
-   */
-  prefetch = async (id: string): Promise<Revision | void> => {
-    if (this.get(id)?.data) {
-      return;
+    const documentId = RevisionHelper.documentIdFromLatestId(id);
+    if (documentId) {
+      return item && !force ? item : this.fetchLatest(documentId);
     }
 
-    return this.fetch(id);
-  };
+    return super.fetch(id, { ...options, force });
+  }
 
   /**
    * Retrieves all revisions for a given document ID
@@ -58,9 +45,26 @@ export default class RevisionsStore extends Store<Revision> {
    * @param documentId - the id of the document to fetch the latest revision for.
    * @returns A promise that resolves to the latest revision for the given document.
    */
-  fetchLatest = async (documentId: string) => {
-    const res = await client.post(`/revisions.info`, { documentId });
-    this.addPolicies(res.policies);
-    return this.add(res.data);
+  fetchLatest = async (documentId: string): Promise<Revision> => {
+    const id = RevisionHelper.latestId(documentId);
+    const inflight = this.requests.get(id);
+    if (inflight) {
+      return inflight;
+    }
+
+    const promise = client
+      .post(`/revisions.info`, { documentId })
+      .then((res) =>
+        runInAction(() => {
+          this.addPolicies(res.policies);
+          return this.add(res.data);
+        })
+      )
+      .finally(() => {
+        this.requests.delete(id);
+      });
+
+    this.requests.set(id, promise);
+    return promise;
   };
 }


### PR DESCRIPTION
Opening a revision from the history sidebar currently waits on a network request before the content appears. This prefetches the revision when the user hovers a list item, so the view is instant on click.

- Wire the existing click-intent hover hook into the revision list item to fetch the revision after the standard short delay, cancelling on mouse leave.
- The store's `fetch` now returns a cached latest revision when its content is already loaded, matching the behaviour for regular revision ids.
- Latest revision requests are tracked in the store's in-flight map, so a hover followed by a click does not fetch twice.