### PR TITLE
fix: Members receive authorization error when importing a document

### DIFF
--- a/server/routes/api/attachments/attachments.test.ts
+++ b/server/routes/api/attachments/attachments.test.ts
@@ -226,21 +226,50 @@ describe("#attachments.create", () => {
       }
     });
 
-    it.each([AttachmentPreset.Import, AttachmentPreset.WorkspaceImport])(
-      "should not allow upload using %s preset",
-      async (preset) => {
-        const user = await buildUser();
-        const res = await server.post("/api/attachments.create", user, {
-          body: {
-            name: "test.zip",
-            contentType: "application/zip",
-            size: 10000,
-            preset,
-          },
-        });
-        expect(res.status).toEqual(403);
-      }
-    );
+    it("should not allow upload using workspaceImport preset", async () => {
+      const user = await buildUser();
+      const res = await server.post("/api/attachments.create", user, {
+        body: {
+          name: "test.zip",
+          contentType: "application/zip",
+          size: 10000,
+          preset: AttachmentPreset.WorkspaceImport,
+        },
+      });
+      expect(res.status).toEqual(403);
+    });
+
+    it("should create expiring attachment using import preset", async () => {
+      const user = await buildUser();
+      const res = await server.post("/api/attachments.create", user, {
+        body: {
+          name: "test.zip",
+          contentType: "application/zip",
+          size: 10000,
+          preset: AttachmentPreset.Import,
+        },
+      });
+      expect(res.status).toEqual(200);
+
+      const body = await res.json();
+      const attachment = await Attachment.findByPk(body.data.attachment.id, {
+        rejectOnEmpty: true,
+      });
+      expect(attachment.expiresAt).toBeTruthy();
+    });
+
+    it("should not allow viewer to upload using import preset", async () => {
+      const user = await buildViewer();
+      const res = await server.post("/api/attachments.create", user, {
+        body: {
+          name: "test.zip",
+          contentType: "application/zip",
+          size: 10000,
+          preset: AttachmentPreset.Import,
+        },
+      });
+      expect(res.status).toEqual(403);
+    });
 
     it("should not allow attachment creation for other documents", async () => {
       const user = await buildUser();

--- a/server/routes/api/attachments/attachments.ts
+++ b/server/routes/api/attachments/attachments.ts
@@ -103,11 +103,11 @@ router.post(
     if (preset === AttachmentPreset.Avatar) {
       assertIn(contentType, AttachmentValidation.avatarContentTypes);
     } else {
-      if (
-        preset === AttachmentPreset.Import ||
-        preset === AttachmentPreset.WorkspaceImport
-      ) {
+      if (preset === AttachmentPreset.WorkspaceImport) {
         authorize(user, "createImport", user.team);
+      }
+      if (preset === AttachmentPreset.Import) {
+        authorize(user, "createDocument", user.team);
       }
       if (preset === AttachmentPreset.Emoji) {
         assertIn(contentType, AttachmentValidation.emojiContentTypes);


### PR DESCRIPTION
Since #13654 the single-document import flow failed for non-admin members. The attachment upload for that flow was gated behind the workspace-import ability, which is admin-only.

- Only the workspace import preset now requires the workspace import ability
- The single-document import preset requires the same ability as creating a document