### PR TITLE
fix: Table of contents clicks ignored while a search term is active

### DIFF
--- a/app/scenes/Document/components/MultiplayerEditor.tsx
+++ b/app/scenes/Document/components/MultiplayerEditor.tsx
@@ -290,11 +290,15 @@ function MultiplayerEditor(
     ];
   }, [remoteProvider, user, ydoc, props.extensions]);
 
+  // Read through a ref so the callback runs once per sync, not per identity.
+  const onSyncedRef = useRef(onSynced);
+  onSyncedRef.current = onSynced;
+
   useEffect(() => {
     if ((!hasLocalPersistence || isLocalSynced) && isRemoteSynced) {
-      void onSynced?.();
+      void onSyncedRef.current?.();
     }
-  }, [onSynced, hasLocalPersistence, isLocalSynced, isRemoteSynced]);
+  }, [hasLocalPersistence, isLocalSynced, isRemoteSynced]);
 
   // Disconnect the realtime connection while idle. `isIdle` also checks for
   // page visibility and will immediately disconnect when a tab is hidden.


### PR DESCRIPTION
After opening a document from search results the URL carries the search term. Clicking a heading in the table of contents pushed a new hash, which gave the sync callback a new identity and re-ran it. The find command then reset to the first match and scrolled the page back, so the heading click had no visible effect.

- Read the sync callback through a ref in `MultiplayerEditor` so it runs once per sync rather than on every location change.
- Hash navigation no longer resets the current search match.