### PR TITLE
fix: Scroll position reset when navigating between revisions

### DIFF
--- a/app/scenes/Document/components/DataLoader.tsx
+++ b/app/scenes/Document/components/DataLoader.tsx
@@ -137,8 +137,8 @@ function DataLoader({ match, children }: Props) {
   );
 
   React.useEffect(() => {
+    setError(null);
     if (revisionId) {
-      setError(null);
       void fetchRevisionById(revisionId, setError);
     }
   }, [fetchRevisionById, revisionId]);

--- a/app/scenes/Document/components/DataLoader.tsx
+++ b/app/scenes/Document/components/DataLoader.tsx
@@ -138,6 +138,7 @@ function DataLoader({ match, children }: Props) {
 
   React.useEffect(() => {
     if (revisionId) {
+      setError(null);
       void fetchRevisionById(revisionId, setError);
     }
   }, [fetchRevisionById, revisionId]);

--- a/app/scenes/Document/components/Document.tsx
+++ b/app/scenes/Document/components/Document.tsx
@@ -343,7 +343,6 @@ function DocumentScene({
       <MeasuredContainer
         as={Background}
         name="container"
-        key={revision ? revision.id : document.id}
         column
         auto
         onDragOver={handleDragOver}

--- a/app/scenes/Document/components/RevisionViewer.tsx
+++ b/app/scenes/Document/components/RevisionViewer.tsx
@@ -118,6 +118,7 @@ function RevisionViewer(props: Props, ref: React.Ref<TEditor>) {
   // extension — usually only arrives on a later render; without this neither
   // the highlights nor the change count would ever appear.
   const editorKey = [
+    revision.id,
     showChanges ? "changes" : "no-changes",
     compareToRevisionId ?? revision.before?.id ?? "none",
     comparisonData ? "loaded" : "pending",

--- a/app/scenes/Document/index.tsx
+++ b/app/scenes/Document/index.tsx
@@ -30,7 +30,7 @@ export default function DocumentScene(props: Props) {
   const { ui } = useStores();
   const history = useHistory();
   const { pane, isSplitView } = useSplitView();
-  const { documentSlug, revisionId } = props.match.params;
+  const { documentSlug } = props.match.params;
   const currentPath = props.location.pathname;
   useTrackLastVisitedPath(currentPath);
 
@@ -63,16 +63,12 @@ export default function DocumentScene(props: Props) {
   const urlParts = documentSlug ? documentSlug.split("-") : [];
   const urlId = urlParts.length ? urlParts[urlParts.length - 1] : undefined;
 
-  // Normalize the key so that it is *stable* between renders.
-  // Without this, the initial value can be "<urlId>/undefined" and then flip to
-  // "<urlId>/" when React stringifies `undefined` on the next render, causing a
-  // full unmount/mount cycle of the document subtree. Keeping the key constant
-  // prevents extra network requests and preserves editor state on resize.
-  const key = revisionId ? `${urlId}/${revisionId}` : urlId;
-
+  // The revision is deliberately not part of the key: remounting the subtree
+  // between revisions would empty the page while the next one loads and reset
+  // the scroll position. DataLoader refetches when the revision id changes.
   return (
     <DataLoader
-      key={key}
+      key={urlId}
       match={props.match}
       history={props.history}
       location={props.location}


### PR DESCRIPTION
Switching between revisions in the document history remounted the whole document scene, which emptied the page while the next revision loaded and reset the scroll position to the top.

- The document scene key no longer includes the revision id, so moving between revisions keeps the scene mounted and only refetches the revision.
- The outer document container is no longer keyed by revision id for the same reason.
- The revision viewer includes the revision id in the editor key so the editor remounts with the new content.
- A failed revision fetch is cleared when the revision id changes, since the remount no longer does this.