### PR TITLE
fix: Editor node drags show the sidebar document ghost

### DIFF
--- a/app/components/Sidebar/components/DragPlaceholder.tsx
+++ b/app/components/Sidebar/components/DragPlaceholder.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import type { XYCoord } from "react-dnd";
 import { useDragLayer } from "react-dnd";
+import { NativeTypes } from "react-dnd-html5-backend";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import useStores from "~/hooks/useStores";
@@ -15,6 +16,10 @@ const layerStyles: React.CSSProperties = {
   width: "100%",
   height: "100%",
 };
+
+// Browser-native drags (files, text, or ProseMirror nodes leaving the editor)
+// are tracked by react-dnd too, but they are not sidebar items.
+const nativeItemTypes = new Set<string | symbol>(Object.values(NativeTypes));
 
 // Keep the ghost beside the pointer so it never covers the drop cursor.
 const POINTER_OFFSET_X = 12;
@@ -41,14 +46,21 @@ const DragPlaceholder = () => {
   const { t } = useTranslation();
   const { ui } = useStores();
 
-  const { isDragging, item, pointerOffset } = useDragLayer((monitor) => ({
-    item: monitor.getItem(),
-    itemType: monitor.getItemType(),
-    pointerOffset: monitor.getClientOffset(),
-    isDragging: monitor.isDragging(),
-  }));
+  const { isDragging, item, itemType, pointerOffset } = useDragLayer(
+    (monitor) => ({
+      item: monitor.getItem(),
+      itemType: monitor.getItemType(),
+      pointerOffset: monitor.getClientOffset(),
+      isDragging: monitor.isDragging(),
+    })
+  );
 
-  if (!isDragging || !pointerOffset) {
+  if (
+    !isDragging ||
+    !pointerOffset ||
+    !itemType ||
+    nativeItemTypes.has(itemType)
+  ) {
     return null;
   }
 

--- a/shared/editor/nodes/Notice.tsx
+++ b/shared/editor/nodes/Notice.tsx
@@ -42,7 +42,7 @@ export default class Notice extends Node {
         "(list | blockquote | hr | paragraph | heading | code_block | code_fence | attachment)+",
       group: "block",
       defining: true,
-      draggable: true,
+      draggable: false,
       parseDOM: [
         {
           tag: `div.${EditorStyleHelper.notice}`,


### PR DESCRIPTION
Dragging an editor node past the edge of the editor showed the sidebar's document drag ghost with an "Untitled" label. react-dnd tracks any browser-native drag (ProseMirror nodes, text, files) as a native item once it leaves the editor surface, and the drag placeholder rendered a document row for every active drag.

- Drag placeholder now ignores react-dnd native item types, so only sidebar and document list items render a ghost
- Notice blocks are no longer accidentally draggable