### PR TITLE
perf: Optimize document queries by excluding content when not needed

### DIFF
--- a/server/routes/api/comments/comments.ts
+++ b/server/routes/api/comments/comments.ts
@@ -209,7 +209,11 @@ router.post(
 
     let comments, total;
     if (documentId) {
-      const document = await Document.findByPk(documentId, { userId: user.id });
+      const document = await Document.findByPk(documentId, {
+        userId: user.id,
+        // The body is only needed to resolve anchor text for each comment.
+        includeContent: !!includeAnchorText,
+      });
       authorize(user, "read", document);
       [comments, total] = await Promise.all([
         Comment.findAll(params),

--- a/server/routes/api/documents/documents.ts
+++ b/server/routes/api/documents/documents.ts
@@ -792,7 +792,10 @@ router.post(
     const { id, startDate, endDate } = ctx.input.body;
     const { user } = ctx.state.auth;
 
-    const document = await Document.findByPk(id, { userId: user.id });
+    const document = await Document.findByPk(id, {
+      userId: user.id,
+      includeContent: false,
+    });
     authorize(user, "listViews", document);
 
     if (!document.insightsEnabled) {
@@ -829,6 +832,7 @@ router.post(
     const actor = ctx.state.auth.user;
     const document = await Document.findByPk(id, {
       userId: actor.id,
+      includeContent: false,
     });
     authorize(actor, "read", document);
 
@@ -911,7 +915,10 @@ router.post(
   async (ctx: APIContext<T.DocumentsChildrenReq>) => {
     const { id } = ctx.input.body;
     const { user } = ctx.state.auth;
-    const document = await Document.findByPk(id, { userId: user.id });
+    const document = await Document.findByPk(id, {
+      userId: user.id,
+      includeContent: false,
+    });
 
     authorize(user, "read", document);
 

--- a/server/routes/api/events/events.ts
+++ b/server/routes/api/events/events.ts
@@ -66,6 +66,7 @@ router.post(
     if (documentId) {
       const document = await Document.findByPk(documentId, {
         userId: user.id,
+        includeContent: false,
       });
       authorize(user, "read", document);
       where = { ...where, documentId };

--- a/server/routes/api/pins/pins.ts
+++ b/server/routes/api/pins/pins.ts
@@ -69,7 +69,10 @@ router.post(
     const { user } = ctx.state.auth;
     const { documentId, collectionId } = ctx.input.body;
 
-    const document = await Document.findByPk(documentId, { userId: user.id });
+    const document = await Document.findByPk(documentId, {
+      userId: user.id,
+      includeContent: false,
+    });
     authorize(user, "read", document);
 
     // There can be only one pin with these props.

--- a/server/routes/api/relationships/relationships.ts
+++ b/server/routes/api/relationships/relationships.ts
@@ -74,6 +74,7 @@ router.post(
 
     const anchorDocument = await Document.findByPk(anchorId, {
       userId: user.id,
+      includeContent: false,
       rejectOnEmpty: true,
     });
     authorize(user, "read", anchorDocument);

--- a/server/routes/api/subscriptions/subscriptions.ts
+++ b/server/routes/api/subscriptions/subscriptions.ts
@@ -47,6 +47,7 @@ router.post(
       // documentId will be available here
       const document = await Document.findByPk(documentId!, {
         userId: user.id,
+        includeContent: false,
       });
       authorize(user, "read", document);
 
@@ -91,6 +92,7 @@ router.post(
       // documentId will be available here
       const document = await Document.findByPk(documentId!, {
         userId: user.id,
+        includeContent: false,
       });
       authorize(user, "read", document);
 

--- a/server/routes/api/views/views.ts
+++ b/server/routes/api/views/views.ts
@@ -24,6 +24,7 @@ router.post(
 
     const document = await Document.findByPk(documentId, {
       userId: user.id,
+      includeContent: false,
     });
     authorize(user, "listViews", document);
 
@@ -51,6 +52,7 @@ router.post(
 
     const document = await Document.findByPk(documentId, {
       userId: user.id,
+      includeContent: false,
     });
     authorize(user, "read", document);
 


### PR DESCRIPTION
## Summary

Several high-traffic API endpoints load a document only to run a policy check, yet `Document.findByPk()` fetches the full `content`, `text` and `state` columns on every request. The read policy only inspects ownership, membership and collection fields, so these lookups now pass `includeContent: false`, which switches to the existing `withoutContent` scope already used by the revisions endpoints.

Production data (Sentry browser timings, last 7 days) shows the affected endpoints are among the most called in the app: `views.list` and `comments.list` at ~230k calls each, `relationships.list` at ~227k, and `views.create` with a p95 of 5.5s.

## Endpoints changed

- **views.list** and **views.create** (`views.ts`)
- **comments.list** (`comments.ts`): content is loaded only when `includeAnchorText` is passed, the sole consumer of the body. The web client never sends this flag.
- **relationships.list** (`relationships.ts`): anchor document lookup
- **subscriptions.list** and **subscriptions.info** (`subscriptions.ts`)
- **events.list** (`events.ts`): when filtering by `documentId`
- **pins.info** (`pins.ts`)
- **documents.insights**, **documents.users** and **documents.documents** (`documents.ts`)

Endpoints that present or mutate the document afterwards (for example `shares.info`, `pins.create`, `subscriptions.create`, `documents.restore`, comment mutations) are intentionally unchanged.

## Verification

- Route test files for every touched handler pass locally (511 tests), including the existing test that `comments.list` still returns anchor text when requested.
- `yarn tsc` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017swPbmq4SwtkE15fcRhdcU