### PR TITLE
fix: pinned document cards ignore clicks and trackpad taps (delay activation)

### DIFF
--- a/app/components/PinnedDocuments.tsx
+++ b/app/components/PinnedDocuments.tsx
@@ -82,8 +82,7 @@ function PinnedDocuments({
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {
-        delay: 100,
-        tolerance: 5,
+        distance: 8,
       },
     }),
     useSensor(KeyboardSensor, {


### PR DESCRIPTION
Fixes #4268.

Clicks and especially trackpad taps on Home/collection pinned cards frequently do nothing. Cause: the `PointerSensor` in `PinnedDocuments` uses `activationConstraint: { delay: 100, tolerance: 5 }`. Any stationary press held 100 ms or longer activates a drag, `DocumentCard` then sets `pointer-events: none` while dragging, and the pointerup/click lands behind the card, so the `Link` never navigates. A firm mouse click is ~60-90 ms and usually works; a trackpad tap is held ~180 ms by libinput/macOS tap-and-drag detection, so it always fails. Measured with synthesized pointer sequences: holds of 70/90 ms navigate, 95/100/110/130/180 ms do not.

Fix: use a distance constraint instead (`{ distance: 8 }`). A stationary press never activates, so clicks and taps of any duration navigate; drag-to-reorder still starts after 8 px of movement. #13498 (1.10.0) added the context menu but left the delay constraint in place, so the bug is still present there.

Tested on 1.10.0 (self-hosted) in Firefox and Chromium with synthesized holds and real trackpad taps.

Side note, separate from this change: `build/app/sw.js` is served with `Cache-Control: max-age=31536000, immutable`. Firefox does not revalidate immutable responses even for service-worker update checks, so a changed `sw.js` never installs there without a URL change. Serving `sw.js` as `no-cache` would avoid that; happy to open a separate PR if wanted.
