### PR TITLE
fix: Links in view mode ignore modifier clicks, drag and keyboard activation

### DIFF
--- a/shared/editor/marks/Link.tsx
+++ b/shared/editor/marks/Link.tsx
@@ -144,6 +144,45 @@ export default class Link extends Mark<LinkOptions> {
   }
 
   get plugins() {
+    /**
+     * Returns the anchor element for a mouse event on a link, or undefined if
+     * the event does not target a navigable link.
+     */
+    const getLinkTarget = (event: MouseEvent) => {
+      if (event.button !== 0 && event.button !== 1) {
+        return undefined;
+      }
+
+      const target =
+        event.target instanceof Element ? event.target.closest("a") : null;
+      if (!target) {
+        return undefined;
+      }
+
+      if (
+        target.getAttribute("role") === "button" ||
+        target.matches(".component-attachment *")
+      ) {
+        return undefined;
+      }
+
+      return target;
+    };
+
+    /**
+     * Returns true if the event targets the image of the currently selected
+     * image node, which handles its own clicks.
+     */
+    const isSelectedImage = (view: EditorView, event: MouseEvent) => {
+      const selectedDOMNode = view.nodeDOM(view.state.selection.from);
+      return (
+        selectedDOMNode instanceof HTMLSpanElement &&
+        selectedDOMNode.classList.contains("component-image") &&
+        event.target instanceof HTMLImageElement &&
+        selectedDOMNode.contains(event.target)
+      );
+    };
+
     const handleClick = (view: EditorView, pos: number) => {
       const { doc, tr } = view.state;
       const range = getMarkRange(
@@ -184,60 +223,23 @@ export default class Link extends Mark<LinkOptions> {
             return false;
           },
           mousedown: (view: EditorView, event: MouseEvent) => {
-            const target = (event.target as HTMLElement)?.closest("a");
-            if (
-              !(target instanceof HTMLAnchorElement) ||
-              (event.button !== 0 && event.button !== 1)
-            ) {
+            const target = getLinkTarget(event);
+            if (!target || !view.editable) {
               return false;
             }
 
-            if (
-              target.role === "button" ||
-              target.matches(".component-attachment *")
-            ) {
+            if (isSelectedImage(view, event)) {
               return false;
             }
 
-            // If an image is selected in write mode, disallow navigation to its href
-            const selectedDOMNode = view.nodeDOM(view.state.selection.from);
-            if (
-              view.editable &&
-              selectedDOMNode &&
-              selectedDOMNode instanceof HTMLSpanElement &&
-              selectedDOMNode.classList.contains("component-image") &&
-              event.target instanceof HTMLImageElement &&
-              selectedDOMNode.contains(event.target)
-            ) {
-              return false;
-            }
-
-            // clicking a link while editing should show the link toolbar,
-            // clicking in read-only will navigate
-            if (!view.editable || (view.editable && !view.hasFocus())) {
-              const href =
-                target.href ||
-                (target.parentNode instanceof HTMLAnchorElement
-                  ? target.parentNode.href
-                  : "");
-
-              try {
-                const sanitized = sanitizeUrl(href);
-                if (this.options.onClickLink && sanitized) {
-                  event.stopPropagation();
-                  event.preventDefault();
-                  this.options.onClickLink(sanitized, event);
-                }
-              } catch (_err) {
-                this.editor.props.onNotice?.(
-                  t("Sorry, that type of link is not supported"),
-                  "error"
-                );
-              }
-
+            // Clicking a link while editing but unfocused must not move focus
+            // into the editor, the click handler will navigate instead.
+            if (!view.hasFocus()) {
+              event.preventDefault();
               return true;
             }
 
+            // Clicking a link while editing selects it to show the toolbar.
             const result = view.posAtCoords({
               left: event.clientX,
               top: event.clientY,
@@ -250,31 +252,47 @@ export default class Link extends Mark<LinkOptions> {
 
             return false;
           },
-          click: (_view: EditorView, event: MouseEvent) => {
-            if (
-              !(event.target instanceof HTMLAnchorElement) ||
-              (event.button !== 0 && event.button !== 1)
-            ) {
+          click: (view: EditorView, event: MouseEvent) => {
+            const target = getLinkTarget(event);
+            if (!target) {
               return false;
             }
 
-            if (
-              event.target.role === "button" ||
-              event.target.matches(".component-attachment *")
-            ) {
-              return false;
-            }
+            if (view.editable && view.hasFocus()) {
+              if (isSelectedImage(view, event)) {
+                return false;
+              }
 
-            // Prevent all default click behavior of links, see mousedown above
-            // for custom link handling.
-            if (this.options.onClickLink) {
+              // Links are not followed while editing.
               event.stopPropagation();
               event.preventDefault();
+              return false;
             }
 
-            return false;
+            const href = sanitizeUrl(target.href);
+            if (!this.options.onClickLink || !href) {
+              return false;
+            }
+
+            event.stopPropagation();
+            event.preventDefault();
+
+            try {
+              this.options.onClickLink(href, event);
+            } catch (_err) {
+              this.editor.props.onNotice?.(
+                t("Sorry, that type of link is not supported"),
+                "error"
+              );
+            }
+
+            return true;
           },
           keydown: (view: EditorView, event: KeyboardEvent) => {
+            if (!view.editable) {
+              return false;
+            }
+
             if (event.key !== " " && event.key !== "Enter") {
               return false;
             }

--- a/shared/editor/marks/Link.tsx
+++ b/shared/editor/marks/Link.tsx
@@ -153,9 +153,11 @@ export default class Link extends Mark<LinkOptions> {
         return undefined;
       }
 
+      // SVG anchors, such as those inside Mermaid diagrams, are handled by
+      // their own extension and have a non-string href.
       const target =
         event.target instanceof Element ? event.target.closest("a") : null;
-      if (!target) {
+      if (!(target instanceof HTMLAnchorElement)) {
         return undefined;
       }
 
@@ -167,20 +169,6 @@ export default class Link extends Mark<LinkOptions> {
       }
 
       return target;
-    };
-
-    /**
-     * Returns true if the event targets the image of the currently selected
-     * image node, which handles its own clicks.
-     */
-    const isSelectedImage = (view: EditorView, event: MouseEvent) => {
-      const selectedDOMNode = view.nodeDOM(view.state.selection.from);
-      return (
-        selectedDOMNode instanceof HTMLSpanElement &&
-        selectedDOMNode.classList.contains("component-image") &&
-        event.target instanceof HTMLImageElement &&
-        selectedDOMNode.contains(event.target)
-      );
     };
 
     const handleClick = (view: EditorView, pos: number) => {
@@ -228,7 +216,9 @@ export default class Link extends Mark<LinkOptions> {
               return false;
             }
 
-            if (isSelectedImage(view, event)) {
+            // A linked image is selected by ProseMirror and handled by its
+            // node view while editing.
+            if (event.target instanceof HTMLImageElement) {
               return false;
             }
 
@@ -258,11 +248,14 @@ export default class Link extends Mark<LinkOptions> {
               return false;
             }
 
-            if (view.editable && view.hasFocus()) {
-              if (isSelectedImage(view, event)) {
-                return false;
-              }
+            // A linked image opens the lightbox rather than navigating while
+            // editing, the node view handles the click.
+            if (view.editable && event.target instanceof HTMLImageElement) {
+              event.preventDefault();
+              return false;
+            }
 
+            if (view.editable && view.hasFocus()) {
               // Links are not followed while editing.
               event.stopPropagation();
               event.preventDefault();


### PR DESCRIPTION
Links in the editor were followed on mousedown rather than click, which bypassed native browser behavior and only matched clicks landing directly on the anchor element.

- Move navigation from the mousedown handler to the click handler so keyboard activation, dragging, and modifier clicks behave natively in read-only mode
- Resolve the nearest anchor for child elements such as inline code, fixing links opening twice in Firefox
- Prevent navigation on child elements of a link while editing
- Skip the autolink keydown handler in read-only mode
- Read the role attribute directly for compatibility with browsers lacking `Element.role`

closes #13596