### PR TITLE
fix: Byte range handling for media in Safari

### DIFF
--- a/plugins/storage/server/api/files.test.ts
+++ b/plugins/storage/server/api/files.test.ts
@@ -672,53 +672,6 @@ describe("#files.get byte ranges", () => {
   it("should serve the requested range", async () => {
     const { key, content } = await buildFile();
     const res = await server.get(`/api/files.get?key=${key}`, {
-      headers: { Range: "bytes=0-1" },
-    });
-
-    expect(res.status).toEqual(206);
-    expect(res.headers.get("Content-Length")).toEqual("2");
-    expect(res.headers.get("Content-Range")).toEqual(
-      `bytes 0-1/${content.length}`
-    );
-    expect(Buffer.from(await res.arrayBuffer())).toEqual(
-      content.subarray(0, 2)
-    );
-  });
-
-  it("should serve a single byte range", async () => {
-    const { key, content } = await buildFile();
-    const res = await server.get(`/api/files.get?key=${key}`, {
-      headers: { Range: "bytes=0-0" },
-    });
-
-    expect(res.status).toEqual(206);
-    expect(res.headers.get("Content-Length")).toEqual("1");
-    expect(res.headers.get("Content-Range")).toEqual(
-      `bytes 0-0/${content.length}`
-    );
-    expect(Buffer.from(await res.arrayBuffer())).toEqual(
-      content.subarray(0, 1)
-    );
-  });
-
-  it("should serve an open ended range", async () => {
-    const { key, content } = await buildFile();
-    const res = await server.get(`/api/files.get?key=${key}`, {
-      headers: { Range: "bytes=10-" },
-    });
-
-    expect(res.status).toEqual(206);
-    expect(res.headers.get("Content-Length")).toEqual(
-      String(content.length - 10)
-    );
-    expect(res.headers.get("Content-Range")).toEqual(
-      `bytes 10-${content.length - 1}/${content.length}`
-    );
-  });
-
-  it("should serve a suffix range", async () => {
-    const { key, content } = await buildFile();
-    const res = await server.get(`/api/files.get?key=${key}`, {
       headers: { Range: "bytes=-100" },
     });
 
@@ -732,20 +685,7 @@ describe("#files.get byte ranges", () => {
     );
   });
 
-  it("should clamp a range that runs past the end of the file", async () => {
-    const { key, content } = await buildFile();
-    const res = await server.get(`/api/files.get?key=${key}`, {
-      headers: { Range: `bytes=0-${content.length + 1000}` },
-    });
-
-    expect(res.status).toEqual(206);
-    expect(res.headers.get("Content-Length")).toEqual(String(content.length));
-    expect(res.headers.get("Content-Range")).toEqual(
-      `bytes 0-${content.length - 1}/${content.length}`
-    );
-  });
-
-  it("should fail with status 416 when the range starts past the end of the file", async () => {
+  it("should fail with status 416 when the range cannot be satisfied", async () => {
     const { key, content } = await buildFile();
     const res = await server.get(`/api/files.get?key=${key}`, {
       headers: { Range: `bytes=${content.length}-` },
@@ -755,15 +695,5 @@ describe("#files.get byte ranges", () => {
     expect(res.headers.get("Content-Range")).toEqual(
       `bytes */${content.length}`
     );
-  });
-
-  it("should serve the whole file when multiple ranges are requested", async () => {
-    const { key, content } = await buildFile();
-    const res = await server.get(`/api/files.get?key=${key}`, {
-      headers: { Range: "bytes=0-1, 10-20" },
-    });
-
-    expect(res.status).toEqual(200);
-    expect(res.headers.get("Content-Length")).toEqual(String(content.length));
   });
 });

--- a/plugins/storage/server/api/files.test.ts
+++ b/plugins/storage/server/api/files.test.ts
@@ -632,3 +632,138 @@ describe("#files.get", () => {
     expect(res.headers.get("Content-Type")).toEqual("application/zip");
   });
 });
+
+describe("#files.get byte ranges", () => {
+  const fileName = "avatar.jpg";
+
+  const buildFile = async () => {
+    const user = await buildUser();
+    const attachment = await buildAttachment(
+      {
+        teamId: user.teamId,
+        userId: user.id,
+        contentType: "image/jpeg",
+        acl: "public-read",
+      },
+      fileName
+    );
+
+    const source = path.resolve(__dirname, "..", "test", "fixtures", fileName);
+    const destination = path.join(
+      env.FILE_STORAGE_LOCAL_ROOT_DIR,
+      attachment.key
+    );
+
+    ensureDirSync(path.dirname(destination));
+    copyFileSync(source, destination);
+
+    return { key: attachment.key, content: await readFile(source) };
+  };
+
+  it("should serve the whole file when no range is requested", async () => {
+    const { key, content } = await buildFile();
+    const res = await server.get(`/api/files.get?key=${key}`);
+
+    expect(res.status).toEqual(200);
+    expect(res.headers.get("Accept-Ranges")).toEqual("bytes");
+    expect(res.headers.get("Content-Length")).toEqual(String(content.length));
+  });
+
+  it("should serve the requested range", async () => {
+    const { key, content } = await buildFile();
+    const res = await server.get(`/api/files.get?key=${key}`, {
+      headers: { Range: "bytes=0-1" },
+    });
+
+    expect(res.status).toEqual(206);
+    expect(res.headers.get("Content-Length")).toEqual("2");
+    expect(res.headers.get("Content-Range")).toEqual(
+      `bytes 0-1/${content.length}`
+    );
+    expect(Buffer.from(await res.arrayBuffer())).toEqual(
+      content.subarray(0, 2)
+    );
+  });
+
+  it("should serve a single byte range", async () => {
+    const { key, content } = await buildFile();
+    const res = await server.get(`/api/files.get?key=${key}`, {
+      headers: { Range: "bytes=0-0" },
+    });
+
+    expect(res.status).toEqual(206);
+    expect(res.headers.get("Content-Length")).toEqual("1");
+    expect(res.headers.get("Content-Range")).toEqual(
+      `bytes 0-0/${content.length}`
+    );
+    expect(Buffer.from(await res.arrayBuffer())).toEqual(
+      content.subarray(0, 1)
+    );
+  });
+
+  it("should serve an open ended range", async () => {
+    const { key, content } = await buildFile();
+    const res = await server.get(`/api/files.get?key=${key}`, {
+      headers: { Range: "bytes=10-" },
+    });
+
+    expect(res.status).toEqual(206);
+    expect(res.headers.get("Content-Length")).toEqual(
+      String(content.length - 10)
+    );
+    expect(res.headers.get("Content-Range")).toEqual(
+      `bytes 10-${content.length - 1}/${content.length}`
+    );
+  });
+
+  it("should serve a suffix range", async () => {
+    const { key, content } = await buildFile();
+    const res = await server.get(`/api/files.get?key=${key}`, {
+      headers: { Range: "bytes=-100" },
+    });
+
+    expect(res.status).toEqual(206);
+    expect(res.headers.get("Content-Length")).toEqual("100");
+    expect(res.headers.get("Content-Range")).toEqual(
+      `bytes ${content.length - 100}-${content.length - 1}/${content.length}`
+    );
+    expect(Buffer.from(await res.arrayBuffer())).toEqual(
+      content.subarray(-100)
+    );
+  });
+
+  it("should clamp a range that runs past the end of the file", async () => {
+    const { key, content } = await buildFile();
+    const res = await server.get(`/api/files.get?key=${key}`, {
+      headers: { Range: `bytes=0-${content.length + 1000}` },
+    });
+
+    expect(res.status).toEqual(206);
+    expect(res.headers.get("Content-Length")).toEqual(String(content.length));
+    expect(res.headers.get("Content-Range")).toEqual(
+      `bytes 0-${content.length - 1}/${content.length}`
+    );
+  });
+
+  it("should fail with status 416 when the range starts past the end of the file", async () => {
+    const { key, content } = await buildFile();
+    const res = await server.get(`/api/files.get?key=${key}`, {
+      headers: { Range: `bytes=${content.length}-` },
+    });
+
+    expect(res.status).toEqual(416);
+    expect(res.headers.get("Content-Range")).toEqual(
+      `bytes */${content.length}`
+    );
+  });
+
+  it("should serve the whole file when multiple ranges are requested", async () => {
+    const { key, content } = await buildFile();
+    const res = await server.get(`/api/files.get?key=${key}`, {
+      headers: { Range: "bytes=0-1, 10-20" },
+    });
+
+    expect(res.status).toEqual(200);
+    expect(res.headers.get("Content-Length")).toEqual(String(content.length));
+  });
+});

--- a/plugins/storage/server/api/files.ts
+++ b/plugins/storage/server/api/files.ts
@@ -27,6 +27,9 @@ import * as T from "./schema";
 
 const router = new Router();
 
+/** Returned when the requested range lies entirely outside of the file. */
+const unsatisfiable = Symbol("unsatisfiable");
+
 router.post(
   "files.create",
   rateLimiter(RateLimiterStrategy.TwentyFivePerMinute),
@@ -158,7 +161,13 @@ router.get(
     // Handle byte range requests
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests
     const stats = await (FileStorage as LocalStorage).stat(key);
-    const range = getByteRange(ctx, stats.size);
+    const range = getByteRange(ctx.headers.range, stats.size);
+
+    if (range === unsatisfiable) {
+      ctx.status = 416;
+      ctx.set("Content-Range", `bytes */${stats.size}`);
+      return;
+    }
 
     if (range) {
       ctx.status = 206;
@@ -175,22 +184,58 @@ router.get(
   }
 );
 
+/**
+ * Parses a single byte range from a Range header, resolved against the size of
+ * the file being requested.
+ *
+ * @param header The value of the Range header, if any.
+ * @param size The size of the file in bytes.
+ * @returns The range to serve, `unsatisfiable` if it lies outside of the file,
+ * or undefined if the entire file should be served.
+ */
 function getByteRange(
-  ctx: APIContext<T.FilesGetReq>,
+  header: string | undefined,
   size: number
-): { start: number; end: number } | undefined {
-  const { range } = ctx.headers;
-  if (!range) {
+): { start: number; end: number } | typeof unsatisfiable | undefined {
+  if (!header) {
     return;
   }
 
-  const match = range.match(/bytes=(\d+)-(\d+)?/);
+  // Only a single range is supported, requests for multiple ranges are served
+  // in full instead.
+  const match = header.trim().match(/^bytes=(\d*)-(\d*)$/);
   if (!match) {
     return;
   }
 
-  const start = parseInt(match[1], 10);
-  const end = parseInt(match[2], 10) || size - 1;
+  const [, first, last] = match;
+
+  if (size === 0) {
+    return unsatisfiable;
+  }
+
+  // A range with no start requests the final N bytes of the file.
+  if (first === "") {
+    const suffixLength = parseInt(last, 10);
+    if (isNaN(suffixLength)) {
+      return;
+    }
+    if (suffixLength === 0) {
+      return unsatisfiable;
+    }
+    return { start: Math.max(size - suffixLength, 0), end: size - 1 };
+  }
+
+  const start = parseInt(first, 10);
+  if (start >= size) {
+    return unsatisfiable;
+  }
+
+  // A range with no end, or one that runs past the file, ends at the last byte.
+  const end = last === "" ? size - 1 : Math.min(parseInt(last, 10), size - 1);
+  if (end < start) {
+    return unsatisfiable;
+  }
 
   return { start, end };
 }

--- a/plugins/storage/server/api/files.ts
+++ b/plugins/storage/server/api/files.ts
@@ -23,12 +23,10 @@ import type LocalStorage from "@server/storage/files/LocalStorage";
 import type { APIContext } from "@server/types";
 import { RateLimiterStrategy } from "@server/utils/RateLimiter";
 import { getJWTPayload } from "@server/utils/jwt";
+import { ByteRangeHelper } from "../utils/ByteRangeHelper";
 import * as T from "./schema";
 
 const router = new Router();
-
-/** Returned when the requested range lies entirely outside of the file. */
-const unsatisfiable = Symbol("unsatisfiable");
 
 router.post(
   "files.create",
@@ -161,9 +159,9 @@ router.get(
     // Handle byte range requests
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests
     const stats = await (FileStorage as LocalStorage).stat(key);
-    const range = getByteRange(ctx.headers.range, stats.size);
+    const range = ByteRangeHelper.parse(ctx.headers.range, stats.size);
 
-    if (range === unsatisfiable) {
+    if (range === ByteRangeHelper.unsatisfiable) {
       ctx.status = 416;
       ctx.set("Content-Range", `bytes */${stats.size}`);
       return;
@@ -183,62 +181,6 @@ router.get(
     ctx.body = await FileStorage.getFileStream(key, range);
   }
 );
-
-/**
- * Parses a single byte range from a Range header, resolved against the size of
- * the file being requested.
- *
- * @param header The value of the Range header, if any.
- * @param size The size of the file in bytes.
- * @returns The range to serve, `unsatisfiable` if it lies outside of the file,
- * or undefined if the entire file should be served.
- */
-function getByteRange(
-  header: string | undefined,
-  size: number
-): { start: number; end: number } | typeof unsatisfiable | undefined {
-  if (!header) {
-    return;
-  }
-
-  // Only a single range is supported, requests for multiple ranges are served
-  // in full instead.
-  const match = header.trim().match(/^bytes=(\d*)-(\d*)$/);
-  if (!match) {
-    return;
-  }
-
-  const [, first, last] = match;
-
-  if (size === 0) {
-    return unsatisfiable;
-  }
-
-  // A range with no start requests the final N bytes of the file.
-  if (first === "") {
-    const suffixLength = parseInt(last, 10);
-    if (isNaN(suffixLength)) {
-      return;
-    }
-    if (suffixLength === 0) {
-      return unsatisfiable;
-    }
-    return { start: Math.max(size - suffixLength, 0), end: size - 1 };
-  }
-
-  const start = parseInt(first, 10);
-  if (start >= size) {
-    return unsatisfiable;
-  }
-
-  // A range with no end, or one that runs past the file, ends at the last byte.
-  const end = last === "" ? size - 1 : Math.min(parseInt(last, 10), size - 1);
-  if (end < start) {
-    return unsatisfiable;
-  }
-
-  return { start, end };
-}
 
 /**
  * Verifies a short-lived signature authorizing an upload to a single key.

--- a/plugins/storage/server/utils/ByteRangeHelper.test.ts
+++ b/plugins/storage/server/utils/ByteRangeHelper.test.ts
@@ -1,0 +1,96 @@
+import { ByteRangeHelper } from "./ByteRangeHelper";
+
+const { unsatisfiable } = ByteRangeHelper;
+
+describe("ByteRangeHelper.parse", () => {
+  it("should serve the whole file when no header is present", () => {
+    expect(ByteRangeHelper.parse(undefined, 100)).toBeUndefined();
+    expect(ByteRangeHelper.parse("", 100)).toBeUndefined();
+  });
+
+  it("should serve the whole file when the header is malformed", () => {
+    expect(ByteRangeHelper.parse("bytes=abc-", 100)).toBeUndefined();
+    expect(ByteRangeHelper.parse("bytes=-", 100)).toBeUndefined();
+    expect(ByteRangeHelper.parse("items=0-1", 100)).toBeUndefined();
+    expect(ByteRangeHelper.parse("0-1", 100)).toBeUndefined();
+  });
+
+  it("should serve the whole file when multiple ranges are requested", () => {
+    expect(ByteRangeHelper.parse("bytes=0-1, 10-20", 100)).toBeUndefined();
+  });
+
+  it("should parse a closed range", () => {
+    expect(ByteRangeHelper.parse("bytes=0-1", 100)).toEqual({
+      start: 0,
+      end: 1,
+    });
+    expect(ByteRangeHelper.parse("bytes=10-20", 100)).toEqual({
+      start: 10,
+      end: 20,
+    });
+  });
+
+  it("should parse a single byte range", () => {
+    expect(ByteRangeHelper.parse("bytes=0-0", 100)).toEqual({
+      start: 0,
+      end: 0,
+    });
+    expect(ByteRangeHelper.parse("bytes=99-99", 100)).toEqual({
+      start: 99,
+      end: 99,
+    });
+  });
+
+  it("should tolerate surrounding whitespace", () => {
+    expect(ByteRangeHelper.parse(" bytes=0-1 ", 100)).toEqual({
+      start: 0,
+      end: 1,
+    });
+  });
+
+  it("should parse an open ended range", () => {
+    expect(ByteRangeHelper.parse("bytes=10-", 100)).toEqual({
+      start: 10,
+      end: 99,
+    });
+  });
+
+  it("should parse a suffix range", () => {
+    expect(ByteRangeHelper.parse("bytes=-10", 100)).toEqual({
+      start: 90,
+      end: 99,
+    });
+  });
+
+  it("should clamp a suffix range longer than the file", () => {
+    expect(ByteRangeHelper.parse("bytes=-500", 100)).toEqual({
+      start: 0,
+      end: 99,
+    });
+  });
+
+  it("should clamp a range that runs past the end of the file", () => {
+    expect(ByteRangeHelper.parse("bytes=0-1000", 100)).toEqual({
+      start: 0,
+      end: 99,
+    });
+  });
+
+  it("should be unsatisfiable when the range starts past the end", () => {
+    expect(ByteRangeHelper.parse("bytes=100-", 100)).toBe(unsatisfiable);
+    expect(ByteRangeHelper.parse("bytes=100-200", 100)).toBe(unsatisfiable);
+  });
+
+  it("should be unsatisfiable when the end is before the start", () => {
+    expect(ByteRangeHelper.parse("bytes=5-2", 100)).toBe(unsatisfiable);
+  });
+
+  it("should be unsatisfiable for a zero length suffix", () => {
+    expect(ByteRangeHelper.parse("bytes=-0", 100)).toBe(unsatisfiable);
+  });
+
+  it("should be unsatisfiable for an empty file", () => {
+    expect(ByteRangeHelper.parse("bytes=0-", 0)).toBe(unsatisfiable);
+    expect(ByteRangeHelper.parse("bytes=-1", 0)).toBe(unsatisfiable);
+  });
+});

--- a/plugins/storage/server/utils/ByteRangeHelper.ts
+++ b/plugins/storage/server/utils/ByteRangeHelper.ts
@@ -1,0 +1,67 @@
+/** A resolved byte range, inclusive at both ends. */
+export interface ByteRange {
+  start: number;
+  end: number;
+}
+
+export class ByteRangeHelper {
+  /** Returned when the requested range lies entirely outside of the file. */
+  static readonly unsatisfiable: unique symbol = Symbol("unsatisfiable");
+
+  /**
+   * Parses a single byte range from a Range header, resolved against the size
+   * of the file being requested.
+   *
+   * @param header The value of the Range header, if any.
+   * @param size The size of the file in bytes.
+   * @returns The range to serve, `unsatisfiable` if it lies outside of the
+   * file, or undefined if the entire file should be served.
+   */
+  static parse(
+    header: string | undefined,
+    size: number
+  ): ByteRange | typeof ByteRangeHelper.unsatisfiable | undefined {
+    if (!header) {
+      return;
+    }
+
+    // Only a single range is supported, requests for multiple ranges are
+    // served in full instead.
+    const match = header.trim().match(/^bytes=(\d*)-(\d*)$/);
+    if (!match) {
+      return;
+    }
+
+    const [, first, last] = match;
+
+    if (size === 0) {
+      return this.unsatisfiable;
+    }
+
+    // A range with no start requests the final N bytes of the file.
+    if (first === "") {
+      const suffixLength = parseInt(last, 10);
+      if (isNaN(suffixLength)) {
+        return;
+      }
+      if (suffixLength === 0) {
+        return this.unsatisfiable;
+      }
+      return { start: Math.max(size - suffixLength, 0), end: size - 1 };
+    }
+
+    const start = parseInt(first, 10);
+    if (start >= size) {
+      return this.unsatisfiable;
+    }
+
+    // A range with no end, or one that runs past the file, ends at the last
+    // byte.
+    const end = last === "" ? size - 1 : Math.min(parseInt(last, 10), size - 1);
+    if (end < start) {
+      return this.unsatisfiable;
+    }
+
+    return { start, end };
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -103,7 +103,13 @@ export default ({ mode }: ConfigEnv) =>
               },
             },
             {
-              urlPattern: /api\/files\.get/,
+              // Limited to images, as media and PDFs are loaded with byte range
+              // requests which Safari cannot play back when the response is
+              // served by a service worker.
+              urlPattern: ({ url, request }) =>
+                url.pathname.endsWith("/api/files.get") &&
+                request.destination === "image" &&
+                !request.headers.has("range"),
               handler: "CacheFirst",
               options: {
                 cacheName: "files-cache",
@@ -112,9 +118,8 @@ export default ({ mode }: ConfigEnv) =>
                   maxAgeSeconds: 604800, // 7 days
                 },
                 cacheableResponse: {
-                  statuses: [0, 200, 206], // Include partial content for range requests
+                  statuses: [200],
                 },
-                rangeRequests: true, // Allow range requests for partial content
               },
             },
           ],


### PR DESCRIPTION
Investigation of #13691 — Safari cannot play uploaded videos on self-hosted instances using local file storage, while Chrome can.

**These fixes are likely but not proven.** Four real defects in the byte range path were found and fixed, all reproduced by execution, but the reporter's exact Safari failure could not be reproduced (no Safari available), and none of the fixed cases is on Safari's *documented* request pattern. See "What is still unresolved" below before treating this as closed.

## Verified bugs — `plugins/storage/server/api/files.ts`

The parser was `range.match(/bytes=(\d+)-(\d+)?/)` with `parseInt(match[2], 10) || size - 1`:

| Request | Old behaviour | Correct |
| --- | --- | --- |
| `bytes=-100` (suffix) | no match → **200 with the whole body** | 206, last 100 bytes |
| `bytes=0-0` | `parseInt("0") \|\| size-1` → **whole file**, `Content-Range: bytes 0-99697/99698` | 206, 1 byte |
| `bytes=0-999999` on a 99698 byte file | `Content-Range: bytes 0-999999/99698` + `Content-Length: 1000000`, body **truncated** | clamped to EOF |
| `bytes=200-` past EOF | `end < start` → `ValidationError` → **400** | **416** with `Content-Range: bytes */size` |

The first two are relevant because Safari rejects a `200` answer to a range request outright, and the headers quoted in the issue (`Content-Range: bytes 0-99697/99698` for a 99698 byte file) are exactly what the `bytes=0-0` path emits.

`getByteRange` is rewritten to follow RFC 9110: suffix ranges, open ended ranges, clamping to EOF, and 416 for a range starting past the end. Multi-range requests are served in full rather than silently answered with only the first range.

## Verified bug — `vite.config.ts` (service worker)

The `/api/files.get` route was `CacheFirst` with `cacheableResponse.statuses: [0, 200, 206]` and `rangeRequests: true`. Two problems:

- The Cache API **refuses to store a 206** (spec mandated `TypeError`), so every media chunk request produced a failed `cache.put` and nothing was ever cached. The `rangeRequests` plugin was dead code as a result.
- Serving media through `event.respondWith` is a well known cause of playback failure in Safari.

The route is narrowed to images without a `Range` header, and the dead 206/`rangeRequests` config is dropped. Verified in the built `sw.js`.
