### PR TITLE
fix: Checklist with multiple items corrupts neighbouring lists

### DIFF
--- a/shared/editor/rules/checkboxes.test.ts
+++ b/shared/editor/rules/checkboxes.test.ts
@@ -94,3 +94,45 @@ it("converts an ordered list containing a checkbox item", () => {
   expect(checkboxList?.content?.[0].type).toBe("checkbox_item");
   expect(checkboxList?.content?.[1].type).toBe("checkbox_item");
 });
+
+it("leaves neighbouring lists untouched when a checklist has multiple items", () => {
+  const markdown = `## Before 1
+- B1 a
+- B1 b
+
+## Before 2
+- B2 a
+- B2 b
+
+## Tasks
+- [ ] task one
+- [ ] task two
+
+## After 1
+- A1 a
+- A1 b
+
+## After 2
+- A2 a`;
+
+  const ast = parser.parse(markdown);
+  const json = ast?.toJSON();
+
+  const checkboxLists = findNodes(json, "checkbox_list");
+  expect(checkboxLists).toHaveLength(1);
+  expect(checkboxLists[0]?.content).toHaveLength(2);
+
+  const bulletLists = findNodes(json, "bullet_list");
+  expect(bulletLists).toHaveLength(4);
+  for (const list of bulletLists) {
+    for (const item of list?.content ?? []) {
+      expect(item.type).toBe("list_item");
+    }
+  }
+
+  const output = serializer.serialize(ast);
+  expect(output).toContain("B2 a");
+  expect(output).toContain("A1 a");
+  expect(output).toContain("A1 b");
+  expect(output).not.toContain("[ ] B2 a");
+});

--- a/shared/editor/rules/checkboxes.ts
+++ b/shared/editor/rules/checkboxes.ts
@@ -24,13 +24,17 @@ function isListItem(token: Token): boolean {
 
 function isListOpen(token: Token): boolean {
   return (
-    token.type === "bullet_list_open" || token.type === "ordered_list_open"
+    token.type === "bullet_list_open" ||
+    token.type === "ordered_list_open" ||
+    token.type === "checkbox_list_open"
   );
 }
 
 function isListClose(token: Token): boolean {
   return (
-    token.type === "bullet_list_close" || token.type === "ordered_list_close"
+    token.type === "bullet_list_close" ||
+    token.type === "ordered_list_close" ||
+    token.type === "checkbox_list_close"
   );
 }
 


### PR DESCRIPTION
Since #13665, importing Markdown with a checklist of N items converted the N-1 bullet lists before it into checkbox lists and dropped the N-1 bullet lists after it. The rule processes items backwards and the search for the enclosing list skipped tokens that were already renamed, so it walked into neighbouring lists at the same level.

- Match already converted `checkbox_list_open` and `checkbox_list_close` tokens when locating the enclosing list, so the search stops at the current list
- closes #13722