### PR TITLE
fix(policies): let guests with edit rights duplicate documents again

### DIFF
--- a/server/policies/document.test.ts
+++ b/server/policies/document.test.ts
@@ -317,6 +317,93 @@ describe("membership ids", () => {
   });
 });
 
+describe("duplicate", () => {
+  it("should allow members to duplicate from a read-write collection", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const collection = await buildCollection({
+      teamId: team.id,
+      permission: CollectionPermission.ReadWrite,
+    });
+    const doc = await buildDocument({
+      teamId: team.id,
+      collectionId: collection.id,
+    });
+    const document = await Document.findByPk(doc.id, { userId: user.id });
+    const abilities = serialize(user, document);
+    expect(abilities.duplicate).toBeTruthy();
+  });
+
+  it("should allow members to duplicate from a read-only collection", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({ teamId: team.id });
+    const collection = await buildCollection({
+      teamId: team.id,
+      permission: CollectionPermission.Read,
+    });
+    const doc = await buildDocument({
+      teamId: team.id,
+      collectionId: collection.id,
+    });
+    const document = await Document.findByPk(doc.id, { userId: user.id });
+    const abilities = serialize(user, document);
+    expect(abilities.duplicate).toBeTruthy();
+  });
+
+  it("should allow guests to duplicate documents they can update", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({
+      teamId: team.id,
+      role: UserRole.Guest,
+    });
+    const collection = await buildCollection({
+      teamId: team.id,
+      permission: null,
+    });
+    const doc = await buildDocument({
+      teamId: team.id,
+      collectionId: collection.id,
+    });
+    await UserMembership.create({
+      documentId: doc.id,
+      userId: user.id,
+      createdById: user.id,
+      permission: DocumentPermission.ReadWrite,
+    });
+    const document = await Document.findByPk(doc.id, { userId: user.id });
+    const abilities = serialize(user, document);
+    expect(abilities.update).toBeTruthy();
+    expect(abilities.duplicate).toBeTruthy();
+  });
+
+  it("should not allow guests to duplicate read-only documents", async () => {
+    const team = await buildTeam();
+    const user = await buildUser({
+      teamId: team.id,
+      role: UserRole.Guest,
+    });
+    const collection = await buildCollection({
+      teamId: team.id,
+      permission: null,
+    });
+    const doc = await buildDocument({
+      teamId: team.id,
+      collectionId: collection.id,
+    });
+    await UserMembership.create({
+      documentId: doc.id,
+      userId: user.id,
+      createdById: user.id,
+      permission: DocumentPermission.Read,
+    });
+    const document = await Document.findByPk(doc.id, { userId: user.id });
+    const abilities = serialize(user, document);
+    expect(abilities.read).toBeTruthy();
+    expect(abilities.update).toEqual(false);
+    expect(abilities.duplicate).toEqual(false);
+  });
+});
+
 describe("no collection", () => {
   it("should allow no permissions for team member", async () => {
     const team = await buildTeam();

--- a/server/policies/document.ts
+++ b/server/policies/document.ts
@@ -129,7 +129,13 @@ allow(User, "duplicate", Document, (actor, document) =>
     !!document?.isActive,
     isTeamMutable(actor),
     can(actor, "read", document),
-    can(actor, "createDocument", actor.team)
+    or(
+      can(actor, "createDocument", actor.team),
+      // Guests and viewers are never team-level creators (see createDocument
+      // on Team above), but may duplicate documents they can update - the
+      // destination is still authorized separately in documents.duplicate.
+      can(actor, "update", document)
+    )
   )
 );
 


### PR DESCRIPTION
## Summary

Fixes #13715.

#13198 (9796407) moved the `duplicate` ability gate to team-level `createDocument`. Guests and viewers can never hold a team-level `createDocument` grant (see the rule on `Team` above), so that policy change silently removed the duplicate action for guests who legitimately have edit rights on the source document via a document membership. This is the regression reported in #13715 ("Users with edit permissions can no longer duplicate documents").

The gate is widened to match the pre-1.10 capability: allow `duplicate` when the actor can `createDocument` at team level (members - preserves the #13198 fix) **or** `update` the source document (guests/viewers with document-level edit membership). As before, read access to the source is sufficient to copy its content, and the destination collection is authorized separately in `documents.duplicate`, so the guest path grants nothing the actor couldn't already do by hand.

## Tests

New cases in `server/policies/document.test.ts`:

- members can duplicate from read-write and read-only collections (regression guard for #13198, previously untested)
- guests with a read-write document membership can duplicate (this issue)
- guests with a read-only document membership cannot duplicate

Test status, disclosed honestly: the policy tests require Outline's Postgres test database, which could not be provisioned in this sandbox, so they were not executed here - the change was verified by tracing the cancan rule chain (`serialize` -> `duplicate` gate -> `createDocument`/`update` abilities) and CI will run the suite. The test file compiles against existing imports only (no new imports needed).

> Built by breken, your AI support engineer - breken.ai - this one's on us.
