### PR TITLE
fix: Crash when image caption blurs during node view teardown

### DIFF
--- a/shared/editor/nodes/Image.test.ts
+++ b/shared/editor/nodes/Image.test.ts
@@ -1,17 +1,5 @@
-import type { EditorState } from "prosemirror-state";
-import type * as React from "react";
-import type { Editor } from "../../../app/editor";
-import {
-  createEditorState,
-  doc,
-  findNodes,
-  parser,
-  schema,
-  serializer,
-} from "../../test/editor";
+import { findNodes, parser, serializer } from "../../test/editor";
 import { ImageSource } from "../lib/FileHelper";
-import type { ComponentProps } from "../types";
-import Image from "./Image";
 
 const findImageNode = (doc: ReturnType<typeof parser.parse>) => {
   const imageNode = findNodes(doc?.toJSON(), "image")[0];
@@ -80,69 +68,5 @@ describe("Image node source attribute round-trip", () => {
     const imageNode = findImageNode(doc);
     expect(imageNode.attrs.source).toBeFalsy();
     expect(imageNode.attrs.title).toBe("Caption source=example");
-  });
-});
-
-describe("Image caption blur", () => {
-  const createEditor = (state: EditorState) => {
-    const dispatch = vi.fn();
-    const image = new Image();
-    image.bindEditor({ view: { state, dispatch } } as unknown as Editor);
-    return { image, dispatch };
-  };
-
-  const blurEvent = (innerText: string) =>
-    ({
-      currentTarget: { innerText },
-    }) as unknown as React.FocusEvent<HTMLParagraphElement>;
-
-  const imageDoc = () =>
-    doc(
-      schema.nodes.paragraph.create(
-        null,
-        schema.nodes.image.create({
-          src: "https://example.com/a.png",
-          alt: "old",
-        })
-      )
-    );
-
-  it("updates the caption when the node is still in the document", () => {
-    const state = createEditorState(imageDoc());
-    const { image, dispatch } = createEditor(state);
-    const node = state.doc.nodeAt(1)!;
-
-    image.handleCaptionBlur({ node, getPos: () => 1 } as ComponentProps)(
-      blurEvent("new")
-    );
-
-    expect(dispatch).toHaveBeenCalledTimes(1);
-    expect(dispatch.mock.calls[0][0].doc.nodeAt(1)?.attrs.alt).toBe("new");
-  });
-
-  it("ignores the blur when the node view has been destroyed", () => {
-    const state = createEditorState(imageDoc());
-    const { image, dispatch } = createEditor(state);
-    const node = state.doc.nodeAt(1)!;
-    const getPos = () => undefined as unknown as number;
-
-    expect(() =>
-      image.handleCaptionBlur({ node, getPos } as ComponentProps)(
-        blurEvent("new")
-      )
-    ).not.toThrow();
-    expect(dispatch).not.toHaveBeenCalled();
-  });
-
-  it("ignores the blur when the position no longer holds an image", () => {
-    const state = createEditorState(imageDoc());
-    const { image, dispatch } = createEditor(state);
-    const node = state.doc.nodeAt(1)!;
-
-    image.handleCaptionBlur({ node, getPos: () => 0 } as ComponentProps)(
-      blurEvent("new")
-    );
-
-    expect(dispatch).not.toHaveBeenCalled();
   });
 });

--- a/shared/editor/nodes/Image.test.ts
+++ b/shared/editor/nodes/Image.test.ts
@@ -1,5 +1,17 @@
-import { findNodes, parser, serializer } from "../../test/editor";
+import type { EditorState } from "prosemirror-state";
+import type * as React from "react";
+import type { Editor } from "../../../app/editor";
+import {
+  createEditorState,
+  doc,
+  findNodes,
+  parser,
+  schema,
+  serializer,
+} from "../../test/editor";
 import { ImageSource } from "../lib/FileHelper";
+import type { ComponentProps } from "../types";
+import Image from "./Image";
 
 const findImageNode = (doc: ReturnType<typeof parser.parse>) => {
   const imageNode = findNodes(doc?.toJSON(), "image")[0];
@@ -68,5 +80,69 @@ describe("Image node source attribute round-trip", () => {
     const imageNode = findImageNode(doc);
     expect(imageNode.attrs.source).toBeFalsy();
     expect(imageNode.attrs.title).toBe("Caption source=example");
+  });
+});
+
+describe("Image caption blur", () => {
+  const createEditor = (state: EditorState) => {
+    const dispatch = vi.fn();
+    const image = new Image();
+    image.bindEditor({ view: { state, dispatch } } as unknown as Editor);
+    return { image, dispatch };
+  };
+
+  const blurEvent = (innerText: string) =>
+    ({
+      currentTarget: { innerText },
+    }) as unknown as React.FocusEvent<HTMLParagraphElement>;
+
+  const imageDoc = () =>
+    doc(
+      schema.nodes.paragraph.create(
+        null,
+        schema.nodes.image.create({
+          src: "https://example.com/a.png",
+          alt: "old",
+        })
+      )
+    );
+
+  it("updates the caption when the node is still in the document", () => {
+    const state = createEditorState(imageDoc());
+    const { image, dispatch } = createEditor(state);
+    const node = state.doc.nodeAt(1)!;
+
+    image.handleCaptionBlur({ node, getPos: () => 1 } as ComponentProps)(
+      blurEvent("new")
+    );
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch.mock.calls[0][0].doc.nodeAt(1)?.attrs.alt).toBe("new");
+  });
+
+  it("ignores the blur when the node view has been destroyed", () => {
+    const state = createEditorState(imageDoc());
+    const { image, dispatch } = createEditor(state);
+    const node = state.doc.nodeAt(1)!;
+    const getPos = () => undefined as unknown as number;
+
+    expect(() =>
+      image.handleCaptionBlur({ node, getPos } as ComponentProps)(
+        blurEvent("new")
+      )
+    ).not.toThrow();
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("ignores the blur when the position no longer holds an image", () => {
+    const state = createEditorState(imageDoc());
+    const { image, dispatch } = createEditor(state);
+    const node = state.doc.nodeAt(1)!;
+
+    image.handleCaptionBlur({ node, getPos: () => 0 } as ComponentProps)(
+      blurEvent("new")
+    );
+
+    expect(dispatch).not.toHaveBeenCalled();
   });
 });

--- a/shared/editor/nodes/Image.tsx
+++ b/shared/editor/nodes/Image.tsx
@@ -420,8 +420,15 @@ export default class Image extends SimpleImage {
       const { view } = this.editor;
       const { tr } = view.state;
 
-      // update meta on object
+      // The blur may fire while the node view is being torn down, at which
+      // point the position no longer refers to this image in the document.
       const pos = getPos();
+      const current =
+        pos === undefined ? undefined : view.state.doc.nodeAt(pos);
+      if (current?.type !== node.type) {
+        return;
+      }
+
       const transaction = tr.setNodeMarkup(pos, undefined, {
         ...node.attrs,
         alt: caption,

--- a/shared/editor/nodes/Video.tsx
+++ b/shared/editor/nodes/Video.tsx
@@ -159,8 +159,15 @@ export default class Video extends Node {
       const { view } = this.editor;
       const { tr } = view.state;
 
-      // update meta on object
+      // The blur may fire while the node view is being torn down, at which
+      // point the position no longer refers to this video in the document.
       const pos = getPos();
+      const current =
+        pos === undefined ? undefined : view.state.doc.nodeAt(pos);
+      if (current?.type !== node.type) {
+        return;
+      }
+
       const transaction = tr.setNodeMarkup(pos, undefined, {
         ...node.attrs,
         title: caption,


### PR DESCRIPTION
Fixes OUTLINE-CLOUD-D6D

## Summary

The image and video caption blur handlers call `setNodeMarkup` with the position returned by the node view's `getPos`. When the blur fires while ProseMirror is tearing down the node's DOM, `getPos` returns `undefined`, and `doc.nodeAt(undefined)` walks every child of the document until it throws `RangeError: Index N out of range`.

This change resolves the position first and returns early unless the document still holds a node of the same type there.

## Changes

- `shared/editor/nodes/Image.tsx`: guard the caption blur handler against a stale or missing position.
- `shared/editor/nodes/Video.tsx`: same guard for the identical video caption handler.
