### PR TITLE
chore(deps-dev): bump fflate from 0.8.2 to 0.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -380,6 +380,7 @@
     "zod": "^4.5.4",
     "@types/markdown-it": "14.1.2",
     "ip-address@npm:10.1.0": "^10.2.0",
+    "fflate": "^0.8.3",
     "minimatch@npm:9.0.1": "9.0.9",
     "lodash@npm:4.17.21": "^4.18.1",
     "ws@npm:~8.17.1": "^8.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11289,10 +11289,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fflate@npm:^0.8.2":
-  version: 0.8.2
-  resolution: "fflate@npm:0.8.2"
-  checksum: 10c0/03448d630c0a583abea594835a9fdb2aaf7d67787055a761515bf4ed862913cfd693b4c4ffd5c3f3b355a70cf1e19033e9ae5aedcca103188aaff91b8bd6e293
+"fflate@npm:^0.8.3":
+  version: 0.8.3
+  resolution: "fflate@npm:0.8.3"
+  checksum: 10c0/eab181ca37f5348ae76d4b6f840e0026e30220e33153289ac942222d8b9638237d486507dbcc09878d724095bd354993a2ee48bbee99c8f2c6440d4448719aa7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

`fflate@0.8.2` — pulled in transitively via `@vitest/ui`'s dependency
on `fflate: "npm:^0.8.2"` — is affected by
[GHSA-px8p-9vwx-vf98](https://github.com/advisories/GHSA-px8p-9vwx-vf98)
(CVE-2026-45820, CVSS 7.5): `unzipSync()` can enter an infinite loop
when parsing a malformed ZIP64 archive whose central directory entry
declares `compressed_size=0xFFFFFFFF` but omits the required ZIP64
extra field — an out-of-bounds read coerces to `0`, keeping the loop
condition permanently true. Fixed upstream in `fflate@0.8.3`.

`fflate` isn't a direct dependency of this project, so I pinned it via
the existing `resolutions` block (following the same pattern already
used here for `ip-address`, `minimatch`, `lodash`, etc.) rather than
hand-editing `yarn.lock`, then ran a real `yarn install` to regenerate
the lockfile. `0.8.3` is a patch release and satisfies every existing
`^0.8.2` range in the tree, so no other manifest needed to change.

## Verification

- `osv-scanner` against the regenerated `yarn.lock` no longer reports
  the advisory (confirmed before/after).
- `yarn test:shared` — 1406 tests passed, 22 skipped, 0 failures.
- Found via a general dependency audit of this repo with
  [scan-cli](https://github.com/boazgarty/code-scanner) (OSV-Scanner +
  Trivy), independently cross-checked directly against `yarn.lock`.

## Test plan

- [x] `osv-scanner` shows the advisory resolved
- [x] `yarn test:shared` passes
- [ ] CI (server/app test projects need Postgres/Redis I didn't spin
      up locally for this change — no server/app source touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiAnqd5yr3CkAcKuMGdEZY