### PR TITLE
fix: render block menu trigger icon synchronously

### DIFF
--- a/app/editor/extensions/BlockMenu.tsx
+++ b/app/editor/extensions/BlockMenu.tsx
@@ -3,6 +3,7 @@ import { action } from "mobx";
 import { PlusIcon } from "outline-icons";
 import { Plugin } from "prosemirror-state";
 import { Decoration, DecorationSet } from "prosemirror-view";
+import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
 import type { WidgetProps } from "@shared/editor/lib/Extension";
 import { PlaceholderPlugin } from "@shared/editor/plugins/PlaceholderPlugin";
@@ -29,7 +30,10 @@ export default class BlockMenuExtension extends Suggestion {
     const button = document.createElement("button");
     button.className = "block-menu-trigger";
     button.type = "button";
-    createRoot(button).render(<PlusIcon />);
+    const root = createRoot(button);
+    flushSync(() => {
+      root.render(<PlusIcon />);
+    });
 
     return [
       ...super.plugins,


### PR DESCRIPTION
## Summary

React was upgraded, and the block menu trigger icon could be missing when its ProseMirror decoration was inserted before React had committed the icon render.

This change renders `PlusIcon` synchronously immediately after creating the button root, ensuring that the button is fully populated before ProseMirror mounts it as the `block-menu-trigger` decoration.

## Why this is needed

The block menu trigger is created as a DOM widget outside the normal React tree. With the newer React rendering behavior, the previous asynchronous `root.render` call can leave the widget button empty at the moment ProseMirror attaches it to the editor. Using `flushSync` preserves the existing widget lifecycle while guaranteeing that the icon is present when the decoration is displayed.

This is a user-visible regression introduced by the React upgrade and should be merged promptly so editors can reliably discover and open the block menu from an empty top-level paragraph.

## Scope

- Adds `flushSync` from `react-dom`.
- Wraps the existing `PlusIcon` render only.
- Does not change block menu behavior, decoration positioning, or event handling.

## Testing

- Verified the cherry-picked diff applies cleanly to the current `upstream/main` baseline after resolving the one-line rendering conflict.
- Ran `git show --check` and `git diff --check` successfully.
- Attempted the repository lint command for the changed file; the checkout does not currently have the `oxlint` executable installed (`command not found: oxlint`).