### PR TITLE
fix: Show notice type for list selections

### DIFF
--- a/app/editor/menus/notice.tsx
+++ b/app/editor/menus/notice.tsx
@@ -7,6 +7,7 @@ import {
   WarningIcon,
 } from "outline-icons";
 import { NoticeTypes } from "@shared/editor/nodes/Notice";
+import { findParentNode } from "@shared/editor/queries/findParentNode";
 import type { MenuItem, SelectionContext } from "@shared/editor/types";
 
 /**
@@ -16,8 +17,11 @@ import type { MenuItem, SelectionContext } from "@shared/editor/types";
  * @returns an array of menu items.
  */
 export default function noticeMenuItems(ctx: SelectionContext): MenuItem[] {
-  const node = ctx.selection.$from.node(-1);
-  const currentStyle = node?.attrs.style as NoticeTypes;
+  const notice = findParentNode(
+    (node) => node.type === ctx.schema.nodes.container_notice
+  )(ctx.selection);
+  const currentStyle: NoticeTypes =
+    notice?.node.attrs.style ?? NoticeTypes.Info;
 
   const mapping = {
     [NoticeTypes.Info]: t("Info notice"),

--- a/shared/editor/nodes/Notice.tsx
+++ b/shared/editor/nodes/Notice.tsx
@@ -10,6 +10,7 @@ import type { Command, EditorState, Transaction } from "prosemirror-state";
 import type { Primitive } from "utility-types";
 import toggleWrap from "../commands/toggleWrap";
 import type { MarkdownSerializerState } from "../lib/markdown/serializer";
+import { findParentNodeClosestToPos } from "../queries/findParentNode";
 import noticesRule from "../rules/notices";
 import { EditorStyleHelper } from "../styles/EditorStyleHelper";
 import type { ComponentProps } from "../types";
@@ -125,19 +126,23 @@ export default class Notice extends Node {
   ): boolean => {
     const { tr, selection } = state;
     const { $from } = selection;
-    const node = $from.node(-1);
+    const notice = findParentNodeClosestToPos(
+      $from,
+      (node) => node.type === state.schema.nodes.container_notice
+    );
 
-    if (node?.type.name === this.name) {
-      if (dispatch) {
-        const transaction = tr.setNodeMarkup($from.before(-1), undefined, {
-          ...node.attrs,
-          style,
-        });
-        dispatch(transaction);
-      }
-      return true;
+    if (!notice) {
+      return false;
     }
-    return false;
+
+    if (dispatch) {
+      const transaction = tr.setNodeMarkup(notice.pos, undefined, {
+        ...notice.node.attrs,
+        style,
+      });
+      dispatch(transaction);
+    }
+    return true;
   };
 
   component = (props: ComponentProps) => {


### PR DESCRIPTION
Ensure the floating toolbar uses the containing notice when the cursor is inside a nested list.

- Show the correct notice type instead of relying on the direct parent node.
- Apply notice type changes to the containing notice from nested list selections.