### PR TITLE
fix: Serve service worker with no-cache header

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -71,9 +71,15 @@ if (env.isProduction) {
         // Hashed static assets get 1 year expiry plus immutable flag
         maxAge: Day.ms * 365,
         immutable: true,
-        setHeaders: (res) => {
+        setHeaders: (res, filePath) => {
           res.setHeader("Service-Worker-Allowed", "/");
           res.setHeader("Access-Control-Allow-Origin", "*");
+
+          // The service worker is not hashed and must always be revalidated
+          // so that browsers detect and install new versions.
+          if (path.basename(filePath) === "sw.js") {
+            res.setHeader("Cache-Control", "no-cache");
+          }
         },
       });
     } catch (err) {


### PR DESCRIPTION
The service worker was served from the hashed static path with a one year immutable cache header. Firefox does not revalidate immutable responses on service worker update checks, so a new sw.js never installed there without a URL change.

- Serve sw.js with a no-cache header so browsers always revalidate it
- All other hashed static assets keep the long-lived immutable header