### PR TITLE
fix: Allow viewers with collection write access to import documents

### DIFF
--- a/server/routes/api/attachments/attachments.test.ts
+++ b/server/routes/api/attachments/attachments.test.ts
@@ -258,7 +258,7 @@ describe("#attachments.create", () => {
       expect(attachment.expiresAt).toBeTruthy();
     });
 
-    it("should not allow viewer to upload using import preset", async () => {
+    it("should allow viewer to upload using import preset", async () => {
       const user = await buildViewer();
       const res = await server.post("/api/attachments.create", user, {
         body: {
@@ -268,7 +268,13 @@ describe("#attachments.create", () => {
           preset: AttachmentPreset.Import,
         },
       });
-      expect(res.status).toEqual(403);
+      expect(res.status).toEqual(200);
+
+      const body = await res.json();
+      const attachment = await Attachment.findByPk(body.data.attachment.id, {
+        rejectOnEmpty: true,
+      });
+      expect(attachment.expiresAt).toBeTruthy();
     });
 
     it("should not allow attachment creation for other documents", async () => {

--- a/server/routes/api/attachments/attachments.ts
+++ b/server/routes/api/attachments/attachments.ts
@@ -106,9 +106,6 @@ router.post(
       if (preset === AttachmentPreset.WorkspaceImport) {
         authorize(user, "createImport", user.team);
       }
-      if (preset === AttachmentPreset.Import) {
-        authorize(user, "createDocument", user.team);
-      }
       if (preset === AttachmentPreset.Emoji) {
         assertIn(contentType, AttachmentValidation.emojiContentTypes);
       }


### PR DESCRIPTION
Viewers can be granted edit or manage rights on individual collections, but the import upload was gated on the workspace-level document creation permission which viewers never have. The upload step now only requires workspace membership, and the collection-level check in documents.import remains the authoritative gate.

- Remove the workspace-level createDocument check for the import attachment preset
- Import uploads stay private, size limited, rate limited, and expire after 24 hours